### PR TITLE
CORDA-2705 - Prevent duplicates in cache and fix the mappings persisted for confidential identities

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -8,6 +8,7 @@ import net.corda.core.node.services.UnknownAnonymousPartyException
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.MAX_HASH_HEX_SIZE
 import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.debug
 import net.corda.node.services.api.IdentityServiceInternal
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.nodeapi.internal.crypto.X509CertificateFactory
@@ -137,7 +138,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     override fun registerIdentity(identity: PartyAndCertificate, isNewRandomIdentity: Boolean): PartyAndCertificate? {
-        log.debug("Registering identity $identity")
+        log.debug { "Registering identity $identity" }
         val identityCertChain = identity.certPath.x509Certificates
         val key = mapToKey(identity)
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapNonConcurrentTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapNonConcurrentTest.kt
@@ -55,10 +55,7 @@ class AppendOnlyPersistentMapNonConcurrentTest {
 
     @Test
     fun `map prevents duplicates, when key has been evicted from cache, but present in database`() {
-        val map = database.transaction {
-            createMap(1)
-        }
-
+        val map = createMap(1)
 
         database.transaction {
             map.addWithDuplicatesAllowed(1, "1")

--- a/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapNonConcurrentTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapNonConcurrentTest.kt
@@ -1,0 +1,79 @@
+package net.corda.node.services.persistence
+
+import net.corda.core.schemas.MappedSchema
+import net.corda.node.services.schema.NodeSchemaService
+import net.corda.node.utilities.AppendOnlyPersistentMap
+import net.corda.nodeapi.internal.persistence.DatabaseConfig
+import net.corda.testing.internal.TestingNamedCacheFactory
+import net.corda.testing.internal.configureDatabase
+import net.corda.testing.node.MockServices
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Test
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+
+class AppendOnlyPersistentMapNonConcurrentTest {
+
+    private val database = configureDatabase(MockServices.makeTestDataSourceProperties(),
+            DatabaseConfig(),
+            { null }, { null },
+            NodeSchemaService(setOf(MappedSchema(AppendOnlyPersistentMapTest::class.java, 1, listOf(AppendOnlyPersistentMapNonConcurrentTest.PersistentMapEntry::class.java)))))
+
+    @Entity
+    @javax.persistence.Table(name = "persist_map_test")
+    class PersistentMapEntry(
+            @Id
+            @Column(name = "key")
+            var key: Long = -1,
+
+            @Column(name = "value", length = 16)
+            var value: String = ""
+    )
+
+    class TestMap(cacheSize: Long) : AppendOnlyPersistentMap<Long, String, PersistentMapEntry, Long>(
+            cacheFactory = TestingNamedCacheFactory(cacheSize),
+            name = "ApoendOnlyPersistentMap_test",
+            toPersistentEntityKey = { it },
+            fromPersistentEntity = { Pair(it.key, it.value) },
+            toPersistentEntity = { key: Long, value: String ->
+                PersistentMapEntry().apply {
+                    this.key = key
+                    this.value = value
+                }
+            },
+            persistentEntityClass = PersistentMapEntry::class.java
+    )
+
+    private fun createMap(cacheSize: Long) = TestMap(cacheSize)
+
+    @After
+    fun closeDatabase() {
+        database.close()
+    }
+
+    @Test
+    fun `map prevents duplicates, when key has been evicted from cache, but present in database`() {
+        val map = database.transaction {
+            createMap(1)
+        }
+
+
+        database.transaction {
+            map.addWithDuplicatesAllowed(1, "1")
+            map.addWithDuplicatesAllowed(3, "3")
+        }
+
+        database.transaction {
+            map.addWithDuplicatesAllowed(1, "2")
+        }
+
+        val result = database.transaction {
+            map[1]
+        }
+
+        assertThat(result).isEqualTo("1")
+    }
+
+}


### PR DESCRIPTION
## Changes
This change removes some bugs that led to the issue described in the linked ticket. What was happening is the following: when a confidential identity was registered, the `principalToParties` was updated, which is a mapping from x500 name to the hash of the identity's key. This could potentially override the existing mapping from the associated legal identity. Indeed, that was happening only in a specific case, where the cache was small enough to cause evictions. In this case, an unrelated bug in `AppendOnlyPersistentMap` led to this mapping replacing the existing one (from the legal identity) only in the cache, without replacing it in the DB though.

As a result, this contains the following 2 changes:

- Registration of confidential identities is adjusted, so that only `keyToParties` is being updated, instead of `principalToParties`. I believe that to be safe, since I can't see any use-case, where this mapping can be relevant.
- A small adjustment has been made to the `AppendOnlyPersistentMap` so that when a value is in the DB, but not in cache, then the cache is populated with the existing value (instead of the new one), essentially fully preventing duplicates.

## Testing
- Repeated the test as specified in the ticket with the new changes (using Azure + Daywatch) and the payment transactions with confidential identities worked in both ways.
- Also, added another unit test for the cache issue. The confidential identities issue is already tested by the current unit tests, but was masked because the cache used is large enough to not cause evictions during the unit tests.