### PR TITLE
[CORDA-2737] Buffer events from observables in ProgressTracker until subscribed to

### DIFF
--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -5,7 +5,6 @@ import net.corda.core.internal.STRUCTURAL_STEP_PREFIX
 import net.corda.core.serialization.CordaSerializable
 import rx.Observable
 import rx.Subscription
-import rx.subjects.PublishSubject
 import rx.subjects.ReplaySubject
 import java.util.*
 
@@ -91,8 +90,8 @@ class ProgressTracker(vararg inputSteps: Step) {
     private var _allStepsCache: List<Pair<Int, Step>> = _allSteps()
 
     // This field won't be serialized.
-    private val _changes by transient { PublishSubject.create<Change>() }
-    private val _stepsTreeChanges by transient { PublishSubject.create<List<Pair<Int, String>>>() }
+    private val _changes by transient { ReplaySubject.create<Change>() }
+    private val _stepsTreeChanges by transient { ReplaySubject.create<List<Pair<Int, String>>>() }
     private val _stepsTreeIndexChanges by transient { ReplaySubject.create<Int>() }
 
     var currentStep: Step

--- a/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
@@ -181,7 +181,7 @@ class ProgressTrackerTest {
         // Put current state as a first change for simplicity when asserting.
         val stepsTreeNotification = mutableListOf<List<Pair<Int, String>>>()
         pt.stepsTreeChanges.subscribe {
-            stepsTreeNotification += (it)
+            stepsTreeNotification += it
         }
 
         fun assertCurrentStepsTree(index:Int, step: ProgressTracker.Step) {

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,14 +4,6 @@ Changelog
 Here's a summary of what's changed in each Corda release. For guidance on how to upgrade code from the previous
 release, see :doc:`app-upgrade-notes`.
 
-.. _changelog_v4.1:
-
-Version 4.1
------------
-
-* When tracking flows via RPC, events that occurred in the flow before observables are subscribed to will be replayed to the subscriber on subscription.
-Previously, these events would be lost.
-
 .. _changelog_v4.0:
 
 Version 4.0

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 Here's a summary of what's changed in each Corda release. For guidance on how to upgrade code from the previous
 release, see :doc:`app-upgrade-notes`.
 
+.. _changelog_v4.1:
+
+Version 4.1
+-----------
+
+* When tracking flows via RPC, events that occurred in the flow before observables are subscribed to will be replayed to the subscriber on subscription.
+Previously, these events would be lost.
+
 .. _changelog_v4.0:
 
 Version 4.0

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt
@@ -10,14 +10,16 @@ import net.corda.core.utilities.ProgressTracker
 import java.util.*
 
 /**
- * Initiates a flow that self-issues cash (which should then be sent to recipient(s) using a payment transaction).
+ * Initiates a flow that self-issues cash and then send this to a recipient.
  *
  * We issue cash only to ourselves so that all KYC/AML checks on payments are enforced consistently, rather than risk
  * checks for issuance and payments differing. Outside of test scenarios it would be extremely unusual to issue cash
  * and immediately transfer it, so impact of this limitation is considered minimal.
  *
  * @param amount the amount of currency to issue.
- * @param issuerBankPartyRef a reference to put on the issued currency.
+ * @param issueRef a reference to put on the issued currency.
+ * @param recipient the recipient of the currency
+ * @param anonymous if true, the recipient of the cash will be anonymous. Should be true for normal usage
  * @param notary the notary to set on the output states.
  */
 @StartableByRPC
@@ -31,9 +33,9 @@ class CashIssueAndPaymentFlow(val amount: Amount<Currency>,
                 issueRef: OpaqueBytes,
                 recipient: Party,
                 anonymous: Boolean,
-                notary: Party) : this(amount, issueRef, recipient, anonymous, notary, tracker())
+                notary: Party) : this(amount, issueRef, recipient, anonymous, notary, ProgressTracker())
 
-    constructor(request: IssueAndPaymentRequest) : this(request.amount, request.issueRef, request.recipient, request.anonymous, request.notary, tracker())
+    constructor(request: IssueAndPaymentRequest) : this(request.amount, request.issueRef, request.recipient, request.anonymous, request.notary, ProgressTracker())
 
     @Suspendable
     override fun call(): Result {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -193,6 +193,7 @@ class FlowFrameworkTests {
         assertThat(receivingFiber.state).isEqualTo(Strand.State.WAITING)
         assertThat((erroringFlow.get().stateMachine as FlowStateMachineImpl).state).isEqualTo(Strand.State.WAITING)
         assertThat(erroringFlowSteps.get()).containsExactly(
+                Notification.createOnNext(ProgressTracker.STARTING),
                 Notification.createOnNext(ExceptionFlow.START_STEP),
                 Notification.createOnError(erroringFlow.get().exceptionThrown)
         )
@@ -413,6 +414,7 @@ class FlowFrameworkTests {
         erroringFlowFuture.getOrThrow()
         val flowSteps = erroringFlowSteps.get()
         assertThat(flowSteps).containsExactly(
+                Notification.createOnNext(ProgressTracker.STARTING),
                 Notification.createOnNext(ExceptionFlow.START_STEP),
                 Notification.createOnError(erroringFlowFuture.get().exceptionThrown)
         )

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -78,7 +78,6 @@ abstract class ANSIProgressRenderer {
 
         flowProgressHandle?.apply {
             stepsTreeIndexFeed?.apply {
-                treeIndex = snapshot
                 treeIndexProcessed.add(snapshot)
                 subscriptionIndex = updates.subscribe({
                     treeIndex = it
@@ -87,7 +86,6 @@ abstract class ANSIProgressRenderer {
                 }, { done(it) }, { done(null) })
             }
             stepsTreeFeed?.apply {
-                tree = snapshot
                 subscriptionTree = updates.subscribe({
                     remapIndices(it)
                     tree = it


### PR DESCRIPTION
When running tracked flows via RPC, often the first few steps from the `ProgressTracker` will be lost. This happens as the `ProgressTracker` observables are "hot", meaning they start emitting events before anyone has subscribed to the observable. This means the flow has often completed the first few events before any observer has subscribed. This PR changes the progress tracker observables to all buffer events before an observer subscribes.

Carrying this out results in a number of progress tracking issues becoming visible relating to the `CashIssueAndPaymentFlow`. In particular, this defines a top level progress tracker that is never stepped through, which has been removed. A related issue is that the progress tracking for issuance of cash is overwritten by that for paying it, which is easily visible on the shell. It turns out that fixing that fixing this by introducing intermediate steps in the progress tracker results in another bug being exposed in the `ANSIProgressRenderer`, and so this has been postponed for a future ticket.

Changes:
 - Force observables in the `ProgressTracker` to buffer events until an observer subscribes to them
 - Remove the top level progress tracker from `CashIssueAndPaymentFlow`
 - Add a note to the changelog to indicate the behaviour has changed slightly
 - Update out of date comments above `CashIssueAndPaymentFlow`
 - Add new unit tests for `ProgressTracker`

Testing:
 - Unit tests.
 - Manual tests observing the progress tracking on the shell. This still does not function correctly for `CashIssueAndPaymentFlow`, which will be addressed in a follow up JIRA.
 - Using @tudor-malene 's RPC tests, run 500 flows and check that all steps are visible in all flows.
