### PR TITLE
ENT-3333: Return error code for invalid cmdline options

### DIFF
--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -71,7 +71,7 @@ fun CordaCliWrapper.start(args: Array<String>) {
             Help.Ansi.AUTO
         }
         val results = cmd.parseWithHandlers(RunLast().useOut(System.out).useAnsi(defaultAnsiMode),
-                DefaultExceptionHandler<List<Any>>().useErr(System.err).useAnsi(defaultAnsiMode),
+                DefaultExceptionHandler<List<Any>>().useErr(System.err).useAnsi(defaultAnsiMode).andExit(ExitCodes.FAILURE),
                 *args)
         // If an error code has been returned, use this and exit
         results?.firstOrNull()?.let {


### PR DESCRIPTION
If an invalid command line option is specified and the parser is unable to parse the input, return an error code to the caller. This is useful in scripting scenarios where it might be important to detect that Corda failed to start due to invalid command line parameters.