### PR TITLE
CORDA-2884 - Docker build tasks will pull the corda jar from artifactory.

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -18,12 +18,11 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
     maven {
-        url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases'
+        url "${artifactory_contextUrl}/corda-releases"
     }
     maven {
-        url "https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev"
+        url "${artifactory_contextUrl}/corda-dev"
     }
-
 }
 
 configurations {
@@ -32,7 +31,7 @@ configurations {
 
 dependencies{
     compile project(':node')
-    artifactoryCorda group : 'net.corda', name : 'corda', version : project.version.toString(), transitive: false
+    artifactoryCorda "net.corda:corda:${project.version}"
 }
 
 shadowJar {

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -16,9 +16,23 @@ apply plugin: 'application'
 mainClassName = 'net.corda.core.ConfigExporterMain'
 apply plugin: 'com.github.johnrengelman.shadow'
 
+repositories {
+    maven {
+        url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases'
+    }
+    maven {
+        url "https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev"
+    }
+
+}
+
+configurations {
+    artifactoryCorda
+}
 
 dependencies{
     compile project(':node')
+    artifactoryCorda group : 'net.corda', name : 'corda', version : project.version.toString(), transitive: false
 }
 
 shadowJar {
@@ -38,11 +52,11 @@ docker{
 
 task buildDockerFolder(dependsOn: [":node:capsule:buildCordaJAR", shadowJar]) {
     doLast {
-        def cordaJar = project(":node:capsule").buildCordaJAR.archivePath
+        def cordaJar = configurations.artifactoryCorda.singleFile
         project.copy {
             into new File(project.buildDir, "docker-temp")
             from "src/bash/run-corda.sh"
-            from cordaJar
+            from cordaJar.path
             from shadowJar.archivePath
             from "src/config/starting-node.conf"
             from "src/bash/generate-config.sh"


### PR DESCRIPTION
Changed the buildDockerFolder to use the corda artifact for the current project.version. Still packages the built config-exporter from shadowJar.
