### PR TITLE
[CORDA-2784] Remove targetPlatformVersion check from FinalityFlow

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -114,10 +114,6 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     @Throws(NotaryException::class)
     override fun call(): SignedTransaction {
         if (!newApi) {
-            require(CordappResolver.currentTargetVersion < 4) {
-                "A flow session for each external participant to the transaction must be provided. If you wish to continue " +
-                        "using this insecure API then specify a target platform version of less than 4 for your CorDapp."
-            }
             logger.warnOnce("The current usage of FinalityFlow is unsafe. Please consider upgrading your CorDapp to use " +
                     "FinalityFlow with FlowSessions. (${CordappResolver.currentCordapp?.info})")
         } else {

--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -58,19 +58,6 @@ class FinalityFlowTests : WithFinality {
     }
 
     @Test
-    fun `prevent use of the old API if the CorDapp target version is 4`() {
-        val bob = createBob()
-        val stx = aliceNode.issuesCashTo(bob)
-        val resultFuture = CordappResolver.withCordapp(targetPlatformVersion = 4) {
-            @Suppress("DEPRECATION")
-            aliceNode.startFlowAndRunNetwork(FinalityFlow(stx)).resultFuture
-        }
-        assertThatIllegalArgumentException().isThrownBy {
-            resultFuture.getOrThrow()
-        }.withMessageContaining("A flow session for each external participant to the transaction must be provided.")
-    }
-
-    @Test
     fun `allow use of the old API if the CorDapp target version is 3`() {
         val oldBob = createBob(cordapps = listOf(tokenOldCordapp()))
         val stx = aliceNode.issuesCashTo(oldBob)

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -44,11 +44,13 @@ advertise a minimum platform version of 4 and a target version of 5. These numbe
 
 If this app is loaded into a Corda 6 node, that node may implement backwards compatibility workarounds for your app that make it slower,
 less secure, or less featureful. You can opt-in to getting the full benefits of the upgrade by changing your target version to 6. By doing
-this, you promise that you understood all the changes in Corda 6 and have thoroughly tested your app to prove it works.
+this, you promise that you understood all the changes in Corda 6 and have thoroughly tested your app to prove it works. This testing should
+include ensuring that the app exhibits the correct behaviour on a node running at the new target version, and that the app functions
+correctly in a network of nodes running at the same target version.
 
 Target versioning is one of the mechanisms we have to keep the platform evolving and improving, without being permanently constrained to
 being bug-for-bug compatible with old versions. When no apps are loaded that target old versions, any emulations of older bugs or problems
-can be disabled (in Corda 4, an example of this is the old FinalityFlow handler that would accept any transactions into the vault, context free).
+can be disabled.
 
 Publishing versions in your JAR manifests
 -----------------------------------------


### PR DESCRIPTION
In Corda 4, `FinalityFlow` was updated to become an initiated flow, in order to ensure a node does not have to accept any signed transaction it receives without being able to check it first. The old behaviour of `FinalityFlow` was gated behind a `targetPlatformVersion` check, to prevent apps targeting V4 from using the old behaviour.

This is problematic for a few reasons. For an app wishing to be backwards compatible with a version running on V3, this forces the app to set `targetPlatformVersion = 3`, even if the app is thoroughly tested against V4. This goes against the purpose of the `targetPlatformVersion`. Another consequence is that an app remains pinned to `targetPlatformVersion = 3` until it is sure that there are no other apps running at a lower version in the network, which would prevent newer versions of the app from taking advantage of features gated behind `targetPlatformVersion` checks. (Note that the restriction only prevents a new version of the app from initiating `FinalityFlow` with the old version - the old version is able to initiate a `FinalityFlow` and the new version will handle it, assuming the app has been written correctly.)

This fix removes the `targetPlatformVersion` check from `FinalityFlow`, and also provides a few documentation updates to clarify what level of testing would be expected to set a `targetPlatformVersion`.

Testing:
 - Ran a backwards compatible flow using `FinalityFlow` with the upgraded app using `targetPlatformVersion = 4`, and verified that it was able to communicate with a version of the app using an old version of `FinalityFlow`.
