### PR TITLE
[CORDA-2633] Restructure EvolutionSerializationException to print failure reason first

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
@@ -22,9 +22,10 @@ interface EvolutionSerializerFactory {
 class EvolutionSerializationException(remoteTypeInformation: RemoteTypeInformation, reason: String)
     : NotSerializableException(
         """
-            Cannot construct evolution serializer for remote type ${remoteTypeInformation.prettyPrint(false)}
+        Cannot construct evolution serializer for remote type ${remoteTypeInformation.typeIdentifier.name}: $reason
 
-            $reason
+        Full type information:
+        ${remoteTypeInformation.prettyPrint(false)}
         """.trimIndent()
 )
 


### PR DESCRIPTION
This PR reformats the `EvolutionSerializationException` to print the type name and reason for serialization failure before the full type information. This ensures the problem is the first thing displayed in the error message.

An example of the new format:
```
Caused by: net.corda.core.node.services.VaultQueryException: An error occurred w
hile attempting to query the vault: Failed to deserialise group OUTPUTS_GROUP at
 index 0 in transaction:       Cannot construct evolution serializer for remote
type net.corda.examples.obligation.contract.Obligation: Mandatory property defau
lted of local type is not present in remote type. This implies the type has not
evolved in a backwards compatible way. Consider making defaulted nullable in the
 newer version of this type.

      Full type information:
      net.corda.examples.obligation.contract.Obligation: net.corda.core.contract
s.LinearState, net.corda.core.contracts.ContractState
amount: net.corda.core.contracts.Amount<java.util.Currency>
  displayTokenSize: java.math.BigDecimal
  quantity: long
  token: java.util.Currency
borrower: net.corda.core.identity.AbstractParty
  owningKey: java.security.PublicKey
lender: net.corda.core.identity.AbstractParty
  owningKey: java.security.PublicKey
linearId: net.corda.core.contracts.UniqueIdentifier
  externalId (optional): java.lang.String
  id: java.util.UUID
paid: net.corda.core.contracts.Amount<java.util.Currency>
  displayTokenSize: java.math.BigDecimal
  quantity: long
  token: java.util.Currency
```
