### PR TITLE
CORDA-2645 Do not remove exception information in dev mode

### DIFF
--- a/finance/workflows/src/integration-test/kotlin/net/corda/finance/workflows/CashExceptionSerialisationTest.kt
+++ b/finance/workflows/src/integration-test/kotlin/net/corda/finance/workflows/CashExceptionSerialisationTest.kt
@@ -20,7 +20,6 @@ class CashExceptionSerialisationTest {
             val node = startNode(rpcUsers = listOf(User("mark", "dadada", setOf(all())))).getOrThrow()
             val action = { node.rpc.startFlow(CashExceptionSerialisationTest::CashExceptionThrowingFlow).returnValue.getOrThrow() }
             assertThatThrownBy(action).isInstanceOfSatisfying(CashException::class.java) { thrown ->
-                assertThat(thrown).hasNoCause()
                 assertThat(thrown.stackTrace).isEmpty()
             }
         }

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
@@ -28,7 +28,7 @@ class RpcExceptionHandlingTest {
     private val users = listOf(user)
 
     @Test
-    fun `rpc client receives wrapped exceptions in devMode`() {
+    fun `rpc client receives wrapped exceptions in devMode with no stacktraces`() {
         val params = NodeParameters(rpcUsers = users)
         val clientRelevantMessage = "This is for the players!"
 
@@ -40,6 +40,8 @@ class RpcExceptionHandlingTest {
             val devModeNode = startNode(params, BOB_NAME).getOrThrow()
             assertThatThrownBy { devModeNode.throwExceptionFromFlow() }.isInstanceOfSatisfying(ClientRelevantException::class.java) { exception ->
                 assertEquals((exception.cause as CordaRuntimeException).originalExceptionClassName, SQLException::class.qualifiedName)
+                assertThat(exception.stackTrace).isEmpty()
+                assertThat((exception.cause as CordaRuntimeException).stackTrace).isEmpty()
                 assertThat(exception.message).isEqualTo(clientRelevantMessage)
             }
         }
@@ -56,7 +58,6 @@ class RpcExceptionHandlingTest {
 
         fun assertThatThrownExceptionIsReceivedUnwrapped(node: NodeHandle) {
             assertThatThrownBy { node.throwExceptionFromFlow() }.isInstanceOfSatisfying(ClientRelevantException::class.java) { exception ->
-                assertThat(exception.stackTrace).isEmpty()
                 assertThat(exception.message).isEqualTo(clientRelevantMessage)
             }
         }

--- a/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ExceptionSerialisingRpcOpsProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ExceptionSerialisingRpcOpsProxy.kt
@@ -84,11 +84,6 @@ internal class ExceptionSerialisingRpcOpsProxy(private val delegate: CordaRPCOps
                 log(error)
                 CordaRuntimeException(error.message, error)
             }
-
-            if (result is CordaThrowable) {
-                result.stackTrace = arrayOf<StackTraceElement>()
-                result.setCause(null)
-            }
             return result
         }
 


### PR DESCRIPTION
`ExceptionSerialisingRpcOpsProxy` was removing information about the original exception in dev mode. This code has been removed. Although there is no check in `ExceptionSerialisingRpcOpsProxy` for dev mode (and also due to it being about serialising), `ExceptionMaskingRpcOpsProxy` will handle the removal of exception data in non dev mode (production mode)
