### PR TITLE
CORDA-2773 Add support for Custom RPC Jackson serializers

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
@@ -236,8 +236,7 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
     /** Returns a string-to-string map of commands to a string describing available parameter types. */
     val availableCommands: Map<String, String>
         get() {
-            return methodMap.entries().map { entry ->
-                val (name, args) = entry   // TODO: Kotlin 1.1
+            return methodMap.entries().map { (name, args) ->
                 val argStr = if (args.parameterCount == 0) "" else {
                     val paramNames = methodParamNames[name]!!
                     val typeNames = args.parameters.map { it.type.simpleName }

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CustomRPCSerializationJacksonModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CustomRPCSerializationJacksonModule.kt
@@ -1,0 +1,15 @@
+package net.corda.client.jackson.internal
+
+import com.fasterxml.jackson.databind.Module
+
+/**
+ * Should be implemented by CorDapps who wish to declare custom serializers.
+ * Classes of this type will be autodiscovered and registered.
+ */
+interface CustomRPCSerializationFactory {
+
+    /**
+     * The returned [Module] will be registered automatically with the interactive shell.
+     */
+    fun createJacksonModule(): Module
+}

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CustomRPCSerializationJacksonModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CustomRPCSerializationJacksonModule.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.Module
  * Should be implemented by CorDapps who wish to declare custom serializers.
  * Classes of this type will be autodiscovered and registered.
  */
-interface CustomRPCSerializationFactory {
+interface CustomShellSerializationFactory {
 
     /**
      * The returned [Module] will be registered automatically with the interactive shell.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cordapp/CustomRPCSerializationJacksonModule.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cordapp/CustomRPCSerializationJacksonModule.kt
@@ -1,9 +1,0 @@
-package net.corda.nodeapi.internal.cordapp
-
-import com.fasterxml.jackson.databind.module.SimpleModule
-
-/**
- * Should be extended by CorDapps who wish to declare custom serializers.
- * Classes of this type will be autodiscovered and registered.
- */
-abstract class CustomRPCSerializationJacksonModule : SimpleModule()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cordapp/CustomRPCSerializationJacksonModule.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cordapp/CustomRPCSerializationJacksonModule.kt
@@ -1,0 +1,9 @@
+package net.corda.nodeapi.internal.cordapp
+
+import com.fasterxml.jackson.databind.module.SimpleModule
+
+/**
+ * Should be extended by CorDapps who wish to declare custom serializers.
+ * Classes of this type will be autodiscovered and registered.
+ */
+abstract class CustomRPCSerializationJacksonModule : SimpleModule()

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -10,7 +10,7 @@ import com.jcraft.jsch.JSch
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.mock
-import net.corda.client.jackson.internal.CustomRPCSerializationFactory
+import net.corda.client.jackson.internal.CustomShellSerializationFactory
 import net.corda.client.rpc.RPCException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
@@ -408,7 +408,7 @@ class InteractiveShellIntegrationTest {
             }
             runFlowByNameFragment(
                     "DeserializeFlow",
-                    "firstAndLastName: John Doe", output, node.rpc, ansiProgressRenderer, createYamlInputMapper(node.rpc, null))
+                    "firstAndLastName: John Doe", output, node.rpc, ansiProgressRenderer, createYamlInputMapper(node.rpc, this::class.java.classLoader))
         }
         assertThat(successful).isTrue()
     }
@@ -454,7 +454,7 @@ class DeserializeFlow(private val firstAndLastName: FirstAndLastName) : FlowLogi
 }
 
 @Suppress("UNUSED")
-class MyCustomJackson : CustomRPCSerializationFactory {
+class MyCustomJackson : CustomShellSerializationFactory {
     override fun createJacksonModule() = object : SimpleModule() {
 
         override fun setupModule(context: SetupContext) {

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaAuthenticationPlugin.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaAuthenticationPlugin.kt
@@ -7,7 +7,7 @@ import org.crsh.auth.AuthInfo
 import org.crsh.auth.AuthenticationPlugin
 import org.crsh.plugin.CRaSHPlugin
 
-class CordaAuthenticationPlugin(private val rpcOps: (username: String, credential: String) -> CordaRPCOps) : CRaSHPlugin<AuthenticationPlugin<String>>(), AuthenticationPlugin<String> {
+class CordaAuthenticationPlugin(private val rpcOps: (username: String, credential: String) -> CordaRPCOps, private val classLoader: ClassLoader?) : CRaSHPlugin<AuthenticationPlugin<String>>(), AuthenticationPlugin<String> {
 
     companion object {
         private val logger = loggerFor<CordaAuthenticationPlugin>()
@@ -24,7 +24,7 @@ class CordaAuthenticationPlugin(private val rpcOps: (username: String, credentia
         }
         try {
             val ops = rpcOps(username, credential)
-            return CordaSSHAuthInfo(true, ops, isSsh = true)
+            return CordaSSHAuthInfo(true, ops, classLoader, isSsh = true)
         } catch (e: ActiveMQSecurityException) {
             logger.warn(e.message)
         } catch (e: Exception) {

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaSSHAuthInfo.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaSSHAuthInfo.kt
@@ -6,10 +6,10 @@ import net.corda.tools.shell.InteractiveShell.createYamlInputMapper
 import net.corda.tools.shell.utlities.ANSIProgressRenderer
 import org.crsh.auth.AuthInfo
 
-class CordaSSHAuthInfo(val successful: Boolean, val rpcOps: CordaRPCOps, val ansiProgressRenderer: ANSIProgressRenderer? = null, val isSsh: Boolean = false) : AuthInfo {
+class CordaSSHAuthInfo(val successful: Boolean, val rpcOps: CordaRPCOps, val classLoader: ClassLoader?, val ansiProgressRenderer: ANSIProgressRenderer? = null, val isSsh: Boolean = false) : AuthInfo {
     override fun isSuccessful(): Boolean = successful
 
     val yamlInputMapper: ObjectMapper by lazy {
-        createYamlInputMapper(rpcOps)
+        createYamlInputMapper(rpcOps, classLoader)
     }
 }


### PR DESCRIPTION
see https://r3-cev.atlassian.net/browse/CORDA-2773

Added an internal class that extends the Jackson SimpleModule which will get autodiscovered and autowired into the RPC ObjectMapper