### PR TITLE
 ENT-3327: Check for missing certificates directory

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -305,7 +305,9 @@ open class NodeStartup : NodeStartupLogging {
         if (devMode) return true
 
         if (!certDirectory.isDirectory()) {
-            printError("Unable to access certificates directory ${certDirectory.toString()}. This could be because the node has not been registered with the Identity Operator. Node will now shutdown.")
+            printError("Unable to access certificates directory ${certDirectory}. This could be because the node has not been registered with the Identity Operator.")
+            printError("Please see https://docs.corda.net/joining-a-compatibility-zone.html for more information.")
+            printError("Node will now shutdown.")
             return false
         }
         return true

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -164,7 +164,6 @@ open class NodeStartup : NodeStartupLogging {
 
         // Step 10. Start node: create the node, check for other command-line options, add extra logging etc.
         if (attempt {
-                    cmdLineOptions.baseDirectory.createDirectories()
                     afterNodeInitialisation.run(createNode(configuration, versionInfo))
                 }.doOnFailure(Consumer(::handleStartError)) !is Try.Success) return ExitCodes.FAILURE
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -304,7 +304,7 @@ open class NodeStartup : NodeStartupLogging {
     private fun canReadCertificatesDirectory(baseDirectory: Path, devMode: Boolean): Boolean {
         //Test for access to the certificates path and shutdown if we are unable to reach it.
         //We don't do this if devMode==true because the certificates would be created anyway
-        if(devMode) return true
+        if (devMode) return true
 
         val certPath = baseDirectory / CERTIFICATES_DIRECTORY_NAME
         if (!certPath.isDirectory()) {


### PR DESCRIPTION
While the node is starting up, we now check for the presence of the certificates directory. This allows us to print out an easily understandable error message if the directory is not present. An exception is made for devMode, as devMode will result in the directory being created in any case.