### PR TITLE
changing substitution mechanism so that it can work with code blocks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,22 @@ agent, make sure the relevant drive is shared, and click 'Reset credentials'.
 It's probably worth reading [this](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) 
 to get your head around the rst syntax we're using.  
 
+## version placeholders
+
+Currently we support five placeholders that get substituted at build time:
+
+```groovy
+    "|corda_version|" 
+    "|java_version|" 
+    "|kotlin_version|" 
+    "|gradle_plugins_version|" 
+    "|quasar_version|"
+```
+
+If you put one of these in an rst file anywhere (including in a code tag) then it will be substituted with the value in constants.properties 
+(which is in the root of the project) at build time.
+
+The code for this can be found near the top of the conf.py file in the `docs/source` directory.
+
+
+

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -37,7 +37,7 @@ Step 2. Adjust the version numbers in your Gradle build files
 
 Alter the versions you depend on in your Gradle file like so:
 
-.. parsed-literal::
+.. code:: groovy
 
     ext.corda_release_version = '|corda_version|'
     ext.corda_gradle_plugins_version = '|gradle_plugins_version|'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,17 +11,23 @@ with open("../../constants.properties", "r") as f:
     constants_properties_lines = f.readlines()
 constants_properties_dict = dict([l.strip().split('=') for l in constants_properties_lines if not l.startswith("#") and not l.strip() == ""])
 
-rst_epilog = """
-.. |java_version| replace:: 8u%s
-.. |kotlin_version| replace:: %s
-.. |gradle_plugins_version| replace:: %s
-.. |quasar_version| replace:: %s
-.. |corda_version| replace:: %s
-""" % (constants_properties_dict["java8MinUpdateVersion"],
-       constants_properties_dict["kotlinVersion"],
-       constants_properties_dict["gradlePluginsVersion"],
-       constants_properties_dict["quasarVersion"],
-       constants_properties_dict["cordaVersion"])
+def cordaSourceReadReplace(app, docname, source):
+    result = source[0]
+    for key in app.config.corda_substitutions:
+        result = result.replace(key, app.config.corda_substitutions[key])
+    source[0] = result
+
+corda_substitutions = {
+    "|corda_version|" : constants_properties_dict["cordaVersion"],
+    "|java_version|" : "8u"+constants_properties_dict["java8MinUpdateVersion"],
+    "|kotlin_version|" : constants_properties_dict["kotlinVersion"],
+    "|gradle_plugins_version|" : constants_properties_dict["gradlePluginsVersion"],
+    "|quasar_version|" : constants_properties_dict["quasarVersion"]
+}
+
+def setup(app):
+   app.add_config_value('corda_substitutions', {}, True)
+   app.connect('source-read', cordaSourceReadReplace)
 
 ############################################################################
 


### PR DESCRIPTION
Ok this change switches to a mechanism by which we replace the various versions of things in sphinx. The reason is so that we can do substitution inside code blocks.  The pros of this are that we can have nicely styled things and still do substitution.  The obvious downside is that we all think code blocks are sacrosanct!

I've attached a diff between the master and my branch diffs.

And screenshots of the new versions so that we can see they're ok.

If this is accepted I'm happy to go on a mission to replace all the <version> things we have with the relevant versions.

There only are 4 diffs, btw:

`
 ~/dev/corda/corda/docs   nimmaj/corda-2777-doc-subst  grep 'diff -r' ~/tmp/html.diffs 
diff -r /Users/nimmaj/tmp/html.master/_sources/app-upgrade-notes.rst.txt /Users/nimmaj/tmp/html.new/_sources/app-upgrade-notes.rst.txt
diff -r /Users/nimmaj/tmp/html.master/app-upgrade-notes.html /Users/nimmaj/tmp/html.new/app-upgrade-notes.html
diff -r /Users/nimmaj/tmp/html.master/cordapp-build-systems.html /Users/nimmaj/tmp/html.new/cordapp-build-systems.html
diff -r /Users/nimmaj/tmp/html.master/searchindex.js /Users/nimmaj/tmp/html.new/searchindex.js
`

[html.diffs.zip](https://github.com/corda/corda/files/2996320/html.diffs.zip)

I'm ignoring the searchindex.js for the mo.

app-upgrade-notes:

<img width="915" alt="image" src="https://user-images.githubusercontent.com/1755615/54820911-94ff2580-4c98-11e9-9e3f-ac0a1083a28d.png">

cordapp-build-systems:

<img width="915" alt="image" src="https://user-images.githubusercontent.com/1755615/54821046-04751500-4c99-11e9-895b-a6e01cf763b0.png">



# PR Checklist:

- [in docs ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [n/a ] If you added public APIs, did you write the JavaDocs?
- [n/a] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [n/a
 ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)