### PR TITLE
 Create hibernate_sequence database sequence object only if it doesn't exist

### DIFF
--- a/node/src/main/resources/migration/common.changelog-init.xml
+++ b/node/src/main/resources/migration/common.changelog-init.xml
@@ -5,11 +5,17 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet author="R3.Corda" id="1511451595465-1.1" dbms="h2">
+        <preConditions onFail="MARK_RAN">
+            <not><sequenceExists sequenceName="hibernate_sequence"/></not>
+        </preConditions>
         <createSequence sequenceName="hibernate_sequence"/>
     </changeSet>
 
    <changeSet author="R3.Corda" id="1511451595465-1.3" onValidationFail="MARK_RAN">
-       <preConditions onFail="MARK_RAN" onSqlOutput="TEST">  <not> <dbms type="h2"/> </not> </preConditions>
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <not><sequenceExists sequenceName="hibernate_sequence"/></not>
+            <not><dbms type="h2"/></not>
+        </preConditions>
         <createSequence sequenceName="hibernate_sequence" minValue="1"/>
     </changeSet>
 

--- a/node/src/main/resources/migration/common.changelog-init.xml
+++ b/node/src/main/resources/migration/common.changelog-init.xml
@@ -5,7 +5,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet author="R3.Corda" id="1511451595465-1.1" dbms="h2">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
             <not><sequenceExists sequenceName="hibernate_sequence"/></not>
         </preConditions>
         <createSequence sequenceName="hibernate_sequence"/>
@@ -13,8 +13,8 @@
 
    <changeSet author="R3.Corda" id="1511451595465-1.3" onValidationFail="MARK_RAN">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <not><sequenceExists sequenceName="hibernate_sequence"/></not>
             <not><dbms type="h2"/></not>
+            <not><sequenceExists sequenceName="hibernate_sequence"/></not>
         </preConditions>
         <createSequence sequenceName="hibernate_sequence" minValue="1"/>
     </changeSet>


### PR DESCRIPTION
Liquibase initial migration shouldn't fail if hibernate_sequence is already created in the target database. To avoid this we use 'preConditions' check.

My PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
