### PR TITLE
CORDA-2725: Fix logging configuration for DJVM CLI.

### DIFF
--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CommandBase.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CommandBase.kt
@@ -8,6 +8,8 @@ import net.corda.djvm.references.ClassReference
 import net.corda.djvm.references.EntityReference
 import net.corda.djvm.references.MemberReference
 import net.corda.djvm.rewiring.SandboxClassLoadingException
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.core.config.Configurator
 import picocli.CommandLine
 import picocli.CommandLine.Help.Ansi
 import picocli.CommandLine.Option
@@ -102,12 +104,24 @@ abstract class CommandBase : Callable<Boolean> {
             printError("Error: Cannot set verbose and quiet modes at the same time")
             return false
         }
+        configureLogging()
         return try {
             handleCommand()
         } catch (exception: Throwable) {
             printException(exception)
             false
         }
+    }
+
+    private fun configureLogging() {
+        val logLevel = when(level) {
+            Severity.ERROR -> Level.ERROR
+            Severity.WARNING -> Level.WARN
+            Severity.INFORMATIONAL -> Level.INFO
+            Severity.DEBUG -> Level.DEBUG
+            Severity.TRACE -> Level.TRACE
+        }
+        Configurator.setRootLevel(logLevel)
     }
 
     protected fun printException(exception: Throwable) = when (exception) {

--- a/djvm/cli/src/main/resources/log4j2.xml
+++ b/djvm/cli/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
 
-    <ThresholdFilter level="info"/>
+    <ThresholdFilter level="trace"/>
     <Appenders>
         <!-- Will generate up to 10 log files for a given day. During every rollover it will delete
              those that are older than 60 days, but keep the most recent 10 GB -->

--- a/djvm/src/main/kotlin/net/corda/djvm/messages/Severity.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/messages/Severity.kt
@@ -12,7 +12,12 @@ enum class Severity(val shortName: String, val precedence: Int, val color: Strin
     /**
      * Trace message.
      */
-    TRACE("TRACE", 3, null),
+    TRACE("TRACE", 4, null),
+
+    /**
+     * Debug message.
+     */
+    DEBUG("DEBUG", 3, null),
 
     /**
      * Informational message.


### PR DESCRIPTION
- Set DJVM CLI logging threshold to "TRACE".
- Configure root logging level programmatically.
- Support DEBUG logging level.