### PR TITLE
CORDA-2759: Use GlobalTestPortAllocation for Node's integration tests.

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -209,6 +209,9 @@ tasks.withType(JavaCompile) {
 task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
+
+    systemProperty 'testing.global.port.allocation.enabled', true
+    systemProperty 'testing.global.port.allocation.starting.port', 10000
 }
 
 jar {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/GlobalTestPortAllocation.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/GlobalTestPortAllocation.kt
@@ -12,8 +12,8 @@ fun incrementalPortAllocation(startingPortIfNoEnv: Int): PortAllocation {
 
 private object GlobalTestPortAllocation : PortAllocation.Incremental(startingPort = startingPort())
 
-private const val enablingEnvVar = "CORDA_TEST_GLOBAL_PORT_ALLOCATION_ENABLED"
-private const val startingPortEnvVariable = "CORDA_TEST_GLOBAL_PORT_ALLOCATION_STARTING_PORT"
+private const val enablingEnvVar = "TESTING_GLOBAL_PORT_ALLOCATION_ENABLED"
+private const val startingPortEnvVariable = "TESTING_GLOBAL_PORT_ALLOCATION_STARTING_PORT"
 private val enablingSystemProperty = enablingEnvVar.toLowerCase().replace("_", ".")
 private val startingPortSystemProperty = startingPortEnvVariable.toLowerCase().replace("_", ".")
 private const val startingPortDefaultValue = 5000


### PR DESCRIPTION
Node's integration tests are repeatedly creating servers that listen on a small range of ports starting from 10,000. If a previous test's servers don't shut down quickly enough then the next test can accidentally connect to one of them, and then Chaos Happens.

Chaos is Bad. Avoid Chaos by incrementing port allocations globally across all of the Node's integration tests so that lingering servers will be ignored.