### PR TITLE
[CORDA-2837] Ensure certain flows cannot start a session with the local node

### DIFF
--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -95,6 +95,9 @@ private constructor(private val otherSideSession: FlowSession?,
                     "SwapIdentitiesFlow with FlowSessions. (${CordappResolver.currentCordapp?.info})")
             initiateFlow(otherParty!!)
         }
+        require(!serviceHub.myInfo.isLegalIdentity(session.counterparty)) {
+            "Do not attempt to sync identities with the local node"
+        }
         progressTracker.currentStep = GENERATING_IDENTITY
         val ourAnonymousIdentity = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, false)
         val data = buildDataToSign(ourAnonymousIdentity)

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -95,8 +95,8 @@ private constructor(private val otherSideSession: FlowSession?,
                     "SwapIdentitiesFlow with FlowSessions. (${CordappResolver.currentCordapp?.info})")
             initiateFlow(otherParty!!)
         }
-        require(!serviceHub.myInfo.isLegalIdentity(session.counterparty)) {
-            "Do not attempt to sync identities with the local node"
+        if (serviceHub.myInfo.isLegalIdentity(session.counterparty)) {
+            throw SwapIdentitiesException("Attempted to swap identities with the local node")
         }
         progressTracker.currentStep = GENERATING_IDENTITY
         val ourAnonymousIdentity = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, false)

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -72,7 +72,7 @@ class SwapIdentitiesFlowTests {
     fun `cannot swap identities with local node`() {
         assert.that(
                 aliceNode.services.startFlow(SwapIdentitiesInitiator(alice)),
-                willThrow<IllegalArgumentException>()
+                willThrow<SwapIdentitiesException>()
         )
     }
 

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -17,11 +17,13 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.testing.core.*
 import net.corda.testing.internal.matchers.allOf
 import net.corda.testing.internal.matchers.flow.willReturn
+import net.corda.testing.internal.matchers.flow.willThrow
 import net.corda.testing.internal.matchers.hasOnlyEntries
 import net.corda.testing.node.internal.*
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.AfterClass
 import org.junit.Test
+import java.lang.IllegalArgumentException
 import java.security.PublicKey
 
 class SwapIdentitiesFlowTests {
@@ -63,6 +65,14 @@ class SwapIdentitiesFlowTests {
                     )
                 )
             )
+        )
+    }
+
+    @Test
+    fun `cannot swap identities with local node`() {
+        assert.that(
+                aliceNode.services.startFlow(SwapIdentitiesInitiator(alice)),
+                willThrow<IllegalArgumentException>()
         )
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
@@ -91,6 +91,10 @@ class CollectSignaturesFlow @JvmOverloads constructor(val partiallySignedTx: Sig
             "The Initiator of CollectSignaturesFlow must have signed the transaction."
         }
 
+        require(sessionsToCollectFrom.none { serviceHub.myInfo.isLegalIdentity(it.counterparty) }) {
+            "Do not call CollectSignaturesFlow with sessions for the local node - the initiator should have already signed the transaction"
+        }
+
         // The signatures must be valid and the transaction must be valid.
         partiallySignedTx.verifySignaturesExcept(notSigned)
         partiallySignedTx.tx.toLedgerTransaction(serviceHub).verify()

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -121,12 +121,7 @@ abstract class FlowLogic<out T> {
      * that this function does not communicate in itself, the counter-flow will be kicked off by the first send/receive.
      */
     @Suspendable
-    fun initiateFlow(party: Party): FlowSession {
-        if (party == ourIdentity) {
-            throw IllegalArgumentException("Attempted to initiate a flow session with the local node.")
-        }
-        return stateMachine.initiateFlow(party)
-    }
+    fun initiateFlow(party: Party): FlowSession = stateMachine.initiateFlow(party)
 
     /**
      * Specifies the identity, with certificate, to use for this flow. This will be one of the multiple identities that

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -21,6 +21,7 @@ import net.corda.core.utilities.UntrustworthyData
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.toNonEmptySet
 import org.slf4j.Logger
+import java.lang.IllegalArgumentException
 import java.time.Duration
 import java.util.*
 
@@ -120,7 +121,12 @@ abstract class FlowLogic<out T> {
      * that this function does not communicate in itself, the counter-flow will be kicked off by the first send/receive.
      */
     @Suspendable
-    fun initiateFlow(party: Party): FlowSession = stateMachine.initiateFlow(party)
+    fun initiateFlow(party: Party): FlowSession {
+        if (party == ourIdentity) {
+            throw IllegalArgumentException("Attempted to initiate a flow session with the local node.")
+        }
+        return stateMachine.initiateFlow(party)
+    }
 
     /**
      * Specifies the identity, with certificate, to use for this flow. This will be one of the multiple identities that

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -53,7 +53,11 @@ open class CashPaymentFlow(
         val recipientSession = initiateFlow(recipient)
         recipientSession.send(anonymous)
         val anonymousRecipient = if (anonymous) {
-            subFlow(SwapIdentitiesFlow(recipientSession))[recipient]!!
+            if (!serviceHub.myInfo.isLegalIdentity(recipient)) {
+                subFlow(SwapIdentitiesFlow(recipientSession))[recipient]!!
+            } else {
+                serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, false).party.anonymise()
+            }
         } else {
             recipient
         }


### PR DESCRIPTION
When calling the `initiateFlow` API, it is possible to specify the local node as the counterparty. There are some situations where this is desirable, but there are other flows for which this does not make sense. In the platform, `CollectSignaturesFlow` and `SwapIdentitiesFlow` fall into this second category. This PR adds some logic to prevent these flows from using the local node as a counterparty.

Testing:
 - Unit tests
 - Ran the Obligation sample and transferred an obligation to the borrower (so the same node is the borrower and lender). This causes the new logic in `CollectSignaturesFlow` to be hit.
 - Tested the `CashPaymentFlow` when paying the local node in the `SwapIdentitiesFlow` case. There's also a fix for the `CashPaymentFlow` included in this PR.

I have a few points I'd like to make sure get double checked:
 - The change to `SwapIdentitiesFlow` here represents an API behaviour change (I've had to change the finance CorDapp to accommodate it). Is that a safe change to make? Would it benefit from being behind a `targetPlatformVersion` gate? (Note that the same is not true of the `CollectSignaturesFlow`, which doesn't work at the moment if a session to the local node is passed in. This PR just makes the failure happen earlier and is more explicit about what went wrong.)
 - Is this compatible with the plans for accounts?