### PR TITLE
CORDA-2491 Add cordform entrypoint

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,9 @@ Version 4.2
   present in the node in order to verify a chain of transactions using different versions of the same CorDapp - instead the signing key can
   be whitelisted.
 
+* :doc:`design/data-model-upgrades/package-namespace-ownership` configurations can be now be set as described in
+  :ref:`node_package_namespace_ownership`, when using the Cordformation plugin version 4.0.43.
+
 .. _changelog_v4.0:
 
 Version 4.0

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -143,6 +143,27 @@ To copy the same file to all nodes `ext.drivers` can be defined in the top level
         }
     }
 
+Package namespace ownership
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To optionally specify package namespace ownership, the ``networkParameterOverrides`` and ``packageOwnership`` closures can be used:
+
+.. sourcecode:: groovy
+
+    task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
+        [...]
+        networkParameterOverrides {
+            packageOwnership {
+                "com.mypackagename" {
+                    keystore = "_teststore"
+                    keystorePassword = "MyStorePassword"
+                    keystoreAlias = "MyKeyAlias"
+                }
+            }
+        }
+        [...]
+    }
+
+
 Signing Cordapp JARs
 ^^^^^^^^^^^^^^^^^^^^
 The default behaviour of Cordform is to deploy CorDapp JARs "as built":

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -145,7 +145,7 @@ To copy the same file to all nodes `ext.drivers` can be defined in the top level
 
 Package namespace ownership
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To optionally specify package namespace ownership, the ``networkParameterOverrides`` and ``packageOwnership`` closures can be used:
+To specify :doc:`design/data-model-upgrades/package-namespace-ownership` configuration, the optional ``networkParameterOverrides`` and ``packageOwnership`` blocks can be used, similar to the configuration file used in :doc:`network-bootstrapper`:
 
 .. sourcecode:: groovy
 

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -143,6 +143,8 @@ To copy the same file to all nodes `ext.drivers` can be defined in the top level
         }
     }
 
+.. _node_package_namespace_ownership:
+
 Package namespace ownership
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To specify :doc:`design/data-model-upgrades/package-namespace-ownership` configuration, the optional ``networkParameterOverrides`` and ``packageOwnership`` blocks can be used, similar to the configuration file used in :doc:`network-bootstrapper`:

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -8,7 +8,7 @@ description 'Corda node API'
 dependencies {
     compile project(":core")
     compile project(":serialization")  // TODO Remove this once the NetworkBootstrapper class is moved into the tools:bootstrapper module
-    compile project(':common-configuration-parsing')
+    compile project(':common-configuration-parsing') // TODO Remove this dependency once NetworkBootsrapper is moved into tools:bootstrapper
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -8,6 +8,7 @@ description 'Corda node API'
 dependencies {
     compile project(":core")
     compile project(":serialization")  // TODO Remove this once the NetworkBootstrapper class is moved into the tools:bootstrapper module
+    compile project(':common-configuration-parsing')
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -465,7 +465,7 @@ internal constructor(private val initSerEnv: Boolean,
         )
     }
 
-    class AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
+    private class AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
         override fun rpcClientSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()
         override fun rpcServerSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -3,6 +3,7 @@ package net.corda.nodeapi.internal.network
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
+import net.corda.common.configuration.parsing.internal.Configuration
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.*
@@ -196,6 +197,17 @@ internal constructor(private val initSerEnv: Boolean,
     /** Entry point for Cordform */
     fun bootstrapCordform(directory: Path, cordappJars: List<Path>) {
         bootstrap(directory, cordappJars, CopyCordapps.No, fromCordform = true)
+    }
+
+    fun bootstrapCordform(directory: Path, cordappJars: List<Path>, extraConfigurations: String) {
+        val configuration = ConfigFactory.parseString(extraConfigurations).resolve().getObject("networkParameterOverrides").toConfig().parseAsNetworkParametersConfiguration()
+        val networkParametersOverrides = configuration.doOnErrors(::reportErrors).optional ?: throw IllegalStateException("Invalid configuration passed.")
+        bootstrap(directory, cordappJars, CopyCordapps.No, fromCordform = true, networkParametersOverrides = networkParametersOverrides)
+    }
+
+    fun reportErrors(errors: Set<Configuration.Validation.Error>) {
+        System.err.println("Error(s) found parsing the networkParameterOverrides:")
+        errors.forEach { System.err.println("Error parsing ${it.pathAsString}: ${it.message}") }
     }
 
     /** Entry point for the tool */

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -199,6 +199,12 @@ internal constructor(private val initSerEnv: Boolean,
         bootstrap(directory, cordappJars, CopyCordapps.No, fromCordform = true)
     }
 
+    /**
+     * Entry point for Cordform with extra configurations
+     * @param directory - directory on which the network will be deployed
+     * @param cordappJars - List of CordApps to deploy
+     * @param extraConfigurations - HOCON representation of extra configuration parameters
+     */
     fun bootstrapCordform(directory: Path, cordappJars: List<Path>, extraConfigurations: String) {
         val configuration = ConfigFactory.parseString(extraConfigurations).resolve().getObject("networkParameterOverrides").toConfig().parseAsNetworkParametersConfiguration()
         val networkParametersOverrides = configuration.doOnErrors(::reportErrors).optional ?: throw IllegalStateException("Invalid configuration passed.")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -459,7 +459,7 @@ internal constructor(private val initSerEnv: Boolean,
         )
     }
 
-    private class AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
+    class AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
         override fun rpcClientSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()
         override fun rpcServerSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -211,7 +211,7 @@ internal constructor(private val initSerEnv: Boolean,
         bootstrap(directory, cordappJars, CopyCordapps.No, fromCordform = true, networkParametersOverrides = networkParametersOverrides)
     }
 
-    fun reportErrors(errors: Set<Configuration.Validation.Error>) {
+    private fun reportErrors(errors: Set<Configuration.Validation.Error>) {
         System.err.println("Error(s) found parsing the networkParameterOverrides:")
         errors.forEach { System.err.println("Error parsing ${it.pathAsString}: ${it.message}") }
     }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkParameterOverridesSpec.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkParameterOverridesSpec.kt
@@ -52,12 +52,12 @@ internal object NetworkParameterOverridesSpec : Configuration.Specification<Netw
                     val publicKey = ks.getCertificate(configuration[keystoreAlias]).publicKey
                     valid(PackageOwner(javaPackageName, publicKey))
                 } catch (kse: KeyStoreException) {
-                    badValue("Keystore has not been initialized for alias ${configuration[keystoreAlias]}")
+                    badValue("Keystore has not been initialized for alias ${configuration[keystoreAlias]}.")
                 }
             } catch (kse: KeyStoreException) {
-                badValue("Password is incorrect or the key store is damaged for keyStoreFilePath: $suppliedKeystorePath and keyStorePassword: $keystorePassword")
+                badValue("Password is incorrect or the key store is damaged for keyStoreFilePath: $suppliedKeystorePath.")
             } catch (e: IOException) {
-                badValue("Error reading the key store from the file for keyStoreFilePath: $suppliedKeystorePath and keyStorePassword: $keystorePassword ${e.message}")
+                badValue("Error reading the key store from the file for keyStoreFilePath: $suppliedKeystorePath ${e.message}.")
             }
         }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkParameterOverridesSpec.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkParameterOverridesSpec.kt
@@ -1,4 +1,4 @@
-package net.corda.bootstrapper
+package net.corda.nodeapi.internal.network
 
 import com.typesafe.config.Config
 import net.corda.common.configuration.parsing.internal.Configuration
@@ -9,15 +9,13 @@ import net.corda.common.validation.internal.Validated
 import net.corda.core.internal.noPackageOverlap
 import net.corda.core.internal.requirePackageValid
 import net.corda.nodeapi.internal.crypto.loadKeyStore
-import net.corda.nodeapi.internal.network.NetworkParametersOverrides
-import net.corda.nodeapi.internal.network.PackageOwner
 import java.io.IOException
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.KeyStoreException
 
-internal typealias Valid<TARGET> = Validated<TARGET, Configuration.Validation.Error>
+typealias Valid<TARGET> = Validated<TARGET, Configuration.Validation.Error>
 
 fun Config.parseAsNetworkParametersConfiguration(options: Configuration.Validation.Options = Configuration.Validation.Options(strict = false)):
         Valid<NetworkParametersOverrides> = NetworkParameterOverridesSpec.parse(this, options)
@@ -26,15 +24,15 @@ internal fun <T> badValue(msg: String): Valid<T> = Validated.invalid(sequenceOf(
 internal fun <T> valid(value: T): Valid<T> = Validated.valid(value)
 
 internal object NetworkParameterOverridesSpec : Configuration.Specification<NetworkParametersOverrides>("DefaultNetworkParameters") {
-    private val minimumPlatformVersion by int().mapValid(::parsePositiveInteger).optional()
-    private val maxMessageSize by int().mapValid(::parsePositiveInteger).optional()
-    private val maxTransactionSize by int().mapValid(::parsePositiveInteger).optional()
+    private val minimumPlatformVersion by int().mapValid(NetworkParameterOverridesSpec::parsePositiveInteger).optional()
+    private val maxMessageSize by int().mapValid(NetworkParameterOverridesSpec::parsePositiveInteger).optional()
+    private val maxTransactionSize by int().mapValid(NetworkParameterOverridesSpec::parsePositiveInteger).optional()
     private val packageOwnership by nested(PackageOwnershipSpec).list().optional()
     private val eventHorizon by duration().optional()
 
     internal object PackageOwnershipSpec : Configuration.Specification<PackageOwner>("PackageOwners") {
-        private val packageName by string().mapValid(::toPackageName)
-        private val keystore by string().mapValid(::toPath)
+        private val packageName by string().mapValid(PackageOwnershipSpec::toPackageName)
+        private val keystore by string().mapValid(PackageOwnershipSpec::toPath)
         private val keystorePassword by string()
         private val keystoreAlias by string()
 


### PR DESCRIPTION
[CORDA-2491](https://r3-cev.atlassian.net/browse/CORDA-2491)

- Added a new entrypoint for `CordFormation` plugin, with a an additional `String` for extra configuration options. It should be generic enough to pass HOCON representations, not only for networkParameter overrides, but other extra configurations options we might want to pass.
- Moved `NetworkParameterOverridesSpec` from `bootstrapper` to `node-api` to avoid circular dependencies and provide means to validate the HOCON objects passed to the entrypoint.
- Widened the scope of `AMQPParametersSerializationScheme` so it can be used in `CordFormation` tests.
- Removed password logging in case of error.

Related with: corda/corda-gradle-plugins#190, corda/corda#5081