### PR TITLE
CORDA-2477 Improve Signature Constraints documentation

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
@@ -108,7 +108,7 @@ object AutomaticPlaceholderConstraint : AttachmentConstraint {
 
 /**
  * An [AttachmentConstraint] that verifies that the attachment has signers that fulfil the provided [PublicKey].
- * See: [Signature Constraints](https://docs.corda.net/design/data-model-upgrades/signature-constraints.html)
+ * See: [Signature Constraints](https://docs.corda.net/head/api-contract-constraints.html#signature-constraints)
  *
  * @property key A [PublicKey] that must be fulfilled by the owning keys of the attachment's signing parties.
  */

--- a/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
@@ -108,7 +108,7 @@ object AutomaticPlaceholderConstraint : AttachmentConstraint {
 
 /**
  * An [AttachmentConstraint] that verifies that the attachment has signers that fulfil the provided [PublicKey].
- * See: [Signature Constraints](https://docs.corda.net/head/api-contract-constraints.html#signature-constraints)
+ * See: [Signature Constraints](https://docs.corda.net/api-contract-constraints.html#signature-constraints)
  *
  * @property key A [PublicKey] that must be fulfilled by the owning keys of the attachment's signing parties.
  */

--- a/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
@@ -52,7 +52,7 @@ object JarSignatureCollector {
                     """
                     Mismatch between signers ${firstSignerSet.toOrderedPublicKeys()} for file $firstFile
                     and signers ${otherSignerSet.toOrderedPublicKeys()} for file ${otherFile}.
-                    See https://docs.corda.net/design/data-model-upgrades/signature-constraints.html for details of the
+                    See https://docs.corda.net/head/api-contract-constraints.html#signature-constraints for details of the
                     constraints applied to attachment signatures.
                     """.trimIndent().replace('\n', ' '))
         }

--- a/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
@@ -52,7 +52,7 @@ object JarSignatureCollector {
                     """
                     Mismatch between signers ${firstSignerSet.toOrderedPublicKeys()} for file $firstFile
                     and signers ${otherSignerSet.toOrderedPublicKeys()} for file ${otherFile}.
-                    See https://docs.corda.net/head/api-contract-constraints.html#signature-constraints for details of the
+                    See https://docs.corda.net/api-contract-constraints.html#signature-constraints for details of the
                     constraints applied to attachment signatures.
                     """.trimIndent().replace('\n', ' '))
         }

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -94,16 +94,12 @@ Further information into the design of Signature Constraints can be found in its
 Signing CorDapps for use with Signature Constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Expanding on the previous section, for an app to use Signature Constraints, it must be signed by a ``CompositeKey`` The signers of the app can consist
-of a single organisation or multiple organisations. Once the app has been signed it can be distributed across the nodes that intend to
-use it.
+Expanding on the previous section, for an app to use Signature Constraints, it must be signed by a ``CompositeKey`` or a simpler ``PublicKey``.
+The signers of the app can consist of a single organisation or multiple organisations. Once the app has been signed, it can be distributed
+across the nodes that intend to use it.
 
 Each transaction received by a node will then verify that the apps attached to it have the correct signers as specified by its
 Signature Constraints. This ensures that the version of each app is acceptable to the transaction's input states.
-
-Signing an app in this way allows it to be upgraded more easily. As long as the new version is signed by the required signers specified
-by the constraint and follows the :ref:`app versioning requirement <app_versioning_with_signature_constraints>` in the section below, it can be
-upgraded without any further steps.
 
 More information on how to sign an app directly from Gradle can be found in the
 :ref:`CorDapp Jar signing <cordapp_build_system_signing_cordapp_jar_ref>` section of the documentation.
@@ -111,8 +107,11 @@ More information on how to sign an app directly from Gradle can be found in the
 Using Signature Constraints in transactions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Signature Constraints are used by default by the ``TransactionBuilder`` for any issuance transactions if the app attached to it is signed.
+If the app is signed, Signature Constraints will be used by default (in most situations) by the ``TransactionBuilder`` when adding output states.
 This is expanded upon in :ref:`contract_constraints_in_transactions`.
+
+.. note:: Signature Constraints are used by default except when a new transaction contains an input state with a Hash Constraint. In this
+          situation the Hash Constraint is used.
 
 .. _app_versioning_with_signature_constraints:
 

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -62,8 +62,8 @@ There are several types of constraints:
 * **Hash constraint**: Exactly one version of the app can be used with this state. This prevents the app from being upgraded in the future while still
   making use of the state created with the original version.
 * **Compatibility zone whitelisted (or CZ whitelisted) constraint**: The compatibility zone operator lists the hashes of the versions that can be used with a contract class name.
-* **Signature constraint**: Any version of the app signed by the given ``CompositeKey`` can be used. This allows a new version of the app to be produced
-  and applied to an existing state as long as it has been signed by the same ``CompositeKey`` as the original version.
+* **Signature constraint**: Any version of the app signed by the given ``PublicKey`` (or `CompositeKey`) can be used. This allows a new version of the app to be produced
+  and applied to an existing state as long as it has been signed by the same key(s) as the original version.
 * **Always accept constraint**: Any version of the app can be used. This is insecure but convenient for testing.
 
 .. _signature_constraints:

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -86,9 +86,10 @@ Signing CorDapps for use with Signature Constraints
 
 Expanding on the previous section, for an app to use Signature Constraints, it must be signed. The signers of the app can consist
 of a single organisation or multiple organisations. Once the app has been signed it can be distributed across the nodes that intend to
-use it. Each transaction received by a node will verify that the version of the app that they have locally has the same signers as the
-app that was passed along with the transaction. This ensures that they are running a version of the app that the transaction can interact
-with.
+use it.
+
+Each transaction received by a node will then verify that the apps attached to it have the correct signers as specified by its
+Signature Constraints. This ensures that the version of each app is acceptable to the transaction's input states.
 
 Signing an app in this way allows it to be upgraded more easily. As long as the new version is signed by the same signers as the original
 version and follows the :ref:`app versioning requirement <app_versioning_with_signature_constraints>` in the section below, it can be

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -134,11 +134,11 @@ Hash constrained states in private networks
 Where private networks started life using CorDapps with hash constrained states, we have introduced a mechanism to relax the checking of
 these hash constrained states when upgrading to signed CorDapps using signature constraints.
 
-The Java system property ``-Dnet.corda.node.disableHashConstraints="true"`` may be set to relax the hash constraint checking behaviour.
+The Java system property ``-Dnet.corda.node.disableHashConstraints="true"`` may be set to relax the hash constraint checking behaviour. For
+this to work, every participant of the network must set the property to the same value. Therefore, this mode should only be used upon
+"out of band" agreement by all participants in a network.
 
-This mode should only be used upon "out of band" agreement by all participants in a network.
-
-Please also beware that this flag should remain enabled until every hash constrained state is exited from the ledger.
+.. warning:: This flag should remain enabled until every hash constrained state is exited from the ledger.
 
 .. _contract_state_agreement:
 
@@ -225,7 +225,7 @@ To manually define the Contract Constraint of an output state, see the example b
         TransactionBuilder transaction() {
             TransactionBuilder transaction = new TransactionBuilder(notary());
             // Signature Constraint used if app is signed
-            transaction.addOutputState(state, CONTRACT_ID);
+            transaction.addOutputState(state);
             // Explicitly using a Signature Constraint
             transaction.addOutputState(state, CONTRACT_ID, new SignatureAttachmentConstraint(getOurIdentity().getOwningKey()));
             // Explicitly using a Hash Constraint
@@ -245,15 +245,15 @@ To manually define the Contract Constraint of an output state, see the example b
         private fun transaction(): TransactionBuilder {
             val transaction = TransactionBuilder(notary())
             // Signature Constraint used if app is signed
-            transaction.addOutputState(state, CONTRACT_ID)
+            transaction.addOutputState(state)
             // Explicitly using a Signature Constraint
-            transaction.addOutputState(state, CONTRACT_ID, SignatureAttachmentConstraint(ourIdentity.owningKey))
+            transaction.addOutputState(state, constraint = SignatureAttachmentConstraint(ourIdentity.owningKey))
             // Explicitly using a Hash Constraint
-            transaction.addOutputState(state, CONTRACT_ID, HashAttachmentConstraint(serviceHub.cordappProvider.getContractAttachmentID(CONTRACT_ID)!!))
+            transaction.addOutputState(state, constraint = HashAttachmentConstraint(serviceHub.cordappProvider.getContractAttachmentID(CONTRACT_ID)!!))
             // Explicitly using a Whitelisted by Zone Constraint
-            transaction.addOutputState(state, CONTRACT_ID, WhitelistedByZoneAttachmentConstraint)
+            transaction.addOutputState(state, constraint = WhitelistedByZoneAttachmentConstraint)
             // Explicitly using an Always Accept Constraint
-            transaction.addOutputState(state, CONTRACT_ID, AlwaysAcceptAttachmentConstraint)
+            transaction.addOutputState(state, constraint = AlwaysAcceptAttachmentConstraint)
 
             // other transaction things
             return transaction

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -106,7 +106,7 @@ properly for future releases.
    future not hold true. You should know the platform version of the node releases you want to target.
 
 The new ``versionId`` number is a version code for **your** app, and is unrelated to Corda's own versions.
-It is used to informative purposes only. See ":ref:`contract_downgrade_rule_ref`" for more information.
+It is used to informative purposes only. See ":ref:`app_versioning_with_signature_constraints`" for more information.
 
 **Split your app into contract and workflow JARs.** The duplication between ``contract`` and ``workflow`` blocks exists because you should split your app into
 two separate JARs/modules, one that contains on-ledger validation code like states and contracts, and one
@@ -418,13 +418,13 @@ to be governed by a contract that is either:
 1. The outer class of the state class, if the state is an inner class of a contract. This is a common design pattern.
 2. Annotated with ``@BelongsToContract`` which specifies the contract class explicitly.
 
-Learn more by reading ":ref:`implicit_constraint_types`". If an app targets Corda 3 or lower (i.e. does not specify a target version),
+Learn more by reading :ref:`contract_state_agreement`. If an app targets Corda 3 or lower (i.e. does not specify a target version),
 states that point to contracts outside their package will trigger a log warning but validation will proceed.
 
 Step 9. Learn about signature constraints and JAR signing
 ---------------------------------------------------------
 
-:doc:`design/data-model-upgrades/signature-constraints` are a new data model feature introduced in Corda 4. They make it much easier to
+:ref:`signature_constraints` are a new data model feature introduced in Corda 4. They make it much easier to
 deploy application upgrades smoothly and in a decentralised manner. Signature constraints are the new default mode for CorDapps, and
 the act of upgrading your app to use the version 4 Gradle plugins will result in your app being automatically signed, and new states
 automatically using new signature constraints selected automatically based on these signing keys.

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -99,6 +99,6 @@ sophisticated or proprietary business logic, machine learning models, even user 
 being Corda flows or services.
 
 .. important:: The ``versionId`` specified for the JAR manifest is checked by the platform and is used for informative purposes only.
- See ":ref:`contract_downgrade_rule_ref`" for more information.
+ See ":ref:`app_versioning_with_signature_constraints`" for more information.
 
 .. note:: You can read the original design doc here: :doc:`design/targetversion/design`.

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -110,7 +110,7 @@ class JarSignatureCollectorTest {
                 """
             Mismatch between signers [O=Alice Corp, L=Madrid, C=ES, O=Bob Plc, L=Rome, C=IT] for file _signable1
             and signers [O=Bob Plc, L=Rome, C=IT] for file _signable2.
-            See https://docs.corda.net/design/data-model-upgrades/signature-constraints.html for details of the
+            See https://docs.corda.net/head/api-contract-constraints.html#signature-constraints for details of the
             constraints applied to attachment signatures.
             """.trimIndent().replace('\n', ' ')
         ) { dir.getJarSigners(FILENAME) }

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -110,7 +110,7 @@ class JarSignatureCollectorTest {
                 """
             Mismatch between signers [O=Alice Corp, L=Madrid, C=ES, O=Bob Plc, L=Rome, C=IT] for file _signable1
             and signers [O=Bob Plc, L=Rome, C=IT] for file _signable2.
-            See https://docs.corda.net/head/api-contract-constraints.html#signature-constraints for details of the
+            See https://docs.corda.net/api-contract-constraints.html#signature-constraints for details of the
             constraints applied to attachment signatures.
             """.trimIndent().replace('\n', ' ')
         ) { dir.getJarSigners(FILENAME) }


### PR DESCRIPTION
Opened to resolve - https://r3-cev.atlassian.net/browse/CORDA-2477

The Signature Constraint documentation in `api-contract-constraints` was very limited and referred to the design doc for most information. Information was extracted from the design doc and added to the main documentation.

- Reorder the documentation in `api-contract-constraints`
- Add further information on Signature Constraints
- Add code examples for using Contract Constraints with
  `TransactionBuilder`
- Correct some links from other docs
- General tidy up documentation

Note there is no mention of `devMode=true` ignoring missing signatures since this has not been implemented and is unlikely to do so in the future.

Link to the new Signature Constraint docs instead of the design doc in
the code.