### PR TITLE
CORDA-2683: Requests to start unknown flows can be deleted using killFlow

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -136,7 +136,7 @@ internal class CordaRPCOpsImpl(
         return snapshot
     }
 
-    override fun killFlow(id: StateMachineRunId) = smm.killFlow(id)
+    override fun killFlow(id: StateMachineRunId): Boolean = if (smm.killFlow(id)) true else smm.flowHospital.dropSessionInit(id.uuid)
 
     override fun stateMachinesFeed(): DataFeed<List<StateMachineInfo>, StateMachineUpdate> {
         val (allStateMachines, changes) = smm.track()


### PR DESCRIPTION
Normally, these requests are left unacknowledged in the MQ broker to allow recovery via installing the missing CorDapp. If this is not applicable then the request can be dropped (and the other side informed of the error).
