### PR TITLE
CORDA-2393 Improve documentation for PostgreSQL to avoid missing hibernate_sequence

### DIFF
--- a/docs/source/node-database.rst
+++ b/docs/source/node-database.rst
@@ -37,16 +37,14 @@ Note that:
   on the standard schema search path according to the
   `PostgreSQL documentation <https://www.postgresql.org/docs/9.3/static/ddl-schemas.html#DDL-SCHEMAS-PATH>`_, or
   the schema search path must be set explicitly for the user.
-* If a database already contains a schema for the other Corda node,
-  then you need create a ``hibernate_sequence`` sequence object manually while creating a schema for a new Corda node.
+* If your PostgresSQL database is hosting multiple schema instances (using the JDBC URL currentSchema=my_schema)
+  for different Corda nodes, you will need to create a *hibernate_sequence* sequence object manually for each subsequent schema added after the first instance.
+  Corda doesn't provision Hibernate with a schema namespace setting and a sequence object may be not created.
   Run the DDL statement and replace *my_schema* with your schema namespace:
 
   .. sourcecode:: groovy
 
     CREATE SEQUENCE my_schema.hibernate_sequence INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 8 CACHE 1 NO CYCLE;
-
-  Hibernate may skip to create a sequence object for some configurations,
-  if other schema within the same database already contains a sequence with the same name.
 
 SQLServer
 ---------

--- a/docs/source/node-database.rst
+++ b/docs/source/node-database.rst
@@ -32,11 +32,21 @@ configuration for PostgreSQL:
 
 Note that:
 
-* Database schema name can be set in JDBC URL string e.g. currentSchema=myschema
+* Database schema name can be set in JDBC URL string e.g. *currentSchema=my_schema*
 * Database schema name must either match the ``dataSource.user`` value to end up
   on the standard schema search path according to the
   `PostgreSQL documentation <https://www.postgresql.org/docs/9.3/static/ddl-schemas.html#DDL-SCHEMAS-PATH>`_, or
   the schema search path must be set explicitly for the user.
+* If a database already contains a schema for the other Corda node,
+  then you need create a ``hibernate_sequence`` sequence object manually while creating a schema for a new Corda node.
+  Run the DDL statement and replace *my_schema* with your schema namespace:
+
+  .. sourcecode:: groovy
+
+    CREATE SEQUENCE my_schema.hibernate_sequence INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 8 CACHE 1 NO CYCLE;
+
+  Hibernate may skip to create a sequence object for some configurations,
+  if other schema within the same database already contains a sequence with the same name.
 
 SQLServer
 ---------


### PR DESCRIPTION
Documentation improvement for Node Database to explain a manual step to create ``hibernate_sequence`` object, in some cases Hibernate may skip creating the sequence causing imminent error at startup:
```
[1;31m[ERROR] 09:25:18+0530 [main] spi.SqlExceptionHelper.logExceptions - ERROR: relation "hibernate_sequence" does not exist
  Position: 17
[m[1;31m[ERROR] 09:25:19+0530 [main] internal.Node.run - Exception during node startup
[m javax.persistence.PersistenceException: org.hibernate.exception.SQLGrammarException: could not extract ResultSet
 
