### PR TITLE
CORDA-2715 - Update test runner instructions for CorDapp tutorial

### DIFF
--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -487,7 +487,7 @@ Running tests in IntelliJ
 We recommend editing your IntelliJ preferences so that you use the gradle runner - this means that the quasar utils
 plugin will make sure that some flags (like ``-javaagent`` - see "Alternatively..." below) are set for you.
 
-To switch to using the gradle runner:
+To switch to using the Gradle runner:
 
 * Navigate to ``Build, Execution, Deployment -> Build Tools -> Gradle -> Runner`` (or search for `runner`)
 
@@ -497,15 +497,35 @@ To switch to using the gradle runner:
 * set "Delegate IDE build/run actions to gradle" to true
 * set "Run test using:" to "Gradle Test Runner"
 
-Alternatively, to use the built in IntelliJ JUnit test runner, you can:
+If you would prefer to use the built in IntelliJ JUnit test runner, you can either manually copy the quasar jar to, say, the lib
+directory, or you can add some code to your build.gradle file and it will do it for you.  See below for details.
+
+Whichever you pick, with the IntelliJ Junit test runner you will need to specify ``-javaagent:lib/quasar-core-<version>.jar``
+and set the run directory to the project root directory for each test.
+
+The manual approach would be to:
 
 * copy your quasar-core.jar to the ``<project root>/lib/`` dir
 
-  * this will be the one specified in build.gradle - you can find it in your gradle cache
+  * this will be the one specified in build.gradle - you can find it in your Gradle cache
 
     * e.g. on mac/linux you can run something similar to: ``find ~/.gradle/caches -name quasar-core\*.jar``
-* for each test specify ``-javaagent:lib/quasar-core-<version>.jar`` and set the run directory to the project root directory
 
+The Gradle based approach would be to add this to your build.gradle file:
+
+.. sourcecode:: gradle
+
+    apply plugin: 'net.corda.plugins.quasar-utils'
+
+    task installQuasar(type: Copy) {
+        destinationDir rootProject.file("lib")
+        from(configurations.quasar) {
+            rename 'quasar-core(.*).jar', 'quasar.jar'
+        }
+    }
+
+
+and then you can run `gradlew installQuasar`
 
 Debugging your CorDapp
 ----------------------

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -504,7 +504,7 @@ If you would prefer to use the built in IntelliJ JUnit test runner, you can add 
 it will copy your quasar JAR file to the lib directory. You will also need to specify ``-javaagent:lib/quasar.jar``
 and set the run directory to the project root directory for each test.
 
-Add the following to your ``build.gradle`` file:
+Add the following to your ``build.gradle`` file - ideally to a ``build.gradle`` that already contains the quasar-utils plugin line:
 
 .. sourcecode:: groovy
 

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -484,8 +484,9 @@ You can run the CorDapp's integration tests by running the ``Run Integration Tes
 Running tests in IntelliJ
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We recommend editing your IntelliJ preferences so that you use the gradle runner - this means that the quasar utils
-plugin will make sure that some flags (like ``-javaagent`` - see "Alternatively..." below) are set for you.
+We recommend editing your IntelliJ preferences so that you use the Gradle runner - this means that the quasar utils
+plugin will make sure that some flags (like ``-javaagent`` - see :ref:`below <tutorial_cordapp_alternative_test_runners>`) are
+set for you.
 
 To switch to using the Gradle runner:
 
@@ -494,26 +495,18 @@ To switch to using the Gradle runner:
   * Windows: this is in "Settings"
   * MacOS: this is in "Preferences"
 
-* set "Delegate IDE build/run actions to gradle" to true
-* set "Run test using:" to "Gradle Test Runner"
+* Set "Delegate IDE build/run actions to gradle" to true
+* Set "Run test using:" to "Gradle Test Runner"
 
-If you would prefer to use the built in IntelliJ JUnit test runner, you can either manually copy the quasar jar to, say, the lib
-directory, or you can add some code to your build.gradle file and it will do it for you.  See below for details.
+.. _tutorial_cordapp_alternative_test_runners:
 
-Whichever you pick, with the IntelliJ Junit test runner you will need to specify ``-javaagent:lib/quasar-core-<version>.jar``
+If you would prefer to use the built in IntelliJ JUnit test runner, you can add some code to your ``build.gradle`` file and
+it will copy your quasar JAR file to the lib directory. You will also need to specify ``-javaagent:lib/quasar.jar``
 and set the run directory to the project root directory for each test.
 
-The manual approach would be to:
+Add the following to your ``build.gradle`` file:
 
-* copy your quasar-core.jar to the ``<project root>/lib/`` dir
-
-  * this will be the one specified in build.gradle - you can find it in your Gradle cache
-
-    * e.g. on mac/linux you can run something similar to: ``find ~/.gradle/caches -name quasar-core\*.jar``
-
-The Gradle based approach would be to add this to your build.gradle file:
-
-.. sourcecode:: gradle
+.. sourcecode:: groovy
 
     apply plugin: 'net.corda.plugins.quasar-utils'
 
@@ -525,7 +518,7 @@ The Gradle based approach would be to add this to your build.gradle file:
     }
 
 
-and then you can run `gradlew installQuasar`
+and then you can run ``gradlew installQuasar``.
 
 Debugging your CorDapp
 ----------------------

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -481,6 +481,28 @@ Integration tests
 ~~~~~~~~~~~~~~~~~
 You can run the CorDapp's integration tests by running the ``Run Integration Tests - Kotlin`` run configuration.
 
+Running tests in IntelliJ
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We recommend editing your IntelliJ preferences so that you use the gradle runner - this means that the quasar utils
+plugin will make sure that some flags (like ``-javaagent`` - see "Alternatively..." below) are set for you.
+
+To switch to using the gradle runner:
+
+ * Navigate to ``Build, Execution, Deployment -> Build Tools -> Gradle -> Runner`` (or search for `runner`)
+   * Windows: this is in "Settings"
+   * MacOS: this is in "Preferences"
+ * set "Delegate IDE build/run actions to gradle" to true
+ * set "Run test using:" to "Gradle Test Runner"
+
+Alternatively, to use the built in IntelliJ JUnit test runner, you can:
+
+ * copy your quasar-core.jar to the ``<project root>/lib/`` dir
+   * this will be the one specified in build.gradle - you can find it in your gradle cache
+     * e.g. on mac/linux you can run something similar to: ``find ~/.gradle/caches -name quasar-core\*.jar``
+ * for each test specify ``-javaagent:lib/quasar-core-<version>.jar`` and setting the run directory to the project root directory
+
+
 Debugging your CorDapp
 ----------------------
 

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -489,18 +489,22 @@ plugin will make sure that some flags (like ``-javaagent`` - see "Alternatively.
 
 To switch to using the gradle runner:
 
- * Navigate to ``Build, Execution, Deployment -> Build Tools -> Gradle -> Runner`` (or search for `runner`)
-   * Windows: this is in "Settings"
-   * MacOS: this is in "Preferences"
- * set "Delegate IDE build/run actions to gradle" to true
- * set "Run test using:" to "Gradle Test Runner"
+* Navigate to ``Build, Execution, Deployment -> Build Tools -> Gradle -> Runner`` (or search for `runner`)
+
+  * Windows: this is in "Settings"
+  * MacOS: this is in "Preferences"
+
+* set "Delegate IDE build/run actions to gradle" to true
+* set "Run test using:" to "Gradle Test Runner"
 
 Alternatively, to use the built in IntelliJ JUnit test runner, you can:
 
- * copy your quasar-core.jar to the ``<project root>/lib/`` dir
-   * this will be the one specified in build.gradle - you can find it in your gradle cache
-     * e.g. on mac/linux you can run something similar to: ``find ~/.gradle/caches -name quasar-core\*.jar``
- * for each test specify ``-javaagent:lib/quasar-core-<version>.jar`` and setting the run directory to the project root directory
+* copy your quasar-core.jar to the ``<project root>/lib/`` dir
+
+  * this will be the one specified in build.gradle - you can find it in your gradle cache
+
+    * e.g. on mac/linux you can run something similar to: ``find ~/.gradle/caches -name quasar-core\*.jar``
+* for each test specify ``-javaagent:lib/quasar-core-<version>.jar`` and set the run directory to the project root directory
 
 
 Debugging your CorDapp


### PR DESCRIPTION
@anthonykeenan - apols - appear to have used a forked repo for this - will try a non-forked one post this change.

In this PR: https://github.com/corda/cordapp-template-kotlin/pull/46
We have deleted the lib/quasar.jar and updated the docs to change the way we recommend running tests inside IntelliJ. It's a bit controversial, but we did this for the following reasons:
when corda 4 was released, everyone forgot to update the quasar.jar in the template projects to the corda 4 version
customers who had written cordapps based on the template needed to know to update the quasar version in their existing cordapps, but this was missed from the upgrade nodes
we could have written some gradle to automatically download the jar file, but you still have to do the -javaagent dance each time you run a new test
So because of this we picked recommending running using the gradle test runner. This means you run tests the same way that the build does, which is good, and we can leverage the quasar-utils plugin. It also means you can run any test and it just works. I've tested debugging and it feels the same as using the JUnit runner.

# PR Checklist:

- [ran the docs tests] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [n/a ] If you added public APIs, did you write the JavaDocs?
- [n/a] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [n/a] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)