### PR TITLE
CORDA-2280 Automatic propagation of whitelisted to Signature Constraints

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -431,7 +431,7 @@ open class TransactionBuilder(
         constraints.any { it is HashAttachmentConstraint } -> constraints.find { it is HashAttachmentConstraint }!!
 
         // TODO, we don't currently support mixing signature constraints with different signers. This will change once we introduce third party signers.
-        constraints.map { it is SignatureAttachmentConstraint }.size > 1 ->
+        constraints.count { it is SignatureAttachmentConstraint } > 1 ->
             throw IllegalArgumentException("Cannot mix SignatureAttachmentConstraints signed by different parties in the same transaction.")
 
         // This ensures a smooth migration from a Whitelist Constraint to a Signature Constraint
@@ -445,7 +445,7 @@ open class TransactionBuilder(
         }
 
         // This condition is hit when the current node has not installed the latest signed version but has already received states that have been migrated
-        constraints.any { it is WhitelistedByZoneAttachmentConstraint } && constraints.any { it is SignatureAttachmentConstraint } && !attachmentToUse.isSigned ->
+        constraints.any { it is SignatureAttachmentConstraint } && !attachmentToUse.isSigned ->
             throw IllegalArgumentException("Attempting to create an illegal transaction. Please install the latest signed version for the $attachmentToUse Cordapp.")
 
         // When all input states have the same constraint.

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -15,8 +15,7 @@ CorDapp constraints migration
 Corda 4 introduces and recommends building signed CorDapps that issue states with signature constraints.
 When building transactions in Corda 4, existing on ledger states issued before Corda 4 are only automatically transitioned to the new
 Signature Constraint if they were originally using the CZ Whitelisted Constraint. This document explains how to modify existing CorDapp flows to
-explicitly consume and evolve pre Corda 4 states, and outlines a future mechanism where such states will transition automatically
-(without explicit migration code).
+explicitly consume and evolve pre Corda 4 states.
 
 Faced with the exercise of upgrading an existing Corda 3.x CorDapp to Corda 4, you need to consider the following:
 
@@ -169,9 +168,3 @@ The code below details how to explicitly add a Signature Constraint:
 3. As a node operator you need to add the new signed version of the contracts CorDapp to the ``/cordapps`` folder together with the latest version of the flows jar.
    Please also ensure that the original unsigned contracts CorDapp is removed from the ``/cordapps`` folder (this will already be present in the
    nodes attachments store) to ensure the lookup code in step 3 retrieves the correct signed contract CorDapp JAR.
-
-Later releases
-~~~~~~~~~~~~~~
-
-The next version of Corda will provide automatic transition of *CZ whitelisted* constrained states. This means that signed CorDapps running on a Corda 4.x node will
-automatically propagate any pre-existing on-ledger *CZ whitelisted* constrained states (and generate *signature* constrained outputs).

--- a/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
@@ -2,13 +2,13 @@ package net.corda.contracts
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.CordaRuntimeException
 import net.corda.core.contracts.*
+import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
-import net.corda.core.internal.deleteRecursively
-import net.corda.core.internal.div
-import net.corda.core.internal.packageName
+import net.corda.core.internal.*
 import net.corda.core.messaging.startFlow
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
@@ -23,16 +23,23 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.NodeParameters
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.CustomCordapp
 import net.corda.testing.node.internal.cordappWithPackages
 import net.corda.testing.node.internal.internalDriver
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Assume.assumeFalse
 import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Paths
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class SignatureConstraintVersioningTests {
 
-    private val base = cordappWithPackages(MessageState::class.packageName, DummyMessageContract::class.packageName).signed()
+    private val baseUnsinded = cordappWithPackages(MessageState::class.packageName, DummyMessageContract::class.packageName)
+    private val base = baseUnsinded.signed()
+    private val oldUnsigedCordapp = baseUnsinded.copy(versionId = 2)
+//    private val base = cordappWithPackages(MessageState::class.packageName, DummyMessageContract::class.packageName).signed()
     private val oldCordapp = base.copy(versionId = 2)
     private val newCordapp = base.copy(versionId = 3)
     private val user = User("mark", "dadada", setOf(startFlow<CreateMessage>(), startFlow<ConsumeMessage>(), invokeRpc("vaultQuery")))
@@ -44,9 +51,9 @@ class SignatureConstraintVersioningTests {
         assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
 
         val stateAndRef: StateAndRef<MessageState>? = internalDriver(
-                inMemoryDB = false,
-                startNodesInProcess = isQuasarAgentSpecified(),
-                networkParameters = testNetworkParameters(notaries = emptyList(), minimumPlatformVersion = 4)
+            inMemoryDB = false,
+            startNodesInProcess = isQuasarAgentSpecified(),
+            networkParameters = testNetworkParameters(notaries = emptyList(), minimumPlatformVersion = 4)
         ) {
             val nodeName = {
                 val nodeHandle = startNode(NodeParameters(rpcUsers = listOf(user), additionalCordapps = listOf(oldCordapp))).getOrThrow()
@@ -59,7 +66,13 @@ class SignatureConstraintVersioningTests {
             }()
             val result = {
                 (baseDirectory(nodeName) / "cordapps").deleteRecursively()
-                val nodeHandle = startNode(NodeParameters(providedName = nodeName, rpcUsers = listOf(user), additionalCordapps = listOf(newCordapp))).getOrThrow()
+                val nodeHandle = startNode(
+                    NodeParameters(
+                        providedName = nodeName,
+                        rpcUsers = listOf(user),
+                        additionalCordapps = listOf(newCordapp)
+                    )
+                ).getOrThrow()
                 var result: StateAndRef<MessageState>? = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
                     val page = it.proxy.vaultQuery(MessageState::class.java)
                     page.states.singleOrNull()
@@ -78,6 +91,82 @@ class SignatureConstraintVersioningTests {
         }
         assertNotNull(stateAndRef)
         assertEquals(transformetMessage, stateAndRef!!.state.data.message)
+    }
+
+    @Test
+    fun `auto migration from WhitelistConstraint to SignatureConstraint`() {
+        val stateAndRef =
+            `use states to create transaction with newer cordapp`(oldUnsigedCordapp, newCordapp, listOf(oldUnsigedCordapp, newCordapp))
+        assertNotNull(stateAndRef)
+        assertEquals(transformetMessage, stateAndRef!!.state.data.message)
+    }
+
+    //TODO the test actually doesn't check that signature constraint was used for the second transaction
+    @Test
+    fun `auto migration from WhitelistConstraint to SignatureConstraint fail for not whitelisted signed JAR`() {
+        assertThatExceptionOfType(CordaRuntimeException::class.java).isThrownBy {
+            `use states to create transaction with newer cordapp`(oldUnsigedCordapp, newCordapp, emptyList())
+        }.withMessageContaining("Selected output constraint: $WhitelistedByZoneAttachmentConstraint not satisfying")
+    }
+
+    private fun `use states to create transaction with newer cordapp`(
+        cordapp: CustomCordapp,
+        newCordapp: CustomCordapp,
+        whiteListedCordapps: List<CustomCordapp>
+    ): StateAndRef<MessageState>? {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+
+        val attachmentHashes = whiteListedCordapps.map { Files.newInputStream(it.jarFile).readFully().sha256() }
+
+        return internalDriver(
+            inMemoryDB = false,
+            startNodesInProcess = isQuasarAgentSpecified(),
+            networkParameters = testNetworkParameters(
+                notaries = emptyList(),
+                minimumPlatformVersion = 4, whitelistedContractImplementations = mapOf(TEST_MESSAGE_CONTRACT_PROGRAM_ID to attachmentHashes)
+            )
+        ) {
+            // create transaction using first Cordapp
+            var (nodeName, baseDirectory) = {
+                val nodeHandle = startNode(NodeParameters(rpcUsers = listOf(user), additionalCordapps = listOf(cordapp))).getOrThrow()
+                val nodeName = nodeHandle.nodeInfo.singleIdentity().name
+                CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                    it.proxy.startFlow(::CreateMessage, message, defaultNotaryIdentity).returnValue.getOrThrow()
+                }
+                nodeHandle.stop()
+                Pair(nodeName, nodeHandle.baseDirectory)
+            }()
+
+            // delete the first cordapp
+            val cordappPath = baseDirectory.resolve(Paths.get("cordapps")).resolve(cordapp.jarFile.fileName)
+            cordappPath.delete()
+
+            // create transaction using the upgraded cordapp resuing   input for transaction
+            var result = {
+                val nodeHandle = startNode(
+                    NodeParameters(
+                        providedName = nodeName,
+                        rpcUsers = listOf(user),
+                        additionalCordapps = listOf(newCordapp)
+                    )
+                ).getOrThrow()
+                var result: StateAndRef<MessageState>? = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                    val page = it.proxy.vaultQuery(MessageState::class.java)
+                    page.states.singleOrNull()
+                }
+                CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                    it.proxy.startFlow(::ConsumeMessage, result!!, defaultNotaryIdentity).returnValue.getOrThrow()
+                }
+                result = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                    val page = it.proxy.vaultQuery(MessageState::class.java)
+                    page.states.singleOrNull()
+                }
+
+                nodeHandle.stop()
+                result
+            }()
+            result
+        }
     }
 }
 


### PR DESCRIPTION
If a single whitelisted constraint is being used by input states and the version of the cordapp changes + is signed, then the constraint will transition to a signature constraint.

Tests were taken from another pr that was started (https://github.com/corda/corda/pull/4596)

Created to resolve - https://r3-cev.atlassian.net/browse/CORDA-2280