### PR TITLE
Minor tweaks and improvements in docs TOC to aid navigation and access.

### DIFF
--- a/docs/source/api-persistence.rst
+++ b/docs/source/api-persistence.rst
@@ -12,7 +12,7 @@ API: Persistence
 Corda offers developers the option to expose all or some parts of a contract state to an *Object Relational Mapping*
 (ORM) tool to be persisted in a *Relational Database Management System* (RDBMS).
 
-The purpose of this, is to assist `vault <https://docs.corda.net/vault.html>`_
+The purpose of this, is to assist :doc:`key-concepts-vault`
 development and allow for the persistence of state data to a custom database table. Persisted states held in the
 vault are indexed for the purposes of executing queries. This also allows for relational joins between Corda tables
 and the organization's existing data.

--- a/docs/source/building-a-cordapp-index.rst
+++ b/docs/source/building-a-cordapp-index.rst
@@ -14,10 +14,8 @@ CorDapps
    debugging-a-cordapp
    versioning
    upgrading-cordapps
+   cordapp-constraint-migration
+   cordapp-upgradeability
    secure-coding-guidelines
    flow-overriding
-   corda-api
    flow-cookbook
-   cheat-sheet
-   vault
-   soft-locking

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,9 +98,9 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['./design/README.md']
 if tags.has('pdfmode'):
-    exclude_patterns = ['./design']
+    exclude_patterns = ['./design', './design/README.md']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/design/design-docs-index.rst
+++ b/docs/source/design/design-docs-index.rst
@@ -1,8 +1,9 @@
 Design Docs
 ===========
 
-.. toctree::
+.. conditional-toctree::
    :maxdepth: 1
+   :if_tag: htmlmode
 
    design-review-process.md
    certificate-hierarchies/design.md

--- a/docs/source/design/design-docs-index.rst
+++ b/docs/source/design/design-docs-index.rst
@@ -1,0 +1,24 @@
+Design Docs
+===========
+
+.. toctree::
+   :maxdepth: 1
+
+   design-review-process.md
+   certificate-hierarchies/design.md
+   failure-detection-master-election/design.md
+   float/design.md
+   hadr/design.md
+   kafka-notary/design.md
+   monitoring-management/design.md
+   sgx-integration/design.md
+   reference-states/design.md
+   sgx-infrastructure/design.md
+   threat-model/corda-threat-model.md
+   data-model-upgrades/signature-constraints.md
+   data-model-upgrades/package-namespace-ownership.md
+   targetversion/design.md
+   data-model-upgrades/migrate-to-signature-constraint.md
+   versioning/contract-versioning.md
+   linear-pointer/design.md
+   maximus/design.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,8 @@ We look forward to seeing what you can do with Corda!
    release-notes
    app-upgrade-notes
    node-upgrade-notes
+   corda-api
+   cheat-sheet
 
 .. toctree::
    :caption: Development
@@ -88,24 +90,6 @@ We look forward to seeing what you can do with Corda!
 
    contributing-index.rst
    deterministic-modules.rst
+   design/design-docs-index.rst
    changelog
 
-.. conditional-toctree::
-   :caption: Design docs
-   :maxdepth: 2
-   :if_tag: htmlmode
-
-   design/design-review-process.md
-   design/certificate-hierarchies/design.md
-   design/failure-detection-master-election/design.md
-   design/float/design.md
-   design/hadr/design.md
-   design/kafka-notary/design.md
-   design/monitoring-management/design.md
-   design/sgx-integration/design.md
-   design/reference-states/design.md
-   design/sgx-infrastructure/design.md
-   design/threat-model/corda-threat-model.md
-   design/data-model-upgrades/signature-constraints.md
-   design/data-model-upgrades/package-namespace-ownership.md
-   design/targetversion/design.md

--- a/docs/source/key-concepts-vault.rst
+++ b/docs/source/key-concepts-vault.rst
@@ -1,6 +1,11 @@
 Vault
 =====
 
+.. toctree::
+   :maxdepth: 1
+
+   soft-locking.rst
+
 The vault contains data extracted from the ledger that is considered relevant to the node’s owner, stored in a relational model
 that can be easily queried and worked with.
 

--- a/docs/source/key-concepts.rst
+++ b/docs/source/key-concepts.rst
@@ -19,6 +19,7 @@ This section should be read in order:
    key-concepts-flows
    key-concepts-consensus
    key-concepts-notaries
+   key-concepts-vault
    key-concepts-time-windows
    key-concepts-oracles
    key-concepts-node

--- a/docs/source/node-internals-index.rst
+++ b/docs/source/node-internals-index.rst
@@ -5,5 +5,4 @@ Node internals
    :maxdepth: 1
 
    node-services
-   vault
    messaging


### PR DESCRIPTION
Minor re-structuring to include:
- Corda API link moves to top-level (near top)
- Cheatsheet moves to top-level
- Design documents grouped under sub-header in Contributions
- Vault / Soft-locking moved to key concepts
- added toc entries for missing references as reported by `WARNING: document isn't included in any toctree`