### PR TITLE
CORDA-2783 - Improve error message for initial registration with devMode=true

### DIFF
--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -93,7 +93,9 @@ open class SharedNodeCmdLineOptions {
 class InitialRegistrationCmdLineOptions : SharedNodeCmdLineOptions() {
     override fun parseConfiguration(configuration: Config): Valid<NodeConfiguration> {
         return super.parseConfiguration(configuration).doIfValid { config ->
-            require(!config.devMode || config.devModeOptions?.allowCompatibilityZone == true)
+            require(!config.devMode || config.devModeOptions?.allowCompatibilityZone == true) {
+                "Cannot perform initial registration when 'devMode' is true, unless 'devModeOptions.allowCompatibilityZone' is also true."
+            }
             require(config.compatibilityZoneURL != null || config.networkServices != null) {
                 "compatibilityZoneURL or networkServices must be present in the node configuration file in registration mode."
             }


### PR DESCRIPTION
In response to [CORDA-2783](https://r3-cev.atlassian.net/browse/CORDA-2783):

If `devMode=true` is set in the config, and `devModeOptions.allowCompatibilityZone` isn't, the node would fail with an uninformative message `Failed requirement`. With this fix, the following output gets produced instead:

```
   ______               __
  / ____/     _________/ /___ _
 / /     __  / ___/ __  / __ `/         Computers are useless. They can only
/ /___  /_/ / /  / /_/ / /_/ /          give you answers.  -- Picasso
\____/     /_/   \__,_/\__,_/

--- Corda Open Source 5.0-SNAPSHOT (a1f7c4f) -------------------------------------------------------------


Logs can be found in                    : C:\Users\TommyLillehagen\IdeaProjects\test-node\logs
Cannot perform initial registration when 'devMode' is true, unless 'devModeOptions.allowCompatibilityZone' is also true.
```