### PR TITLE
RELEASE - Fix DemoBench Windows installer (#3451)

### DIFF
--- a/tools/demobench/package-demobench-exe.bat
+++ b/tools/demobench/package-demobench-exe.bat
@@ -11,7 +11,7 @@ if "%DIRNAME%" == "" set DIRNAME=.
 call %DIRNAME%\..\..\gradlew -PpackageType=exe javapackage %*
 if ERRORLEVEL 1 goto Fail
 @echo
-@echo Wrote installer to %DIRNAME%\build\javapackage\bundles\
+@echo Wrote installer to %DIRNAME%build\javapackage\bundles\
 @echo
 goto end
 

--- a/tools/demobench/package/bugfixes/apply.bat
+++ b/tools/demobench/package/bugfixes/apply.bat
@@ -29,14 +29,14 @@ if exist "%BUILDDIR%" rmdir /s /q "%BUILDDIR%"
 mkdir "%BUILDDIR%"
 
 for /r "%SOURCEDIR%" %%j in (*.java) do (
-    javac -O -d "%BUILDDIR%" "%%j"
+    "%JAVA_HOME%\bin\javac" -O -d "%BUILDDIR%" "%%j"
     if ERRORLEVEL 1 (
         @echo "Failed to compile %%j"
         exit /b 1
     )
 )
 
-jar uvf %1 -C "%BUILDDIR%" .
+"%JAVA_HOME%\bin\jar" uvf %1 -C "%BUILDDIR%" .
 if ERRORLEVEL 1 (
     @echo "Failed to update %1"
     exit /b 1


### PR DESCRIPTION
Specify paths to build tools correctly or else bugfixes will not applied.
(cherry picked from commit 4cc4e3f01bd95c9454b3487d6e1f29b53aace077)

This is not essential for 3.4 release, but helps a lot when building DemoBench installer on Windows.