### PR TITLE
CORDA-2757 / ENT-3060 - Change log level in flow transition executor

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt
@@ -46,12 +46,12 @@ class TransitionExecutorImpl(
                     // error as that may result in an infinite loop, e.g. error propagation fails -> record error -> propagate fails again.
                     // Instead we just keep around the old error state and wait for a new schedule, perhaps
                     // triggered from a flow hospital
-                    log.error("Error while executing $action during transition to errored state, aborting transition", exception)
+                    log.warn("Error while executing $action during transition to errored state, aborting transition", exception)
                     return Pair(FlowContinuation.Abort, previousState.copy(isFlowResumed = false))
                 } else {
                     // Otherwise error the state manually keeping the old flow state and schedule a DoRemainingWork
                     // to trigger error propagation
-                    log.error("Error while executing $action, erroring state", exception)
+                    log.info("Error while executing $action, erroring state", exception)
                     val newState = previousState.copy(
                             checkpoint = previousState.checkpoint.copy(
                                     errorState = previousState.checkpoint.errorState.addErrors(


### PR DESCRIPTION
Leave error logging for the flow hospital ([ENT-3060](https://r3-cev.atlassian.net/browse/ENT-3060), moved to [CORDA-2757](https://r3-cev.atlassian.net/browse/CORDA-2757))