### PR TITLE
CORDA-2572 Alter the message of a `FlowException` on receiving side

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -2,6 +2,7 @@ package net.corda.core.flows
 
 import net.corda.core.CordaException
 import net.corda.core.CordaRuntimeException
+import net.corda.core.identity.Party
 
 // DOCSTART 1
 /**
@@ -28,6 +29,8 @@ open class FlowException(message: String?, cause: Throwable?, var originalErrorI
     constructor(cause: Throwable?) : this(cause?.toString(), cause)
     constructor() : this(null, null)
 
+    var peer: Party? = null
+
     override fun getErrorId(): Long? = originalErrorId
 }
 // DOCEND 1
@@ -41,6 +44,8 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
         CordaRuntimeException(message, cause), IdentifiableException {
     constructor(message: String, cause: Throwable?) : this(message, cause, null)
     constructor(message: String) : this(message, null)
+
+    var peer: Party? = null
 
     override fun getErrorId(): Long? = originalErrorId
 }

--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -29,7 +29,8 @@ open class FlowException(message: String?, cause: Throwable?, var originalErrorI
     constructor(cause: Throwable?) : this(cause?.toString(), cause)
     constructor() : this(null, null)
 
-    var peer: Party? = null
+    // private field with obscure name to ensure it is not overridden
+    private var _peer: Party? = null
 
     override fun getErrorId(): Long? = originalErrorId
 }
@@ -45,7 +46,8 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
     constructor(message: String, cause: Throwable?) : this(message, cause, null)
     constructor(message: String) : this(message, null)
 
-    var peer: Party? = null
+    // private field with obscure name to ensure it is not overridden
+    private var _peer: Party? = null
 
     override fun getErrorId(): Long? = originalErrorId
 }

--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -30,7 +30,7 @@ open class FlowException(message: String?, cause: Throwable?, var originalErrorI
     constructor() : this(null, null)
 
     // private field with obscure name to ensure it is not overridden
-    private var _peer: Party? = null
+    private var peer: Party? = null
 
     override fun getErrorId(): Long? = originalErrorId
 }
@@ -47,7 +47,7 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
     constructor(message: String) : this(message, null)
 
     // private field with obscure name to ensure it is not overridden
-    private var _peer: Party? = null
+    private var peer: Party? = null
 
     override fun getErrorId(): Long? = originalErrorId
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -173,9 +173,10 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     private fun Throwable.fillInLocalStackTrace(): Throwable {
         fillInStackTrace()
         // provide useful information that can be displayed to the user
+        // reflection use to access private field
         when (this) {
             is UnexpectedFlowEndException -> {
-                peer?.let {
+                this.declaredField<Party?>("_peer").value?.let {
                     stackTrace = arrayOf(
                         StackTraceElement(
                             "Received unexpected counter-flow exception from peer",
@@ -187,7 +188,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                 }
             }
             is FlowException -> {
-                peer?.let {
+                this.declaredField<Party?>("_peer").value?.let {
                     stackTrace = arrayOf(
                         StackTraceElement(
                             "Received counter-flow exception from peer",

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -176,7 +176,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
         // reflection use to access private field
         when (this) {
             is UnexpectedFlowEndException -> {
-                this.declaredField<Party?>("_peer").value?.let {
+                DeclaredField<Party?>(UnexpectedFlowEndException::class.java, "peer", this).value?.let {
                     stackTrace = arrayOf(
                         StackTraceElement(
                             "Received unexpected counter-flow exception from peer",
@@ -188,7 +188,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                 }
             }
             is FlowException -> {
-                this.declaredField<Party?>("_peer").value?.let {
+                DeclaredField<Party?>(FlowException::class.java, "peer", this).value?.let {
                     stackTrace = arrayOf(
                         StackTraceElement(
                             "Received counter-flow exception from peer",

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -171,33 +171,36 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     }
 
     private fun fillInStackTrace(throwable: Throwable): Throwable {
-        throwable.apply {
+        return throwable.apply {
             fillInStackTrace()
             // provide useful information that can be displayed to the user
             when (this) {
                 is UnexpectedFlowEndException -> {
                     if (peer != null) {
-                        stackTrace += StackTraceElement(
-                            "Received unexpected counter-flow exception from peer",
-                            " ${peer!!.name}",
-                            null,
-                            -1
-                        )
+                        stackTrace = arrayOf(
+                            StackTraceElement(
+                                "Received unexpected counter-flow exception from peer",
+                                " ${peer!!.name}",
+                                null,
+                                -1
+                            )
+                        ) + stackTrace
                     }
                 }
                 is FlowException -> {
                     if (peer != null) {
-                        throwable.stackTrace += StackTraceElement(
-                            "Received counter-flow exception from peer",
-                            " ${peer!!.name}",
-                            null,
-                            -1
-                        )
+                        stackTrace = arrayOf(
+                            StackTraceElement(
+                                "Received counter-flow exception from peer",
+                                " ${peer!!.name}",
+                                null,
+                                -1
+                            )
+                        ) + stackTrace
                     }
                 }
             }
         }
-        return throwable
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -179,9 +179,9 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                 DeclaredField<Party?>(UnexpectedFlowEndException::class.java, "peer", this).value?.let {
                     stackTrace = arrayOf(
                         StackTraceElement(
-                            "Received unexpected counter-flow exception from peer",
-                            " ${it.name}",
-                            null,
+                            "Received unexpected counter-flow exception from peer ${it.name}",
+                            "",
+                            "",
                             -1
                         )
                     ) + stackTrace
@@ -191,9 +191,9 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                 DeclaredField<Party?>(FlowException::class.java, "peer", this).value?.let {
                     stackTrace = arrayOf(
                         StackTraceElement(
-                            "Received counter-flow exception from peer",
-                            " ${it.name}",
-                            null,
+                            "Received counter-flow exception from peer ${it.name}",
+                            "",
+                            "",
                             -1
                         )
                     ) + stackTrace

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.statemachine.transitions
 
+import net.corda.core.flows.FlowException
 import net.corda.core.flows.UnexpectedFlowEndException
 import net.corda.node.services.statemachine.Action
 import net.corda.node.services.statemachine.ConfirmSessionMessage
@@ -120,6 +121,10 @@ class DeliverSessionMessageTransition(
 
         return when (sessionState) {
             is SessionState.Initiated -> {
+                when(exception) {
+                    is UnexpectedFlowEndException -> exception.peer = sessionState.peerParty
+                    is FlowException -> exception.peer = sessionState.peerParty
+                }
                 val checkpoint = currentState.checkpoint
                 val sessionId = event.sessionMessage.recipientSessionId
                 val flowError = FlowError(payload.errorId, exception)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
@@ -2,6 +2,8 @@ package net.corda.node.services.statemachine.transitions
 
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.UnexpectedFlowEndException
+import net.corda.core.identity.Party
+import net.corda.core.internal.declaredField
 import net.corda.node.services.statemachine.Action
 import net.corda.node.services.statemachine.ConfirmSessionMessage
 import net.corda.node.services.statemachine.DataSessionMessage
@@ -121,9 +123,10 @@ class DeliverSessionMessageTransition(
 
         return when (sessionState) {
             is SessionState.Initiated -> {
-                when(exception) {
-                    is UnexpectedFlowEndException -> exception.peer = sessionState.peerParty
-                    is FlowException -> exception.peer = sessionState.peerParty
+                when (exception) {
+                    // reflection used to access private field
+                    is UnexpectedFlowEndException -> exception.declaredField<Party?>("_peer").value = sessionState.peerParty
+                    is FlowException -> exception.declaredField<Party?>("_peer").value = sessionState.peerParty
                 }
                 val checkpoint = currentState.checkpoint
                 val sessionId = event.sessionMessage.recipientSessionId

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -186,6 +186,7 @@ class FlowFrameworkTests {
                 .isThrownBy { receivingFiber.resultFuture.getOrThrow() }
                 .withMessage("Nothing useful")
                 .withStackTraceContaining(ReceiveFlow::class.java.name)  // Make sure the stack trace is that of the receiving flow
+                .withStackTraceContaining("Received counter-flow exception from peer")
         bobNode.database.transaction {
             assertThat(bobNode.internals.checkpointStorage.checkpoints()).isEmpty()
         }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -11,6 +11,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
+import net.corda.core.internal.DeclaredField
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.node.services.PartyInfo
@@ -38,6 +39,7 @@ import net.corda.testing.node.internal.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType
+import org.assertj.core.api.Condition
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -45,6 +47,7 @@ import rx.Notification
 import rx.Observable
 import java.time.Instant
 import java.util.*
+import java.util.function.Predicate
 import kotlin.reflect.KClass
 import kotlin.test.assertFailsWith
 
@@ -207,6 +210,29 @@ class FlowFrameworkTests {
         // Make sure the original stack trace isn't sent down the wire
         val lastMessage = receivedSessionMessages.last().message as ExistingSessionMessage
         assertThat((lastMessage.payload as ErrorSessionMessage).flowException!!.stackTrace).isEmpty()
+    }
+
+    @Test
+    fun `sub-class of FlowException can have a peer field without causing serialisation problems`() {
+        val exception = MyPeerFlowException("Nothing useful", alice)
+        bobNode.registerCordappFlowFactory(ReceiveFlow::class) {
+            ExceptionFlow { exception }
+        }
+
+        val receivingFiber = aliceNode.services.startFlow(ReceiveFlow(bob)) as FlowStateMachineImpl
+
+        mockNet.runNetwork()
+
+        assertThatExceptionOfType(MyPeerFlowException::class.java)
+            .isThrownBy { receivingFiber.resultFuture.getOrThrow() }
+            .has(Condition(Predicate<MyPeerFlowException> { it.peer == alice }, "subclassed peer field has original value"))
+            .has(Condition(Predicate<MyPeerFlowException> {
+                DeclaredField<Party?>(
+                    FlowException::class.java,
+                    "peer",
+                    it
+                ).value == bob
+            }, "FlowException's private peer field has value set"))
     }
 
     private class ConditionalExceptionFlow(val otherPartySession: FlowSession, val sendPayload: Any) : FlowLogic<Unit>() {
@@ -732,6 +758,8 @@ internal class MyFlowException(override val message: String) : FlowException() {
     override fun equals(other: Any?): Boolean = other is MyFlowException && other.message == this.message
     override fun hashCode(): Int = message.hashCode()
 }
+
+internal class MyPeerFlowException(override val message: String, val peer: Party) : FlowException()
 
 @InitiatingFlow
 internal class SendAndReceiveFlow(private val otherParty: Party, private val payload: Any, private val otherPartySession: FlowSession? = null) : FlowLogic<Any>() {


### PR DESCRIPTION
When an exception is thrown the receiving party / counter flow will receive the `FlowException` with an altered message indicating it has come from the sending party / counter flow.

Locally the thrown exception will remain the same.