### PR TITLE
CashUtils.generateSpend: add anonymous flag, default to true

### DIFF
--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/CashUtils.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/CashUtils.kt
@@ -29,7 +29,6 @@ object CashUtils {
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.
-     * @param anonymous whether or not to use CI to send the change to
      * @return A [Pair] of the same transaction builder passed in as [tx], and the list of keys that need to sign
      *         the resulting transaction for it to be valid.
      * @throws InsufficientBalanceException when a cash spending transaction fails because
@@ -43,8 +42,7 @@ object CashUtils {
                       tx: TransactionBuilder,
                       amount: Amount<Currency>,
                       to: AbstractParty,
-                      onlyFromParties: Set<AbstractParty> = emptySet(),
-                      anonymous: Boolean = true): Pair<TransactionBuilder, List<PublicKey>> {
+                      onlyFromParties: Set<AbstractParty> = emptySet()): Pair<TransactionBuilder, List<PublicKey>> {
         return generateSpend(services, tx, listOf(PartyAndAmount(to, amount)), services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties, anonymous)
     }
 
@@ -58,7 +56,9 @@ object CashUtils {
      *           to move the cash will be added on top.
      * @param amount How much currency to send.
      * @param to the recipient party.
-     * @param ourIdentity well known identity to create a new confidential identity from if anonymous is true, for sending change to.
+     * @param ourIdentity ourIdentity is used to determine the where the change will be sent.
+     *                    If anonymous is true then an anonymous identity will be generated from this and the change
+     *                    will be spent to that, otherwise ourIdentity will be used as is.
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.
@@ -94,7 +94,6 @@ object CashUtils {
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.
-     * @param anonymous whether or not to use CI to send the change to
      * @return A [Pair] of the same transaction builder passed in as [tx], and the list of keys that need to sign
      *         the resulting transaction for it to be valid.
      * @throws InsufficientBalanceException when a cash spending transaction fails because
@@ -107,9 +106,8 @@ object CashUtils {
     fun generateSpend(services: ServiceHub,
                       tx: TransactionBuilder,
                       payments: List<PartyAndAmount<Currency>>,
-                      onlyFromParties: Set<AbstractParty> = emptySet(),
-                      anonymous: Boolean = true): Pair<TransactionBuilder, List<PublicKey>> {
-        return generateSpend(services, tx, payments, services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties, anonymous)
+                      onlyFromParties: Set<AbstractParty> = emptySet()): Pair<TransactionBuilder, List<PublicKey>> {
+        return generateSpend(services, tx, payments, services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties)
     }
 
     /**
@@ -121,7 +119,9 @@ object CashUtils {
      * @param tx A builder, which may contain inputs, outputs and commands already. The relevant components needed
      *           to move the cash will be added on top.
      * @param payments A list of amounts to pay, and the party to send the payment to.
-     * @param ourIdentity well known identity to create a new confidential identity from if anonymous is true, for sending change to.
+     * @param ourIdentity ourIdentity is used to determine the where the change will be sent.
+     *                    If anonymous is true then an anonymous identity will be generated from this and the change
+     *                    will be spent to that, otherwise ourIdentity will be used as is.
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/CashUtils.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/CashUtils.kt
@@ -43,7 +43,7 @@ object CashUtils {
                       amount: Amount<Currency>,
                       to: AbstractParty,
                       onlyFromParties: Set<AbstractParty> = emptySet()): Pair<TransactionBuilder, List<PublicKey>> {
-        return generateSpend(services, tx, listOf(PartyAndAmount(to, amount)), services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties, anonymous)
+        return generateSpend(services, tx, listOf(PartyAndAmount(to, amount)), services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties)
     }
 
     /**

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/CashUtils.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/CashUtils.kt
@@ -29,6 +29,7 @@ object CashUtils {
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.
+     * @param anonymous whether or not to use CI to send the change to
      * @return A [Pair] of the same transaction builder passed in as [tx], and the list of keys that need to sign
      *         the resulting transaction for it to be valid.
      * @throws InsufficientBalanceException when a cash spending transaction fails because
@@ -42,8 +43,9 @@ object CashUtils {
                       tx: TransactionBuilder,
                       amount: Amount<Currency>,
                       to: AbstractParty,
-                      onlyFromParties: Set<AbstractParty> = emptySet()): Pair<TransactionBuilder, List<PublicKey>> {
-        return generateSpend(services, tx, listOf(PartyAndAmount(to, amount)), services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties)
+                      onlyFromParties: Set<AbstractParty> = emptySet(),
+                      anonymous: Boolean = true): Pair<TransactionBuilder, List<PublicKey>> {
+        return generateSpend(services, tx, listOf(PartyAndAmount(to, amount)), services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties, anonymous)
     }
 
     /**
@@ -56,10 +58,11 @@ object CashUtils {
      *           to move the cash will be added on top.
      * @param amount How much currency to send.
      * @param to the recipient party.
-     * @param ourIdentity well known identity to create a new confidential identity from, for sending change to.
+     * @param ourIdentity well known identity to create a new confidential identity from if anonymous is true, for sending change to.
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.
+     * @param anonymous whether or not to use CI to send the change to
      * @return A [Pair] of the same transaction builder passed in as [tx], and the list of keys that need to sign
      *         the resulting transaction for it to be valid.
      * @throws InsufficientBalanceException when a cash spending transaction fails because
@@ -73,8 +76,9 @@ object CashUtils {
                       amount: Amount<Currency>,
                       ourIdentity: PartyAndCertificate,
                       to: AbstractParty,
-                      onlyFromParties: Set<AbstractParty> = emptySet()): Pair<TransactionBuilder, List<PublicKey>> {
-        return generateSpend(services, tx, listOf(PartyAndAmount(to, amount)), ourIdentity, onlyFromParties)
+                      onlyFromParties: Set<AbstractParty> = emptySet(),
+                      anonymous: Boolean = true): Pair<TransactionBuilder, List<PublicKey>> {
+        return generateSpend(services, tx, listOf(PartyAndAmount(to, amount)), ourIdentity, onlyFromParties, anonymous)
     }
 
     /**
@@ -90,6 +94,7 @@ object CashUtils {
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.
+     * @param anonymous whether or not to use CI to send the change to
      * @return A [Pair] of the same transaction builder passed in as [tx], and the list of keys that need to sign
      *         the resulting transaction for it to be valid.
      * @throws InsufficientBalanceException when a cash spending transaction fails because
@@ -102,8 +107,9 @@ object CashUtils {
     fun generateSpend(services: ServiceHub,
                       tx: TransactionBuilder,
                       payments: List<PartyAndAmount<Currency>>,
-                      onlyFromParties: Set<AbstractParty> = emptySet()): Pair<TransactionBuilder, List<PublicKey>> {
-        return generateSpend(services, tx, payments, services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties)
+                      onlyFromParties: Set<AbstractParty> = emptySet(),
+                      anonymous: Boolean = true): Pair<TransactionBuilder, List<PublicKey>> {
+        return generateSpend(services, tx, payments, services.myInfo.legalIdentitiesAndCerts.single(), onlyFromParties, anonymous)
     }
 
     /**
@@ -115,10 +121,11 @@ object CashUtils {
      * @param tx A builder, which may contain inputs, outputs and commands already. The relevant components needed
      *           to move the cash will be added on top.
      * @param payments A list of amounts to pay, and the party to send the payment to.
-     * @param ourIdentity well known identity to create a new confidential identity from, for sending change to.
+     * @param ourIdentity well known identity to create a new confidential identity from if anonymous is true, for sending change to.
      * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
      *                        of given parties. This can be useful if the party you're trying to pay has expectations
      *                        about which type of asset claims they are willing to accept.
+     * @param anonymous whether or not to use CI to send the change to
      * @return A [Pair] of the same transaction builder passed in as [tx], and the list of keys that need to sign
      *         the resulting transaction for it to be valid.
      * @throws InsufficientBalanceException when a cash spending transaction fails because
@@ -131,7 +138,8 @@ object CashUtils {
                       tx: TransactionBuilder,
                       payments: List<PartyAndAmount<Currency>>,
                       ourIdentity: PartyAndCertificate,
-                      onlyFromParties: Set<AbstractParty> = emptySet()): Pair<TransactionBuilder, List<PublicKey>> {
+                      onlyFromParties: Set<AbstractParty> = emptySet(),
+                      anonymous: Boolean = true): Pair<TransactionBuilder, List<PublicKey>> {
         fun deriveState(txState: TransactionState<Cash.State>, amt: Amount<Issued<Currency>>, owner: AbstractParty): TransactionState<Cash.State> {
             return txState.copy(data = txState.data.copy(amount = amt, owner = owner))
         }
@@ -141,17 +149,18 @@ object CashUtils {
         val cashSelection = AbstractCashSelection.getInstance { services.jdbcSession().metaData }
         val acceptableCoins = cashSelection.unconsumedCashStatesForSpending(services, totalAmount, onlyFromParties, tx.notary, tx.lockId)
         val revocationEnabled = false // Revocation is currently unsupported
-        // Generate a new identity that change will be sent to for confidentiality purposes. This means that a
+        // If anonymous is true, generate a new identity that change will be sent to for confidentiality purposes. This means that a
         // third party with a copy of the transaction (such as the notary) cannot identify who the change was
         // sent to
-        val changeIdentity = services.keyManagementService.freshKeyAndCert(ourIdentity, revocationEnabled)
+        val changeIdentity = if (anonymous) services.keyManagementService.freshKeyAndCert(ourIdentity, revocationEnabled).party.anonymise() else ourIdentity.party
         return OnLedgerAsset.generateSpend(
                 tx,
                 payments,
                 acceptableCoins,
-                changeIdentity.party.anonymise(),
+                changeIdentity,
                 ::deriveState,
                 Cash()::generateMoveCommand
         )
     }
 }
+


### PR DESCRIPTION
This one replaces #5047 which touches too many unnecessary files. We only need to change one file CashUtils.kt. 
Mike,
Can we add a flag to the generateSpend functions in CashUtils to indicate whether or not to use CI for the party who is going to receive the change? Default to true so this change won't impact existing usages.
We have disabled the CA function of our node certs so the current generateSpend which uses CI exclusively would fail for our use case. Providing that flag will give the developer the tool to override that behavior.
That way, we don't have to fork away the Corda codebase.