### PR TITLE
ENT-3422 introduce JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ buildscript {
     ext.netty_version = '4.1.22.Final'
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.3'
-    ext.junit_version = '4.12'
     ext.junit_platform_version = '1.4.2'
     ext.junit_jupiter_version = '5.4.2'
     ext.mockito_version = '2.18.3'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ buildscript {
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.3'
     ext.junit_version = '4.12'
+    ext.junit_platform_version = '1.4.2'
+    ext.junit_jupiter_version = '5.4.2'
     ext.mockito_version = '2.18.3'
     ext.mockito_kotlin_version = '1.5.0'
     ext.hamkrest_version = '1.4.2.2'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     ext {
         guava_version = constants.getProperty("guavaVersion")
         assertj_version = '3.9.1'
-        junit_version = '4.12'
     }
 }
 

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -19,7 +19,9 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 jar {

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -44,13 +44,17 @@ dependencies {
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
 
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     testCompile project(':test-utils')
 
     // Integration test helpers
-    integrationTestCompile "junit:junit:$junit_version"
+    integrationTestImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    integrationTestImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    integrationTestRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     integrationTestCompile project(':node-driver')
 }
 

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -14,7 +14,9 @@ dependencies {
     compile project(':finance:contracts')
 
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     testCompile project(':test-utils')

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -76,7 +76,9 @@ dependencies {
 
     // Unit testing helpers.
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     testCompile project(':node-driver')
@@ -91,7 +93,9 @@ dependencies {
     smokeTestCompile "org.apache.logging.log4j:log4j-core:$log4j_version"
     smokeTestCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"
-    smokeTestCompile "junit:junit:$junit_version"
+    smokeTestImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    smokeTestImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    smokeTestRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 task integrationTest(type: Test) {

--- a/common/configuration-parsing/build.gradle
+++ b/common/configuration-parsing/build.gradle
@@ -12,7 +12,11 @@ dependencies {
     compile project(":common-validation")
 
     testCompile group: "org.jetbrains.kotlin", name: "kotlin-test", version: kotlin_version
-    testCompile group: "junit", name: "junit", version: junit_version
+    
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
+    
     testCompile group: "org.assertj", name: "assertj-core", version: assertj_version
 }
 

--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -13,7 +13,9 @@ dependencies {
     cordaCompile project(':core')
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // Guava: Google test library (collections test suite)
     testCompile "com.google.guava:guava-testlib:$guava_version"

--- a/core-deterministic/testing/build.gradle
+++ b/core-deterministic/testing/build.gradle
@@ -15,7 +15,10 @@ dependencies {
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 // This module has no artifact and only contains tests.

--- a/core-deterministic/testing/data/build.gradle
+++ b/core-deterministic/testing/data/build.gradle
@@ -12,7 +12,9 @@ dependencies {
 
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testCompile "org.jetbrains.kotlin:kotlin-reflect"
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 jar.enabled = false

--- a/core-deterministic/testing/verifier/build.gradle
+++ b/core-deterministic/testing/verifier/build.gradle
@@ -20,7 +20,8 @@ dependencies {
 
     // Compile against the deterministic artifacts to ensure that we use only the deterministic API subset.
     compileOnly configurations.deterministicArtifacts
-    api "junit:junit:$junit_version"
+    api "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    api "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
 }
 
 jar {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -54,7 +54,10 @@ processSmokeTestResources {
 }
 
 dependencies {
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
+    
     testCompile "commons-fileupload:commons-fileupload:$fileupload_version"
 
     // Guava: Google test library (collections test suite)
@@ -89,7 +92,9 @@ dependencies {
     // Smoke tests do NOT have any Node code on the classpath!
     smokeTestCompile project(':smoke-test-utils')
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"
-    smokeTestCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // RxJava: observable streams of events.
     compile "io.reactivex:rxjava:$rxjava_version"

--- a/djvm/djvm/build.gradle
+++ b/djvm/djvm/build.gradle
@@ -35,7 +35,10 @@ dependencies {
     shadow "io.github.classgraph:classgraph:$class_graph_version"
 
     // Test utilities
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
+    
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     jdkRt "net.corda:deterministic-rt:latest.integration"

--- a/experimental/avalanche/build.gradle
+++ b/experimental/avalanche/build.gradle
@@ -8,7 +8,9 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "info.picocli:picocli:$picocli_version"
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 jar.enabled = false

--- a/experimental/behave/build.gradle
+++ b/experimental/behave/build.gradle
@@ -65,7 +65,9 @@ dependencies {
 
     // Unit Tests
 
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
 
     // Scenarios / End-to-End Tests

--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -20,6 +20,8 @@ dependencies {
 
     compile "com.google.guava:guava:$guava_version"
 
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile project(':node-driver')
 }

--- a/experimental/corda-utils/build.gradle
+++ b/experimental/corda-utils/build.gradle
@@ -23,5 +23,7 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(':node-driver')
 
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -15,7 +15,9 @@ dependencies {
 
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/finance/workflows/build.gradle
+++ b/finance/workflows/build.gradle
@@ -37,7 +37,9 @@ dependencies {
     
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -42,7 +42,9 @@ dependencies {
     runtime 'com.mattbertolini:liquibase-slf4j:2.0.0'
 
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile project(':node-driver')

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -129,7 +129,9 @@ dependencies {
     compile "com.typesafe:config:$typesafe_config_version"
 
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
     testCompile project(':test-utils')
     testCompile project(':client:jfx')
@@ -167,7 +169,9 @@ dependencies {
     compile "info.picocli:picocli:$picocli_version"
 
     // Integration test helpers
-    integrationTestCompile "junit:junit:$junit_version"
+    integrationTestImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    integrationTestImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    integrationTestRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     integrationTestCompile "org.assertj:assertj-core:${assertj_version}"
 
     // AgentLoader: dynamic loading of JVM agents

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -54,7 +54,9 @@ dependencies {
         // and we don't need another one.
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
 
     integrationTestCompile project(':webserver')

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -25,7 +25,9 @@ dependencies {
     compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"
 
     // Test dependencies
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 def nodeTask = tasks.getByPath(':node:capsule:assemble')

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -69,7 +69,9 @@ dependencies {
     }
 
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     integrationTestCompile project(path: ":samples:irs-demo:web", configuration: "demoArtifacts")

--- a/samples/irs-demo/cordapp/contracts-irs/build.gradle
+++ b/samples/irs-demo/cordapp/contracts-irs/build.gradle
@@ -11,7 +11,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
 
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 cordapp {

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -24,7 +24,9 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
 
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     cordapp project(':samples:irs-demo:cordapp:contracts-irs')

--- a/samples/network-verifier/workflows/build.gradle
+++ b/samples/network-verifier/workflows/build.gradle
@@ -8,7 +8,9 @@ dependencies {
     cordapp project(':samples:network-verifier:contracts')
 
     testCompile project(":test-utils")
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 cordapp {

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -58,7 +58,9 @@ dependencies {
 
     // Test dependencies
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -55,7 +55,9 @@ dependencies {
         // and we don't need another one.
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/samples/trader-demo/workflows-trader/build.gradle
+++ b/samples/trader-demo/workflows-trader/build.gradle
@@ -11,7 +11,9 @@ dependencies {
     cordapp project(':finance:workflows')
     
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile project(':node-driver')

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -29,7 +29,9 @@ dependencies {
 
     // Integration test helpers
     testCompile "org.assertj:assertj-core:$assertj_version"
-    integrationTestCompile "junit:junit:$junit_version"
+    integrationTestImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    integrationTestImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    integrationTestRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // Jetty dependencies for NetworkMapClient test.
     // Web stuff: for HTTP[S] servlets

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -7,7 +7,10 @@ dependencies {
     compile group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.9.0"
     compile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.0"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+"
-    compile "junit:junit:$junit_version"
+    compile "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    compile "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
 }
 compileKotlin {

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -9,12 +9,17 @@ dependencies {
     compile project(":common-logging")
 
     // Unit testing helpers.
-    compile "junit:junit:$junit_version"
+    compile "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    compile "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
     compile 'org.hamcrest:hamcrest-library:1.3'
     compile "com.nhaarman:mockito-kotlin:$mockito_kotlin_version"
     compile "org.mockito:mockito-core:$mockito_version"
     compile "org.assertj:assertj-core:$assertj_version"
     compile "com.natpryce:hamkrest:$hamkrest_version"
+
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 jar {

--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -74,7 +74,9 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(':webserver')
 
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
 }

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -8,7 +8,9 @@ mainClassName = 'net.corda.explorer.Main'
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // TornadoFX: A lightweight Kotlin framework for working with JavaFX UI's.
     compile 'no.tornado:tornadofx:1.5.9'

--- a/tools/shell/build.gradle
+++ b/tools/shell/build.gradle
@@ -55,7 +55,9 @@ dependencies {
     compile "org.apache.logging.log4j:log4j-core:$log4j_version"
 
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile project(':test-utils')
     testCompile project(':finance:contracts')

--- a/tools/worldmap/build.gradle
+++ b/tools/worldmap/build.gradle
@@ -4,5 +4,7 @@ dependencies {
     implementation project(':core')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -61,7 +61,9 @@ dependencies {
     compileOnly "co.paralleluniverse:capsule:$capsule_version"
 
     integrationTestCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_jupiter_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 }
 
 task integrationTest(type: Test) {


### PR DESCRIPTION
Replace references to JUnit 4 in each module's `build.gradle` to JUnit 5.