### PR TITLE
CORDA-2765 Make TransactionVerificationExceptions serializable

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -43,11 +43,6 @@ class AttachmentResolutionException(val hash: SecureHash) : FlowException("Attac
  * is expressed using a subclass. TransactionVerificationException is a [FlowException] and thus when thrown inside
  * a flow, the details of the failure will be serialised, propagated to the peer and rethrown.
  *
- * If you add a new class extending [TransactionVerificationException], please add a test in `TransactionVerificationExceptionSerializationTests`
- * proving that it can actually be serialised. As a rule, exceptions intended to be serialised _must_ have a corresponding readable property
- * for every named constructor parameter - so make your constructor parameters `val`s even if nothing other than the serializer is ever
- * going to read them.
- *
  * @property txId the Merkle root hash (identifier) of the transaction that failed verification.
  */
 @Suppress("MemberVisibilityCanBePrivate")
@@ -300,4 +295,11 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
                     "At this time these are not loadable because the DJVM sandbox has not yet been integrated. " +
                     "You will need to install that app version yourself, to whitelist it for use. " +
                     "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
+
+    /*
+    If you add a new class extending [TransactionVerificationException], please add a test in `TransactionVerificationExceptionSerializationTests`
+    proving that it can actually be serialised. As a rule, exceptions intended to be serialised _must_ have a corresponding readable property
+    for every named constructor parameter - so make your constructor parameters `val`s even if nothing other than the serializer is ever
+    going to read them.
+    */
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -43,6 +43,11 @@ class AttachmentResolutionException(val hash: SecureHash) : FlowException("Attac
  * is expressed using a subclass. TransactionVerificationException is a [FlowException] and thus when thrown inside
  * a flow, the details of the failure will be serialised, propagated to the peer and rethrown.
  *
+ * If you add a new class extending [TransactionVerificationException], please add a test in `TransactionVerificationExceptionSerializationTests`
+ * proving that it can actually be serialised. As a rule, exceptions intended to be serialised _must_ have a corresponding readable property
+ * for every named constructor parameter - so make your constructor parameters `val`s even if nothing other than the serializer is ever
+ * going to read them.
+ *
  * @property txId the Merkle root hash (identifier) of the transaction that failed verification.
  */
 @Suppress("MemberVisibilityCanBePrivate")
@@ -269,7 +274,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      */
     @CordaSerializable
     @KeepForDJVM
-    class OverlappingAttachmentsException(txId: SecureHash, path: String) : TransactionVerificationException(txId, "Multiple attachments define a file at $path.", null)
+    class OverlappingAttachmentsException(txId: SecureHash, val path: String) : TransactionVerificationException(txId, "Multiple attachments define a file at $path.", null)
 
     /**
      * Thrown to indicate that a contract attachment is not signed by the network-wide package owner. Please note that
@@ -277,20 +282,20 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      * and because attachment classloaders are reused this is independent of any particular transaction.
      */
     @CordaSerializable
-    class PackageOwnershipException(txId: SecureHash, val attachmentHash: AttachmentId, val invalidClassName: String, val packageName: String) : TransactionVerificationException(txId,
+    class PackageOwnershipException(txId: SecureHash, @Suppress("unused") val attachmentHash: AttachmentId, @Suppress("unused") val invalidClassName: String, val packageName: String) : TransactionVerificationException(txId,
             """The attachment JAR: $attachmentHash containing the class: $invalidClassName is not signed by the owner of package $packageName specified in the network parameters.
            Please check the source of this attachment and if it is malicious contact your zone operator to report this incident.
            For details see: https://docs.corda.net/network-map.html#network-parameters""".trimIndent(), null)
 
     @CordaSerializable
-    class InvalidAttachmentException(txId: SecureHash, attachmentHash: AttachmentId) : TransactionVerificationException(txId,
+    class InvalidAttachmentException(txId: SecureHash, @Suppress("unused") val attachmentHash: AttachmentId) : TransactionVerificationException(txId,
             "The attachment $attachmentHash is not a valid ZIP or JAR file.".trimIndent(), null)
 
     // TODO: Make this descend from TransactionVerificationException so that untrusted attachments cause flows to be hospitalized.
     /** Thrown during classloading upon encountering an untrusted attachment (eg. not in the [TRUSTED_UPLOADERS] list) */
     @KeepForDJVM
     @CordaSerializable
-    class UntrustedAttachmentsException(txId: SecureHash, val ids: List<SecureHash>) :
+    class UntrustedAttachmentsException(val txId: SecureHash, val ids: List<SecureHash>) :
             CordaException("Attempting to load untrusted transaction attachments: $ids. " +
                     "At this time these are not loadable because the DJVM sandbox has not yet been integrated. " +
                     "You will need to install that app version yourself, to whitelist it for use. " +

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt
@@ -24,6 +24,7 @@ class TransactionVerificationExceptionSerialisationTests {
     private val context get() = AMQP_RPC_CLIENT_CONTEXT
 
     private val txid = SecureHash.allOnesHash
+    private val attachmentHash = SecureHash.allOnesHash
     private val factory = defaultFactory()
 
     @Test
@@ -122,5 +123,56 @@ class TransactionVerificationExceptionSerialisationTests {
         assertEquals(exception.message, exception2.message)
         assertEquals(exception.cause?.message, exception2.cause?.message)
         assertEquals(exception.txId, exception2.txId)
+    }
+
+    @Test
+    fun overlappingAttachmentsExceptionTest() {
+        val exc = TransactionVerificationException.OverlappingAttachmentsException(txid, "foo/bar/baz")
+        val exc2 = DeserializationInput(factory).deserialize(
+                SerializationOutput(factory).serialize(exc, context),
+                context)
+
+        assertEquals(exc.message, exc2.message)
+    }
+
+    @Test
+    fun packageOwnershipExceptionTest() {
+        val exc = TransactionVerificationException.PackageOwnershipException(
+                txid,
+                attachmentHash,
+                "InvalidClass",
+                "com.invalid")
+
+        val exc2 = DeserializationInput(factory).deserialize(
+                SerializationOutput(factory).serialize(exc, context),
+                context)
+
+        assertEquals(exc.message, exc2.message)
+    }
+
+    @Test
+    fun invalidAttachmentExceptionTest() {
+        val exc = TransactionVerificationException.InvalidAttachmentException(
+                txid,
+                attachmentHash)
+
+        val exc2 = DeserializationInput(factory).deserialize(
+                SerializationOutput(factory).serialize(exc, context),
+                context)
+
+        assertEquals(exc.message, exc2.message)
+    }
+
+    @Test
+    fun untrustedAttachmentsExceptionTest() {
+        val exc = TransactionVerificationException.UntrustedAttachmentsException(
+                txid,
+                listOf(attachmentHash))
+
+        val exc2 = DeserializationInput(factory).deserialize(
+                SerializationOutput(factory).serialize(exc, context),
+                context)
+
+        assertEquals(exc.message, exc2.message)
     }
 }


### PR DESCRIPTION
An exception intended for serialization needs to expose via publicly readable properties all of the values it requires to populate its constructor, or the custom ThrowableSerializer will fail (typically by trying to call that constructor reflectively, passing in a `null` where no null value is expected, and failing Kotlin's own null-check on the method).

Some of the newer `TransactionVerificationExceptions` don't do this, and don't get propagated properly to the RPC client as a result. This PR fixes that, unit tests the fix, and adds a comment explaining what needs to be done.