### PR TITLE
CORDA-2787 docs warnings

### DIFF
--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -234,7 +234,7 @@ The same example in Java:
 
 
 Starting a node missing CorDapp(s)
-*********************************
+**********************************
 
 When running the Corda node ensure all CordDapp JARs are placed in ``cordapps`` directory of each node.
 By default Gradle Cordform task ``deployNodes`` copies all JARs if CorDapps to deploy are specified.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Version 4.0
 * New configuration property ``database.initialiseAppSchema`` with values ``UPDATE``, ``VALIDATE`` and ``NONE``.
   The property controls the behavior of the Hibernate DDL generation. ``UPDATE`` performs an update of CorDapp schemas, while
   ``VALIDATE`` only verifies their integrity.  The property does not affect the node-specific DDL handling and
-   complements ``database.initialiseSchema`` to disable DDL handling altogether.
+  complements ``database.initialiseSchema`` to disable DDL handling altogether.
 
 * ``JacksonSupport.createInMemoryMapper`` was incorrectly marked as deprecated and is no longer so.
 

--- a/docs/source/cli-ux-guidelines.rst
+++ b/docs/source/cli-ux-guidelines.rst
@@ -74,7 +74,7 @@ Parameter stability
 ~~~~~~~~~~~~~~~~~~~
 
 * Avoid removing parameters. If, for some reason, a parameter needs to be renamed, add a new parameter with the new name and deprecate the old parameter, or alternatively
-keep both versions of the parameter. See :ref:`cli-ux-backwards-compatibility` for more information.
+    keep both versions of the parameter. See :ref:`cli-ux-backwards-compatibility` for more information.
 
 
 Notes for adding a new a command line application

--- a/docs/source/corda-network/index.md
+++ b/docs/source/corda-network/index.md
@@ -69,10 +69,10 @@ The Corda Network provides an endpoint serving an empty certificate revocation l
 This is intended for deployments that do not provide a CRL infrastructure but still require strict CRL mode checking.
 In order to use this, add the following to your configuration file:
 
-		.. parsed-literal::
+.. parsed-literal::
 
-        tlsCertCrlDistPoint = "https://crl.cordaconnect.org/cordatls.crl"
-				tlsCertCrlIssuer = "C=US, L=New York, O=R3 HoldCo LLC, OU=Corda, CN=Corda Root CA"
+    tlsCertCrlDistPoint = "https://crl.cordaconnect.org/cordatls.crl"
+            tlsCertCrlIssuer = "C=US, L=New York, O=R3 HoldCo LLC, OU=Corda, CN=Corda Root CA"
 
 This set-up ensures that the TLS-level certificates are embedded with the CRL distribution point referencing the CRL issued by R3.
 In cases where a proprietary CRL infrastructure is provided those values need to be changed accordingly.

--- a/docs/source/cordapp-build-systems.rst
+++ b/docs/source/cordapp-build-systems.rst
@@ -158,7 +158,7 @@ For further information about managing dependencies, see
 
 Signing the CorDapp JAR
 ^^^^^^^^^^^^^^^^^^^^^^^
-The ``cordapp`` plugin can sign the generated CorDapp JAR file using `JAR signing and verification tool <https://docs.oracle.com/javase/tutorial/deployment/jar/signing.html>`_.
+The ``cordapp`` plugin can sign the generated CorDapp JAR file using `JAR signing and verification tool <https://docs.oracle.com/javase/tutorial/deployment/jar/signing.html>`__.
 Signing the CorDapp enables its contract classes to use signature constraints instead of other types of the constraints,
 for constraints explanation refer to :doc:`api-contract-constraints`.
 By default the JAR file is signed by Corda development certificate.
@@ -253,7 +253,7 @@ Then the build process can set the value for *custom.sigalg* system property and
 
     ./gradlew -Dcustom.sigalg="SHA256withECDSA" -Dsigning.keystore="/path/to/keystore.jks" -Dsigning.alias="alias" -Dsigning.storepass="password" -Dsigning.keypass="password"
 
-To check if CorDapp is signed use `JAR signing and verification tool <https://docs.oracle.com/javase/tutorial/deployment/jar/verify.html>`_:
+To check if CorDapp is signed use `JAR signing and verification tool <https://docs.oracle.com/javase/tutorial/deployment/jar/verify.html>`__:
 
 .. sourcecode:: shell
 

--- a/docs/source/cordapp-build-systems.rst
+++ b/docs/source/cordapp-build-systems.rst
@@ -113,7 +113,7 @@ Here is an overview of the various Corda dependencies:
 * ``corda-mock`` - A small library of useful mocks. Use if the classes are useful to you
 * ``corda-node`` - The Corda node. Do not depend on. Used only by the Corda fat JAR and indirectly in testing
   frameworks. (If your CorDapp _must_ depend on this for some reason then it should use the ``compileOnly``
-  configuration here - but please _don't_ do this if you can possibly avoid it!)
+  configuration here - but please don't do this if you can possibly avoid it!)
 * ``corda-node-api`` - The node API. Required to bootstrap a local network
 * ``corda-node-driver`` - Testing utility for programmatically starting nodes from JVM languages. Use for tests
 * ``corda-rpc`` - The Corda RPC client library. Used when writing an RPC client

--- a/docs/source/design/data-model-upgrades/migrate-to-signature-constraint.md
+++ b/docs/source/design/data-model-upgrades/migrate-to-signature-constraint.md
@@ -69,7 +69,7 @@ A normal node would just download the signed jar using the normal process for th
 
 ### Caveats 
 
-###### Someone really wants to issue states with the HashConstraint, and ensure that can never change. 
+#### Someone really wants to issue states with the HashConstraint, and ensure that can never change. 
 
  - As mentioned above the transaction builder could only automatically transition states created pre-v4.  
  
@@ -80,7 +80,7 @@ A normal node would just download the signed jar using the normal process for th
  The option in this case is to force such parties to actually create a new contract (maybe subclass the version they want), own it, and hardcode the check as above.
 
 
-######  Some nodes haven't upgraded all their states by the time a new release is already being used on the network.
+####  Some nodes haven't upgraded all their states by the time a new release is already being used on the network.
 
  - A transaction mixing an original HashConstraint state, and a v2 Signature constraint state will not pass. The only way out is to strongly "encourage" nodes to upgrade before the new release.
   

--- a/docs/source/design/linear-pointer/design.md
+++ b/docs/source/design/linear-pointer/design.md
@@ -73,7 +73,7 @@ class LinearPointer(override val pointer: UniqueIdentifier) : StatePointer {
 }
 ```
 
-#### Bi-directional link
+### Bi-directional link
 
 Symmetrical relationships can be modelled by embedding a `LinearPointer` in the pointed-to `LinearState` which points in the "opposite" direction. **Note:** this can only work if both states are `LinearState`s.
 
@@ -81,7 +81,7 @@ Symmetrical relationships can be modelled by embedding a `LinearPointer` in the 
 
 It is important to note that this design only standardises a pattern which is currently possible with the platform. In other words, this design does not enable anything new.
 
-#### Tokens
+### Tokens
 
 Uncoupling token type definitions from the notion of ownership. Using the `LinearPointer`, `Token` states can include an `Amount` of some pointed-to type. The pointed-to type can evolve independently from the `Token` state which should just be concerned with the question of ownership.
 

--- a/docs/source/design/monitoring-management/design.md
+++ b/docs/source/design/monitoring-management/design.md
@@ -113,7 +113,7 @@ Expanding on the first goal identified above, the following requirements have be
    Audit data should include sufficient contextual information to enable optimal off-line analysis.
    Auditing should apply to all Corda node processes (running CorDapps, notaries, oracles).
 
-#### Use Cases
+### Use Cases
 
 It is envisaged that operational management and support teams will use the metrics and information collated from this
 design, either directly or through an integrated enterprise-wide systems management platform, to perform the following:
@@ -177,7 +177,7 @@ There are a number of activities and parts to the solution proposal:
    queue), and exposes key metrics using JMX (using role-based authentication using Artemis's JAAS plug-in support to 
    ensure Artemis cannot be controlled via JMX)..
 
-##### Restrictions
+### Restrictions
 
 As of Corda M11, Java serialisation in the Corda node has been restricted, meaning MBeans access via the JMX port will no longer work.
 
@@ -200,7 +200,7 @@ include:
 | [Collectd](https://collectd.org/)        | OS          | Collector agent (written in C circa 2005). Data acquisition and storage handled by over 90 plugins. |
 | [Telegraf](https://github.com/influxdata/telegraf) | OS          | Collector agent (written in Go, active community) |
 | [Graphite](https://graphiteapp.org/)     | OS          | Monitoring tool that stores, retrieves, shares, and visualizes time-series data. |
-| [StatsD](https://github.com/etsy/statsd) | OS          | Collector daemon that runs on the [Node.js](http://nodejs.org/) platform and listens for statistics, like counters and timers, sent over [UDP](http://en.wikipedia.org/wiki/User_Datagram_Protocol) or [TCP](http://en.wikipedia.org/wiki/Transmission_Control_Protocol) and sends aggregates to one or more pluggable backend services (e.g., [Graphite](http://graphite.readthedocs.org/)). |
+| [StatsD](https://github.com/etsy/statsd) | OS          | Collector daemon that runs on the [Node.js](http://nodejs.org/) platform and listens for statistics, like counters and timers, sent over [UDP](http://en.wikipedia.org/wiki/User_Datagram_Protocol) or [TCP](http://en.wikipedia.org/wiki/Transmission_Control_Protocol) and sends aggregates to one or more pluggable backend services (e.g., Graphite). |
 | [fluentd](https://www.fluentd.org/)      | OS          | Collector daemon which collects data directly from logs and databases. Often used to analyze event logs, application logs, and clickstreams (a series of mouse clicks). |
 | [Prometheus](https://prometheus.io/)     | OS          | End to end monitoring solution using time-series data (eg. metric name and a set of key-value pairs) and includes collection, storage, query and visualization. |
 | [NewRelic](https://newrelic.com/)        | £           | Full stack instrumentation for application monitoring and real-time analytics solution. |
@@ -446,7 +446,6 @@ Primary node services exposed publicly via ServiceHub (SH) or internally by Serv
 | CordaPersistence                         | SHI  | CordaPersistence                   | INFO coverage within `HibernateConfiguration` |
 | CordappProviderInternal                  | SHI  | CordappProviderImpl                | none                                     |
 | VaultServiceInternal                     | SHI  | NodeVaultService                   | see SH                                   |
-|                                          |      |                                    |                                          |
 
 Corda subsystem components:
 
@@ -458,7 +457,6 @@ Corda subsystem components:
 | NotaryService              | RaftNonValidatingNotaryService           | as above                                 |
 | NotaryService              | BFTNonValidatingNotaryService            | Logging coverage (info, debug)           |
 | Doorman                    | DoormanServer (Enterprise only)          | Some logging (info, warn, error), and use of `println` |
-|                            |                                          |                                          |
 
 Corda core flows:
 
@@ -467,19 +465,18 @@ Corda core flows:
 | FinalityFlow                            | none                | NotaryException                          | NOTARISING, BROADCASTING      |
 | NotaryFlow                              | none                | NotaryException (NotaryError types: TimeWindowInvalid, TransactionInvalid, WrongNotary), IllegalStateException, some via `check` assertions | REQUESTING, VALIDATING        |
 | NotaryChangeFlow                        | none                | StateReplacementException                | SIGNING, NOTARY               |
-| SendTransactionFlow                     | none                | FetchDataFlow.HashNotFound (FlowException) |                               |
-| ReceiveTransactionFlow                  | none                | SignatureException, AttachmentResolutionException, TransactionResolutionException, TransactionVerificationException |                               |
-| ResolveTransactionsFlow                 | none                | FetchDataFlow.HashNotFound (FlowException), ExcessivelyLargeTransactionGraph (FlowException) |                               |
-| FetchAttachmentsFlow                    | none                | FetchDataFlow.HashNotFound               |                               |
-| FetchTransactionsFlow                   | none                | FetchDataFlow.HashNotFound               |                               |
-| FetchDataFlow                           | some logging (info) | FetchDataFlow.HashNotFound               |                               |
+| SendTransactionFlow                     | none                | FetchDataFlow.HashNotFound (FlowException) | none                        |
+| ReceiveTransactionFlow                  | none                | SignatureException, AttachmentResolutionException, TransactionResolutionException, TransactionVerificationException | none                              |
+| ResolveTransactionsFlow                 | none                | FetchDataFlow.HashNotFound (FlowException), ExcessivelyLargeTransactionGraph (FlowException) |  none                             |
+| FetchAttachmentsFlow                    | none                | FetchDataFlow.HashNotFound               | none                          |
+| FetchTransactionsFlow                   | none                | FetchDataFlow.HashNotFound               | none                          |
+| FetchDataFlow                           | some logging (info) | FetchDataFlow.HashNotFound               | none                          |
 | AbstractStateReplacementFlow.Instigator | none                | StateReplacementException                | SIGNING, NOTARY               |
 | AbstractStateReplacementFlow.Acceptor   | none                | StateReplacementException                | VERIFYING, APPROVING          |
 | CollectSignaturesFlow                   | none                | IllegalArgumentException via `require` assertions | COLLECTING, VERIFYING         |
-| CollectSignatureFlow                    | none                | as above                                 |                               |
+| CollectSignatureFlow                    | none                | as above                                 | none                          |
 | SignTransactionFlow                     | none                | FlowException, possibly other (general) Exception | RECEIVING, VERIFYING, SIGNING |
-| ContractUpgradeFlow                     | none                | FlowException                            |                               |
-|                                         |                     |                                          |                               |
+| ContractUpgradeFlow                     | none                | FlowException                            | none                          |
 
 Corda finance flows:
 

--- a/docs/source/design/sgx-infrastructure/details/attestation.md
+++ b/docs/source/design/sgx-infrastructure/details/attestation.md
@@ -1,9 +1,9 @@
 ### Terminology recap
 
-**measurement**: The hash of an enclave image, uniquely pinning the code and related configuration
-**report**: A datastructure produced by an enclave including the measurement and other non-static properties of the
+* **measurement**: The hash of an enclave image, uniquely pinning the code and related configuration
+* **report**: A datastructure produced by an enclave including the measurement and other non-static properties of the
   running enclave instance (like the security version number of the hardware)
-**quote**: A signed report of an enclave produced by Intel's quoting enclave.
+* **quote**: A signed report of an enclave produced by Intel's quoting enclave.
 
 # Attestation
 

--- a/docs/source/design/versioning/contract-versioning.md
+++ b/docs/source/design/versioning/contract-versioning.md
@@ -144,9 +144,9 @@ The Cordapp gradle plugin should be amended to differentiate between a "flows" m
 
 In the build.gradle file of the contracts module, there should be a `version` property that needs be incremented for each release.
 
-This `version' will be used for the regular release, and be part of the jar name.
+This `version` will be used for the regular release, and be part of the jar name.
 
-Also, when packaging the contract for release, the `version` should be added by the plugin to the manifest file, together with other properties like `target-platform-version.
+Also, when packaging the contract for release, the `version` should be added by the plugin to the manifest file, together with other properties like `target-platform-version`.
 
 When loading the contractJar in the attachment storage, the version should be saved as a column, so it is easily accessible.
  

--- a/docs/source/design/versioning/contract-versioning.md
+++ b/docs/source/design/versioning/contract-versioning.md
@@ -39,7 +39,7 @@ Corda is designed such that the flow that builds the transaction (on its executi
 But because input states are actually output states that are serialised with the previous transaction (built using a potentially different version of the contract), this means that states serialised with a version of the ContractJAR will need to be deserialisable with a different version. 
 
 
-.. image:: resources/tx-chain.png
+.. image:: ../../resources/tx-chain.png
    :scale: 25%
    :align: center
 
@@ -77,7 +77,7 @@ This design is not about:
 
 ### Assumptions and trade-offs made for the current version
 
-##### We assume that ContractStates will never change their semantics in a way that would impact other Contracts or Flows that depend on them.
+#### We assume that ContractStates will never change their semantics in a way that would impact other Contracts or Flows that depend on them.
  
 E.g.: If various contracts depend on Cash, the assumption is that no new field will be added to Cash that would have an influence over the amount or the owner (the fundamental fields of Cash).
 It is always safe to mix new CashStates with older states that depend on it. 
@@ -89,7 +89,7 @@ This is not a very strong definition, so we will have to create more formalised 
 If any contract breaks this assumption, in Corda 4 there will be no platform support the transition to the new version. The burden of coordinating with all the other cordapp developers and nodes is on the original developer.
 
 
-##### Flow to Flow communication could be lossy for objects that are not ContractStates or Commands.
+#### Flow to Flow communication could be lossy for objects that are not ContractStates or Commands.
 
 Explanation: 
 Flows communicate by passing around various objects, and eventually the entire TransactionBuilder.
@@ -99,7 +99,7 @@ The decision was that the node that sends data would decide (if his version is h
 The objects that live on the ledger like ContractStates and Commands that the other party actually has to sign, will not be allowed to lose any data.
  
 
-##### We assume that cordapp developers will correctly understand all implications and handle backwards compatibility themselves.
+#### We assume that cordapp developers will correctly understand all implications and handle backwards compatibility themselves.
 Basically they will have to realise that any version of a flow can talk to any other version, and code accordingly. 
 
 This get particularly tricky when there are reusable inline subflows involved.
@@ -285,7 +285,7 @@ Terminology:
 - Tx1, Tx2 - are transactions between parties.
 
 
-#### Scenario 1 - Spending a state with an older contract. 
+### Scenario 1 - Spending a state with an older contract. 
 - V1: com.megacorp.token.MegaToken(amount: Amount, owner: Party)
 - V2: com.megacorp.token.MegaToken(amount: Amount, owner: Party, accumulatedDebt: Amount? = 0)
 
@@ -299,7 +299,7 @@ Terminology:
 Solution: This was analysed above. It will be solved by the non-downgrade rule and the serialization engine changes.
 
 
-#### Scenario 2: - Running an explicit upgrade  written against an older contract version.
+### Scenario 2: - Running an explicit upgrade  written against an older contract version.
 - V1: com.megacorp.token.MegaToken(amount: Amount, owner: Party)
 - V2: com.megacorp.token.MegaToken(amount: Amount, owner: Party, accumulatedDebt: Amount? = 0)
 - Another company creates a better com.gigacorp.token.GigaToken that is an UpgradedContract designed to replace the MegaToken via an explicit upgrade, but develop against V1 ( as V2 was not released at the time of development).
@@ -313,7 +313,7 @@ Same as before:
 Solution: This attack breaks the assumption we made that contracts will not be adding fields that change it fundamentally.
 
 
-#### Scenario 3 - Flows installed by 2 peers compiled against different contract versions.
+### Scenario 3 - Flows installed by 2 peers compiled against different contract versions.
 - Alice runs V1 of the MegaToken FlowsJAR, while Bob runs V2.
 - Bob builds a new transaction where he transfers a state with accumulatedDebt To Alice.
 - Alice is not able to correctly evaluate the business proposition, as she does not know that there even exists an accumulatedDebt field, but still signs it as if it was debt free.
@@ -321,7 +321,7 @@ Solution: This attack breaks the assumption we made that contracts will not be a
 Solution: Solved by the assumption that peer-to-peer communication can be lossy, and the peer with the higher version is responsible to send the right data
 
 
-#### Scenario 4 - Developer attempts to rename a field from one version to the next. 
+### Scenario 4 - Developer attempts to rename a field from one version to the next. 
 - V1: com.megacorp.token.MegaToken(amount: Amount, owner: Party, accumulatedDebt: Amount )
 - V2: com.megacorp.token.MegaToken(amount: Amount, owner: Party, currentDebt: Amount)
 
@@ -331,7 +331,7 @@ This would break as soon as you try to spend a V1 state with V2, because there i
 Solution: Not possible for now, as it breaks the serialisation evolution rules. Could be added as a new feature in the future.
 
 
-#### Scenario 5 - Contract verification logic becomes more strict in a new version. General concerns.
+### Scenario 5 - Contract verification logic becomes more strict in a new version. General concerns.
 - V1: check that amount > 10
 - V2: check that amount > 12 
 
@@ -349,7 +349,7 @@ The question is how important it is, that amount is >12?
 
 Solution: This is not addressed in the current design doc. It needs to be explored in more depth.
 
-#### Scenario 6 - Contract verification logic becomes more strict in a new version. ???
+### Scenario 6 - Contract verification logic becomes more strict in a new version. ???
 - V1: check that amount > 10
 - V2: check that amount > 12
 
@@ -362,7 +362,7 @@ Solution: This is not addressed in the current design doc. It needs to be explor
 Solution: Same as Scenario 5.
 
 
-#### Scenario 7 - Contract verification logic becomes less strict.
+### Scenario 7 - Contract verification logic becomes less strict.
 - V1: check that amount > 12
 - V2: check that amount > 10 
 
@@ -373,7 +373,7 @@ Because there was no change in the actual structure of the state it means the fl
 Solution: This should not require any change.
 
 
-#### Scenario 8 - Contract depends on another Contract.
+### Scenario 8 - Contract depends on another Contract.
 - V1: com.megacorp.token.MegaToken(amount: Amount, owner: Party)
 - V2: com.megacorp.token.MegaToken(amount: Amount, owner: Party, accumulatedDebt: Amount? = 0)
 
@@ -387,7 +387,7 @@ Alice swaps MegaToken-v2 for SuperToken-v1 with Bob in a transaction. If Alice s
 Solution: Solved by the assumption we made that contracts don't change fundamentally.
 
 
-#### Scenario 9 - A new command is added or removed 
+### Scenario 9 - A new command is added or removed 
 - V1 of com.megacorp.token.MegaToken has 3 Commands: Issue, Move, Exit
 - V2 of com.megacorp.token.MegaToken has 4 Commands: Issue, Move, Exit, AddDebt
 - V3 of com.megacorp.token.MegaToken has 3 Commands: Issue, Move, Exit

--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -24,7 +24,7 @@ You can find out more about network maps and network parameters from :doc:`netwo
 Bootstrapping a test network
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Corda Network Bootstrapper can be downloaded from `here <https://www.corda.net/resources>`_.
+The Corda Network Bootstrapper can be downloaded from `here <https://www.corda.net/resources>`__.
 
 Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. "devMode" must be set to true. Then run the
 following command:
@@ -282,7 +282,7 @@ ignored. If a field is not provided and you are bootstrapping a new network, a s
 are updating an existing network, the value in the existing network parameters file will be used.
 
 .. note:: All fields can be used with placeholders for environment variables. For example: ``${KEY_STORE_PASSWORD}`` would be replaced by the contents of environment
-variable ``KEY_STORE_PASSWORD``. See: :ref:`corda-configuration-hiding-sensitive-data` .
+    variable ``KEY_STORE_PASSWORD``. See: :ref:`corda-configuration-hiding-sensitive-data` .
 
 The available configuration fields are listed below:
 
@@ -293,7 +293,7 @@ The available configuration fields are listed below:
 :maxTransactionSize: The maximum permitted transaction size, in bytes.
 
 :eventHorizon: The time after which nodes will be removed from the network map if they have not been seen during this period. This parameter uses
-    the ``parse`` function on the ``java.time.Duration`` class to interpret the data. See `here <https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence->`_
+    the ``parse`` function on the ``java.time.Duration`` class to interpret the data. See `here <https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence->`__
     for information on valid inputs.
 
 :packageOwnership: A list of package owners. See `Package namespace ownership`_ for more information. For each package owner, the following fields
@@ -355,7 +355,7 @@ For each package to be registered, the following are required:
 :keystoreAlias: The alias for the name associated with the certificate to be associated with the package namespace.
 
 Using the `Example CorDapp <https://github.com/corda/cordapp-example>`_ as an example, we will initialise a simple network and then register and unregister a package namespace.
-Checkout the Example CorDapp and follow the instructions to build it `here <https://docs.corda.net/tutorial-cordapp.html#building-the-example-cordapp>`_.
+Checkout the Example CorDapp and follow the instructions to build it `here <https://docs.corda.net/tutorial-cordapp.html#building-the-example-cordapp>`__.
 
 .. note:: You can point to any existing bootstrapped corda network (this will have the effect of updating the associated network parameters file).
 

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -87,7 +87,7 @@ formats for accessing MBeans, and provides client libraries to work with that pr
 
 Here are a few ways to build dashboards and extract monitoring data for a node:
 
-* `hawtio <http://hawt.io>`_ is a web based console that connects directly to JVM's that have been instrumented with a
+* `Hawtio <http://hawt.io>`_ is a web based console that connects directly to JVM's that have been instrumented with a
   jolokia agent. This tool provides a nice JMX dashboard very similar to the traditional JVisualVM / JConsole MBbeans original.
 * `JMX2Graphite <https://github.com/logzio/jmx2graphite>`_ is a tool that can be pointed to /monitoring/json and will
   scrape the statistics found there, then insert them into the Graphite monitoring tool on a regular basis. It runs
@@ -135,7 +135,7 @@ When starting Corda nodes using the 'driver DSL', you should see a startup messa
 **Starting out-of-process Node USA Bank Corp, debug port is not enabled, jolokia monitoring port is 7005 {}**
 
 
-The following diagram illustrates Corda flow metrics visualized using `hawtio <https://hawt.io>`_ :
+The following diagram illustrates Corda flow metrics visualized using hawtio:
 
 .. image:: resources/hawtio-jmx.png
 
@@ -178,9 +178,8 @@ Take a simple node config that wishes to protect the node cryptographic stores:
 By delegating to a password store, and using `command substitution` it is possible to ensure that sensitive passwords never appear in plain text.
 The below examples are of loading Corda with the KEY_PASS and TRUST_PASS variables read from a program named ``corporatePasswordStore``.
 
-
 Bash
-~~~~
+++++
 
 .. sourcecode:: shell
 
@@ -188,9 +187,8 @@ Bash
 
 .. warning:: If this approach is taken, the passwords will appear in the shell history.
 
-
 Windows PowerShell
-~~~~~~~~~~~~~~~~~~
+++++++++++++++++++
 
 .. sourcecode:: shell
 

--- a/docs/source/node-commandline.rst
+++ b/docs/source/node-commandline.rst
@@ -1,5 +1,5 @@
 Node command-line options
-====================
+=========================
 
 The node can optionally be started with the following command-line options:
 


### PR DESCRIPTION
This gets rid of a lot of the html docs warnings.  Left to do (in another issue):

 * fix latex warnings
 * fix the ``WARNING: Could not lex literal_block as "kotlin". Highlighting skipped.`` type issues (requires a fix to the payments Kotlin lexer)
 * fix the dedent issues
 * fix the docs build docs which I suspect are somewhat out of date


# PR Checklist:

- [docs] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [n/a ] If you added public APIs, did you write the JavaDocs?
- [n/a ] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [n/a ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
