### PR TITLE
CORDA-4954 : Improvements to docker image : compatible with v3.3; image size; truststore

### DIFF
--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -49,11 +49,11 @@ function generateGenericCZConfig(){
         java -jar config-exporter.jar "GENERIC-CZ" "/opt/corda/starting-node.conf" "${CONFIG_FOLDER}/node.conf"
 
         java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar \
-                initial-registration \
-                --base-directory=/opt/corda \
-                --config-file=/etc/corda/node.conf \
-                --network-root-truststore-password=${NETWORK_TRUST_PASSWORD} \
-                --network-root-truststore=${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} &&\
+                --initial-registration \
+                --base-directory /opt/corda \
+                --config-file ${CONFIG_FOLDER}/node.conf \
+                --network-root-truststore-password ${NETWORK_TRUST_PASSWORD} \
+                --network-root-truststore ${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} &&\
         echo "Succesfully registered with ${DOORMAN_URL}, starting corda" && \
         run-corda
     fi

--- a/docker/src/bash/run-corda.sh
+++ b/docker/src/bash/run-corda.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-: ${JVM_ARGS='-XX:+UseG1GC'}
-
-JVM_ARGS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap "${JVM_ARGS}
 
 if [[ ${JVM_ARGS} == *"Xmx"* ]]; then
   echo "WARNING: the use of the -Xmx flag is not recommended within docker containers. Use the --memory option passed to the container to limit heap size"
 fi
 
-java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar --base-directory=/opt/corda --config-file=/etc/corda/node.conf ${CORDA_ARGS}
+java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar --base-directory /opt/corda --config-file ${CONFIG_FOLDER}/node.conf ${CORDA_ARGS}

--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,8 +1,6 @@
 FROM azul/zulu-openjdk:8u192
 
-# Add packages and clean cache
-# Create dirs
-# Create corda user
+## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install bash curl unzip && \
@@ -16,7 +14,9 @@ RUN apt-get update && \
     mkdir -p /opt/corda/additional-node-infos && \
     mkdir -p /etc/corda && \
     addgroup corda && \
-    useradd corda -g corda -m -d /opt/corda
+    useradd corda -g corda -m -d /opt/corda && \
+    chown -R corda:corda /opt/corda && \
+    chown -R corda:corda /etc/corda
 
 ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
     PERSISTENCE_FOLDER="/opt/corda/persistence" \
@@ -31,39 +31,32 @@ ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
     CORDA_ARGS=""
 
 ##CORDAPPS FOLDER
+VOLUME ["/opt/corda/cordapps"]
 ##PERSISTENCE FOLDER
+VOLUME ["/opt/corda/persistence"]
 ##CERTS FOLDER
+VOLUME ["/opt/corda/certificates"]
 ##OPTIONAL JDBC DRIVERS FOLDER
+VOLUME ["/opt/corda/drivers"]
 ##LOG FOLDER
+VOLUME ["/opt/corda/logs"]
 ##ADDITIONAL NODE INFOS FOLDER
+VOLUME ["/opt/corda/additional-node-infos"]
 ##CONFIG LOCATION
-VOLUME ["/opt/corda/cordapps"] \
-       ["/opt/corda/persistence"] \
-       ["/opt/corda/certificates"] \
-       ["/opt/corda/drivers"] \
-       ["/opt/corda/logs"] \
-       ["/opt/corda/additional-node-infos"] \
-       ["/etc/corda"]
+VOLUME ["/etc/corda"]
 
 ##CORDA JAR
-##CONFIG MANIPULATOR JAR
-##CONFIG GENERATOR SHELL SCRIPT
-##CORDA RUN SCRIPT
-##BASE CONFIG FOR GENERATOR
 COPY --chown=corda:corda corda.jar /opt/corda/bin/corda.jar
+##CONFIG MANIPULATOR JAR
 COPY --chown=corda:corda config-exporter.jar /opt/corda/config-exporter.jar
+##CONFIG GENERATOR SHELL SCRIPT
 COPY --chown=corda:corda generate-config.sh /opt/corda/bin/config-generator
+##CORDA RUN SCRIPT
 COPY --chown=corda:corda run-corda.sh /opt/corda/bin/run-corda
+##BASE CONFIG FOR GENERATOR
 COPY --chown=corda:corda starting-node.conf /opt/corda/starting-node.conf
 
-##CHANGE OWNER TO CORDA
-##SET EXECUTABLE PERMISSIONS
-RUN chown -R corda:corda /opt/corda && \
-    chown -R corda:corda /etc/corda && \
-    chmod +x /opt/corda/bin/config-generator  && \
-    chmod +x /opt/corda/bin/run-corda
-
-WORKDIR /opt/corda
-
 USER "corda"
+EXPOSE ${MY_P2P_PORT} ${MY_RPC_PORT} ${MY_RPC_ADMIN_PORT}
+WORKDIR /opt/corda
 CMD ["run-corda"]

--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,70 +1,69 @@
 FROM azul/zulu-openjdk:8u192
 
-RUN apt-get update && apt-get -y upgrade && apt-get -y install bash curl unzip
-
+# Add packages and clean cache
 # Create dirs
-RUN mkdir -p /opt/corda/cordapps
-RUN mkdir -p /opt/corda/persistence
-RUN mkdir -p /opt/corda/certificates
-RUN mkdir -p /opt/corda/drivers
-RUN mkdir -p /opt/corda/logs
-RUN mkdir -p /opt/corda/bin
-RUN mkdir -p /opt/corda/additional-node-infos
-RUN mkdir -p /etc/corda
-
 # Create corda user
-RUN addgroup corda && \
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install bash curl unzip && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /opt/corda/cordapps && \
+    mkdir -p /opt/corda/persistence && \
+    mkdir -p /opt/corda/certificates && \
+    mkdir -p /opt/corda/drivers && \
+    mkdir -p /opt/corda/logs && \
+    mkdir -p /opt/corda/bin && \
+    mkdir -p /opt/corda/additional-node-infos && \
+    mkdir -p /etc/corda && \
+    addgroup corda && \
     useradd corda -g corda -m -d /opt/corda
 
-WORKDIR /opt/corda
-
-ENV CORDAPPS_FOLDER="/opt/corda/cordapps"
-ENV PERSISTENCE_FOLDER="/opt/corda/persistence"
-ENV CERTIFICATES_FOLDER="/opt/corda/certificates"
-ENV DRIVERS_FOLDER="/opt/corda/drivers"
-ENV CONFIG_FOLDER="/etc/corda"
-
-ENV MY_P2P_PORT=10200
-ENV MY_RPC_PORT=10201
-ENV MY_RPC_ADMIN_PORT=10202
-
-RUN chown -R corda:corda /opt/corda
-RUN chown -R corda:corda /etc/corda
+ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
+    PERSISTENCE_FOLDER="/opt/corda/persistence" \
+    CERTIFICATES_FOLDER="/opt/corda/certificates" \
+    DRIVERS_FOLDER="/opt/corda/drivers" \
+    CONFIG_FOLDER="/etc/corda" \
+    MY_P2P_PORT=10200 \
+    MY_RPC_PORT=10201 \
+    MY_RPC_ADMIN_PORT=10202 \
+    PATH=$PATH:/opt/corda/bin \
+    JVM_ARGS="-XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " \
+    CORDA_ARGS=""
 
 ##CORDAPPS FOLDER
-VOLUME ["/opt/corda/cordapps"]
 ##PERSISTENCE FOLDER
-VOLUME ["/opt/corda/persistence"]
 ##CERTS FOLDER
-VOLUME ["/opt/corda/certificates"]
 ##OPTIONAL JDBC DRIVERS FOLDER
-VOLUME ["/opt/corda/drivers"]
 ##LOG FOLDER
-VOLUME ["/opt/corda/logs"]
 ##ADDITIONAL NODE INFOS FOLDER
-VOLUME ["/opt/corda/additional-node-infos"]
 ##CONFIG LOCATION
-VOLUME ["/etc/corda"]
-
+VOLUME ["/opt/corda/cordapps"] \
+       ["/opt/corda/persistence"] \
+       ["/opt/corda/certificates"] \
+       ["/opt/corda/drivers"] \
+       ["/opt/corda/logs"] \
+       ["/opt/corda/additional-node-infos"] \
+       ["/etc/corda"]
 
 ##CORDA JAR
-ADD --chown=corda:corda corda.jar /opt/corda/bin/corda.jar
 ##CONFIG MANIPULATOR JAR
-ADD --chown=corda:corda config-exporter.jar /opt/corda/config-exporter.jar
 ##CONFIG GENERATOR SHELL SCRIPT
-ADD --chown=corda:corda generate-config.sh /opt/corda/bin/config-generator
 ##CORDA RUN SCRIPT
-ADD --chown=corda:corda run-corda.sh /opt/corda/bin/run-corda
 ##BASE CONFIG FOR GENERATOR
-ADD --chown=corda:corda starting-node.conf /opt/corda/starting-node.conf
+COPY --chown=corda:corda corda.jar /opt/corda/bin/corda.jar
+COPY --chown=corda:corda config-exporter.jar /opt/corda/config-exporter.jar
+COPY --chown=corda:corda generate-config.sh /opt/corda/bin/config-generator
+COPY --chown=corda:corda run-corda.sh /opt/corda/bin/run-corda
+COPY --chown=corda:corda starting-node.conf /opt/corda/starting-node.conf
+
+##CHANGE OWNER TO CORDA
 ##SET EXECUTABLE PERMISSIONS
-RUN chmod +x /opt/corda/bin/config-generator
-RUN chmod +x /opt/corda/bin/run-corda
+RUN chown -R corda:corda /opt/corda && \
+    chown -R corda:corda /etc/corda && \
+    chmod +x /opt/corda/bin/config-generator  && \
+    chmod +x /opt/corda/bin/run-corda
 
-ENV PATH=$PATH:/opt/corda/bin
-
-EXPOSE $MY_P2P_PORT
-EXPOSE $MY_RPC_PORT
+WORKDIR /opt/corda
 
 USER "corda"
 CMD ["run-corda"]

--- a/docker/src/docker/DockerfileAL
+++ b/docker/src/docker/DockerfileAL
@@ -1,16 +1,13 @@
 FROM amazonlinux:2
 
-WORKDIR /opt/corda
-
-# Add packages and clean cache
-# Create dirs
-# Create corda user
+## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN amazon-linux-extras enable corretto8 && \
     yum -y install java-1.8.0-amazon-corretto-devel  && \
     yum -y install bash && \
     yum -y install curl && \
     yum -y install unzip && \
     yum clean all && \
+    rm -rf /var/cache/yum && \
     mkdir -p /opt/corda/cordapps && \
     mkdir -p /opt/corda/persistence && \
     mkdir -p /opt/corda/certificates && \
@@ -20,7 +17,9 @@ RUN amazon-linux-extras enable corretto8 && \
     mkdir -p /opt/corda/additional-node-infos && \
     mkdir -p /etc/corda && \
     groupadd corda && \
-    useradd corda -g corda -m -d /opt/corda
+    useradd corda -g corda -m -d /opt/corda && \
+    chown -R corda:corda /opt/corda && \
+    chown -R corda:corda /etc/corda
 
 ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
     PERSISTENCE_FOLDER="/opt/corda/persistence" \
@@ -35,37 +34,32 @@ ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
     CORDA_ARGS=""
 
 ##CORDAPPS FOLDER
+VOLUME ["/opt/corda/cordapps"]
 ##PERSISTENCE FOLDER
+VOLUME ["/opt/corda/persistence"]
 ##CERTS FOLDER
+VOLUME ["/opt/corda/certificates"]
 ##OPTIONAL JDBC DRIVERS FOLDER
+VOLUME ["/opt/corda/drivers"]
 ##LOG FOLDER
+VOLUME ["/opt/corda/logs"]
 ##ADDITIONAL NODE INFOS FOLDER
+VOLUME ["/opt/corda/additional-node-infos"]
 ##CONFIG LOCATION
-VOLUME ["/opt/corda/cordapps"] \
-       ["/opt/corda/persistence"] \
-       ["/opt/corda/certificates"] \
-       ["/opt/corda/drivers"] \
-       ["/opt/corda/logs"] \
-       ["/opt/corda/additional-node-infos"] \
-       ["/etc/corda"]
+VOLUME ["/etc/corda"]
 
 ##CORDA JAR
-##CONFIG MANIPULATOR JAR
-##CONFIG GENERATOR SHELL SCRIPT
-##CORDA RUN SCRIPT
-##BASE CONFIG FOR GENERATOR
 COPY --chown=corda:corda corda.jar /opt/corda/bin/corda.jar
+##CONFIG MANIPULATOR JAR
 COPY --chown=corda:corda config-exporter.jar /opt/corda/config-exporter.jar
+##CONFIG GENERATOR SHELL SCRIPT
 COPY --chown=corda:corda generate-config.sh /opt/corda/bin/config-generator
+##CORDA RUN SCRIPT
 COPY --chown=corda:corda run-corda.sh /opt/corda/bin/run-corda
+##BASE CONFIG FOR GENERATOR
 COPY --chown=corda:corda starting-node.conf /opt/corda/starting-node.conf
 
-##CHANGE OWNER TO CORDA
-##SET EXECUTABLE PERMISSIONS
-RUN chown -R corda:corda /opt/corda && \
-    chown -R corda:corda /etc/corda && \
-    chmod +x /opt/corda/bin/config-generator  && \
-    chmod +x /opt/corda/bin/run-corda
-
 USER "corda"
+EXPOSE ${MY_P2P_PORT} ${MY_RPC_PORT} ${MY_RPC_ADMIN_PORT}
+WORKDIR /opt/corda
 CMD ["run-corda"]

--- a/docker/src/docker/DockerfileAL
+++ b/docker/src/docker/DockerfileAL
@@ -1,74 +1,71 @@
 FROM amazonlinux:2
 
-RUN amazon-linux-extras enable corretto8
-RUN yum -y install java-1.8.0-amazon-corretto-devel
-RUN yum -y install bash
-RUN yum -y install curl
-RUN yum -y install unzip
-
-# Create dirs
-RUN mkdir -p /opt/corda/cordapps
-RUN mkdir -p /opt/corda/persistence
-RUN mkdir -p /opt/corda/certificates
-RUN mkdir -p /opt/corda/drivers
-RUN mkdir -p /opt/corda/logs
-RUN mkdir -p /opt/corda/bin
-RUN mkdir -p /opt/corda/additional-node-infos
-RUN mkdir -p /etc/corda
-
-# Create corda user
-RUN groupadd corda && \
-    useradd corda -g corda -m -d /opt/corda
-
 WORKDIR /opt/corda
 
-ENV CORDAPPS_FOLDER="/opt/corda/cordapps"
-ENV PERSISTENCE_FOLDER="/opt/corda/persistence"
-ENV CERTIFICATES_FOLDER="/opt/corda/certificates"
-ENV DRIVERS_FOLDER="/opt/corda/drivers"
-ENV CONFIG_FOLDER="/etc/corda"
+# Add packages and clean cache
+# Create dirs
+# Create corda user
+RUN amazon-linux-extras enable corretto8 && \
+    yum -y install java-1.8.0-amazon-corretto-devel  && \
+    yum -y install bash && \
+    yum -y install curl && \
+    yum -y install unzip && \
+    yum clean all && \
+    mkdir -p /opt/corda/cordapps && \
+    mkdir -p /opt/corda/persistence && \
+    mkdir -p /opt/corda/certificates && \
+    mkdir -p /opt/corda/drivers && \
+    mkdir -p /opt/corda/logs && \
+    mkdir -p /opt/corda/bin && \
+    mkdir -p /opt/corda/additional-node-infos && \
+    mkdir -p /etc/corda && \
+    groupadd corda && \
+    useradd corda -g corda -m -d /opt/corda
 
-ENV MY_P2P_PORT=10200
-ENV MY_RPC_PORT=10201
-ENV MY_RPC_ADMIN_PORT=10202
-
-RUN chown -R corda:corda /opt/corda
-RUN chown -R corda:corda /etc/corda
+ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
+    PERSISTENCE_FOLDER="/opt/corda/persistence" \
+    CERTIFICATES_FOLDER="/opt/corda/certificates" \
+    DRIVERS_FOLDER="/opt/corda/drivers" \
+    CONFIG_FOLDER="/etc/corda" \
+    MY_P2P_PORT=10200 \
+    MY_RPC_PORT=10201 \
+    MY_RPC_ADMIN_PORT=10202 \
+    PATH=$PATH:/opt/corda/bin \
+    JVM_ARGS="-XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " \
+    CORDA_ARGS=""
 
 ##CORDAPPS FOLDER
-VOLUME ["/opt/corda/cordapps"]
 ##PERSISTENCE FOLDER
-VOLUME ["/opt/corda/persistence"]
 ##CERTS FOLDER
-VOLUME ["/opt/corda/certificates"]
 ##OPTIONAL JDBC DRIVERS FOLDER
-VOLUME ["/opt/corda/drivers"]
 ##LOG FOLDER
-VOLUME ["/opt/corda/logs"]
 ##ADDITIONAL NODE INFOS FOLDER
-VOLUME ["/opt/corda/additional-node-infos"]
 ##CONFIG LOCATION
-VOLUME ["/etc/corda"]
-
+VOLUME ["/opt/corda/cordapps"] \
+       ["/opt/corda/persistence"] \
+       ["/opt/corda/certificates"] \
+       ["/opt/corda/drivers"] \
+       ["/opt/corda/logs"] \
+       ["/opt/corda/additional-node-infos"] \
+       ["/etc/corda"]
 
 ##CORDA JAR
-ADD --chown=corda:corda corda.jar /opt/corda/bin/corda.jar
 ##CONFIG MANIPULATOR JAR
-ADD --chown=corda:corda config-exporter.jar /opt/corda/config-exporter.jar
 ##CONFIG GENERATOR SHELL SCRIPT
-ADD --chown=corda:corda generate-config.sh /opt/corda/bin/config-generator
 ##CORDA RUN SCRIPT
-ADD --chown=corda:corda run-corda.sh /opt/corda/bin/run-corda
 ##BASE CONFIG FOR GENERATOR
-ADD --chown=corda:corda starting-node.conf /opt/corda/starting-node.conf
+COPY --chown=corda:corda corda.jar /opt/corda/bin/corda.jar
+COPY --chown=corda:corda config-exporter.jar /opt/corda/config-exporter.jar
+COPY --chown=corda:corda generate-config.sh /opt/corda/bin/config-generator
+COPY --chown=corda:corda run-corda.sh /opt/corda/bin/run-corda
+COPY --chown=corda:corda starting-node.conf /opt/corda/starting-node.conf
+
+##CHANGE OWNER TO CORDA
 ##SET EXECUTABLE PERMISSIONS
-RUN chmod +x /opt/corda/bin/config-generator
-RUN chmod +x /opt/corda/bin/run-corda
-
-ENV PATH=$PATH:/opt/corda/bin
-
-EXPOSE $MY_P2P_PORT
-EXPOSE $MY_RPC_PORT
+RUN chown -R corda:corda /opt/corda && \
+    chown -R corda:corda /etc/corda && \
+    chmod +x /opt/corda/bin/config-generator  && \
+    chmod +x /opt/corda/bin/run-corda
 
 USER "corda"
 CMD ["run-corda"]

--- a/docker/test-docker.sh
+++ b/docker/test-docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tests Corda docker by registering with test doorman
+# Tests Corda docker by registering with a test doorman
 IMAGE=${1:-corda/corda-corretto-4.0}
 
 # Start up test-doorman, if not already running
@@ -39,7 +39,7 @@ docker run -d --name corda-test-${SALT} --network="host" \
         -e CORDA_ARGS="--log-to-console --no-local-shell" \
         $IMAGE  config-generator --generic
 
-# Succesfully registered with http://localhost:8080
+# Succesfully registered (with http://localhost:8080)
 docker logs -f corda-test-${SALT} | grep -q "Succesfully registered"
 if [ ! "$(docker ps -q -f name=corda-test-${SALT})" ]; then
     echo "TEST-DOCKER: FAIL corda-test has exited."
@@ -51,7 +51,7 @@ else
     echo "TEST-DOCKER: SUCCESS : Succesfully registered with http://localhost:8080"
 fi
 
-# Node for "Test-2294" started up and registered in 22.84 sec
+# Node started up and registered
 docker logs -f corda-test-${SALT} | grep -q "started up and registered in"
 if [ ! "$(docker ps -q -f name=corda-test-${SALT})" ]; then
     echo "TEST-DOCKER: FAIL corda-test has exited."
@@ -61,6 +61,7 @@ if [ ! "$(docker ps -q -f name=corda-test-${SALT})" ]; then
     exit 1
 else
     echo "TEST-DOCKER:  SUCCESS : Node started up and registered"
+    echo "TEST-DOCKER:  SUCCESS : tear down"
     rm -f $(pwd)/network-root-truststore.jks
     docker rm -f corda-test-${SALT}
     exit 0

--- a/docker/test-docker.sh
+++ b/docker/test-docker.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Tests Corda docker by registering with test doorman
+IMAGE=${1:-corda/corda-corretto-4.0}
+
+# Start up test-doorman, if not already running
+if [ ! "$(docker ps -q -f name=test-doorman)" ]; then
+    if [ "$(docker ps -aq -f status=exited -f name=test-doorman)" ]; then
+        echo "TEST-DOCKER: test-doorman is in a status=exited state. I will remove."
+        docker rm -f test-doorman
+    fi
+    echo "TEST-DOCKER: test-doorman is not running. I will start."
+    docker run -d --rm --name test-doorman -p 8080:8080 \
+    -e NMS_MONGO_CONNECTION_STRING=embed \
+    -e NMS_TLS=false \
+    -e NMS_DOORMAN=true \
+    -e NMS_CERTMAN=false \
+    cordite/network-map
+else
+    echo "TEST-DOCKER: test-door man is already running. I will use this instance."
+fi
+
+# Wait for test-doorman and then download truststore
+while [[ "$(curl -s -o network-root-truststore.jks -w ''%{http_code}'' http://localhost:8080/network-map/truststore)" != "200" ]]; do
+    echo "TEST-DOCKER: waiting 5 seconds for test-doorman to serve..."
+    sleep 5
+done
+
+# Test corda docker
+echo "TEST-DOCKER: Run config-generator in corda docker with image: ${IMAGE}"
+SALT=${RANDOM}
+docker run -d --name corda-test-${SALT} --network="host" \
+        -e MY_LEGAL_NAME="O=Test-${SALT},L=Berlin,C=DE"     \
+        -e MY_PUBLIC_ADDRESS="localhost"       \
+        -e NETWORKMAP_URL="http://localhost:8080"    \
+        -e DOORMAN_URL="http://localhost:8080"      \
+        -e NETWORK_TRUST_PASSWORD="trustpass"       \
+        -e MY_EMAIL_ADDRESS="cordauser@r3.com"      \
+        -v $(pwd)/network-root-truststore.jks:/opt/corda/certificates/network-root-truststore.jks \
+        -e CORDA_ARGS="--log-to-console --no-local-shell" \
+        $IMAGE  config-generator --generic
+
+# Succesfully registered with http://localhost:8080
+docker logs -f corda-test-${SALT} | grep -q "Succesfully registered"
+if [ ! "$(docker ps -q -f name=corda-test-${SALT})" ]; then
+    echo "TEST-DOCKER: FAIL corda-test has exited."
+    docker logs corda-test-${SALT}
+    rm -f $(pwd)/network-root-truststore.jks
+    docker rm -f corda-test-${SALT}
+    exit 1
+else
+    echo "TEST-DOCKER: SUCCESS : Succesfully registered with http://localhost:8080"
+fi
+
+# Node for "Test-2294" started up and registered in 22.84 sec
+docker logs -f corda-test-${SALT} | grep -q "started up and registered in"
+if [ ! "$(docker ps -q -f name=corda-test-${SALT})" ]; then
+    echo "TEST-DOCKER: FAIL corda-test has exited."
+    docker logs corda-test-${SALT}
+    rm -f $(pwd)/network-root-truststore.jks
+    docker rm -f corda-test-${SALT}
+    exit 1
+else
+    echo "TEST-DOCKER:  SUCCESS : Node started up and registered"
+    rm -f $(pwd)/network-root-truststore.jks
+    docker rm -f corda-test-${SALT}
+    exit 0
+fi


### PR DESCRIPTION


#4954 
# CORDA-4954
  * Changes made as per issue.
  * Truststore proposal not implemented.  More design discussions required first.
  * EXPOSE left in to improve maintainability.

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?

_tests completed_ 
  * New `test-docker.sh` script added to ensure docker image works.
  * Regression tested against last release (4.0) and latest snapshot (20190329190533).
  * Tests run against images created with `./gradlew buildOfficialCorrettoDockerImage  buildOfficialZuluDockerImage`


```bash
### Zulu
#### latest release
./test-docker.sh corda/corda-zulu-4.0:RELEASE
TEST-IMAGE-corda/corda-zulu-4.0:RELEASE: SUCCESS : Succesfully registered with http://localhost:8080
TEST-IMAGE-corda/corda-zulu-4.0:RELEASE:  SUCCESS : Node started up and registered

####  latest snapshot
./test-docker.sh corda/corda-zulu-5.0-snapshot:20190329190533
TEST-IMAGE-corda/corda-zulu-5.0-snapshot:20190329190533: SUCCESS : Succesfully registered with http://localhost:8080
TEST-IMAGE-corda/corda-zulu-5.0-snapshot:20190329190533:  SUCCESS : Node started up and registered

####  local build
./test-docker.sh corda/corda-zulu-5.0-snapshot:latest
TEST-IMAGE-corda/corda-zulu-5.0-snapshot:latest: SUCCESS : Succesfully registered with http://localhost:8080
TEST-IMAGE-corda/corda-zulu-5.0-snapshot:latest:  SUCCESS : Node started up and registered

### Corretto
####  latest release
./test-docker.sh corda/corda-corretto-4.0:RELEASE
TEST-IMAGE-corda/corda-corretto-4.0:RELEASE: SUCCESS : Succesfully registered with http://localhost:8080
TEST-IMAGE-corda/corda-corretto-4.0:RELEASE:  SUCCESS : Node started up and registered

#### latest snapshot
./test-docker.sh corda/corda-corretto-5.0-snapshot:20190329190533
TEST-IMAGE-corda/corda-corretto-5.0-snapshot:20190329190533: SUCCESS : Succesfully registered with http://localhost:8080
TEST-IMAGE-corda/corda-corretto-5.0-snapshot:20190329190533:  SUCCESS : Node started up and registered

####  local build
./test-docker.sh corda/corda-corretto-5.0-snapshot:latest
TEST-IMAGE-corda/corda-corretto-5.0-snapshot:latest: SUCCESS : Succesfully registered with http://localhost:8080
TEST-IMAGE-corda/corda-corretto-5.0-snapshot:latest:  SUCCESS : Node started up and registered
```

- [x] If you added public APIs, did you write the JavaDocs? 

_No change_  

- [x] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?

_No interest_


- [x] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

_Certificate below_

Thanks for your code, it's appreciated! :)


> Developer Certificate of Origin
> Version 1.1
> 
> Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
> 1 Letterman Drive
> Suite D4700
> San Francisco, CA, 94129
> 
> Everyone is permitted to copy and distribute verbatim copies of this
> license document, but changing it is not allowed.
> 
> Developer's Certificate of Origin 1.1
> 
> By making a contribution to this project, I, Richard Crook, certify that:
> 
> (a) The contribution was created in whole or in part by me and I
>     have the right to submit it under the open source license
>     indicated in the file; or
> 
> (b) The contribution is based upon previous work that, to the best
>     of my knowledge, is covered under an appropriate open source
>     license and I have the right under that license to submit that
>     work with modifications, whether created in whole or in part
>     by me, under the same open source license (unless I am
>     permitted to submit under a different license), as indicated
>     in the file; or
> 
> (c) The contribution was provided directly to me by some other
>     person who certified (a), (b) or (c) and I have not modified
>     it.
> 
> (d) I understand and agree that this project and the contribution
>     are public and that a record of the contribution (including all
>     personal information I submit with it, including my sign-off) is
>     maintained indefinitely and may be redistributed consistent with
>     this project or the open source license(s) involved.