### PR TITLE
CORDA-2506: Better handling of invalid log path

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -72,7 +72,7 @@ open class NodeStartupCli : CordaCliWrapper("corda", "Runs a Corda Node") {
     private val initialRegistrationCli by lazy { InitialRegistrationCli(startup) }
     private val validateConfigurationCli by lazy { ValidateConfigurationCli() }
 
-    override fun initLogging():Boolean = this.initLogging(cmdLineOptions.baseDirectory)
+    override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     override fun additionalSubCommands() = setOf(networkCacheCli, justGenerateNodeInfoCli, justGenerateRpcSslCertsCli, initialRegistrationCli, validateConfigurationCli)
 
@@ -438,7 +438,7 @@ interface NodeStartupLogging {
     }
 }
 
-fun CliWrapperBase.initLogging(baseDirectory: Path) : Boolean {
+fun CliWrapperBase.initLogging(baseDirectory: Path): Boolean {
     System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
     if (verbose) {
         System.setProperty("consoleLoggingEnabled", "true")
@@ -448,19 +448,17 @@ fun CliWrapperBase.initLogging(baseDirectory: Path) : Boolean {
 
     //Test for access to the logging path and shutdown if we are unable to reach it.
     val logPath = baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME
-    try{
+    try {
         logPath.createDirectories()
-    }
-    catch(e: IOException){        
-        println(ShellConstants.RED + "Unable to create logging directory ${logPath.toString()}. Node will now shutdown." + ShellConstants.RESET)
+    } catch (e: IOException) {
+        println("$ShellConstants.RED Unable to create logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
+        return false
+    } catch (e: SecurityException) {
+        println("$ShellConstants.RED Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
         return false
     }
-    catch(e: SecurityException){
-        println(ShellConstants.RED + "Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown." + ShellConstants.RESET)
-        return false
-    }
-    if(!logPath.exists()) {
-        println(ShellConstants.RED + "Unable to access logging directory ${logPath.toString()}. Node will now shutdown." + ShellConstants.RESET)
+    if (!logPath.isDirectory()) {
+        println("$ShellConstants.RED Unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
         return false
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -37,7 +37,6 @@ import java.io.RandomAccessFile
 import java.lang.management.ManagementFactory
 import java.net.InetAddress
 import java.nio.channels.UnresolvedAddressException
-import java.io.File
 import java.nio.file.Path
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
@@ -449,9 +448,20 @@ fun CliWrapperBase.initLogging(baseDirectory: Path) : Boolean {
     }
 
     //Test for access to the logging path and shutdown if we are unable to reach it.
-    val logPath = File((baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
-    if(!logPath.mkdirs() && !logPath.exists()) {
-        println("Unable to access logging directory ${logPath.getAbsolutePath()}. Node will now shutdown.")
+    val logPath = baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME
+    try{
+        logPath.createDirectories()
+    }
+    catch(e: IOException){        
+        println("Unable to create logging directory ${logPath.toString()}. Node will now shutdown.")
+        return false
+    }
+    catch(e: SecurityException){
+        println("Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
+        return false
+    }
+    if(!logPath.exists()) {
+        println("Unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
         return false
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -5,6 +5,7 @@ import net.corda.cliutils.CliWrapperBase
 import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.CordaVersionProvider
 import net.corda.cliutils.ExitCodes
+import net.corda.cliutils.ShellConstants
 import net.corda.core.contracts.HashAttachmentConstraint
 import net.corda.core.crypto.Crypto
 import net.corda.core.internal.*
@@ -453,15 +454,15 @@ fun CliWrapperBase.initLogging(baseDirectory: Path) : Boolean {
         logPath.createDirectories()
     }
     catch(e: IOException){        
-        println("Unable to create logging directory ${logPath.toString()}. Node will now shutdown.")
+        println(ShellConstants.RED + "Unable to create logging directory ${logPath.toString()}. Node will now shutdown." + ShellConstants.RESET)
         return false
     }
     catch(e: SecurityException){
-        println("Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
+        println(ShellConstants.RED + "Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown." + ShellConstants.RESET)
         return false
     }
     if(!logPath.exists()) {
-        println("Unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
+        println(ShellConstants.RED + "Unable to access logging directory ${logPath.toString()}. Node will now shutdown." + ShellConstants.RESET)
         return false
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -1,6 +1,7 @@
 package net.corda.node.internal
 
 import io.netty.channel.unix.Errors
+import net.corda.cliutils.printError
 import net.corda.cliutils.CliWrapperBase
 import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.CordaVersionProvider
@@ -451,14 +452,14 @@ fun CliWrapperBase.initLogging(baseDirectory: Path): Boolean {
     try {
         logPath.createDirectories()
     } catch (e: IOException) {
-        println("${ShellConstants.RED}Unable to create logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
+        printError("Unable to create logging directory ${logPath.toString()}. Node will now shutdown.")
         return false
     } catch (e: SecurityException) {
-        println("${ShellConstants.RED}Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
+        printError("Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
         return false
     }
     if (!logPath.isDirectory()) {
-        println("${ShellConstants.RED}Unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
+        printError("Unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
         return false
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -127,7 +127,6 @@ open class NodeStartup : NodeStartupLogging {
 
     fun initialiseAndRun(cmdLineOptions: SharedNodeCmdLineOptions, afterNodeInitialisation: RunAfterNodeInitialisation): Int {
         this.cmdLineOptions = cmdLineOptions
-        println("initialise and run")
 
         // Step 1. Check for supported Java version.
         if (isInvalidJavaVersion()) return ExitCodes.FAILURE
@@ -269,7 +268,6 @@ open class NodeStartup : NodeStartupLogging {
         // exists, we try to take the file lock first before replacing it and if that fails it means we're being started
         // twice with the same directory: that's a user error and we should bail out.
         val pidFile = (baseDirectory / "process-id").toFile()
-        println("about to create pid file")
         try {
             pidFile.createNewFile()
             val pidFileRw = RandomAccessFile(pidFile, "rw")

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -451,14 +451,14 @@ fun CliWrapperBase.initLogging(baseDirectory: Path): Boolean {
     try {
         logPath.createDirectories()
     } catch (e: IOException) {
-        println("$ShellConstants.RED Unable to create logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
+        println("${ShellConstants.RED}Unable to create logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
         return false
     } catch (e: SecurityException) {
-        println("$ShellConstants.RED Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
+        println("${ShellConstants.RED}Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
         return false
     }
     if (!logPath.isDirectory()) {
-        println("$ShellConstants.RED Unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
+        println("${ShellConstants.RED}Unable to access logging directory ${logPath.toString()}. Node will now shutdown.$ShellConstants.RESET")
         return false
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -30,7 +30,7 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
         return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, startup))
     }
 
-    override fun initLogging() : Boolean = this.initLogging(cmdLineOptions.baseDirectory)
+    override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     @Mixin
     val cmdLineOptions = InitialRegistrationCmdLineOptions()

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -30,7 +30,7 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
         return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, startup))
     }
 
-    override fun initLogging() = this.initLogging(cmdLineOptions.baseDirectory)
+    override fun initLogging() : Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     @Mixin
     val cmdLineOptions = InitialRegistrationCmdLineOptions()

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
@@ -32,7 +32,7 @@ internal class ValidateConfigurationCli : CliWrapperBase("validate-configuration
     @Mixin
     private val cmdLineOptions = SharedNodeCmdLineOptions()
 
-    override fun initLogging() = initLogging(cmdLineOptions.baseDirectory)
+    override fun initLogging(): Boolean = initLogging(cmdLineOptions.baseDirectory)
 
     override fun runProgram(): Int {
         val rawConfig = cmdLineOptions.rawConfiguration().doOnErrors(cmdLineOptions::logRawConfigurationErrors).optional ?: return ExitCodes.FAILURE

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -1,5 +1,6 @@
 package net.corda.cliutils
 
+import net.corda.cliutils.ExitCodes
 import net.corda.core.internal.rootMessage
 import net.corda.core.utilities.contextLogger
 import org.fusesource.jansi.AnsiConsole
@@ -123,12 +124,13 @@ abstract class CliWrapperBase(val alias: String, val description: String) : Call
 
     // This needs to be called before loggers (See: NodeStartup.kt:51 logger called by lazy, initLogging happens before).
     // Node's logging is more rich. In corda configurations two properties, defaultLoggingLevel and consoleLogLevel, are usually used.
-    open fun initLogging() {
+    open fun initLogging() : Boolean {
         System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
         if (verbose) {
             System.setProperty("consoleLogLevel", specifiedLogLevel)
         }
         System.setProperty("log-path", Paths.get(".").toString())
+        return true
     }
 
     // Override this function with the actual method to be run once all the arguments have been parsed. The return number
@@ -178,7 +180,9 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
     }
 
     override fun call(): Int {
-        initLogging()
+        if(!initLogging()){
+            return ExitCodes.FAILURE
+        }
         logger.info("Application Args: ${args.joinToString(" ")}")
         installShellExtensionsParser.updateShellExtensions()
         return runProgram()

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -124,7 +124,7 @@ abstract class CliWrapperBase(val alias: String, val description: String) : Call
 
     // This needs to be called before loggers (See: NodeStartup.kt:51 logger called by lazy, initLogging happens before).
     // Node's logging is more rich. In corda configurations two properties, defaultLoggingLevel and consoleLogLevel, are usually used.
-    open fun initLogging() : Boolean {
+    open fun initLogging(): Boolean {
         System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
         if (verbose) {
             System.setProperty("consoleLogLevel", specifiedLogLevel)
@@ -143,7 +143,9 @@ abstract class CliWrapperBase(val alias: String, val description: String) : Call
         return runProgram()
     }
 
-    val specifiedLogLevel: String by lazy { System.getProperty("log4j2.level")?.toLowerCase(Locale.ENGLISH) ?: loggingLevel.name.toLowerCase(Locale.ENGLISH) }
+    val specifiedLogLevel: String by lazy {
+        System.getProperty("log4j2.level")?.toLowerCase(Locale.ENGLISH) ?: loggingLevel.name.toLowerCase(Locale.ENGLISH)
+    }
 }
 
 /**
@@ -180,7 +182,7 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
     }
 
     override fun call(): Int {
-        if(!initLogging()){
+        if (!initLogging()) {
             return ExitCodes.FAILURE
         }
         logger.info("Application Args: ${args.joinToString(" ")}")
@@ -189,12 +191,10 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
     }
 
     fun printHelp() = cmd.usage(System.out)
-
 }
 
 fun printWarning(message: String) = System.err.println("${ShellConstants.YELLOW}$message${ShellConstants.RESET}")
 fun printError(message: String) = System.err.println("${ShellConstants.RED}$message${ShellConstants.RESET}")
-
 
 /**
  * Useful commonly used constants applicable to many CLI tools

--- a/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt
+++ b/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt
@@ -60,6 +60,7 @@ class StandaloneShell : CordaCliWrapper("corda-shell", "The Corda standalone she
         super.initLogging()
         SLF4JBridgeHandler.removeHandlersForRootLogger() // The default j.u.l config adds a ConsoleHandler.
         SLF4JBridgeHandler.install()
+        return true
     }
 
     override fun runProgram(): Int {

--- a/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt
+++ b/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt
@@ -56,7 +56,7 @@ class StandaloneShell : CordaCliWrapper("corda-shell", "The Corda standalone she
 
     private fun getManifestEntry(key: String) = if (Manifests.exists(key)) Manifests.read(key) else "Unknown"
 
-    override fun initLogging() {
+    override fun initLogging() : Boolean {
         super.initLogging()
         SLF4JBridgeHandler.removeHandlersForRootLogger() // The default j.u.l config adds a ConsoleHandler.
         SLF4JBridgeHandler.install()


### PR DESCRIPTION
Test if we have access to the logging path (baseDirectory/logs) before attempting to write to them. This allows us to shut down gracefully with an easily understandable error message.
Without doing this, the log4j2 will attempt to access the logPath when it first uses the logger in the call() function.
This does involve changing the signature of initiLogging to return a Boolean. This allows call() to know whether initLogging was successful and hence either continue execution or shut down.