### PR TITLE
CORDA-2832: Improved error reporting in interactive shell when an error occurs after a ctor is matched.

### DIFF
--- a/tools/shell/src/test/java/net/corda/tools/shell/InteractiveShellJavaTest.java
+++ b/tools/shell/src/test/java/net/corda/tools/shell/InteractiveShellJavaTest.java
@@ -30,6 +30,7 @@ import java.util.*;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class InteractiveShellJavaTest {
     private static TestIdentity megaCorp = new TestIdentity(new CordaX500Name("MegaCorp", "London", "GB"));
@@ -257,6 +258,16 @@ public class InteractiveShellJavaTest {
             check("amount: $100", "", FlowB.class);
         } catch (InteractiveShell.NoApplicableConstructor e) {
             assertEquals("[amount: Amount<Currency>, abc: int]: missing parameter abc", e.getErrors().get(1));
+        }
+    }
+
+    @Test
+    public void flowStartWithUnknownParty() throws InteractiveShell.NoApplicableConstructor {
+        try {
+            check("party: nonexistent", "", FlowA.class);
+        } catch (InteractiveShell.NoApplicableConstructor e) {
+            assertTrue(e.getErrors().get(0).contains("No matching Party found"));
+            assertEquals(1, e.getErrors().size());
         }
     }
 }

--- a/tools/shell/src/test/kotlin/net/corda/tools/shell/InteractiveShellTest.kt
+++ b/tools/shell/src/test/kotlin/net/corda/tools/shell/InteractiveShellTest.kt
@@ -154,7 +154,7 @@ class InteractiveShellTest {
 
     @Test
     fun flowStartWithArrayType() = check(
-            input = "b: [ One, Two, Three, Four ]",
+            input = "c: [ One, Two, Three, Four ]",
             expected = "One+Two+Three+Four"
     )
 
@@ -174,7 +174,7 @@ class InteractiveShellTest {
     fun flowStartNoArgs() = check("", "")
 
     @Test(expected = InteractiveShell.NoApplicableConstructor::class)
-    fun flowMissingParam() = check("c: Yo", "")
+    fun flowMissingParam() = check("d: Yo", "")
 
     @Test(expected = InteractiveShell.NoApplicableConstructor::class)
     fun flowTooManyParams() = check("b: 12, c: Yo, d: Bar", "")
@@ -190,7 +190,7 @@ class InteractiveShellTest {
                 "[pair: Pair<Amount<Currency>, SecureHash.SHA256>]: missing parameter pair",
                 "[party: Party]: missing parameter party",
                 "[b: Integer, amount: Amount<UserValue>]: missing parameter b",
-                "[b: String[]]: missing parameter b",
+                "[c: String[]]: missing parameter c",
                 "[b: Integer, c: String]: missing parameter b",
                 "[a: String]: missing parameter a",
                 "[b: Integer]: missing parameter b"
@@ -275,7 +275,7 @@ class FlowA(val a: String) : FlowLogic<String>() {
     constructor(pair: Pair<Amount<Currency>, SecureHash.SHA256>) : this(pair.toString())
     constructor(party: Party) : this(party.name.toString())
     constructor(b: Int?, amount: Amount<UserValue>) : this("${(b ?: 0) + amount.quantity} ${amount.token}")
-    constructor(b: Array<String>) : this(b.joinToString("+"))
+    constructor(c: Array<String>) : this(c.joinToString("+"))
     constructor(amounts: Array<Amount<UserValue>>) : this(amounts.joinToString("++", transform = Amount<UserValue>::toString))
 
     override val progressTracker = ProgressTracker()


### PR DESCRIPTION
The interactive shell implementation will try to match the passed in flow start argument list with each flow constructor in turn. Apart from the matching constructor there will be either too few or too many arguments specified, or missing parameters. All these errors are accumulated into a list.

If the matching constructor also fails for a legitimate reason, e.g. the Party cannot be found then this error is also added to the cumulative list and the whole list is sent back to the user and displayed in the shell. This is not right, only the errors related to the matching constructor should be displayed. This is now done in this PR, if there is no matching constructor then all errors are returned as before.

Note that we do not support two matching constructors with the same parameter names but different only by type. However the previous implementation would allow this. The first matching constructor that succeeded would be used, previous matching constructors that failed would be ignored. In this implementation if the first matching constructor fails then the error is reported.