### PR TITLE
CORDA-2804: Replace JPA 2.1 annotations with JPA 2.2.

### DIFF
--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     // and without any obviously non-deterministic ones such as Hibernate.
     deterministicLibraries "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     deterministicLibraries "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    deterministicLibraries "org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final"
+    deterministicLibraries "javax.persistence:javax.persistence-api:2.2"
     deterministicLibraries "org.bouncycastle:bcprov-jdk15on:$bouncycastle_version"
     deterministicLibraries "org.bouncycastle:bcpkix-jdk15on:$bouncycastle_version"
     deterministicLibraries "com.google.code.findbugs:jsr305:$jsr305_version"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -106,8 +106,8 @@ dependencies {
     compile "org.bouncycastle:bcprov-jdk15on:${bouncycastle_version}"
     compile "org.bouncycastle:bcpkix-jdk15on:${bouncycastle_version}"
 
-    // JPA 2.1 annotations.
-    compile "org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final"
+    // JPA 2.2 annotations.
+    compile "javax.persistence:javax.persistence-api:2.2"
 
     // required to use @Type annotation
     compile "org.hibernate:hibernate-core:$hibernate_version"


### PR DESCRIPTION
We have already upgraded Hibernate from 5.2.6 to 5.3.6, and Hibernate 5.3.x uses JPA 2.2. We should therefore upgrade Corda to use the JPA 2.2 annotations as well.