### PR TITLE
CORDA-2633 Restructure evolution serialization errors to print reason first

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
@@ -22,9 +22,10 @@ interface EvolutionSerializerFactory {
 class EvolutionSerializationException(remoteTypeInformation: RemoteTypeInformation, reason: String)
     : NotSerializableException(
         """
-            Cannot construct evolution serializer for remote type ${remoteTypeInformation.prettyPrint(false)}
+        Cannot construct evolution serializer for remote type ${remoteTypeInformation.typeIdentifier.name}: $reason
 
-            $reason
+        Full type information:
+        ${remoteTypeInformation.prettyPrint(false)}
         """.trimIndent()
 )
 


### PR DESCRIPTION
This is a backport of CORDA-2633 to release/4.
