### PR TITLE
Use `compileOnly` instead of `cordaCompile` in irs-demo to depend on `node` module

### DIFF
--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     
     // only included to control the `DemoClock` as part of the demo application
     // normally `:node` should not be depended on in any CorDapps
-    cordaCompile project(':node')
+    compileOnly project(':node')
 
     // Cordapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps


### PR DESCRIPTION
`compileOnly` instead of `cordaCompile` should be used as per https://docs.corda.net/cordapp-build-systems.html#corda-dependencies

The irs-demo uses `cordaCompile` to bring in the `node` module. This has been changed to `compileOnly`.