### PR TITLE
corda-2781 replace manual versions with substitutions

### DIFF
--- a/docs/source/api-scanner.rst
+++ b/docs/source/api-scanner.rst
@@ -36,7 +36,7 @@ broken Corda's API.
 How it works
 ------------
 
-The ``generateApi`` Gradle task writes a summary of Corda's public API into the file ``build/api/api-corda-<version>.txt``.
+The ``generateApi`` Gradle task writes a summary of Corda's public API into the file ``build/api/api-corda-|corda_version|.txt``.
 The ``.ci/check-api-changes.sh`` script then compares this file with the contents of ``.ci/api-current.txt``, which is a
 managed file within the Corda repository.
 

--- a/docs/source/api-testing.rst
+++ b/docs/source/api-testing.rst
@@ -161,8 +161,8 @@ Further examples
 * See the flow testing tutorial :doc:`here <flow-testing>`
 * See the oracle tutorial :doc:`here <oracles>` for information on testing ``@CordaService`` classes
 * Further examples are available in the Example CorDapp in
-  `Java <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/java-source/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
-  `Kotlin <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
+  `Java <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-java/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
+  `Kotlin <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
 
 Contract testing
 ----------------
@@ -380,5 +380,5 @@ Further examples
 
 * See the flow testing tutorial :doc:`here <tutorial-test-dsl>`
 * Further examples are available in the Example CorDapp in
-  `Java <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/java-source/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
-  `Kotlin <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
+  `Java <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-java/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
+  `Kotlin <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_

--- a/docs/source/api-testing.rst
+++ b/docs/source/api-testing.rst
@@ -161,8 +161,8 @@ Further examples
 * See the flow testing tutorial :doc:`here <flow-testing>`
 * See the oracle tutorial :doc:`here <oracles>` for information on testing ``@CordaService`` classes
 * Further examples are available in the Example CorDapp in
-  `Java <https://github.com/corda/cordapp-example/blob/release-V3/java-source/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
-  `Kotlin <https://github.com/corda/cordapp-example/blob/release-V3/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
+  `Java <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/java-source/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
+  `Kotlin <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
 
 Contract testing
 ----------------
@@ -380,5 +380,5 @@ Further examples
 
 * See the flow testing tutorial :doc:`here <tutorial-test-dsl>`
 * Further examples are available in the Example CorDapp in
-  `Java <https://github.com/corda/cordapp-example/blob/release-V3/java-source/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
-  `Kotlin <https://github.com/corda/cordapp-example/blob/release-V3/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
+  `Java <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/java-source/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
+  `Kotlin <https://github.com/corda/cordapp-example/blob/release-V|platform_version|/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -445,7 +445,7 @@ been removed.
 
 You have some choices here:
 
-* Upgrade your ``quasar.jar`` to the version consistent with your Corda version
+* Upgrade your ``quasar.jar`` to ``|quasar_version|``
 * Delete your ``lib`` directory and switch to using the Gradle test runner
 
 Instructions for both options can be found in :ref:`Running tests in Intellij <tutorial_cordapp_running_tests_intellij>`.

--- a/docs/source/azure-vm.rst
+++ b/docs/source/azure-vm.rst
@@ -101,28 +101,7 @@ The nodes you will use to send and receive Yo messages require the Yo! CorDapp j
 
 Connect to one of your Corda nodes (make sure this is not the Notary node) using an SSH client of your choice (e.g. Putty) and log into the virtual machine using the public IP address and your SSH key or username / password combination you defined in Step 1 of the Azure build process. Type the following command:
 
-For Corda nodes running release M10
-
-.. sourcecode:: shell
-
-	cd /opt/corda/cordapps
-	wget http://downloads.corda.net/cordapps/net/corda/yo/0.10.1/yo-0.10.1.jar
-
-For Corda nodes running release M11
-
-.. sourcecode:: shell
-
-	cd /opt/corda/cordapps
-	wget http://downloads.corda.net/cordapps/net/corda/yo/0.11.0/yo-0.11.0.jar
-
-For Corda nodes running version 2
-
-.. sourcecode:: shell
-
-	cd /opt/corda/plugins
-	wget http://ci-artifactory.corda.r3cev.com/artifactory/cordapp-showcase/yo-4.jar
-
-
+Build the yo cordapp sample which you can find here: https://github.com/corda/samples/tree/release-V|platform_version|/yo-cordapp and install it in the cordapp directory.
 
 Now restart Corda and the Corda webserver using the following commands or restart your Corda VM from the Azure portal:
 

--- a/docs/source/cli-application-shell-extensions.rst
+++ b/docs/source/cli-application-shell-extensions.rst
@@ -34,7 +34,7 @@ For example, for the Corda node, install the shell extensions using
 
 .. code-block:: shell
 
-   java -jar corda-<version>.jar install-shell-extensions
+   java -jar corda-|corda_version|.jar install-shell-extensions
 
 And then run the node by running:
 
@@ -62,15 +62,11 @@ Once the shell extensions have been installed, you can upgrade them in one of tw
 List of existing CLI applications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+----------------------------------------------------------------+--------------------------------------------------------------+--------------------------------+
-| Description                                                    | JAR name                                                     | Alias                          |
-+----------------------------------------------------------------+--------------------------------------------------------------+--------------------------------+
-| :ref:`Corda node<starting-an-individual-corda-node>`           | ``corda-<version>.jar``                                      | ``corda --<option>``           |
-+----------------------------------------------------------------+--------------------------------------------------------------+--------------------------------+
-| :doc:`Network bootstrapper<network-bootstrapper>`              | ``corda-tools-network-bootstrapper-<version>.jar``           | ``bootstrapper --<option>``    |
-+----------------------------------------------------------------+--------------------------------------------------------------+--------------------------------+
-| :ref:`Standalone shell<standalone-shell>`                      | ``corda-tools-shell-cli-<version>.jar``                      | ``corda-shell --<option>``     |
-+----------------------------------------------------------------+--------------------------------------------------------------+--------------------------------+
-| :doc:`Blob inspector<blob-inspector>`                          | ``corda-tools-blob-inspector-<version>.jar``                 | ``blob-inspector --<option>``  |
-+----------------------------------------------------------------+--------------------------------------------------------------+--------------------------------+
-
+=========================================================   ==============================   ==========================================================
+Description                                                 Alias                            JAR Name
+=========================================================   ==============================   ==========================================================
+:ref:`Corda node<starting-an-individual-corda-node>`        ``corda --<option>``             ``corda-|corda_version|.jar``
+:doc:`Network bootstrapper<network-bootstrapper>`           ``bootstrapper --<option>``      ``corda-tools-network-bootstrapper-|corda_version|.jar``
+:ref:`Standalone shell<standalone-shell>`                   ``corda-shell --<option>``       ``corda-tools-shell-cli-|corda_version|.jar``
+:doc:`Blob inspector<blob-inspector>`                       ``blob-inspector --<option>``    ``corda-tools-blob-inspector-|corda_version|.jar``
+=========================================================   ==============================   ==========================================================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,8 @@ corda_substitutions = {
     "|java_version|" : "8u"+constants_properties_dict["java8MinUpdateVersion"],
     "|kotlin_version|" : constants_properties_dict["kotlinVersion"],
     "|gradle_plugins_version|" : constants_properties_dict["gradlePluginsVersion"],
-    "|quasar_version|" : constants_properties_dict["quasarVersion"]
+    "|quasar_version|" : constants_properties_dict["quasarVersion"],
+    "|platform_version|" : constants_properties_dict["platformVersion"]
 }
 
 def setup(app):

--- a/docs/source/cordapp-build-systems.rst
+++ b/docs/source/cordapp-build-systems.rst
@@ -55,7 +55,7 @@ Corda you're developing against:
 
 The current versions used are as follows:
 
-.. parsed-literal::
+.. code::
 
     ext.corda_release_version = '|corda_version|'
     ext.corda_gradle_plugins_version = '|gradle_plugins_version|'

--- a/docs/source/deploying-a-node.rst
+++ b/docs/source/deploying-a-node.rst
@@ -26,10 +26,10 @@ handling, and ensures the Corda service is run at boot.
    ``mkdir /opt/corda; chown corda:corda /opt/corda``
 
 3. Download the `Corda jar <https://r3.bintray.com/corda/net/corda/corda/>`_
-   (under ``/VERSION_NUMBER/corda-VERSION_NUMBER.jar``) and place it in ``/opt/corda``
+   (under ``/|corda_version|/corda-|corda_version|.jar``) and place it in ``/opt/corda``
 
 4. (Optional) Download the `Corda webserver jar <http://r3.bintray.com/corda/net/corda/corda-webserver/>`_
-   (under ``/VERSION_NUMBER/corda-VERSION_NUMBER.jar``) and place it in ``/opt/corda``
+   (under ``/|corda_version|/corda-|corda_version|.jar``) and place it in ``/opt/corda``
 
 5. Create a directory called ``cordapps`` in ``/opt/corda`` and save your CorDapp jar file to it. Alternatively, download one of
    our `sample CorDapps <https://www.corda.net/samples/>`_ to the ``cordapps`` directory
@@ -187,11 +187,11 @@ at boot, and means the Corda service stays running with no users connected to th
 
    * A supported Java distribution. The supported versions are listed in :doc:`getting-set-up`
 
-1. Create a Corda directory and download the Corda jar. Replace ``VERSION_NUMBER`` with the desired version. Here's an
+1. Create a Corda directory and download the Corda jar. Here's an
    example using PowerShell::
 
         mkdir C:\Corda
-        wget http://jcenter.bintray.com/net/corda/corda/VERSION_NUMBER/corda-VERSION_NUMBER.jar -OutFile C:\Corda\corda.jar
+        wget http://jcenter.bintray.com/net/corda/corda/|corda_version|/corda-|corda_version|.jar -OutFile C:\Corda\corda.jar
 
 2. Create a directory called ``cordapps`` in ``C:\Corda\`` and save your CorDapp jar file to it. Alternatively,
    download one of our `sample CorDapps <https://www.corda.net/samples/>`_ to the ``cordapps`` directory

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -26,7 +26,7 @@ The Cordform task
 -----------------
 Corda provides a gradle plugin called ``Cordform`` that allows you to automatically generate and configure a set of
 nodes for testing and demos. Here is an example ``Cordform`` task called ``deployNodes`` that creates three nodes, defined
-in the `Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin/blob/release-V|platform_version|/build.gradle#L100>`_:
+in the `Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin/blob/release-V|platform_version|/build.gradle#L95>`_:
 
 .. sourcecode:: groovy
 
@@ -251,7 +251,7 @@ following line to each node's ``node.conf`` file:
 
 Where ``2222`` is the port you want to open to SSH into the shell.
 
-Below you can find the example task from the `IRS Demo <https://github.com/corda/corda/blob/release-V|platform_version|/samples/irs-demo/cordapp/build.gradle#L111>`_ included in the samples directory of main Corda GitHub repository:
+Below you can find the example task from the `IRS Demo <https://github.com/corda/corda/blob/release/|platform_version|/samples/irs-demo/cordapp/build.gradle#L111>`_ included in the samples directory of main Corda GitHub repository:
 
 .. sourcecode:: groovy
 

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -9,7 +9,7 @@ A node can be created manually by creating a folder that contains the following 
 
 * The Corda JAR
 
-    * Can be downloaded from https://r3.bintray.com/corda/net/corda/corda/ (under /VERSION_NUMBER/corda-VERSION_NUMBER.jar)
+    * Can be downloaded from https://r3.bintray.com/corda/net/corda/corda/ (under /|corda_version|/corda-|corda_version|.jar)
 
 * A node configuration file entitled ``node.conf``, configured as per :doc:`corda-configuration-file`
 
@@ -17,7 +17,7 @@ A node can be created manually by creating a folder that contains the following 
 
 * **Optional:** A webserver JAR entitled ``corda-webserver.jar`` that will connect to the node via RPC
 
-    * The (deprecated) default webserver can be downloaded from http://r3.bintray.com/corda/net/corda/corda-webserver/ (under /VERSION_NUMBER/corda-VERSION_NUMBER.jar)
+    * The (deprecated) default webserver can be downloaded from http://r3.bintray.com/corda/net/corda/corda-webserver/ (under /|corda_version|/corda-|corda_version|.jar)
     * A Spring Boot alternative can be found here: https://github.com/corda/spring-webserver
 
 The remaining files and folders described in :doc:`node-structure` will be generated at runtime.
@@ -26,7 +26,7 @@ The Cordform task
 -----------------
 Corda provides a gradle plugin called ``Cordform`` that allows you to automatically generate and configure a set of
 nodes for testing and demos. Here is an example ``Cordform`` task called ``deployNodes`` that creates three nodes, defined
-in the `Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin/blob/release-V3/build.gradle#L100>`_:
+in the `Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin/blob/release-V|platform_version|/build.gradle#L100>`_:
 
 .. sourcecode:: groovy
 
@@ -251,7 +251,7 @@ following line to each node's ``node.conf`` file:
 
 Where ``2222`` is the port you want to open to SSH into the shell.
 
-Below you can find the example task from the `IRS Demo <https://github.com/corda/corda/blob/release-V3.0/samples/irs-demo/cordapp/build.gradle#L111>`_ included in the samples directory of main Corda GitHub repository:
+Below you can find the example task from the `IRS Demo <https://github.com/corda/corda/blob/release-V|platform_version|/samples/irs-demo/cordapp/build.gradle#L111>`_ included in the samples directory of main Corda GitHub repository:
 
 .. sourcecode:: groovy
 

--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -29,7 +29,7 @@ The Corda Network Bootstrapper can be downloaded from `here <https://www.corda.n
 Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. "devMode" must be set to true. Then run the
 following command:
 
-``java -jar network-bootstrapper-VERSION.jar --dir <nodes-root-dir>``
+``java -jar network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>``
 
 For example running the command on a directory containing these files:
 
@@ -153,7 +153,7 @@ can use the Network Bootstrapper on the following network structure:
 
 Then run the Network Bootstrapper again from the root dir:
 
-``java -jar network-bootstrapper-VERSION.jar --dir <nodes-root-dir>``
+``java -jar network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>``
 
 Which will give the following:
 
@@ -224,7 +224,7 @@ For example, with the following pre-generated network:
 
 Then run the Network Bootstrapper again from the root dir:
 
-``java -jar network-bootstrapper-VERSION.jar --dir <nodes-root-dir>``
+``java -jar network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>``
 
 To give the following:
 
@@ -271,11 +271,11 @@ Overriding network parameters via a file
 
 You can provide a network parameters overrides file using the following syntax:
 
-``java -jar network-bootstrapper-VERSION.jar --network-parameter-overrides=<path_to_file>``
+``java -jar network-bootstrapper-|corda_version|.jar --network-parameter-overrides=<path_to_file>``
 
 Or alternatively, by using the short form version:
 
-``java -jar network-bootstrapper-VERSION.jar -n=<path_to_file>``
+``java -jar network-bootstrapper-|corda_version|.jar -n=<path_to_file>``
 
 The network parameter overrides file is a HOCON file with the following fields, all of which are optional. Any field that is not provided will be
 ignored. If a field is not provided and you are bootstrapping a new network, a sensible default value will be used. If a field is not provided and you

--- a/docs/source/running-a-notary.rst
+++ b/docs/source/running-a-notary.rst
@@ -35,14 +35,14 @@ Crash fault-tolerant (experimental)
 ===================================
 
 Corda provides a prototype `Raft-based <http://atomix.io/>`_ highly available notary implementation. You can try it out on our
-`notary demo <https://github.com/corda/corda/tree/release-V|platform_version|/samples/notary-demo>`_ page. Note that it has known limitations
+`notary demo <https://github.com/corda/corda/tree/release/|platform_version|/samples/notary-demo>`_ page. Note that it has known limitations
 and is not recommended for production use.
 
 Byzantine fault-tolerant (experimental)
 =======================================
 
 A prototype BFT notary implementation based on `BFT-Smart <https://github.com/bft-smart/library>`_ is available. You can
-try it out on our `notary demo <https://github.com/corda/corda/tree/release-V|platform_version|/samples/notary-demo>`_ page. Note that it
+try it out on our `notary demo <https://github.com/corda/corda/tree/release/|platform_version|/samples/notary-demo>`_ page. Note that it
 is still experimental and there is active work ongoing for a production ready solution. Additionally, BFT-Smart requires Java
 serialization which is disabled by default in Corda due to security risks, and it will only work in dev mode where this can
 be customised.

--- a/docs/source/running-a-notary.rst
+++ b/docs/source/running-a-notary.rst
@@ -35,14 +35,14 @@ Crash fault-tolerant (experimental)
 ===================================
 
 Corda provides a prototype `Raft-based <http://atomix.io/>`_ highly available notary implementation. You can try it out on our
-`notary demo <https://github.com/corda/corda/tree/release-V3.1/samples/notary-demo>`_ page. Note that it has known limitations
+`notary demo <https://github.com/corda/corda/tree/release-V|platform_version|/samples/notary-demo>`_ page. Note that it has known limitations
 and is not recommended for production use.
 
 Byzantine fault-tolerant (experimental)
 =======================================
 
 A prototype BFT notary implementation based on `BFT-Smart <https://github.com/bft-smart/library>`_ is available. You can
-try it out on our `notary demo <https://github.com/corda/corda/tree/release-V3.1/samples/notary-demo>`_ page. Note that it
+try it out on our `notary demo <https://github.com/corda/corda/tree/release-V|platform_version|/samples/notary-demo>`_ page. Note that it
 is still experimental and there is active work ongoing for a production ready solution. Additionally, BFT-Smart requires Java
 serialization which is disabled by default in Corda due to security risks, and it will only work in dev mode where this can
 be customised.

--- a/docs/source/testnet-explorer-corda.rst
+++ b/docs/source/testnet-explorer-corda.rst
@@ -34,21 +34,21 @@ couple of resources.
 
    .. code:: bash
 
-       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-contracts-/<VERSION>-corda/corda-finance-contracts-<VERSION>-corda.jar
-       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-workflows-/<VERSION>-corda/corda-finance-workflows-<VERSION>-corda.jar
+       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-contracts-|corda_version|-corda/corda-finance-contracts-|corda_version|-corda.jar
+       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-workflows-|corda_version|-corda/corda-finance-workflows-|corda_version|-corda.jar
 
    This is required to run some flows to check your connections, and to issue/transfer cash to counterparties. Copy it to
    the Corda installation location:
 
    .. code:: bash
 
-       sudo cp /home/<USER>/corda-finance-<VERSION>-corda.jar /opt/corda/cordapps/
+       sudo cp /home/<USER>/corda-finance-|corda_version|-corda.jar /opt/corda/cordapps/
 
 #. Run the following to create a config file for the finance CorDapp:
 
    .. code:: bash
 
-       echo "issuableCurrencies = [ USD ]" > /opt/corda/cordapps/config/corda-finance-<VERSION>-corda.conf
+       echo "issuableCurrencies = [ USD ]" > /opt/corda/cordapps/config/corda-finance-|corda_version|-corda.conf
 
 #. Restart the Corda node:
 
@@ -70,7 +70,7 @@ couple of resources.
 
    .. code:: bash
 
-       http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-tools-explorer/<VERSION>-corda/corda-tools-explorer-<VERSION>-corda.jar
+       http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-tools-explorer/|corda_version|-corda/corda-tools-explorer-|corda_version|-corda.jar
 
    .. warning:: This Node Explorer is incompatible with the Corda Enterprise distribution and vice versa as they currently
       use different serialisation schemes (Kryo vs AMQP).
@@ -79,7 +79,7 @@ couple of resources.
 
    .. code:: bash
 
-       java -jar corda-tools-explorer-<VERSION>-corda.jar
+       java -jar corda-tools-explorer-|corda_version|-corda.jar
 
    .. image:: resources/explorer-login.png
 

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -224,8 +224,8 @@ Building the example CorDapp
       ├── certificates
       ├── corda.jar              // The Corda node runtime
       ├── cordapps               // The node's CorDapps
-      │   ├── corda-finance-contracts-4.0-corda.jar
-      │   ├── corda-finance-workflows-4.0-corda.jar
+      │   ├── corda-finance-contracts-|corda_version|-corda.jar
+      │   ├── corda-finance-workflows-|corda_version|-corda.jar
       │   └── cordapp-example-0.1.jar
       ├── drivers
       ├── logs
@@ -265,14 +265,14 @@ For each node, the ``runnodes`` script creates a node tab/window:
    / /___  /_/ / /  / /_/ / /_/ /          always say "Ah, Interesting!"
    \____/     /_/   \__,_/\__,_/
 
-   --- Corda Open Source corda-3.0 (4157c25) -----------------------------------------------
+   --- Corda Open Source corda-|corda_version| (4157c25) -----------------------------------------------
 
 
    Logs can be found in                    : /Users/joeldudley/Desktop/cordapp-example/workflows-kotlin/build/nodes/PartyA/logs
    Database connection url is              : jdbc:h2:tcp://localhost:59472/node
    Incoming connection address             : localhost:10005
    Listening on port                       : 10005
-   Loaded CorDapps                         : corda-finance-corda-3.0, cordapp-example-0.1, corda-core-corda-3.0
+   Loaded CorDapps                         : corda-finance-corda-|corda_version|, cordapp-example-0.1, corda-core-corda-|corda_version|
    Node for "PartyA" started up and registered in 38.59 sec
 
 

--- a/docs/source/writing-a-cordapp.rst
+++ b/docs/source/writing-a-cordapp.rst
@@ -42,7 +42,7 @@ You should base your project on one of the following templates:
 * `Kotlin Template CorDapp <https://github.com/corda/cordapp-template-kotlin>`_ (for CorDapps written in Kotlin)
 
 Please use the branch of the template that corresponds to the major version of Corda you are using. For example,
-someone building a CorDapp on Corda 3.2 should use the ``release-V3`` branch of the template.
+someone building a CorDapp on Corda 4.1 should use the ``release-V4`` branch of the template.
 
 Build system
 ^^^^^^^^^^^^


### PR DESCRIPTION
post checkin to make substitutions work in code blocks, went through the code base and replaced static versions with the placeholders.

there was an error - one of the tables disappeared due to formatting issues so I've changed the way we do that table.  will go through the docs and remove all the warnings next I suspect...

# PR Checklist:

- [docs, yes ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [n/a ] If you added public APIs, did you write the JavaDocs?
- [n/a ] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [n/a ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)