### PR TITLE
CORDA-2632 Handle exceptions when file does not exist.

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
@@ -127,7 +127,7 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
         return method.parameters.mapIndexed { index, param ->
             when {
                 param.isNamePresent -> param.name
-            // index + 1 because the first Kotlin reflection param is 'this', but that doesn't match Java reflection.
+                // index + 1 because the first Kotlin reflection param is 'this', but that doesn't match Java reflection.
                 kf != null -> kf.parameters[index + 1].name ?: throw UnparseableCallException.ReflectionDataMissing(method.name, index)
                 else -> throw UnparseableCallException.ReflectionDataMissing(method.name, index)
             }
@@ -153,7 +153,7 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
         class MissingParameter(methodName: String, val paramName: String, command: String) : UnparseableCallException("Parameter $paramName missing from attempt to invoke $methodName in command: $command")
         class TooManyParameters(methodName: String, command: String) : UnparseableCallException("Too many parameters provided for $methodName: $command")
         class ReflectionDataMissing(methodName: String, argIndex: Int) : UnparseableCallException("Method $methodName missing parameter name at index $argIndex")
-        class NoSuchFile(filename: String) : UnparseableCallException("File ${filename} not found")
+        class NoSuchFile(filename: String) : UnparseableCallException("File $filename not found")
         class FailedParse(e: Exception) : UnparseableCallException(e.message ?: e.toString(), e)
     }
 
@@ -201,7 +201,7 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
             val entryType = om.typeFactory.constructType(argType)
             try {
                 om.readValue<Any>(entry.traverse(om), entryType)
-            } catch( e : java.nio.file.NoSuchFileException) {
+            } catch (e: java.nio.file.NoSuchFileException) {
                 throw UnparseableCallException.NoSuchFile(e.file ?: entry.toString())
             } catch (e: Exception) {
                 throw UnparseableCallException.FailedParse(e)

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
@@ -153,6 +153,7 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
         class MissingParameter(methodName: String, val paramName: String, command: String) : UnparseableCallException("Parameter $paramName missing from attempt to invoke $methodName in command: $command")
         class TooManyParameters(methodName: String, command: String) : UnparseableCallException("Too many parameters provided for $methodName: $command")
         class ReflectionDataMissing(methodName: String, argIndex: Int) : UnparseableCallException("Method $methodName missing parameter name at index $argIndex")
+        class NoSuchFile(filename: String) : UnparseableCallException("File ${filename} not found")
         class FailedParse(e: Exception) : UnparseableCallException(e.message ?: e.toString(), e)
     }
 
@@ -200,6 +201,8 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
             val entryType = om.typeFactory.constructType(argType)
             try {
                 om.readValue<Any>(entry.traverse(om), entryType)
+            } catch( e : java.nio.file.NoSuchFileException) {
+                throw UnparseableCallException.NoSuchFile(e.file ?: entry.toString())
             } catch (e: Exception) {
                 throw UnparseableCallException.FailedParse(e)
             }

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -497,6 +497,12 @@ object InteractiveShell {
                     throw e.rootCause
                 }
             }
+        } catch(e: StringToMethodCallParser.UnparseableCallException.FailedParse) {
+            out.println("Failed while parsing arguments.", Color.red)
+            val cause = e.cause
+            if (cause is java.nio.file.NoSuchFileException) {
+                out.println("File not found.")
+            }
         } catch (e: StringToMethodCallParser.UnparseableCallException) {
             out.println(e.message, Color.red)
             out.println("Please try 'man run' to learn what syntax is acceptable")

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -497,15 +497,11 @@ object InteractiveShell {
                     throw e.rootCause
                 }
             }
-        } catch(e: StringToMethodCallParser.UnparseableCallException.FailedParse) {
-            out.println("Failed while parsing arguments.", Color.red)
-            val cause = e.cause
-            if (cause is java.nio.file.NoSuchFileException) {
-                out.println("File not found.")
-            }
         } catch (e: StringToMethodCallParser.UnparseableCallException) {
             out.println(e.message, Color.red)
-            out.println("Please try 'man run' to learn what syntax is acceptable")
+            if (e !is StringToMethodCallParser.UnparseableCallException.NoSuchFile) {
+                out.println("Please try 'man run' to learn what syntax is acceptable")
+            }
         } catch (e: Exception) {
             out.println("RPC failed: ${e.rootCause}", Color.red)
         } finally {


### PR DESCRIPTION
Added a catch clause for the specific case of StringToMethodCallParser.UnparseableCallException.FailedParse which is only thrown during argument parsing.
CORDA-2632
