### PR TITLE
CORDA-2725: Include DEBUG in DJVM CLI help's list of logging levels.

### DIFF
--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CommandBase.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CommandBase.kt
@@ -21,7 +21,7 @@ abstract class CommandBase : Callable<Boolean> {
 
     @Option(
             names = ["-l", "--level"],
-            description = ["The minimum severity level to log (TRACE, INFO, WARNING or ERROR."],
+            description = ["The minimum severity level to log (TRACE, DEBUG, INFO, WARNING or ERROR."],
             converter = [SeverityConverter::class]
     )
     protected var level: Severity = Severity.WARNING


### PR DESCRIPTION
Include the new `DEBUG` level in the output of `--help`.