### PR TITLE
CORDA-2782 allow un-whitelisted Comparable

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt
@@ -122,10 +122,9 @@ internal enum class CommonPropertyNames {
     IncludeInternalInfo,
 }
 
-
-
 fun ClassWhitelist.requireWhitelisted(type: Type) {
-    if (!this.isWhitelisted(type.asClass())) {
+    // See CORDA-2782 for explanation of the special exemption made for Comparable
+    if (!this.isWhitelisted(type.asClass()) && type.asClass() != java.lang.Comparable::class.java) {
         throw AMQPNotSerializableException(
                 type,
                 "Class \"$type\" is not on the whitelist or annotated with @CordaSerializable.")


### PR DESCRIPTION
Because vault queries have properties of type `Comparable<T>`, and the default whitelist used in RPC serialisation does not include `Comparable`. we need to make special exception for `Comparable` when checking against the whitelist. (The alternative approach of adding `Comparable` to the default whitelist was tried, but amounted to a wide-ranging change in what gets sent on the wire during RPC serialisation, which caused breakages elsewhere).

This was not an issue in Corda OS v3 because Kryo serialisation was used for RPC.