### PR TITLE
CORDA-2629: Provide a better error msg when notary type misconfig

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
@@ -75,7 +75,7 @@ class NotaryLoader(
     /** Validates that the notary is correctly configured by comparing the configured type against the type advertised in the network map cache */
     private fun validateNotaryType(myNotaryIdentity: PartyAndCertificate?, services: ServiceHubInternal) {
         var configuredAsValidatingNotary = services.configuration.notary?.validating
-        val notaryParty = myNotaryIdentity?.party ?: throw IllegalStateException("Notary doesn't have a party")
+        val notaryParty = myNotaryIdentity?.party ?: throw IllegalStateException("Could not establish notary identity of this node")
         var validatingNotaryInNetworkMapCache = services.networkMapCache.isValidatingNotary(notaryParty)
         
         if(configuredAsValidatingNotary != validatingNotaryInNetworkMapCache) {

--- a/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
@@ -79,7 +79,8 @@ class NotaryLoader(
         var validatingNotaryInNetworkMapCache = services.networkMapCache.isValidatingNotary(notaryParty)
         
         if(configuredAsValidatingNotary != validatingNotaryInNetworkMapCache) {
-            throw IllegalStateException("There is a discrepancy in the configured notary type and the one advertised in the network parameters - shutting down.")    
+            throw IllegalStateException("There is a discrepancy in the configured notary type and the one advertised in the network parameters - shutting down. " 
+            + "Configured as validating: ${configuredAsValidatingNotary}. Advertised as validating: ${validatingNotaryInNetworkMapCache}")    
         }
     }
     

--- a/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
@@ -55,6 +55,8 @@ class NotaryLoader(
     }
 
     fun loadService(myNotaryIdentity: PartyAndCertificate?, services: ServiceHubInternal, cordappLoader: CordappLoader): NotaryService {
+        validateNotaryType(myNotaryIdentity, services)
+
         val serviceClass = builtInServiceClass ?: scanCorDapps(cordappLoader)
         log.info("Starting notary service: $serviceClass")
 
@@ -70,6 +72,17 @@ class NotaryLoader(
         return constructor.newInstance(services, notaryKey)
     }
 
+    /** Validates that the notary is correctly configured by comparing the configured type against the type advertised in the network map cache */
+    private fun validateNotaryType(myNotaryIdentity: PartyAndCertificate?, services: ServiceHubInternal) {
+        var configuredAsValidatingNotary = services.configuration.notary?.validating
+        val notaryParty = myNotaryIdentity?.party ?: throw IllegalStateException("Notary doesn't have a party")
+        var validatingNotaryInNetworkMapCache = services.networkMapCache.isValidatingNotary(notaryParty)
+        
+        if(configuredAsValidatingNotary != validatingNotaryInNetworkMapCache) {
+            throw IllegalStateException("There is a discrepancy in the configured notary type and the one advertised in the network parameters - shutting down.")    
+        }
+    }
+    
     /** Looks for the config specified notary service implementation in loaded CorDapps. This mechanism is for internal use only. */
     private fun scanCorDapps(cordappLoader: CordappLoader): Class<out NotaryService> {
         val loadedImplementations = cordappLoader.cordapps.mapNotNull { it.notaryService }

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -101,7 +101,7 @@ class TimedFlowTests {
             val networkParameters = NetworkParametersCopier(testNetworkParameters(listOf(NotaryInfo(notaryIdentity, false))))
             val notaryConfig = mock<NotaryConfig> {
                 whenever(it.serviceLegalName).thenReturn(serviceLegalName)
-                whenever(it.validating).thenReturn(true)
+                whenever(it.validating).thenReturn(false)
                 whenever(it.className).thenReturn(TestNotaryService::class.java.name)
             }
 


### PR DESCRIPTION
If a notary service is misconfigured with the type (either validating or not validating) stored in the node's configuration not matching that advertised in the network map cache, the notary will throw an exception and fail on startup.
Previously, this misconfiguration would result in an exception being thrown when attempting to notarise a transaction. This change results in the exception being thrown at node startup and the node operator being aware of the misconfiguration earlier.