### PR TITLE
[CORDA-2522] Improve error reporting around failed flows

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -292,7 +292,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
     class UntrustedAttachmentsException(val txId: SecureHash, val ids: List<SecureHash>) :
             CordaException("Attempting to load untrusted transaction attachments: $ids. " +
                     "At this time these are not loadable because the DJVM sandbox has not yet been integrated. " +
-                    "You will need to install that app version yourself, to whitelist it for use. " +
+                    "You will need to manually install the CorDapp to whitelist it for use. " +
                     "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
 
     /*

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -127,7 +127,7 @@ class AttachmentsClassLoader(attachments: List<Attachment>,
 
         if (untrusted.isNotEmpty()) {
             log.warn("Cannot verify transaction $sampleTxId as the following attachment IDs are untrusted: $untrusted." +
-                    "You will need to install that app version yourself, to whitelist it for use. " +
+                    "You will need to manually install the CorDapp to whitelist it for use. " +
                     "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
             throw TransactionVerificationException.UntrustedAttachmentsException(sampleTxId, untrusted)
         }

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -125,8 +125,12 @@ class AttachmentsClassLoader(attachments: List<Attachment>,
                 }
                 .map(Attachment::id)
 
-        if (untrusted.isNotEmpty())
+        if (untrusted.isNotEmpty()) {
+            log.warn("Cannot verify transaction $sampleTxId as the following attachment IDs are untrusted: $untrusted." +
+                    "You will need to install that app version yourself, to whitelist it for use. " +
+                    "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
             throw TransactionVerificationException.UntrustedAttachmentsException(sampleTxId, untrusted)
+        }
 
         // Enforce the no-overlap and package ownership rules.
         checkAttachments(attachments)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -243,7 +243,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
             if(t.isUnrecoverable()) {
                 errorAndTerminate("Caught unrecoverable error from flow. Forcibly terminating the JVM, this might leave resources open, and most likely will.", t)
             }
-            logger.info("Flow raised an error... sending it to flow hospital", t)
+            logger.info("Flow raised an error: ${t.message}. Sending it to flow hospital to record and diagnose.")
             Try.Failure<R>(t)
         }
         val softLocksId = if (hasSoftLockedStates) logic.runId.uuid else null

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -243,7 +243,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
             if(t.isUnrecoverable()) {
                 errorAndTerminate("Caught unrecoverable error from flow. Forcibly terminating the JVM, this might leave resources open, and most likely will.", t)
             }
-            logger.info("Flow raised an error: ${t.message}. Sending it to flow hospital to record and diagnose.")
+            logger.info("Flow raised an error: ${t.message}. Sending it to flow hospital to be triaged.")
             Try.Failure<R>(t)
         }
         val softLocksId = if (hasSoftLockedStates) logic.runId.uuid else null

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -161,7 +161,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
                 .asSequence()
                 .mapIndexed { index, error ->
                     // Rely on the logging context to print details of the flow ID.
-                    log.warn("Error $index of ${errors.size}:", error)
+                    log.warn("Error ${index + 1} of ${errors.size}:", error)
                     val diagnoses: Map<Diagnosis, List<Staff>> = staff.groupBy { it.consult(flowFiber, currentState, error, medicalHistory) }
                     // We're only interested in the highest priority diagnosis for the error
                     val (diagnosis, by) = diagnoses.entries.minBy { it.key }!!

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -160,7 +160,8 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
         return errors
                 .asSequence()
                 .mapIndexed { index, error ->
-                    log.info("Flow ${flowFiber.id} has error [$index]", error)
+                    // Rely on the logging context to print details of the flow ID.
+                    log.warn("Error $index of ${errors.size}:", error)
                     val diagnoses: Map<Diagnosis, List<Staff>> = staff.groupBy { it.consult(flowFiber, currentState, error, medicalHistory) }
                     // We're only interested in the highest priority diagnosis for the error
                     val (diagnosis, by) = diagnoses.entries.minBy { it.key }!!

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt
@@ -39,11 +39,12 @@ class DumpHistoryOnErrorInterceptor(val delegate: TransitionExecutor) : Transiti
             (record ?: ArrayList()).apply { add(transitionRecord) }
         }
 
-        // Just if we decide to propagate, and not if just on the way to the hospital.
+        // Just if we decide to propagate, and not if just on the way to the hospital. Only log at debug level here - the flow transition
+        // information is often unhelpful in the logs, and the actual cause of the problem will be logged elsewhere.
         if (nextState.checkpoint.errorState is ErrorState.Errored && nextState.checkpoint.errorState.propagating) {
-            log.warn("Flow ${fiber.id} errored, dumping all transitions:\n${record!!.joinToString("\n")}")
+            log.debug("Flow ${fiber.id} errored, dumping all transitions:\n${record!!.joinToString("\n")}")
             for (error in nextState.checkpoint.errorState.errors) {
-                log.warn("Flow ${fiber.id} error", error.exception)
+                log.debug("Flow ${fiber.id} error", error.exception)
             }
         }
 


### PR DESCRIPTION
Error reporting around flow failures can be difficult to parse, owing to the error being buried within a lot of other information. This PR makes a few tweaks that aim to improve the clarity of error messages, reduce the amount of duplicate information, and move some of the more verbose logging to lower logging levels.

Changes:
 - In `StaffedFlowHospital`, reword the log that prints each error for a flow to make it clear that (possibly) multiple errors are being printed. Additionally, remove extra information that is printed in the logging context, and promote the log to warn. This is where the exception traceback is printed.
 - In `FlowStateMachineImpl`, remove a duplicate printing of the exception traceback
 - In `AttachmentsClassloader`, add a log at the point where an unverified attachment exception is thrown.
 - In `DumpHistoryOnErrorInterceptor`, move the logs to debug. These logs record all state machine transitions when a flow fails, which is often unnecessary in practice.

Testing
 - Used the upgrade cordapp to send a transaction with the new contract version to a node without it, and looked through the logs to observe the changes.