### PR TITLE
CORDA-2629: Configure smoke-test nodes to have validating notaries.

### DIFF
--- a/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt
+++ b/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt
@@ -101,7 +101,7 @@ class NodeProcess(
             }
 
             (nodeDir / "node.conf").writeText(config.toText())
-            createNetworkParameters(NotaryInfo(notaryParty!!, false), nodeDir)
+            createNetworkParameters(NotaryInfo(notaryParty!!, true), nodeDir)
 
             val process = startNode(nodeDir)
             val client = CordaRPCClient(NetworkHostAndPort("localhost", config.rpcPort))


### PR DESCRIPTION
Ensure that Notary network parameters are consistent with their `node.conf` files.