### PR TITLE
CORDA-2809 - reduce latex/pdf erros

### DIFF
--- a/docs/make-docsite.sh
+++ b/docs/make-docsite.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "Generating PDF document ..."
-make latexpdf
+make latexpdf LATEXMKOPTS="-quiet"
 
 echo "Generating HTML pages ..."
 make html


### PR DESCRIPTION
Candidly this is a bit of a nightmare.

The error file is currently over 7000 lines and no-one is looking at it.

Lots of the errors are things like "the reference doesn't exist" but we actually expect this in the first couple of passes through by the converter.

Given that we are actively missing real errors (like tables disappearing) in the html pages, in the noise of the latex build, I propose we:

 * basically hide the latex/pdf errors
 * fix the rest of the html errors
 * fail the build if the html docs error

In this way we will notice errors and those that we see we know we need to fix.

This PR represents turning off the latex warnings.

# PR Checklist:

- [docs ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ n/a] If you added public APIs, did you write the JavaDocs?
- [ n/a] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [ n/a] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)