### PR TITLE
CORDA-2860 relax property type checking (#5028)

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
@@ -4,6 +4,7 @@ import com.google.common.reflect.TypeToken
 import net.corda.core.KeepForDJVM
 import net.corda.core.internal.isPublic
 import net.corda.core.serialization.SerializableCalculatedProperty
+import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.amqp.MethodClassifier.*
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -32,21 +33,20 @@ data class PropertyDescriptor(val field: Field?, val setter: Method?, val getter
      */
     fun validate() {
         getter?.apply {
-            val getterType = genericReturnType
             field?.apply {
-                if (!getterType.isSupertypeOf(genericReturnType))
-                    throw AMQPNotSerializableException(
-                            declaringClass,
-                            "Defined getter for parameter $name returns type $getterType " +
+                if (!getter.returnType.boxesOrIsAssignableFrom(field.type))
+                   throw AMQPNotSerializableException(
+                           declaringClass,
+                            "Defined getter for parameter $name returns type ${getter.returnType} " +
                                     "yet underlying type is $genericType")
             }
         }
 
         setter?.apply {
-            val setterType = genericParameterTypes[0]!!
+            val setterType = setter.parameterTypes[0]!!
 
             field?.apply {
-                if (!genericType.isSupertypeOf(setterType))
+                if (!field.type.boxesOrIsAssignableFrom(setterType))
                     throw AMQPNotSerializableException(
                             declaringClass,
                             "Defined setter for parameter $name takes parameter of type $setterType " +
@@ -54,7 +54,7 @@ data class PropertyDescriptor(val field: Field?, val setter: Method?, val getter
             }
 
             getter?.apply {
-                if (!genericReturnType.isSupertypeOf(setterType))
+                if (!getter.returnType.boxesOrIsAssignableFrom(setterType))
                     throw AMQPNotSerializableException(
                             declaringClass,
                             "Defined setter for parameter $name takes parameter of type $setterType, " +
@@ -63,6 +63,9 @@ data class PropertyDescriptor(val field: Field?, val setter: Method?, val getter
         }
     }
 }
+
+private fun Class<*>.boxesOrIsAssignableFrom(other: Class<*>) =
+        isAssignableFrom(other) || kotlin.javaPrimitiveType == other
 
 private fun Type.isSupertypeOf(that: Type) = TypeToken.of(this).isSupertypeOf(that)
 
@@ -85,7 +88,7 @@ private val propertyMethodRegex = Regex("(?<type>get|set|is)(?<var>\\p{Lu}.*)")
  * take a single parameter of a type compatible with exampleProperty and isExampleProperty must
  * return a boolean
  */
-internal fun Class<out Any?>.propertyDescriptors(): Map<String, PropertyDescriptor> {
+internal fun Class<out Any?>.propertyDescriptors(warnInvalid: Boolean = true): Map<String, PropertyDescriptor> {
     val fieldProperties = superclassChain().declaredFields().byFieldName()
 
     return superclassChain().declaredMethods()
@@ -93,8 +96,9 @@ internal fun Class<out Any?>.propertyDescriptors(): Map<String, PropertyDescript
             .thatArePropertyMethods()
             .withValidSignature()
             .byNameAndClassifier(fieldProperties.keys)
-            .toClassProperties(fieldProperties)
-            .validated()
+            .toClassProperties(fieldProperties).run {
+                if (warnInvalid) validated() else this
+            }
 }
 
 /**

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -283,7 +283,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
     }
 
     private fun buildReadOnlyProperties(rawType: Class<*>): Map<PropertyName, LocalPropertyInformation> =
-            rawType.propertyDescriptors().asSequence().mapNotNull { (name, descriptor) ->
+            rawType.propertyDescriptors(warnIfNonComposable).asSequence().mapNotNull { (name, descriptor) ->
                 if (descriptor.field == null || descriptor.getter == null) null
                 else {
                     val paramType = (descriptor.getter.genericReturnType).resolveAgainstContext()
@@ -310,7 +310,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
             parameter.name to index
         }.toMap()
 
-        return rawType.propertyDescriptors().asSequence().mapNotNull { (name, descriptor) ->
+        return rawType.propertyDescriptors(warnIfNonComposable).asSequence().mapNotNull { (name, descriptor) ->
             val normalisedName = when {
                 name in constructorParameterIndices -> name
                 name.decapitalize() in constructorParameterIndices -> name.decapitalize()
@@ -353,7 +353,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
     }
 
     private fun getterSetterProperties(rawType: Class<*>): Sequence<Pair<String, LocalPropertyInformation>> =
-            rawType.propertyDescriptors().asSequence().mapNotNull { (name, descriptor) ->
+            rawType.propertyDescriptors(warnIfNonComposable).asSequence().mapNotNull { (name, descriptor) ->
                 if (descriptor.getter == null || descriptor.setter == null || descriptor.field == null) null
                 else {
                     val paramType = descriptor.getter.genericReturnType

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
@@ -40,7 +40,7 @@ class LocalTypeModelTests {
 
     @Test
     fun `Primitives and collections`() {
-        assertInformation<CollectionHolder<UUID, LocalDateTime>>("CollectionHolder<UUID, LocalDateTime>")
+        assertInformation<CollectionHolder<UUID, String>>("CollectionHolder<UUID, String>")
 
         assertInformation<StringKeyedCollectionHolder<Int>>("""
             StringKeyedCollectionHolder<Integer>(list: List<Integer>, map: Map<String, Integer>, array: List<Integer>[]): CollectionHolder<String, Integer>
@@ -85,9 +85,9 @@ class LocalTypeModelTests {
     fun `interfaces and superclasses`() {
         assertInformation<SuperSuper<Int, Int>>("SuperSuper<Integer, Integer>")
         assertInformation<Super<UUID>>("Super<UUID>: SuperSuper<UUID, Double>")
-        assertInformation<Abstract<LocalDateTime>>("""
-            Abstract<LocalDateTime>: Super<LocalDateTime[]>, SuperSuper<LocalDateTime[], Double>
-              a: LocalDateTime[]
+        assertInformation<Abstract<String>>("""
+            Abstract<String>: Super<String[]>, SuperSuper<String[], Double>
+              a: String[]
               b: Double
         """)
         assertInformation<Concrete>("""


### PR DESCRIPTION
Backport of CORDA-2860

* CORDA-2860 relax property type checking

* Remove redundant check

* Unit test

* Comment linking ticket to test

* More descriptive comment

* Fix test that was broken by jacocoData field being silently added to class

* Revert to previous behaviour around opaques, suppress validation