### PR TITLE
CORDA-2782 REVERT - Add Comparable to default whitelist for vault query criteria using comparables"

### DIFF
--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -25,7 +25,6 @@ import net.corda.finance.workflows.getCashBalance
 import net.corda.finance.workflows.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
-import net.corda.finance.schemas.CashSchemaV1
 import net.corda.java.rpc.StandaloneCordaRPCJavaClientTest
 import net.corda.nodeapi.internal.config.User
 import net.corda.smoketesting.NodeConfig
@@ -219,13 +218,6 @@ class StandaloneCordaRPClientTest {
         log.info("Cash Balances: $cashBalances")
         assertEquals(1, cashBalances.size)
         assertEquals(629.POUNDS, cashBalances[Currency.getInstance("GBP")])
-
-        // Check for cash states using a query criteria comparator
-        val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.greaterThan(10000L) }
-        val customCriteria = QueryCriteria.VaultCustomQueryCriteria(logicalExpression)
-        val customCriteriaResults = rpcProxy.vaultQueryBy<Cash.State>(customCriteria)
-        assertEquals(1, customCriteriaResults.states.size)
-        assertEquals(customCriteriaResults.states.first().state.data.amount.quantity, 529.POUNDS.quantity)
     }
 
     @Test

--- a/serialization-deterministic/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
+++ b/serialization-deterministic/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
@@ -6,7 +6,5 @@ import net.corda.core.serialization.SerializationWhitelist
  * The DJVM does not need whitelisting, by definition.
  */
 object DefaultWhitelist : SerializationWhitelist {
-    override val whitelist = listOf(
-            java.lang.Comparable::class.java    // required for forwards compatibility with default whitelist
-    )
+    override val whitelist: List<Class<Any>> get() = emptyList()
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt
@@ -63,9 +63,6 @@ object DefaultWhitelist : SerializationWhitelist {
 
                     // Implementation of X509Certificate.
                     X509CertImpl::class.java,
-                    CRLReason::class.java,
-
-                    // used in Vault Query criteria comparators (see QueryCriteriaUtils.Builder)
-                    java.lang.Comparable::class.java
+                    CRLReason::class.java
             )
 }


### PR DESCRIPTION
Reverts corda/corda#4920

Caused serialisation issues which were evident both in our behave tests and also in performance tests.

Example:
`[WARN ] 2019-03-26T01:03:39,964Z [Thread-8 (ActiveMQ-client-global-threads)] rpc.RPCServer.clientArtemisMessageHandler - Inbound RPC failed [errorCode=bcgta6, moreInformationAt=https://errors.corda.net/OS/4.0/bcgta6] {actor_id=corda, actor_owning_identity=O=PartyA-f73e241b-2589-4ccb-b7d2-ce179a1904c7, L=London, C=GB, actor_store_id=NODE_CONFIG, invocation_id=155bf49f-3ecb-4593-8675-4d145fea8de3, invocation_timestamp=2019-03-26T01:03:39.963Z, origin=corda, session_id=a256d3a8-0522-40be-ab62-63811c7274f8, session_timestamp=2019-03-26T01:03:38.632Z}
java.io.NotSerializableException: Class "java.lang.Comparable<net.corda.core.contracts.Amount<*>>" is not on the whitelist or annotated with @CordaSerializable.
	at net.corda.serialization.internal.amqp.DeserializationInput.des(DeserializationInput.kt:102) ~[corda-serialization-4.0.jar:?]
	at net.corda.serialization.internal.amqp.DeserializationInput.deserialize(DeserializationInput.kt:119) ~[corda-serialization-4.0.jar:?]`