### PR TITLE
CORDA-2775: Simplify SourceClassLoader logic for DJVM.

### DIFF
--- a/djvm/djvm/build.gradle
+++ b/djvm/djvm/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 jar.enabled = false
 
 shadowJar {
-    baseName'corda-djvm'
+    baseName 'corda-djvm'
     classifier ''
     relocate 'org.objectweb.asm', 'djvm.org.objectweb.asm'
 

--- a/djvm/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -8,7 +8,6 @@ import net.corda.djvm.references.ClassModule
 import net.corda.djvm.references.Member
 import net.corda.djvm.references.MemberModule
 import net.corda.djvm.references.MethodBody
-import net.corda.djvm.source.AbstractSourceClassLoader
 import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.SourceClassLoader
 import org.objectweb.asm.Opcodes.*
@@ -48,7 +47,7 @@ class AnalysisConfiguration private constructor(
         val classModule: ClassModule,
         val memberModule: MemberModule,
         private val bootstrapClassLoader: BootstrapClassLoader?,
-        val supportingClassLoader: AbstractSourceClassLoader,
+        val supportingClassLoader: SourceClassLoader,
         private val isRootConfiguration: Boolean
 ) : Closeable {
 
@@ -299,7 +298,7 @@ class AnalysisConfiguration private constructor(
             classModule: ClassModule = ClassModule(),
             memberModule: MemberModule = MemberModule(),
             bootstrapClassLoader: BootstrapClassLoader? = null,
-            sourceClassLoaderFactory: (ClassResolver, BootstrapClassLoader?) -> AbstractSourceClassLoader = { classResolver, bootstrapCL ->
+            sourceClassLoaderFactory: (ClassResolver, BootstrapClassLoader?) -> SourceClassLoader = { classResolver, bootstrapCL ->
                 SourceClassLoader(emptyList(), classResolver, bootstrapCL)
             }
         ): AnalysisConfiguration {

--- a/djvm/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassResolver.kt
+++ b/djvm/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassResolver.kt
@@ -118,7 +118,7 @@ class ClassResolver(
 
     /**
      * Maps a class name to its equivalent class outside the sandbox.
-     * Needed by [net.corda.djvm.source.AbstractSourceClassLoader].
+     * Needed by [net.corda.djvm.source.SourceClassLoader].
      */
     private fun toSource(className: String): String {
         return if (className in pinnedClasses) {

--- a/djvm/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
+++ b/djvm/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
@@ -7,7 +7,7 @@ import net.corda.djvm.code.ClassMutator
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.code.emptyAsNull
 import net.corda.djvm.references.Member
-import net.corda.djvm.source.AbstractSourceClassLoader
+import net.corda.djvm.source.SourceClassLoader
 import net.corda.djvm.utilities.loggerFor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
@@ -22,7 +22,7 @@ import org.objectweb.asm.MethodVisitor
  */
 open class ClassRewriter(
         private val configuration: SandboxConfiguration,
-        private val classLoader: AbstractSourceClassLoader
+        private val classLoader: SourceClassLoader
 ) {
     private val analysisConfig = configuration.analysisConfiguration
 

--- a/djvm/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -9,8 +9,8 @@ import net.corda.djvm.analysis.ExceptionResolver.Companion.isDJVMException
 import net.corda.djvm.code.asPackagePath
 import net.corda.djvm.code.asResourcePath
 import net.corda.djvm.references.ClassReference
-import net.corda.djvm.source.AbstractSourceClassLoader
 import net.corda.djvm.source.ClassSource
+import net.corda.djvm.source.SourceClassLoader
 import net.corda.djvm.utilities.loggerFor
 import net.corda.djvm.validation.RuleValidator
 import org.objectweb.asm.Type
@@ -27,13 +27,13 @@ import org.objectweb.asm.Type
  * @param parent This classloader's parent classloader.
  */
 class SandboxClassLoader private constructor(
-        private val analysisConfiguration: AnalysisConfiguration,
-        private val ruleValidator: RuleValidator,
-        private val supportingClassLoader: AbstractSourceClassLoader,
-        private val rewriter: ClassRewriter,
-        private val context: AnalysisContext,
-        throwableClass: Class<*>?,
-        parent: ClassLoader?
+    private val analysisConfiguration: AnalysisConfiguration,
+    private val ruleValidator: RuleValidator,
+    private val supportingClassLoader: SourceClassLoader,
+    private val rewriter: ClassRewriter,
+    private val context: AnalysisContext,
+    throwableClass: Class<*>?,
+    parent: ClassLoader?
 ) : ClassLoader(parent ?: getSystemClassLoader()) {
 
     /**

--- a/djvm/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassWriter.kt
+++ b/djvm/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassWriter.kt
@@ -1,7 +1,7 @@
 package net.corda.djvm.rewiring
 
 import net.corda.djvm.code.asPackagePath
-import net.corda.djvm.source.AbstractSourceClassLoader
+import net.corda.djvm.source.SourceClassLoader
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.ClassWriter.COMPUTE_FRAMES
@@ -23,11 +23,11 @@ import org.objectweb.asm.Type
  */
 open class SandboxClassWriter(
         classReader: ClassReader,
-        private val cloader: AbstractSourceClassLoader,
+        private val cloader: SourceClassLoader,
         flags: Int = COMPUTE_FRAMES or COMPUTE_MAXS
 ) : ClassWriter(classReader, flags) {
 
-    override fun getClassLoader(): AbstractSourceClassLoader = cloader
+    override fun getClassLoader(): SourceClassLoader = cloader
 
     /**
      * Get the common super type of [type1] and [type2].

--- a/djvm/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
+++ b/djvm/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
@@ -16,6 +16,8 @@ public class SandboxExecutorJavaTest extends TestBase {
 
     @Test
     public void testTransaction() {
+        //TODO: Transaction should not be a pinned class! It needs
+        //      to be marshalled into and out of the sandbox.
         Set<Class<?>> pinnedClasses = singleton(Transaction.class);
         sandbox(new Object[0], pinnedClasses, WARNING, true, ctx -> {
             SandboxExecutor<Transaction, Void> contractExecutor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());

--- a/djvm/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -17,7 +17,7 @@ import net.corda.djvm.rules.Rule
 import net.corda.djvm.rules.implementation.*
 import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.ClassSource
-import net.corda.djvm.source.SandboxSourceClassLoader
+import net.corda.djvm.source.SourceClassLoader
 import net.corda.djvm.utilities.Discovery
 import net.corda.djvm.validation.RuleValidator
 import org.junit.After
@@ -88,7 +88,7 @@ abstract class TestBase {
                 Whitelist.MINIMAL,
                 bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT),
                 sourceClassLoaderFactory = { classResolver, bootstrapClassLoader ->
-                    SandboxSourceClassLoader(classResolver,  bootstrapClassLoader!!)
+                    SourceClassLoader(classResolver,  bootstrapClassLoader!!)
                 },
                 additionalPinnedClasses = setOf(
                     Utilities::class.java

--- a/djvm/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -37,6 +37,7 @@ class SandboxExecutorTest : TestBase() {
     @Test
     fun `can load and execute contract`() = sandbox(DEFAULT, pinnedClasses = setOf(Transaction::class.java)) {
         val contractExecutor = DeterministicSandboxExecutor<Transaction, Unit>(configuration)
+        //TODO: Transaction should not be a pinned class! It needs to be marshalled into and out of the sandbox.
         val tx = Transaction(1)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { contractExecutor.run<Contract>(tx) }


### PR DESCRIPTION
Simplify the `SourceClassLoader` logic to make it easier for people to use DJVM as a library.

Removing `SandboxSourceClassLoader` means that we don't need `AbstractSourceClassLoader` any more either, leaving us with just `SourceClassLoader` again.