### PR TITLE
CORDA-2861: give the message executor its own artemis session and producer

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
@@ -108,6 +108,8 @@ class P2PMessagingClient(val config: NodeConfiguration,
         var eventsSubscription: Subscription? = null
         var p2pConsumer: P2PMessagingConsumer? = null
         var locator: ServerLocator? = null
+        var executorProducer: ClientProducer? = null
+        var executorSession: ClientSession? = null
         var producer: ClientProducer? = null
         var producerSession: ClientSession? = null
         var bridgeSession: ClientSession? = null
@@ -170,8 +172,10 @@ class P2PMessagingClient(val config: NodeConfiguration,
             // size of 1MB is acknowledged.
             val createNewSession = { sessionFactory!!.createSession(ArtemisMessagingComponent.NODE_P2P_USER, ArtemisMessagingComponent.NODE_P2P_USER, false, true, true, false, ActiveMQClient.DEFAULT_ACK_BATCH_SIZE) }
 
+            executorSession = createNewSession()
             producerSession = createNewSession()
             bridgeSession = createNewSession()
+            executorSession!!.start()
             producerSession!!.start()
             bridgeSession!!.start()
 
@@ -179,6 +183,7 @@ class P2PMessagingClient(val config: NodeConfiguration,
             // Create a queue, consumer and producer for handling P2P network messages.
             // Create a general purpose producer.
             producer = producerSession!!.createProducer()
+            executorProducer = executorSession!!.createProducer()
 
             inboxes += RemoteInboxAddress(myIdentity).queueName
             serviceIdentity?.let {
@@ -190,8 +195,8 @@ class P2PMessagingClient(val config: NodeConfiguration,
             p2pConsumer = P2PMessagingConsumer(inboxes, createNewSession, isDrainingModeOn, drainingModeWasChangedEvents)
 
             messagingExecutor = MessagingExecutor(
-                    producerSession!!,
-                    producer!!,
+                    executorSession!!,
+                    executorProducer!!,
                     versionInfo,
                     this@P2PMessagingClient,
                     ourSenderUUID = ourSenderUUID
@@ -434,6 +439,10 @@ class P2PMessagingClient(val config: NodeConfiguration,
             close(producer)
             producer = null
             producerSession!!.commit()
+
+            close(executorProducer)
+            executorProducer = null
+            executorSession!!.commit()
 
             close(bridgeNotifyConsumer)
             knownQueues.clear()


### PR DESCRIPTION
PR to backport fix for CORDA-2861. 
Master PR is https://github.com/corda/corda/pull/5031