### PR TITLE
CORDA-2750: Fix published names for DJVM artifacts.

### DIFF
--- a/djvm/djvm/build.gradle
+++ b/djvm/djvm/build.gradle
@@ -44,8 +44,8 @@ dependencies {
 jar.enabled = false
 
 shadowJar {
-    archiveBaseName = 'corda-djvm'
-    archiveClassifier = ''
+    baseName'corda-djvm'
+    classifier ''
     relocate 'org.objectweb.asm', 'djvm.org.objectweb.asm'
 
     // These particular classes are only needed to "bootstrap"

--- a/djvm/djvm/cli/build.gradle
+++ b/djvm/djvm/cli/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 jar.enabled = false
 
 shadowJar {
-    archiveBaseName = djvmName
-    archiveClassifier = ''
+    baseName djvmName
+    classifier ''
     manifest {
         attributes(
             'Automatic-Module-Name': 'net.corda.djvm.cli',


### PR DESCRIPTION
Use `baseName` and `classifier` for `shadowJar` tasks to ensure that the artifacts are published to Maven with the correct names.