### PR TITLE
CORDA-2772 - fix edge case when `stickTo.hashCode` return `Int.MIN_VALUE`

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/LazyStickyPool.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/LazyStickyPool.kt
@@ -25,7 +25,12 @@ class LazyStickyPool<A : Any>(
     private val boxes = Array(size) { InstanceBox<A>() }
 
     private fun toIndex(stickTo: Any): Int {
-        return Math.abs(stickTo.hashCode()) % boxes.size
+        return stickTo.hashCode().let { hashCode ->
+            when (hashCode) {
+                Int.MIN_VALUE -> 0
+                else -> Math.abs(hashCode) % boxes.size
+            }
+        }
     }
 
     fun borrow(stickTo: Any): A {


### PR DESCRIPTION
This PR addresses [CORDA-2772](https://r3-cev.atlassian.net/browse/CORDA-2772)
