### PR TITLE
Fix incorrect version identifiers in URL's by adopting |corda_version| consistently.

### DIFF
--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -17,7 +17,7 @@ A node can be created manually by creating a folder that contains the following 
 
 * **Optional:** A webserver JAR entitled ``corda-webserver.jar`` that will connect to the node via RPC
 
-    * The (deprecated) default webserver can be downloaded from http://r3.bintray.com/corda/net/corda/corda-webserver/ (under /|corda_version|/corda-|corda_version|.jar)
+    * The (deprecated) default webserver can be downloaded from http://r3.bintray.com/corda/net/corda/corda-webserver/ (under /|corda_version|/corda-webserver-|corda_version|.jar)
     * A Spring Boot alternative can be found here: https://github.com/corda/spring-webserver
 
 The remaining files and folders described in :doc:`node-structure` will be generated at runtime.

--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -29,7 +29,9 @@ The Corda Network Bootstrapper can be downloaded from `here <https://www.corda.n
 Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. "devMode" must be set to true. Then run the
 following command:
 
-``java -jar network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>``
+.. sourcecode:: bash
+
+    java -jar corda-tools-network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>
 
 For example running the command on a directory containing these files:
 
@@ -153,7 +155,9 @@ can use the Network Bootstrapper on the following network structure:
 
 Then run the Network Bootstrapper again from the root dir:
 
-``java -jar network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>``
+.. sourcecode:: bash
+
+    java -jar corda-tools-network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>
 
 Which will give the following:
 
@@ -224,7 +228,9 @@ For example, with the following pre-generated network:
 
 Then run the Network Bootstrapper again from the root dir:
 
-``java -jar network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>``
+.. sourcecode:: bash
+
+    java -jar corda-tools-network-bootstrapper-|corda_version|.jar --dir <nodes-root-dir>
 
 To give the following:
 
@@ -271,11 +277,15 @@ Overriding network parameters via a file
 
 You can provide a network parameters overrides file using the following syntax:
 
-``java -jar network-bootstrapper-|corda_version|.jar --network-parameter-overrides=<path_to_file>``
+.. sourcecode:: bash
+
+    java -jar corda-tools-network-bootstrapper-|corda_version|.jar --network-parameter-overrides=<path_to_file>
 
 Or alternatively, by using the short form version:
 
-``java -jar network-bootstrapper-|corda_version|.jar -n=<path_to_file>``
+.. sourcecode:: bash
+
+    java -jar corda-tools-network-bootstrapper-|corda_version|.jar -n=<path_to_file>
 
 The network parameter overrides file is a HOCON file with the following fields, all of which are optional. Any field that is not provided will be
 ignored. If a field is not provided and you are bootstrapping a new network, a sensible default value will be used. If a field is not provided and you

--- a/docs/source/testnet-explorer-corda.rst
+++ b/docs/source/testnet-explorer-corda.rst
@@ -34,21 +34,21 @@ couple of resources.
 
    .. code:: bash
 
-       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-contracts-|corda_version|-corda/corda-finance-contracts-|corda_version|-corda.jar
-       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-workflows-|corda_version|-corda/corda-finance-workflows-|corda_version|-corda.jar
+       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-contracts/|corda_version|/corda-finance-contracts-|corda_version|.jar
+       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-workflows/|corda_version|/corda-finance-workflows-|corda_version|.jar
 
    This is required to run some flows to check your connections, and to issue/transfer cash to counterparties. Copy it to
    the Corda installation location:
 
    .. code:: bash
 
-       sudo cp /home/<USER>/corda-finance-|corda_version|-corda.jar /opt/corda/cordapps/
+       sudo cp /home/<USER>/corda-finance-*-|corda_version|.jar /opt/corda/cordapps/
 
 #. Run the following to create a config file for the finance CorDapp:
 
    .. code:: bash
 
-       echo "issuableCurrencies = [ USD ]" > /opt/corda/cordapps/config/corda-finance-|corda_version|-corda.conf
+       echo "issuableCurrencies = [ USD ]" > /opt/corda/cordapps/config/corda-finance-|corda_version|.conf
 
 #. Restart the Corda node:
 
@@ -70,7 +70,7 @@ couple of resources.
 
    .. code:: bash
 
-       http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-tools-explorer/|corda_version|-corda/corda-tools-explorer-|corda_version|-corda.jar
+       http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-tools-explorer/|corda_version|/corda-tools-explorer-|corda_version|.jar
 
    .. warning:: This Node Explorer is incompatible with the Corda Enterprise distribution and vice versa as they currently
       use different serialisation schemes (Kryo vs AMQP).
@@ -79,7 +79,7 @@ couple of resources.
 
    .. code:: bash
 
-       java -jar corda-tools-explorer-|corda_version|-corda.jar
+       java -jar corda-tools-explorer-|corda_version|.jar
 
    .. image:: resources/explorer-login.png
 

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -224,8 +224,8 @@ Building the example CorDapp
       ├── certificates
       ├── corda.jar              // The Corda node runtime
       ├── cordapps               // The node's CorDapps
-      │   ├── corda-finance-contracts-|corda_version|-corda.jar
-      │   ├── corda-finance-workflows-|corda_version|-corda.jar
+      │   ├── corda-finance-contracts-|corda_version|.jar
+      │   ├── corda-finance-workflows-|corda_version|.jar
       │   └── cordapp-example-0.1.jar
       ├── drivers
       ├── logs


### PR DESCRIPTION
Further clean-up after https://github.com/corda/corda/pull/4927 
