### PR TITLE
CORDA-2730: Enforce finance cordapp currency restrictions

### DIFF
--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt
@@ -46,6 +46,8 @@ abstract class AbstractCashFlow<out T>(override val progressTracker: ProgressTra
     abstract class AbstractRequest(val amount: Amount<Currency>)
 }
 
+class UnsupportedCurrencyException internal constructor(message: String) : Exception(message) {}
+
 // The internal constructor here allows the ThrowableSerializer to find a suitable constructor even if the `cause` field is removed using reflection by the RPC proxies.
 class CashException internal constructor(cause: Throwable?, message: String) : FlowException(message, cause) {
     constructor(message: String, cause: Throwable) : this(cause, message)

--- a/finance/workflows/src/test/kotlin/net/corda/finance/internal/CashConfigDataFlowTest.kt
+++ b/finance/workflows/src/test/kotlin/net/corda/finance/internal/CashConfigDataFlowTest.kt
@@ -1,8 +1,13 @@
 package net.corda.finance.internal
 
+import net.corda.core.utilities.OpaqueBytes
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.EUR
+import net.corda.finance.POUNDS
 import net.corda.finance.USD
+import net.corda.finance.flows.CashException
+import net.corda.finance.flows.CashIssueFlow
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.MockNodeParameters
@@ -24,5 +29,22 @@ class CashConfigDataFlowTest {
         ))
         val config = node.startFlow(CashConfigDataFlow()).getOrThrow()
         assertThat(config.issuableCurrencies).containsExactly(EUR, USD)
+    }
+
+    @Test
+    fun `cannot issue unsupported currency`() {
+        val node = mockNet.createNode(MockNodeParameters(
+                additionalCordapps = listOf(FINANCE_WORKFLOWS_CORDAPP.withConfig(mapOf("issuableCurrencies" to listOf("EUR", "USD"))))
+        ))
+
+        val notary = mockNet.defaultNotaryIdentity
+        node.startFlow(CashConfigDataFlow()).getOrThrow()
+
+        val issuerBankPartyRef = OpaqueBytes.of("1".toByte())
+        val future = node.startFlow(CashIssueFlow(amount = 100.POUNDS, issuerBankPartyRef = issuerBankPartyRef, notary = notary))
+
+        assertThatThrownBy {
+            future.getOrThrow()
+        }.isInstanceOf(CashException::class.java).hasMessage("Unsupported currency requested")
     }
 }


### PR DESCRIPTION
Changes CashIssueFlow to verify that the finance workflows cordapp that it is executing in
is configured to support the requested currency. The finance workflows cordapp exposes a
configuration property that stores issuable currencies. We check against this list of
issuable currencies before actually issuing currency.

Note that in the default cause, all currencies are supported. In other words, this only
takes effect if the operator deliberately overrides the list of supported currencies with
a custom list.
