### PR TITLE
BUILD: Try to fix flaky FailNodeOnNotMigratedAttachmentContractsTableNameTests.

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt
@@ -81,6 +81,7 @@ val InProcess.internalServices: StartedNodeServices get() = services as StartedN
 object RandomFree : PortAllocation() {
     override fun nextPort(): Int {
         return ServerSocket().use {
+            it.reuseAddress = true
             it.bind(InetSocketAddress(0))
             it.localPort
         }


### PR DESCRIPTION
* Ensure that this test stops nodes that it starts.
* Also ensure that random ephemeral ports can be reused.

It looks like the test doesn't fail per-se. Just that Gradle is left waiting indefinitely for it to complete properly, and then Team City kills the build when it eventually times out. This sounds like something isn't being closed down properly - try putting `nodeHandle.stop()` inside a `finally` block for starters. And setting `reuseAddress` on the ephemeral port that we want to grab can't hurt either.