### PR TITLE
ENT-3422 switch to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ buildscript {
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.3'
     ext.junit_version = '4.12'
+    ext.junit_platform_version = '1.4.2'
+    ext.junit_jupiter_version = '5.4.2'
     ext.mockito_version = '2.18.3'
     ext.mockito_kotlin_version = '1.5.0'
     ext.hamkrest_version = '1.4.2.2'

--- a/serialization/src/test/java/net/corda/serialization/internal/ForbiddenLambdaSerializationTests.java
+++ b/serialization/src/test/java/net/corda/serialization/internal/ForbiddenLambdaSerializationTests.java
@@ -5,10 +5,10 @@ import net.corda.core.serialization.SerializationContext;
 import net.corda.core.serialization.SerializationFactory;
 import net.corda.core.serialization.SerializedBytes;
 import net.corda.serialization.internal.amqp.SchemaKt;
-import net.corda.testing.core.SerializationEnvironmentRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import net.corda.testing.core.SerializationEnvironmentExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.NotSerializableException;
 import java.io.Serializable;
@@ -23,11 +23,11 @@ public final class ForbiddenLambdaSerializationTests {
     private EnumSet<SerializationContext.UseCase> contexts = EnumSet.complementOf(
             EnumSet.of(SerializationContext.UseCase.Testing));
 
-    @Rule
-    public final SerializationEnvironmentRule testSerialization = new SerializationEnvironmentRule();
+    @RegisterExtension
+    public final SerializationEnvironmentExtension testSerialization = new SerializationEnvironmentExtension();
     private SerializationFactory factory;
 
-    @Before
+    @BeforeEach
     public void setup() {
         factory = testSerialization.getSerializationFactory();
     }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.serialization.internal.CheckpointSerializationContext
 import net.corda.core.serialization.internal.checkpointDeserialize
 import net.corda.core.serialization.internal.checkpointSerialize
 import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.CheckpointSerializationEnvironmentExtension
 import net.corda.testing.core.internal.CheckpointSerializationEnvironmentRule
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.node.MockServices
@@ -16,19 +17,22 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Assert.assertArrayEquals
 import org.junit.Before
 import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import kotlin.test.assertEquals
 
 class ContractAttachmentSerializerTest {
 
-    @Rule
+    @RegisterExtension
     @JvmField
-    val testCheckpointSerialization = CheckpointSerializationEnvironmentRule()
+    val testCheckpointSerialization = CheckpointSerializationEnvironmentExtension()
 
     private lateinit var contextWithToken: CheckpointSerializationContext
     private val mockServices = MockServices(emptyList(), CordaX500Name("MegaCorp", "London", "GB"), rigorousMock())
 
-    @Before
+    @BeforeEach
     fun setup() {
         contextWithToken = testCheckpointSerialization.checkpointSerializationContext.withTokenContext(
                 CheckpointSerializeAsTokenContextImpl(

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/ListsSerializationTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/ListsSerializationTest.kt
@@ -8,14 +8,14 @@ import net.corda.node.services.statemachine.DataSessionMessage
 import net.corda.serialization.internal.amqp.DeserializationInput
 import net.corda.serialization.internal.amqp.Envelope
 import net.corda.serialization.internal.amqp.SerializerFactoryBuilder
-import net.corda.testing.core.SerializationEnvironmentRule
+import net.corda.testing.core.SerializationEnvironmentExtension
 import net.corda.testing.internal.amqpSpecific
 import net.corda.testing.internal.kryoSpecific
 import org.assertj.core.api.Assertions
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.ByteArrayOutputStream
 import java.io.NotSerializableException
 import java.nio.charset.StandardCharsets.US_ASCII
@@ -33,9 +33,9 @@ class ListsSerializationTest {
                 }
     }
 
-    @Rule
     @JvmField
-    val testSerialization = SerializationEnvironmentRule()
+    @RegisterExtension
+    val testSerialization = SerializationEnvironmentExtension()
 
     @Test
     fun `check list can be serialized as root of serialization graph`() {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/MapsSerializationTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/MapsSerializationTest.kt
@@ -8,13 +8,13 @@ import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.node.serialization.kryo.kryoMagic
 import net.corda.node.services.statemachine.DataSessionMessage
-import net.corda.testing.core.SerializationEnvironmentRule
+import net.corda.testing.core.SerializationEnvironmentExtension
 import net.corda.testing.internal.amqpSpecific
 import net.corda.testing.internal.kryoSpecific
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Assert.assertArrayEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.ByteArrayOutputStream
 import java.util.*
 import kotlin.test.assertEquals
@@ -25,9 +25,9 @@ class MapsSerializationTest {
         val smallMap = mapOf("foo" to "bar", "buzz" to "bull")
     }
 
-    @Rule
     @JvmField
-    val testSerialization = SerializationEnvironmentRule()
+    @RegisterExtension
+    val testSerialization = SerializationEnvironmentExtension()
 
     @Test
     fun `check EmptyMap serialization`() = amqpSpecific("kotlin.collections.EmptyMap is not enabled for Kryo serialization") {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationCompatibilityTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationCompatibilityTests.kt
@@ -3,7 +3,8 @@ package net.corda.serialization.internal
 import net.corda.serialization.internal.amqp.custom.ThrowableSerializer
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
 class SerializationCompatibilityTests {
     @Test

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt
@@ -7,11 +7,11 @@ import net.corda.core.serialization.serialize
 import net.corda.node.serialization.kryo.kryoMagic
 import net.corda.node.services.statemachine.DataSessionMessage
 import net.corda.serialization.internal.amqp.propertyDescriptors
-import net.corda.testing.core.SerializationEnvironmentRule
+import net.corda.testing.core.SerializationEnvironmentExtension
 import net.corda.testing.internal.kryoSpecific
 import org.junit.Assert.*
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.ByteArrayOutputStream
 import java.util.*
 import org.assertj.core.api.Assertions.assertThat
@@ -21,9 +21,9 @@ class SetsSerializationTest {
         val javaEmptySetClass = Collections.emptySet<Any>().javaClass
     }
 
-    @Rule
+    @RegisterExtension
     @JvmField
-    val testSerialization = SerializationEnvironmentRule()
+    val testSerialization = SerializationEnvironmentExtension()
 
     @Test
     fun `check set can be serialized as root of serialization graph`() {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt
@@ -11,10 +11,10 @@ import net.corda.testing.core.SerializationEnvironmentExtension
 import net.corda.testing.internal.kryoSpecific
 import org.junit.Assert.*
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.ByteArrayOutputStream
 import java.util.*
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class SetsSerializationTest {
     private companion object {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPExceptionsTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPExceptionsTests.kt
@@ -1,7 +1,7 @@
 package net.corda.serialization.internal.amqp
 
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import kotlin.test.assertEquals
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
@@ -8,7 +8,7 @@ import net.corda.serialization.internal.model.*
 import net.corda.testing.core.SerializationEnvironmentRule
 import org.junit.Assert.assertEquals
 import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.lang.IllegalArgumentException
 import java.util.*
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifierParserTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifierParserTests.kt
@@ -3,7 +3,8 @@ package net.corda.serialization.internal.amqp
 import com.google.common.reflect.TypeToken
 import net.corda.serialization.internal.model.TypeIdentifier
 import org.apache.qpid.proton.amqp.UnsignedShort
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 import java.time.LocalDateTime
@@ -99,48 +100,48 @@ class AMQPTypeIdentifierParserTests {
         verify("java.util.List<net.corda.core.contracts.Command<net.corda.core.contracts.Command<net.corda.core.contracts.CommandData>>>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test trailing text`() {
+    @Test
+    fun `test trailing text`() = assertThrows<NotSerializableException> {
         verify("java.util.Map<java.lang.String, java.lang.Integer>foo")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test trailing comma`() {
+    @Test
+    fun `test trailing comma`() = assertThrows<NotSerializableException> {
         verify("java.util.Map<java.lang.String, java.lang.Integer,>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test leading comma`() {
+    @Test
+    fun `test leading comma`() = assertThrows<NotSerializableException> {
         verify("java.util.Map<,java.lang.String, java.lang.Integer>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test middle comma`() {
+    @Test
+    fun `test middle comma`() = assertThrows<NotSerializableException> {
         verify("java.util.Map<,java.lang.String,, java.lang.Integer>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test trailing close`() {
+    @Test
+    fun `test trailing close`() = assertThrows<NotSerializableException> {
         verify("java.util.Map<java.lang.String, java.lang.Integer>>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test empty params`() {
+    @Test
+    fun `test empty params`() = assertThrows<NotSerializableException> {
         verify("java.util.Map<>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test mid whitespace`() {
+    @Test
+    fun `test mid whitespace`() = assertThrows<NotSerializableException> {
         verify("java.u til.List<java.lang.String>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test mid whitespace2`() {
+    @Test
+    fun `test mid whitespace2`() = assertThrows<NotSerializableException> {
         verify("java.util.List<java.l ng.String>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test wrong number of parameters`() {
+    @Test
+    fun `test wrong number of parameters`() = assertThrows<NotSerializableException> {
         verify("java.util.List<java.lang.String, java.lang.Integer>")
     }
 
@@ -149,13 +150,13 @@ class AMQPTypeIdentifierParserTests {
         verify("java.lang.String")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test parameters on non-generic type`() {
+    @Test
+    fun `test parameters on non-generic type`() = assertThrows<NotSerializableException> {
         verify("java.lang.String<java.lang.Integer>")
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun `test excessive nesting`() {
+    @Test
+    fun `test excessive nesting`() = assertThrows<NotSerializableException> {
         var nested = "java.lang.Integer"
         for (i in 1..AMQPTypeIdentifierParser.MAX_TYPE_PARAM_DEPTH) {
             nested = "java.util.List<$nested>"

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AbstractAMQPSerializationSchemeTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AbstractAMQPSerializationSchemeTest.kt
@@ -13,7 +13,7 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.Matchers
 import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.net.URLClassLoader
 import java.util.concurrent.ThreadLocalRandom
 import java.util.stream.IntStream

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt
@@ -6,7 +6,7 @@ import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import kotlin.test.assertEquals
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistryTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistryTests.kt
@@ -6,7 +6,7 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.finance.contracts.asset.Cash
 import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.lang.reflect.Type
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeAndReturnEnvelopeTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeAndReturnEnvelopeTests.kt
@@ -6,7 +6,7 @@ import net.corda.serialization.internal.amqp.testutils.serialize
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryWithWhitelist
 import net.corda.serialization.internal.amqp.testutils.testName
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt
@@ -5,7 +5,9 @@ import net.corda.serialization.internal.amqp.testutils.deserialize
 import net.corda.serialization.internal.amqp.testutils.serialize
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.NotSerializableException
 import java.util.*
 
 class DeserializeMapTests {
@@ -28,8 +30,8 @@ class DeserializeMapTests {
         DeserializationInput(sf).deserialize(serialisedBytes)
     }
 
-    @Test(expected = java.io.NotSerializableException::class)
-    fun abstractMapFromMapOf() {
+    @Test
+    fun abstractMapFromMapOf() = assertThrows<NotSerializableException> {
         data class C(val c: AbstractMap<String, Int>)
 
         val c = C(mapOf("A" to 1, "B" to 2) as AbstractMap)
@@ -38,8 +40,8 @@ class DeserializeMapTests {
         DeserializationInput(sf).deserialize(serialisedBytes)
     }
 
-    @Test(expected = java.io.NotSerializableException::class)
-    fun abstractMapFromTreeMap() {
+    @Test
+    fun abstractMapFromTreeMap() = assertThrows<NotSerializableException> {
         data class C(val c: AbstractMap<String, Int>)
 
         val c = C(TreeMap(mapOf("A" to 1, "B" to 2)))

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt
@@ -3,7 +3,7 @@ package net.corda.serialization.internal.amqp
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.serialization.internal.carpenter.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 class DeserializeNeedingCarpentryOfEnumsTest : AmqpCarpenterBase(AllWhitelist) {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt
@@ -3,7 +3,7 @@ package net.corda.serialization.internal.amqp
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.serialization.internal.carpenter.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 // These tests work by having the class carpenter build the classes we serialise and then deserialise. Because

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt
@@ -6,7 +6,7 @@ import net.corda.core.serialization.SerializedBytes
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.serialization.internal.carpenter.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeQueryableStateTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeQueryableStateTest.kt
@@ -12,7 +12,7 @@ import net.corda.serialization.internal.AMQP_RPC_SERVER_CONTEXT
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.TestIdentity
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
@@ -2,7 +2,7 @@ package net.corda.serialization.internal.amqp
 
 import net.corda.core.serialization.CordaSerializable
 import net.corda.serialization.internal.amqp.testutils.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import kotlin.test.assertEquals
 import kotlin.test.assertFails

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt
@@ -6,7 +6,7 @@ import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import java.net.URI
 import java.util.*

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt
@@ -10,7 +10,7 @@ import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.File
 import java.io.NotSerializableException
 import java.net.URI

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt
@@ -11,7 +11,8 @@ import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolu
 import net.corda.serialization.internal.amqp.testutils.testName
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.NotSerializableException
 import java.time.DayOfWeek
 import kotlin.test.assertEquals
@@ -155,8 +156,8 @@ class EnumTests {
         assertEquals(c.c, obj.c)
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun changedEnum1() {
+    @Test
+    fun changedEnum1() = assertThrows<NotSerializableException> {
         val url = EnumTests::class.java.getResource("EnumTests.changedEnum1")
 
         data class C(val a: OldBras)
@@ -174,8 +175,8 @@ class EnumTests {
         DeserializationInput(sf1).deserialize(SerializedBytes<C>(sc2))
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun changedEnum2() {
+    @Test
+    fun changedEnum2() = assertThrows<NotSerializableException> {
         val url = EnumTests::class.java.getResource("EnumTests.changedEnum2")
 
         data class C(val a: OldBras2)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
@@ -7,7 +7,7 @@ import net.corda.core.serialization.CordaSerializationTransformRenames
 import net.corda.serialization.internal.model.EnumTransforms
 import net.corda.serialization.internal.model.InvalidEnumTransformsException
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
 class EnumTransformationTests {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/ErrorMessagesTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/ErrorMessagesTests.kt
@@ -6,7 +6,8 @@ import net.corda.serialization.internal.amqp.testutils.testDefaultFactory
 import net.corda.serialization.internal.amqp.testutils.testName
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 
 class ErrorMessagesTests {
@@ -18,7 +19,7 @@ class ErrorMessagesTests {
             "Property '$property' or its getter is non public, this renders class 'class $testname\$C' unserializable -> class $testname\$C"
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Ignore("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
+    @Disabled("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
     @Test
     fun privateProperty() {
         data class C(private val a: Int)
@@ -33,7 +34,7 @@ class ErrorMessagesTests {
     }
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Ignore("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
+    @Disabled("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
     @Test
     fun privateProperty2() {
         data class C(val a: Int, private val b: Int)
@@ -48,7 +49,7 @@ class ErrorMessagesTests {
     }
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Ignore("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
+    @Disabled("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
     @Test
     fun privateProperty3() {
         // despite b being private, the getter we've added is public and thus allows for the serialisation
@@ -65,7 +66,7 @@ class ErrorMessagesTests {
     }
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Ignore("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
+    @Disabled("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
     @Test
     fun protectedProperty() {
         open class C(@Suppress("unused") protected val a: Int)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactoryTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactoryTests.kt
@@ -4,7 +4,7 @@ import net.corda.core.serialization.SerializedBytes
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import kotlin.test.*
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt
@@ -13,14 +13,15 @@ import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.TestIdentity
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.File
 import java.io.NotSerializableException
 import java.net.URI
 import java.time.Instant
 import kotlin.test.assertEquals
 import net.corda.serialization.internal.amqp.custom.InstantSerializer
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.assertThrows
 
 // To regenerate any of the binary test files do the following
 //
@@ -101,8 +102,8 @@ class EvolvabilityTests {
         assertEquals(null, deserializedC.b)
     }
 
-    @Test(expected = NotSerializableException::class)
-    fun addAdditionalParam() {
+    @Test
+    fun addAdditionalParam() = assertThrows<NotSerializableException> {
         val sf = testDefaultFactory()
         val url = EvolvabilityTests::class.java.getResource("EvolvabilityTests.addAdditionalParam")
         @Suppress("UNUSED_VARIABLE")
@@ -309,9 +310,9 @@ class EvolvabilityTests {
         DeserializationInput(factory).deserialize(SerializedBytes<NetworkParametersExample>(url.readBytes()))
     }
 
-    @Test(expected = NotSerializableException::class)
+    @Test
     @Suppress("UNUSED")
-    fun addMandatoryFieldWithAltConstructorUnAnnotated() {
+    fun addMandatoryFieldWithAltConstructorUnAnnotated() = assertThrows<NotSerializableException> {
         val sf = testDefaultFactory()
         val url = EvolvabilityTests::class.java.getResource(
                 "EvolvabilityTests.addMandatoryFieldWithAltConstructorUnAnnotated")
@@ -596,7 +597,7 @@ class EvolvabilityTests {
     // the resulting file and add to the repo, changing the filename as appropriate
     //
     @Test
-    @Ignore("Test fails after moving NetworkParameters and NotaryInfo into core from node-api")
+    @Disabled("Test fails after moving NetworkParameters and NotaryInfo into core from node-api")
     fun readBrokenNetworkParameters() {
         val sf = testDefaultFactory()
         sf.register(net.corda.serialization.internal.amqp.custom.InstantSerializer(sf))
@@ -627,7 +628,7 @@ class EvolvabilityTests {
     // can still deserialize them
     //
     @Test
-    @Ignore("This test simply regenerates the test file used for readBrokenNetworkParameters")
+    @Disabled("This test simply regenerates the test file used for readBrokenNetworkParameters")
     fun `regenerate broken network parameters`() {
         // note: 6a6b6f256 is the sha that generates the file
         val resource = "networkParams.<corda version>.<commit sha>"

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/FingerPrinterTesting.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/FingerPrinterTesting.kt
@@ -1,6 +1,6 @@
 package net.corda.serialization.internal.amqp
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.TestSerializationOutput

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt
@@ -12,7 +12,7 @@ import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import net.corda.testing.core.TestIdentity
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.net.URI
 import java.util.*
 import kotlin.test.assertEquals

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OptionalSerializationTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OptionalSerializationTests.kt
@@ -9,7 +9,7 @@ import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.equalTo
 import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.*
 
 class OptionalSerializationTests {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt
@@ -5,7 +5,7 @@ import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.AMQP_P2P_CONTEXT
 import org.apache.qpid.proton.codec.Data
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.lang.reflect.Type
 import java.security.PublicKey
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/PrivatePropertyTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/PrivatePropertyTests.kt
@@ -7,7 +7,7 @@ import net.corda.serialization.internal.amqp.testutils.*
 import net.corda.serialization.internal.model.ConfigurableLocalTypeModel
 import net.corda.serialization.internal.model.LocalPropertyInformation
 import net.corda.serialization.internal.model.LocalTypeInformation
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.assertj.core.api.Assertions
 import java.io.NotSerializableException
 import java.util.*

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
@@ -17,7 +17,7 @@ import net.corda.serialization.internal.amqp.testutils.serialize
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt
@@ -46,6 +46,7 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 import java.io.IOException
 import java.io.NotSerializableException
+import java.lang.IllegalArgumentException
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.security.cert.X509CRL
@@ -460,7 +461,7 @@ class SerializationOutputTests(private val compression: CordaSerializationEncodi
     }
 
     @Test(expected = NotSerializableException::class)
-    fun `test mismatched property and constructor naming`() {
+    fun `test mismatched property and constructor naming`()  {
         val obj = Mismatch(456)
         serdes(obj)
     }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationPropertyOrdering.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationPropertyOrdering.kt
@@ -2,7 +2,7 @@ package net.corda.serialization.internal.amqp
 
 import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.serialization.internal.amqp.testutils.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import org.apache.qpid.proton.amqp.Symbol
 import java.lang.reflect.Method

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationSchemaTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationSchemaTests.kt
@@ -7,7 +7,7 @@ import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.GlobalTransientClassWhiteList
 import net.corda.serialization.internal.SerializationContextImpl
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 // Make sure all serialization calls in this test don't get stomped on by anything else

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializeAndReturnSchemaTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializeAndReturnSchemaTest.kt
@@ -3,7 +3,7 @@ package net.corda.serialization.internal.amqp
 import net.corda.serialization.internal.amqp.testutils.serializeAndReturnSchema
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
 import net.corda.serialization.internal.amqp.testutils.testName
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StaticInitialisationOfSerializedObjectTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StaticInitialisationOfSerializedObjectTest.kt
@@ -7,7 +7,9 @@ import net.corda.serialization.internal.amqp.testutils.deserialize
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 import java.util.concurrent.ConcurrentHashMap
@@ -40,12 +42,12 @@ class C2(var b: Int) {
 }
 
 class StaticInitialisationOfSerializedObjectTest {
-    @Test(expected = java.lang.ExceptionInInitializerError::class)
-    fun itBlowsUp() {
+    @Test
+    fun itBlowsUp() = assertThrows<ExceptionInInitializerError> {
         C()
     }
 
-    @Ignore("Suppressing this, as it depends on obtaining internal access to serialiser cache")
+    @Disabled("Suppressing this, as it depends on obtaining internal access to serialiser cache")
     @Test
     fun kotlinObjectWithCompanionObject() {
         data class D(val c: C)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StreamTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StreamTests.kt
@@ -5,7 +5,7 @@ import net.corda.serialization.internal.amqp.custom.InputStreamSerializer
 import net.corda.serialization.internal.amqp.testutils.TestSerializationOutput
 import net.corda.serialization.internal.amqp.testutils.deserialize
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactory
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.FilterInputStream
 import java.io.InputStream
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
@@ -6,7 +6,7 @@ import net.corda.serialization.internal.model.ConfigurableLocalTypeModel
 import net.corda.serialization.internal.model.LocalTypeInformation
 import net.corda.serialization.internal.model.TypeModellingFingerPrinter
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/custom/OptionalSerializerTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/custom/OptionalSerializerTest.kt
@@ -4,7 +4,7 @@ import net.corda.serialization.internal.amqp.SerializerFactory
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.junit.Assert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import java.util.*
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/testutils/AMQPTestUtils.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/testutils/AMQPTestUtils.kt
@@ -13,7 +13,7 @@ import net.corda.serialization.internal.amqp.*
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import net.corda.testing.common.internal.ProjectStructure
 import org.apache.qpid.proton.codec.Data
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.File.separatorChar
 import java.io.NotSerializableException
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
@@ -90,7 +90,9 @@ fun testName(): String {
     val classLoader = Thread.currentThread().contextClassLoader
     return Thread.currentThread().stackTrace.first {
         try {
-            classLoader.loadClass(it.className).getMethod(it.methodName).isAnnotationPresent(Test::class.java)
+            classLoader.loadClass(it.className).getMethod(it.methodName).run {
+                isAnnotationPresent(org.junit.Test::class.java) || isAnnotationPresent(org.junit.jupiter.api.Test::class.java)
+            }
         } catch (e: Exception) {
             false
         }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CarpenterExceptionTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CarpenterExceptionTests.kt
@@ -7,7 +7,7 @@ import net.corda.serialization.internal.amqp.testutils.TestSerializationOutput
 import net.corda.serialization.internal.amqp.testutils.deserialize
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactory
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 import kotlin.reflect.jvm.jvmName

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt
@@ -3,9 +3,13 @@ package net.corda.serialization.internal.carpenter
 import net.corda.core.internal.uncheckedCast
 import net.corda.serialization.internal.AllWhitelist
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.beans.Introspector
+import java.io.NotSerializableException
+import java.lang.IllegalArgumentException
 import java.lang.reflect.Field
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import javax.annotation.Nonnull
 import javax.annotation.Nullable
@@ -95,8 +99,8 @@ class ClassCarpenterTest {
         assertEquals("Person{age=32, name=Mike}", i.toString())
     }
 
-    @Test(expected = DuplicateNameException::class)
-    fun duplicates() {
+    @Test
+    fun duplicates() = assertThrows<DuplicateNameException> {
         cc.build(ClassSchema("gen.EmptyClass", emptyMap()))
         cc.build(ClassSchema("gen.EmptyClass", emptyMap()))
     }
@@ -301,8 +305,8 @@ class ClassCarpenterTest {
         assertEquals(testD, i["d"])
     }
 
-    @Test(expected = java.lang.IllegalArgumentException::class)
-    fun `null parameter small int`() {
+    @Test
+    fun `null parameter small int`() = assertThrows<IllegalArgumentException> {
         val className = "iEnjoySwede"
         val schema = ClassSchema(
                 "gen.$className",
@@ -313,8 +317,8 @@ class ClassCarpenterTest {
         clazz.constructors[0].newInstance(a)
     }
 
-    @Test(expected = NullablePrimitiveException::class)
-    fun `nullable parameter small int`() {
+    @Test
+    fun `nullable parameter small int`() = assertThrows<NullablePrimitiveException> {
         val className = "iEnjoySwede"
         val schema = ClassSchema(
                 "gen.$className",
@@ -351,8 +355,8 @@ class ClassCarpenterTest {
         clazz.constructors[0].newInstance(a)
     }
 
-    @Test(expected = java.lang.reflect.InvocationTargetException::class)
-    fun `non nullable parameter integer with null`() {
+    @Test
+    fun `non nullable parameter integer with null`() = assertThrows<InvocationTargetException> {
         val className = "iEnjoyWibble"
         val schema = ClassSchema(
                 "gen.$className",
@@ -383,8 +387,8 @@ class ClassCarpenterTest {
         assertEquals("$className{a=[1, 2, 3]}", i.toString())
     }
 
-    @Test(expected = java.lang.reflect.InvocationTargetException::class)
-    fun `nullable int array throws`() {
+    @Test
+    fun `nullable int array throws`() = assertThrows<InvocationTargetException> {
         val className = "iEnjoySwede"
         val schema = ClassSchema(
                 "gen.$className",

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterWhitelistTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterWhitelistTest.kt
@@ -4,7 +4,8 @@ import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.CordaSerializable
 import org.assertj.core.api.Assertions
 import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 
 class ClassCarpenterWhitelistTest {
@@ -32,7 +33,7 @@ class ClassCarpenterWhitelistTest {
     }
 
     @Test
-    @Ignore("Currently the carpenter doesn't inspect it's whitelist so will carpent anything" +
+    @Disabled("Currently the carpenter doesn't inspect it's whitelist so will carpent anything" +
             "it's asked relying on the serializer factory to not ask for anything")
     fun notWhitelisted() {
         data class A(val a: Int)
@@ -69,7 +70,7 @@ class ClassCarpenterWhitelistTest {
     }
 
     @Test
-    @Ignore("Currently the carpenter doesn't inspect it's whitelist so will carpent anything" +
+    @Disabled("Currently the carpenter doesn't inspect it's whitelist so will carpent anything" +
             "it's asked relying on the serializer factory to not ask for anything")
     fun notWhitelistedButCarpented() {
         // just have the white list reject *Everything* except ints

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt
@@ -3,7 +3,7 @@ package net.corda.serialization.internal.carpenter
 import net.corda.core.serialization.CordaSerializable
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.testSerializationContext
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import java.util.*
 import kotlin.test.assertEquals

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/EnumClassTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/EnumClassTests.kt
@@ -1,7 +1,7 @@
 package net.corda.serialization.internal.carpenter
 
 import net.corda.serialization.internal.AllWhitelist
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/InheritanceSchemaToClassCarpenterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/InheritanceSchemaToClassCarpenterTests.kt
@@ -3,7 +3,7 @@ package net.corda.serialization.internal.carpenter
 import net.corda.core.serialization.CordaSerializable
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.testSerializationContext
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.*
 import java.io.NotSerializableException
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
@@ -4,7 +4,7 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializableCalculatedProperty
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.testSerializationContext
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/SerDeserCarpentryTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/SerDeserCarpentryTest.kt
@@ -4,16 +4,16 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationFactory
 import net.corda.core.serialization.deserialize
 import net.corda.serialization.internal.amqp.testutils.readTestResource
-import net.corda.testing.core.SerializationEnvironmentRule
+import net.corda.testing.core.SerializationEnvironmentExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class SerDeserCarpentryTest {
-    @Rule
+    @RegisterExtension
     @JvmField
-    val testSerialization = SerializationEnvironmentRule()
+    val testSerialization = SerializationEnvironmentExtension()
 
     @Test
     fun implementingGenericInterface() {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/ClassCarpentingTypeLoaderTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/ClassCarpentingTypeLoaderTests.kt
@@ -6,7 +6,7 @@ import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.asClass
 import net.corda.serialization.internal.amqp.testutils.testSerializationContext
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.lang.reflect.Type
 import kotlin.test.assertEquals
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
@@ -6,7 +6,7 @@ import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.lang.reflect.Type
 import java.time.LocalDateTime
 import java.util.*

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/TypeIdentifierTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/TypeIdentifierTests.kt
@@ -2,7 +2,7 @@ package net.corda.serialization.internal.model
 
 import com.google.common.reflect.TypeToken
 import net.corda.serialization.internal.model.TypeIdentifier.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.lang.reflect.Type
 import kotlin.test.assertEquals
 

--- a/serialization/src/test/resources/junit-platform.properties
+++ b/serialization/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.default = concurrent

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -10,11 +10,16 @@ dependencies {
 
     // Unit testing helpers.
     compile "junit:junit:$junit_version"
+    compile "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
     compile 'org.hamcrest:hamcrest-library:1.3'
     compile "com.nhaarman:mockito-kotlin:$mockito_kotlin_version"
     compile "org.mockito:mockito-core:$mockito_version"
     compile "org.assertj:assertj-core:$assertj_version"
     compile "com.natpryce:hamkrest:$hamkrest_version"
+    
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 jar {


### PR DESCRIPTION
* Adds JUnit 5 version numbers and dependencies to gradle build
* Converts serialization unit tests to use JUnit 5 where possible (remaining with JUnit 4 where tests would require more significant changes to be compatible)
* Introduces `SerializationEnvironmentExtension` as a JUnit 5-compatible replacement `SerializationEnvironmentRule`
* Configures serialization test suite to run tests concurrently.