### PR TITLE
CORDA-2827 extend timeout on test

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -101,7 +101,7 @@ class RetryFlowMockTest {
         })
         val count = 10000 // Lots of iterations so the flow keeps going long enough
         nodeA.startFlow(KeepSendingFlow(count, partyB))
-        eventually(waitBetween = Duration.ofMillis(10)) {
+        eventually(duration = Duration.ofSeconds(30), waitBetween = Duration.ofMillis(100)) {
             assertTrue(messagesSent.isNotEmpty())
             assertNotNull(messagesSent.first().senderUUID)
         }
@@ -115,7 +115,7 @@ class RetryFlowMockTest {
         })
         // Now short circuit the iterations so the flow finishes soon.
         KeepSendingFlow.count.set(count - 2)
-        eventually(waitBetween = Duration.ofMillis(10)) {
+        eventually(duration = Duration.ofSeconds(30), waitBetween = Duration.ofMillis(100)) {
             assertTrue(nodeA.smm.allStateMachines.isEmpty())
         }
         assertNull(messagesSent.last().senderUUID)


### PR DESCRIPTION
The default 5-second timeout for `eventually` isn't always sufficient for `RetryFlowMockTest.Restart does not set senderUUID` to complete its work, so we extend it to 30 seconds, with a 100ms retry interval.