### PR TITLE
Backport - Fix tut-two-party-flow kotlin docs + make both versions easier to read

### DIFF
--- a/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlowResponder.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlowResponder.java
@@ -18,10 +18,10 @@ public class IOUFlowResponder extends FlowLogic<Void> {
         this.otherPartySession = otherPartySession;
     }
 
+    // DOCSTART 1
     @Suspendable
     @Override
     public Void call() throws FlowException {
-        // DOCSTART 01
         class SignTxFlow extends SignTransactionFlow {
             private SignTxFlow(FlowSession otherPartySession) {
                 super(otherPartySession);
@@ -44,6 +44,6 @@ public class IOUFlowResponder extends FlowLogic<Void> {
         subFlow(new ReceiveFinalityFlow(otherPartySession, expectedTxId));
 
         return null;
-        // DOCEND 01
     }
+    // DOCEND 1
 }

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/twoparty/IOUFlowResponder.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/twoparty/IOUFlowResponder.kt
@@ -7,7 +7,6 @@ import net.corda.core.flows.*
 import net.corda.docs.kotlin.tutorial.helloworld.IOUFlow
 import net.corda.docs.kotlin.tutorial.helloworld.IOUState
 
-// DOCSTART 01
 // Add these imports:
 import net.corda.core.contracts.requireThat
 import net.corda.core.transactions.SignedTransaction
@@ -15,9 +14,9 @@ import net.corda.core.transactions.SignedTransaction
 // Define IOUFlowResponder:
 @InitiatedBy(IOUFlow::class)
 class IOUFlowResponder(val otherPartySession: FlowSession) : FlowLogic<Unit>() {
+    // DOCSTART 1
     @Suspendable
     override fun call() {
-        // DOCSTART 01
         val signTransactionFlow = object : SignTransactionFlow(otherPartySession) {
             override fun checkTransaction(stx: SignedTransaction) = requireThat {
                 val output = stx.tx.outputs.single().data
@@ -30,6 +29,6 @@ class IOUFlowResponder(val otherPartySession: FlowSession) : FlowLogic<Unit>() {
         val expectedTxId = subFlow(signTransactionFlow).id
 
         subFlow(ReceiveFinalityFlow(otherPartySession, expectedTxId))
-        // DOCEND 01
     }
+    // DOCEND 1
 }

--- a/docs/source/tut-two-party-flow.rst
+++ b/docs/source/tut-two-party-flow.rst
@@ -87,15 +87,15 @@ to respond, we need to update its responder flow to first receive the partially 
 
     .. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/twoparty/IOUFlowResponder.kt
         :language: kotlin
-        :start-after: DOCSTART 01
-        :end-before: DOCEND 01
-        :dedent: 8
+        :start-after: DOCSTART 1
+        :end-before: DOCEND 1
+        :dedent: 4
 
     .. literalinclude:: example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlowResponder.java
         :language: java
-        :start-after: DOCSTART 01
-        :end-before: DOCEND 01
-        :dedent: 8
+        :start-after: DOCSTART 1
+        :end-before: DOCEND 1
+        :dedent: 4
 
 We could write our own flow to handle this process. However, there is also a pre-defined flow called
 ``SignTransactionFlow`` that can handle the process automatically. The only catch is that ``SignTransactionFlow`` is an


### PR DESCRIPTION
(#5024)

- `DOCSTART`s were not in sync
- Incorrect indentation
- Documentation not very clear

(cherry picked from commit 360660e4d77ab17b68617f8d9c46fab451890cbe)