### PR TITLE
CORDA-2848 relax fingerprinter strictness

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
@@ -139,8 +139,7 @@ private class FingerPrintingState(
             is LocalTypeInformation.Abstract -> fingerprintAbstract(type)
             is LocalTypeInformation.Singleton -> fingerprintName(type)
             is LocalTypeInformation.Composable -> fingerprintComposable(type)
-            is LocalTypeInformation.NonComposable -> throw NotSerializableException(
-                    "Attempted to fingerprint non-composable type ${type.typeIdentifier.prettyPrint(false)}")
+            is LocalTypeInformation.NonComposable -> fingerprintNonComposable(type)
         }
     }
 
@@ -169,6 +168,14 @@ private class FingerPrintingState(
             }
 
     private fun fingerprintAbstract(type: LocalTypeInformation.Abstract) =
+            fingerprintWithCustomSerializerOrElse(type) {
+                fingerprintName(type)
+                fingerprintProperties(type.properties)
+                fingerprintInterfaces(type.interfaces)
+                fingerprintTypeParameters(type.typeParameters)
+            }
+
+    private fun fingerprintNonComposable(type: LocalTypeInformation.NonComposable) =
             fingerprintWithCustomSerializerOrElse(type) {
                 fingerprintName(type)
                 fingerprintProperties(type.properties)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
@@ -1,9 +1,14 @@
 package net.corda.serialization.internal.amqp
 
+import net.corda.serialization.internal.AllWhitelist
+import net.corda.serialization.internal.NotSerializable
+import net.corda.serialization.internal.model.ConfigurableLocalTypeModel
 import net.corda.serialization.internal.model.LocalTypeInformation
 import net.corda.serialization.internal.model.TypeModellingFingerPrinter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class TypeModellingFingerPrinterTests {
 
@@ -18,5 +23,24 @@ class TypeModellingFingerPrinterTests {
         val anyType = LocalTypeInformation.Unknown
 
         assertNotEquals(fingerprinter.fingerprint(objectType), fingerprinter.fingerprint(anyType))
+    }
+
+    // Not serializable, because there is no readable property corresponding to the constructor parameter
+    class NonSerializable(a: String)
+
+    class HasTypeParameter<T>
+    data class SuppliesTypeParameter(val value: HasTypeParameter<NonSerializable>)
+
+    // See https://r3-cev.atlassian.net/browse/CORDA-2848
+    @Test
+    fun `can fingerprint type with non-serializable type parameter`() {
+        val typeModel = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, customRegistry))
+        val typeInfo = typeModel.inspect(SuppliesTypeParameter::class.java)
+
+        assertThat(typeInfo).isInstanceOf(LocalTypeInformation.Composable::class.java)
+        val propertyTypeInfo = typeInfo.propertiesOrEmptyMap["value"]?.type as LocalTypeInformation.Composable
+        assertThat(propertyTypeInfo.typeParameters[0]).isInstanceOf(LocalTypeInformation.NonComposable::class.java)
+
+        fingerprinter.fingerprint(typeInfo)
     }
 }


### PR DESCRIPTION
The fingerprinter will refuse to fingerprint any type that is not serializable; however, sometimes types are mentioned (as type parameters) but never used (as the types of concrete property values), and in these cases it is premature to throw an exception during fingerprinting. Instead, we should fingerprint any non-serializable type's publicly readable properties, along with its interfaces and type parameters, just as we would if it were an abstract type.

This is the behaviour of the v3 fingerprinter, which some CorDapps depend on, so we must revert to it.