### PR TITLE
Typo - should be @BelongsToContract not @BelongToContract

### DIFF
--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -87,7 +87,7 @@ indicating the ``Contract`` class to which it is tied:
 
     .. sourcecode:: java
 
-        @BelongToContract(MyContract.class)
+        @BelongsToContract(MyContract.class)
         public class MyState implements ContractState {
             // implementation goes here
         }


### PR DESCRIPTION
Fixing a small typo. Docs should say @BelongsToContract not @BelongToContract