### PR TITLE
[CORDA-2738] Allow the ProgressTracker to cope with child trackers with the same steps

### DIFF
--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -233,9 +233,23 @@ class ProgressTracker(vararg inputSteps: Step) {
         recalculateStepsTreeIndex()
     }
 
+    private fun getStepIndexAtLevel(level: Int): Int {
+        return if (level > 0) {
+            if (stepIndex - 2 >= 0) stepIndex - 2 else 0
+        } else {
+            stepIndex
+        }
+    }
+
+    private fun getCurrentStepTreeIndex(level: Int = 0): Int {
+        val newLevel = level + 1
+        val indexAtLevel = getStepIndexAtLevel(level)
+        val additionalIndex = getChildProgressTracker(currentStep)?.getCurrentStepTreeIndex(newLevel) ?: 0
+        return indexAtLevel + additionalIndex
+    }
+
     private fun recalculateStepsTreeIndex() {
-        val step = currentStepRecursiveWithoutUnstarted()
-        stepsTreeIndex = _allStepsCache.indexOfFirst { it.second == step }
+        stepsTreeIndex = getCurrentStepTreeIndex()
     }
 
     private fun _allSteps(level: Int = 0): List<Pair<Int, Step>> {

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -50,7 +50,9 @@ class ProgressTracker(vararg inputSteps: Step) {
         }
     }
 
-    /** The superclass of all step objects. */
+    /**
+     * The superclass of all step objects.
+     */
     @CordaSerializable
     open class Step(open val label: String) {
         open val changes: Observable<Change> get() = Observable.empty()
@@ -84,7 +86,9 @@ class ProgressTracker(vararg inputSteps: Step) {
 
     private val childProgressTrackers = mutableMapOf<Step, Child>()
 
-    /** The steps in this tracker, same as the steps passed to the constructor but with UNSTARTED and DONE inserted. */
+    /**
+     * The steps in this tracker, same as the steps passed to the constructor but with UNSTARTED and DONE inserted.
+     */
     val steps = arrayOf(UNSTARTED, STARTING, *inputSteps, DONE)
 
     private var _allStepsCache: List<Pair<Int, Step>> = _allSteps()
@@ -151,13 +155,17 @@ class ProgressTracker(vararg inputSteps: Step) {
         }
     }
 
-    /** The zero-based index of the current step in the [steps] array (i.e. with UNSTARTED and DONE) */
+    /**
+     * The zero-based index of the current step in the [steps] array (i.e. with UNSTARTED and DONE)
+     */
     var stepIndex: Int = 0
         private set(value) {
             field = value
         }
 
-    /** The zero-bases index of the current step in a [allStepsLabels] list */
+    /**
+     * The zero-bases index of the current step in a [allStepsLabels] list
+     */
     var stepsTreeIndex: Int = -1
         private set(value) {
             if (value != field) {
@@ -166,8 +174,10 @@ class ProgressTracker(vararg inputSteps: Step) {
             }
         }
 
-    /** Returns the current step, descending into children to find the deepest step we are up to. */
-    @Deprecated("currentStepRecursive should not be used by external clients")
+    /**
+     * Returns the current step, descending into children to find the deepest step we are up to.
+     */
+    @Deprecated("The current step should be obtained by subscribing to the progress observable")
     @Suppress("unused")
     val currentStepRecursive: Step
         get() = getChildProgressTracker(currentStep)?.currentStepRecursive ?: currentStep
@@ -205,15 +215,18 @@ class ProgressTracker(vararg inputSteps: Step) {
         _stepsTreeChanges.onError(error)
     }
 
-    /** The parent of this tracker: set automatically by the parent when a tracker is added as a child */
+    /**
+     * The parent of this tracker: set automatically by the parent when a tracker is added as a child
+     */
     var parent: ProgressTracker? = null
         private set
 
-    /** Walks up the tree to find the top level tracker. If this is the top level tracker, returns 'this'.
-     *  Required for API compatibility.
+    /**
+     * Walks up the tree to find the top level tracker. If this is the top level tracker, returns 'this'.
+     * Required for API compatibility.
      */
-    @Deprecated("topLevelTracker is not expected to be used by external clients.")
-    @Suppress("unused") // TODO: Review by EOY2016 if this property is useful anywhere.
+    @Deprecated("Obtaining tracker tree structure information should be done using the stepsTreeChanges observable")
+    @Suppress("unused")
     val topLevelTracker: ProgressTracker
         get() {
             var cursor: ProgressTracker = this
@@ -297,7 +310,9 @@ class ProgressTracker(vararg inputSteps: Step) {
      */
     val stepsTreeIndexChanges: Observable<Int> get() = _stepsTreeIndexChanges
 
-    /** Returns true if the progress tracker has ended, either by reaching the [DONE] step or prematurely with an error */
+    /**
+     * Returns true if the progress tracker has ended, either by reaching the [DONE] step or prematurely with an error
+     */
     val hasEnded: Boolean get() = _changes.hasCompleted() || _changes.hasThrowable()
 }
 // TODO: Expose the concept of errors.

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -104,9 +104,6 @@ class ProgressTracker(vararg inputSteps: Step) {
             check((value === DONE && hasEnded) || !hasEnded) {
                 "Cannot rewind a progress tracker once it has ended"
             }
-            check(steps.contains(value)) {
-                "Trying to assign step ${value.label} that is not part of this progress tracker (steps: $steps)"
-            }
             if (currentStep == value) return
 
             val index = steps.indexOf(value)

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -166,6 +166,12 @@ class ProgressTracker(vararg inputSteps: Step) {
             }
         }
 
+    /** Returns the current step, descending into children to find the deepest step we are up to. */
+    @Deprecated("currentStepRecursive should not be used by external clients")
+    @Suppress("unused")
+    val currentStepRecursive: Step
+        get() = getChildProgressTracker(currentStep)?.currentStepRecursive ?: currentStep
+
     fun getChildProgressTracker(step: Step): ProgressTracker? = childProgressTrackers[step]?.tracker
 
     fun setChildProgressTracker(step: ProgressTracker.Step, childProgressTracker: ProgressTracker) {
@@ -202,6 +208,18 @@ class ProgressTracker(vararg inputSteps: Step) {
     /** The parent of this tracker: set automatically by the parent when a tracker is added as a child */
     var parent: ProgressTracker? = null
         private set
+
+    /** Walks up the tree to find the top level tracker. If this is the top level tracker, returns 'this'.
+     *  Required for API compatibility.
+     */
+    @Deprecated("topLevelTracker is not expected to be used by external clients.")
+    @Suppress("unused") // TODO: Review by EOY2016 if this property is useful anywhere.
+    val topLevelTracker: ProgressTracker
+        get() {
+            var cursor: ProgressTracker = this
+            while (cursor.parent != null) cursor = cursor.parent!!
+            return cursor
+        }
 
     private fun rebuildStepsTree() {
         _allStepsCache = _allSteps()

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -100,6 +100,9 @@ class ProgressTracker(vararg inputSteps: Step) {
             check((value === DONE && hasEnded) || !hasEnded) {
                 "Cannot rewind a progress tracker once it has ended"
             }
+            check(steps.contains(value)) {
+                "Trying to assign a step that is not part of this progress tracker"
+            }
             if (currentStep == value) return
 
             val index = steps.indexOf(value)
@@ -233,18 +236,16 @@ class ProgressTracker(vararg inputSteps: Step) {
         recalculateStepsTreeIndex()
     }
 
-    private fun getStepIndexAtLevel(level: Int): Int {
-        return if (level > 0) {
-            if (stepIndex - 2 >= 0) stepIndex - 2 else 0
-        } else {
-            stepIndex
-        }
+    private fun getStepIndexAtLevel(): Int {
+        // This gets the index of the current step in the context of this progress tracker, so it will always be at the top level in
+        // the allStepsCache.
+        val index = _allStepsCache.indexOf(Pair(0, currentStep))
+        return if (index >= 0) index else 0
     }
 
-    private fun getCurrentStepTreeIndex(level: Int = 0): Int {
-        val newLevel = level + 1
-        val indexAtLevel = getStepIndexAtLevel(level)
-        val additionalIndex = getChildProgressTracker(currentStep)?.getCurrentStepTreeIndex(newLevel) ?: 0
+    private fun getCurrentStepTreeIndex(): Int {
+        val indexAtLevel = getStepIndexAtLevel()
+        val additionalIndex = getChildProgressTracker(currentStep)?.getCurrentStepTreeIndex() ?: 0
         return indexAtLevel + additionalIndex
     }
 

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -177,7 +177,6 @@ class ProgressTracker(vararg inputSteps: Step) {
     /**
      * Returns the current step, descending into children to find the deepest step we are up to.
      */
-    @Deprecated("The current step should be obtained by subscribing to the progress observable")
     @Suppress("unused")
     val currentStepRecursive: Step
         get() = getChildProgressTracker(currentStep)?.currentStepRecursive ?: currentStep
@@ -225,7 +224,6 @@ class ProgressTracker(vararg inputSteps: Step) {
      * Walks up the tree to find the top level tracker. If this is the top level tracker, returns 'this'.
      * Required for API compatibility.
      */
-    @Deprecated("Obtaining tracker tree structure information should be done using the stepsTreeChanges observable")
     @Suppress("unused")
     val topLevelTracker: ProgressTracker
         get() {

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -206,15 +206,6 @@ class ProgressTracker(vararg inputSteps: Step) {
     var parent: ProgressTracker? = null
         private set
 
-    /** Walks up the tree to find the top level tracker. If this is the top level tracker, returns 'this' */
-    @Suppress("unused") // TODO: Review by EOY2016 if this property is useful anywhere.
-    val topLevelTracker: ProgressTracker
-        get() {
-            var cursor: ProgressTracker = this
-            while (cursor.parent != null) cursor = cursor.parent!!
-            return cursor
-        }
-
     private fun rebuildStepsTree() {
         _allStepsCache = _allSteps()
         _stepsTreeChanges.onNext(allStepsLabels)

--- a/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
@@ -256,7 +256,7 @@ class ProgressTrackerTest {
         pt.currentStep = SimpleSteps.TWO
 
         val stepsIndexNotifications = LinkedList<Int>()
-        pt.stepsTreeIndexChanges.subscribe() {
+        pt.stepsTreeIndexChanges.subscribe {
             stepsIndexNotifications += it
         }
 

--- a/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
@@ -36,12 +36,14 @@ class ProgressTrackerTest {
     lateinit var pt: ProgressTracker
     lateinit var pt2: ProgressTracker
     lateinit var pt3: ProgressTracker
+    lateinit var pt4: ProgressTracker
 
     @Before
     fun before() {
         pt = SimpleSteps.tracker()
         pt2 = ChildSteps.tracker()
         pt3 = BabySteps.tracker()
+        pt4 = ChildSteps.tracker()
     }
 
     @Test
@@ -129,8 +131,8 @@ class ProgressTrackerTest {
         assertCurrentStepsTree(6, SimpleSteps.THREE)
 
         // Assert no structure changes and proper steps propagation.
-        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(1, 2, 4, 6))
-        assertThat(stepsTreeNotification).hasSize(1) // One entry per child progress tracker set
+        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(0, 1, 2, 4, 6))
+        assertThat(stepsTreeNotification).hasSize(2) // The initial tree state, plus one per tree update
     }
 
     @Test
@@ -164,8 +166,8 @@ class ProgressTrackerTest {
         assertCurrentStepsTree(7, ChildSteps.SEA)
 
         // Assert no structure changes and proper steps propagation.
-        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(1, 4, 7))
-        assertThat(stepsTreeNotification).hasSize(2) // One entry per child progress tracker set
+        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(0, 1, 4, 7))
+        assertThat(stepsTreeNotification).hasSize(3) // The initial tree state, plus one per update
     }
     
     @Test
@@ -201,8 +203,8 @@ class ProgressTrackerTest {
         assertCurrentStepsTree(10, SimpleSteps.FOUR)
 
         // Assert no structure changes and proper steps propagation.
-        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(2, 7, 10))
-        assertThat(stepsTreeNotification).hasSize(2) // One state per child progress tracker set
+        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(0, 2, 7, 10))
+        assertThat(stepsTreeNotification).hasSize(3) // The initial tree state, plus one per update.
     }
 
     @Test
@@ -236,8 +238,8 @@ class ProgressTrackerTest {
         assertCurrentStepsTree(3, BabySteps.UNOS)
 
         // Assert no structure changes and proper steps propagation.
-        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(2, 5, 3))
-        assertThat(stepsTreeNotification).hasSize(2) // One state per child progress tracker set
+        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(0, 2, 5, 3))
+        assertThat(stepsTreeNotification).hasSize(3) // The initial tree state, plus one per update
     }
 
     @Test
@@ -262,7 +264,7 @@ class ProgressTrackerTest {
 
         pt2.currentStep = ChildSteps.AYY
 
-        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(1, 2, 3))
+        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(0, 1, 2, 3))
     }
 
     @Test
@@ -281,20 +283,36 @@ class ProgressTrackerTest {
     @Test
     fun `all tree changes seen if subscribed mid flow`() {
         val stepTreeNotifications = mutableListOf<List<Pair<Int, String>>>()
-        pt.setChildProgressTracker(SimpleSteps.TWO, pt2)
+        val firstStepLabels = pt.allStepsLabels
 
-        pt.currentStep = SimpleSteps.ONE
-        pt.currentStep = SimpleSteps.TWO
+        pt.setChildProgressTracker(SimpleSteps.TWO, pt2)
+        val secondStepLabels = pt.allStepsLabels
 
         pt.setChildProgressTracker(SimpleSteps.TWO, pt3)
+        val thirdStepLabels = pt.allStepsLabels
         pt.stepsTreeChanges.subscribe { stepTreeNotifications.add(it)}
 
-        fun assertStepsTree(index: Int, step: ProgressTracker.Step) {
-            assertEquals(step.label, stepTreeNotifications[index][pt.stepsTreeIndex].second)
-        }
+        // Should have one notification for original tree, then one for each time it changed.
+        assertEquals(3, stepTreeNotifications.size)
+        assertEquals(listOf(firstStepLabels, secondStepLabels, thirdStepLabels), stepTreeNotifications)
+    }
+
+    @Test
+    fun `trees with child trackers with duplicate steps reported correctly`() {
+        val stepTreeNotifications = mutableListOf<List<Pair<Int, String>>>()
+        val stepIndexNotifications = mutableListOf<Int>()
+        pt.stepsTreeChanges.subscribe { stepTreeNotifications += it }
+        pt.stepsTreeIndexChanges.subscribe { stepIndexNotifications += it }
+        pt.setChildProgressTracker(SimpleSteps.ONE, pt2)
+        pt.setChildProgressTracker(SimpleSteps.TWO, pt4)
+
+        pt.currentStep = SimpleSteps.ONE
         pt2.currentStep = ChildSteps.AYY
-        pt3.currentStep = BabySteps.UNOS
-        assertStepsTree(0, ChildSteps.AYY)
-        assertStepsTree(1, BabySteps.UNOS)
+        pt2.nextStep()
+        pt2.nextStep()
+        pt.nextStep()
+        pt4.currentStep = ChildSteps.AYY
+
+        assertEquals(listOf(0, 1, 2, 3, 4, 5, 6), stepIndexNotifications)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
@@ -315,4 +315,9 @@ class ProgressTrackerTest {
 
         assertEquals(listOf(0, 1, 2, 3, 4, 5, 6), stepIndexNotifications)
     }
+
+    @Test
+    fun `cannot assign step not belonging to this progress tracker`() {
+        assertFails { pt.currentStep = BabySteps.UNOS }
+    }
 }

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt
@@ -37,9 +37,18 @@ class CashIssueAndPaymentFlow(val amount: Amount<Currency>,
 
     constructor(request: IssueAndPaymentRequest) : this(request.amount, request.issueRef, request.recipient, request.anonymous, request.notary, ProgressTracker())
 
+    companion object {
+        val ISSUING_CASH = ProgressTracker.Step("Issuing cash")
+        val PAYING_RECIPIENT = ProgressTracker.Step("Paying recipient")
+
+        fun tracker() = ProgressTracker(ISSUING_CASH, PAYING_RECIPIENT)
+    }
+
     @Suspendable
     override fun call(): Result {
+        progressTracker.currentStep = ISSUING_CASH
         subFlow(CashIssueFlow(amount, issueRef, notary))
+        progressTracker.currentStep = PAYING_RECIPIENT
         return subFlow(CashPaymentFlow(amount, recipient, anonymous, notary))
     }
 

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt
@@ -33,9 +33,9 @@ class CashIssueAndPaymentFlow(val amount: Amount<Currency>,
                 issueRef: OpaqueBytes,
                 recipient: Party,
                 anonymous: Boolean,
-                notary: Party) : this(amount, issueRef, recipient, anonymous, notary, ProgressTracker())
+                notary: Party) : this(amount, issueRef, recipient, anonymous, notary, tracker())
 
-    constructor(request: IssueAndPaymentRequest) : this(request.amount, request.issueRef, request.recipient, request.anonymous, request.notary, ProgressTracker())
+    constructor(request: IssueAndPaymentRequest) : this(request.amount, request.issueRef, request.recipient, request.anonymous, request.notary, tracker())
 
     companion object {
         val ISSUING_CASH = ProgressTracker.Step("Issuing cash")

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -89,12 +89,16 @@ abstract class ANSIProgressRenderer {
             // last index and last tree is returned, which ensures that updates to either are processed in series.
             updatesSubscription = combineLatest(treeUpdates, indexUpdates) {tree, index -> Pair(tree, index)}.subscribe({
                 val newTree = transformTree(it.first)
+                // Process indices first, as if the tree has changed the associated index with this update is for the old tree. Note that
+                // the one case where this isn't true is the very first update, but in this case the index should be 0 (as this update is
+                // for the initial state). The remapping on a new tree assumes the step at index 0 is always at least current, so this case
+                // is handled there.
+                treeIndex = it.second
+                treeIndexProcessed.add(it.second)
                 if (newTree != tree) {
                     remapIndices(newTree)
                     tree = newTree
                 }
-                treeIndex = it.second
-                treeIndexProcessed.add(it.second)
                 draw(true)
             }, { done(it) }, {done(null)})
         }


### PR DESCRIPTION
This PR is a set of robustness enhancements to the `ProgressTracker` and `AnsiProgressRenderer` that should mean these report the correct steps as being executed under more circumstances. The main fix is to allow multiple child trackers to have the same steps, which happens in, for example, the `CashIssueAndPaymentFlow`. There are also a few other changes to try and remove other sources of bugs, and a few commenting improvements and removal of unneeded code.

Changes:
 - Fixed the calculation of the `stepsTreeIndex` in `ProgressTracker` to account for the same step label existing under multiple top level steps.
 - Fixed the recalculation of indices seen in the `AnsiProgressRenderer` to account for the same step label possibly existing at multiple points in the step tree.
 - Fixed an issue where index and tree updates could race, such that if an index and tree update happened at about the same time the index update could end up applying to either the old or new tree in a non-deterministic way. The two observables are now joined into a single one on the renderer end, such that one update will be fully processed before another starts even if the update types are interleaved.
 - Removed some unneeded properties from the `ProgressTracker`.
 - Moved a comment back to the correct location.
 - Update `CashIssueAndPaymentFlow` to have top-level steps. This prevents an issue where the issuance progress tracker is overwritten by the payment tracker, but as they have the same steps the payment tracker has steps prematurely marked as complete. Unfortunately there is no way of solving this within the progress tracking and rendering code, as there is no way to tell between "tracker has been entirely removed and replaced" and "tracker has been amended by adding a new child".
 - Added unit tests covering fixed functionality.

Testing:
 - Unit tests
 - Multiple manual runs of cash issue, cash payment, and cash issue and payment flows to ensure the output looks sane and is repeatable.
