### PR TITLE
Add documentation on Corda Services / Service classes

### DIFF
--- a/docs/source/api-service-classes.rst
+++ b/docs/source/api-service-classes.rst
@@ -63,7 +63,7 @@ its startup. These can then persist during the service's lifetime.
 Retrieving a Service
 --------------------
 
-A Service class can be retrieved by calling ``ServiceHub.cordaService``. Returning the single instance of the class passed into the function:
+A Service class can be retrieved by calling ``ServiceHub.cordaService`` which returns the single instance of the class passed into the function:
 
 .. container:: codeset
 

--- a/docs/source/api-service-classes.rst
+++ b/docs/source/api-service-classes.rst
@@ -1,0 +1,85 @@
+.. highlight:: kotlin
+.. raw:: html
+
+   <script type="text/javascript" src="_static/jquery.js"></script>
+   <script type="text/javascript" src="_static/codesets.js"></script>
+
+API: Service Classes
+====================
+
+Service classes are long-lived instances that can trigger or be triggered by flows from within a node. A Service class is limited to a
+single instance per node. During startup, the node handles the creation of the service.
+
+Services allow related, reusable, functions to be separated into their own class where their functionality is
+grouped together. These functions can then be called from other services or flows.
+
+Creating a Service
+------------------
+
+To define a Service class:
+
+    * Add the ``CordaService`` annotation
+    * Add a constructor with a single parameter of ``AppServiceHub``
+    * Extend ``SingletonSerializeAsToken``
+
+Below is an empty implementation of a Service class:
+
+.. container:: codeset
+
+   .. sourcecode:: kotlin
+
+        @CordaService
+        class MyCordaService(private val serviceHub: AppServiceHub) : SingletonSerializeAsToken() {
+
+            init {
+                // code ran at service creation / node startup
+            }
+
+            // public api of service
+        }
+
+   .. sourcecode:: java
+
+        @CordaService
+        public class MyCordaService extends SingletonSerializeAsToken {
+
+            private AppServiceHub serviceHub;
+
+            public MyCordaService(AppServiceHub serviceHub) {
+                this.serviceHub = serviceHub;
+                // code ran at service creation / node startup
+            }
+
+            // public api of service
+        }
+
+The ``AppServiceHub`` provides the ``ServiceHub`` functionality to the Service class, with the extra ability to start flows.
+
+.. warning:: Take care starting flows via ``AppServiceHub`` from inside a running flow as it can deadlock the node's flow worker queue,
+             preventing new flows from being started.
+
+Code can be run during node startup when the class is being initialised. To do so, place the code into the ``init`` block or constructor.
+This is useful when a service needs to establish a connection to an external database or setup observables via ``ServiceHub.trackBy`` during
+its startup. These can then persist during the service's lifetime.
+
+Retrieving a Service
+--------------------
+
+A Service class can be retrieved by calling ``ServiceHub.cordaService``. Returning the single instance of the class passed into the function:
+
+.. container:: codeset
+
+   .. sourcecode:: kotlin
+
+        val service: MyCordaService = serviceHub.cordaService(MyCordaService::class.java)
+
+   .. sourcecode:: java
+
+       MyCordaService service = serviceHub.cordaService(MyCordaService.class);
+
+.. warning:: ``ServiceHub.cordaService`` should not be called during initialisation of a flow and should instead be called in line where
+             needed or set after the flow's ``call`` function has been triggered.
+
+
+
+

--- a/docs/source/corda-api.rst
+++ b/docs/source/corda-api.rst
@@ -15,6 +15,7 @@ The following are the core APIs that are used in the development of CorDapps:
    api-flows
    api-identity
    api-service-hub
+   api-service-classes
    api-rpc
    api-core-types
    api-testing


### PR DESCRIPTION
There was no documentation added around creating your own service class. Therefore documentation on the subject has been added, which is currently placed in the Corda API section of the docs.
