### PR TITLE
CORDA-2491 Add package namespace ownership documentation

### DIFF
--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -143,6 +143,27 @@ To copy the same file to all nodes `ext.drivers` can be defined in the top level
         }
     }
 
+Package namespace ownership
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To optionally specify package namespace ownership, the ``networkParameterOverrides`` and ``packageOwnership`` closures can be used:
+
+.. sourcecode:: groovy
+
+    task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
+        [...]
+        networkParameterOverrides {
+            packageOwnership {
+                "com.mypackagename" {
+                    keystore = "_teststore"
+                    keystorePassword = "MyStorePassword"
+                    keystoreAlias = "MyKeyAlias"
+                }
+            }
+        }
+        [...]
+    }
+
+
 Signing Cordapp JARs
 ^^^^^^^^^^^^^^^^^^^^
 The default behaviour of Cordform is to deploy CorDapp JARs "as built":


### PR DESCRIPTION
[CORDA-2491](https://r3-cev.atlassian.net/browse/CORDA-2491)

Simple example on how to use the package namespace ownership with `deployNodes`.

Actual documentation regarding package namespace ownership can already be found under the network bootstrapper section.

Related with: corda/corda#5075, corda/corda-gradle-plugins#190