### PR TITLE
BUILD: Fix some warnings about @BelongsToContract in tests.

### DIFF
--- a/core/src/test/kotlin/net/corda/core/internal/TopologicalSortTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/TopologicalSortTest.kt
@@ -1,9 +1,7 @@
 package net.corda.core.internal
 
 import net.corda.client.mock.Generator
-import net.corda.core.contracts.ContractState
-import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.TransactionState
+import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.crypto.TransactionSignature
@@ -30,11 +28,12 @@ class TopologicalSortTest {
             override val references: List<StateRef> = emptyList()
     ) : CoreTransaction() {
         override val outputs: List<TransactionState<ContractState>> = (1..numberOfOutputs).map {
-            TransactionState(DummyState(), "", notary)
+            TransactionState(DummyState(), Contract::class.java.name, notary)
         }
         override val networkParametersHash: SecureHash? = testNetworkParameters().serialize().hash
     }
 
+    @BelongsToContract(Contract::class)
     class DummyState : ContractState {
         override val participants: List<AbstractParty> = emptyList()
     }

--- a/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt
+++ b/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertFailsWith
 
 class VaultUpdateTests {
     private companion object {
-        const val DUMMY_PROGRAM_ID = "net.corda.core.node.VaultUpdateTests.DummyContract"
+        const val DUMMY_PROGRAM_ID = "net.corda.core.node.VaultUpdateTests\$DummyContract"
         val DUMMY_NOTARY = TestIdentity(DUMMY_NOTARY_NAME, 20).party
         val emptyUpdate = Vault.Update(emptySet(), emptySet(), type = Vault.UpdateType.GENERAL, references = emptySet())
     }
@@ -25,6 +25,7 @@ class VaultUpdateTests {
         }
     }
 
+    @BelongsToContract(DummyContract::class)
     private class DummyState : ContractState {
         override val participants: List<AbstractParty> = emptyList()
     }

--- a/node/src/integration-test/kotlin/net/corda/testMessage/ScheduledState.kt
+++ b/node/src/integration-test/kotlin/net/corda/testMessage/ScheduledState.kt
@@ -45,6 +45,7 @@ class ScheduledResponderFlow(private val otherSide: FlowSession) : FlowLogic<Uni
     }
 }
 
+@BelongsToContract(DummyContract::class)
 data class ScheduledState(val creationTime: Instant,
                           val source: Party,
                           val destination: Party,
@@ -63,6 +64,7 @@ data class ScheduledState(val creationTime: Instant,
     }
 }
 
+@BelongsToContract(DummyContract::class)
 data class SpentState(val identity: String,
                       val source: Party,
                       val destination: Party,

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -40,6 +40,7 @@ class ScheduledFlowTests {
     private lateinit var alice: Party
     private lateinit var bob: Party
 
+    @BelongsToContract(DummyContract::class)
     data class ScheduledState(val creationTime: Instant,
                               val source: Party,
                               val destination: Party,

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
@@ -29,6 +29,7 @@ class ResolveStatePointersTest {
     private val cordapps = listOf("net.corda.testing.contracts")
     private lateinit var services: MockServices
 
+    @BelongsToContract(DummyContract::class)
     private data class Bar(
             override val participants: List<AbstractParty> = listOf(),
             val bar: Int = 0,
@@ -36,6 +37,7 @@ class ResolveStatePointersTest {
             override val linearId: UniqueIdentifier = UniqueIdentifier()
     ) : LinearState
 
+    @BelongsToContract(DummyContract::class)
     private data class Foo<T : LinearState>(val baz: LinearPointer<T>, override val participants: List<AbstractParty>) : ContractState
 
     private val barOne = Bar(listOf(myself.party), 1)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -117,10 +117,12 @@ class VaultSoftLockManagerTest {
 
     private abstract class ParticipantState(override val participants: List<AbstractParty>) : ContractState
 
+    @BelongsToContract(ContractImpl::class)
     private class PlainOldState(participants: List<AbstractParty>) : ParticipantState(participants) {
         constructor(nodePair: NodePair) : this(listOf(nodePair.client.info.singleIdentity()))
     }
 
+    @BelongsToContract(ContractImpl::class)
     private class FungibleAssetImpl(participants: List<AbstractParty>) : ParticipantState(participants), FungibleAsset<Unit> {
         constructor(nodePair: NodePair) : this(listOf(nodePair.client.info.singleIdentity()))
 

--- a/node/src/test/kotlin/net/corda/node/testing/MessageChainState.kt
+++ b/node/src/test/kotlin/net/corda/node/testing/MessageChainState.kt
@@ -15,6 +15,7 @@ import javax.persistence.Table
 @CordaSerializable
 data class MessageData(val value: String)
 
+@BelongsToContract(MessageChainContract::class)
 data class MessageChainState(val message: MessageData, val by: Party, override val linearId: UniqueIdentifier = UniqueIdentifier(), val extraParty: Party? = null) : LinearState, QueryableState {
     override val participants: List<AbstractParty> = if (extraParty == null) listOf(by) else listOf(by, extraParty)
 


### PR DESCRIPTION
The build logs are full of warnings about States not being correctly associated with their Contracts. Resolve the easy/obvious ones.