### PR TITLE
CORDA-2782 Add Comparable to default whitelist for vault query criteria using comparables

### DIFF
--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -25,6 +25,7 @@ import net.corda.finance.workflows.getCashBalance
 import net.corda.finance.workflows.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
+import net.corda.finance.schemas.CashSchemaV1
 import net.corda.java.rpc.StandaloneCordaRPCJavaClientTest
 import net.corda.nodeapi.internal.config.User
 import net.corda.smoketesting.NodeConfig
@@ -218,6 +219,13 @@ class StandaloneCordaRPClientTest {
         log.info("Cash Balances: $cashBalances")
         assertEquals(1, cashBalances.size)
         assertEquals(629.POUNDS, cashBalances[Currency.getInstance("GBP")])
+
+        // Check for cash states using a query criteria comparator
+        val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.greaterThan(10000L) }
+        val customCriteria = QueryCriteria.VaultCustomQueryCriteria(logicalExpression)
+        val customCriteriaResults = rpcProxy.vaultQueryBy<Cash.State>(customCriteria)
+        assertEquals(1, customCriteriaResults.states.size)
+        assertEquals(customCriteriaResults.states.first().state.data.amount.quantity, 529.POUNDS.quantity)
     }
 
     @Test

--- a/serialization-deterministic/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
+++ b/serialization-deterministic/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
@@ -6,5 +6,7 @@ import net.corda.core.serialization.SerializationWhitelist
  * The DJVM does not need whitelisting, by definition.
  */
 object DefaultWhitelist : SerializationWhitelist {
-    override val whitelist: List<Class<Any>> get() = emptyList()
+    override val whitelist = listOf(
+            java.lang.Comparable::class.java    // required for forwards compatibility with default whitelist
+    )
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
@@ -66,6 +66,6 @@ object DefaultWhitelist : SerializationWhitelist {
                     CRLReason::class.java,
 
                     // used in Vault Query criteria comparators (see QueryCriteriaUtils.Builder)
-                    Comparable::class.java
+                    java.lang.Comparable::class.java
             )
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
@@ -63,6 +63,9 @@ object DefaultWhitelist : SerializationWhitelist {
 
                     // Implementation of X509Certificate.
                     X509CertImpl::class.java,
-                    CRLReason::class.java
+                    CRLReason::class.java,
+
+                    // used in Vault Query criteria comparators (see QueryCriteriaUtils.Builder)
+                    Comparable::class.java
             )
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2782

Discussed preferred approach towards fixing the broken **serialization-deterministic** **_VerifyTransactionTest_** unit test which generates a binary file for a transaction and then attempts to verify this using the deterministic code. 
@r3domfox attempted to suppress the new _java.lang.Comparable_ default whitelisted type in the serializer schema generation but this caused a binary compatibility break. The simplest solution was to add the new _java.lang.Comparable_ whitelisted type to the equivalent deterministic default whitelist.