### PR TITLE
Increase the wait time for events as it can take longer on some envir…

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcReconnectTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcReconnectTests.kt
@@ -251,7 +251,7 @@ class RpcReconnectTests {
             var nrRetries = 0
 
             // It might be necessary to wait more for all events to arrive when the node is slow.
-            while (allCashStates.size < nrOfFlowsToRun && nrRetries++ < 3) {
+            while (allCashStates.size < nrOfFlowsToRun && nrRetries++ < 50) {
                 Thread.sleep(2000)
                 allCashStates = readCashStates()
             }


### PR DESCRIPTION
The 3 retries was a bit too optimistic.

It appears that events keep arriving even 20 seconds after finishing all flows on Oracle.
