### PR TITLE
CORDA-2653 - during initialisation a Corda Service should have a thread context classloader

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -575,21 +575,33 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
 
     private fun installCordaServices() {
         val loadedServices = cordappLoader.cordapps.flatMap { it.services }
-        loadedServices.forEach {
-            try {
-                installCordaService(it)
-            } catch (e: NoSuchMethodException) {
-                log.error("${it.name}, as a Corda service, must have a constructor with a single parameter of type " +
-                        ServiceHub::class.java.name)
-            } catch (e: ServiceInstantiationException) {
-                if (e.cause != null) {
-                    log.error("Corda service ${it.name} failed to instantiate. Reason was: ${e.cause?.rootMessage}", e.cause)
-                } else {
-                    log.error("Corda service ${it.name} failed to instantiate", e)
+
+        // This sets the Cordapp classloader on the contextClassLoader of the current thread, prior to initializing services
+        // Needed because of bug CORDA-2653 - some Corda services can utilise third-party libraries that require access to
+        // the Thread context class loader
+
+        val oldContextClassLoader : ClassLoader? = Thread.currentThread().contextClassLoader
+        try {
+            Thread.currentThread().contextClassLoader = cordappLoader.appClassLoader
+
+            loadedServices.forEach {
+                try {
+                    installCordaService(it)
+                } catch (e: NoSuchMethodException) {
+                    log.error("${it.name}, as a Corda service, must have a constructor with a single parameter of type " +
+                            ServiceHub::class.java.name)
+                } catch (e: ServiceInstantiationException) {
+                    if (e.cause != null) {
+                        log.error("Corda service ${it.name} failed to instantiate. Reason was: ${e.cause?.rootMessage}", e.cause)
+                    } else {
+                        log.error("Corda service ${it.name} failed to instantiate", e)
+                    }
+                } catch (e: Exception) {
+                    log.error("Unable to install Corda service ${it.name}", e)
                 }
-            } catch (e: Exception) {
-                log.error("Unable to install Corda service ${it.name}", e)
             }
+        } finally {
+            Thread.currentThread().contextClassLoader = oldContextClassLoader
         }
     }
 


### PR DESCRIPTION
This is regarding JIRA: [CORDA-2653](https://r3-cev.atlassian.net/browse/CORDA-2653).

During the initalisation of a `CordaService` if `Thread.currentThread().getContextClassLoader()` is `null`, certain third party libraries may fail to load. 

This fix ensures that a classloader is available during initialisation. 