### PR TITLE
CORDA-825 Test jdbc session and entity manager in corda service constuctors

### DIFF
--- a/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
@@ -90,6 +90,16 @@ class CordaServiceTest {
         nodeA.services.cordaService(VaultQueryService::class.java)
     }
 
+    @Test
+    fun `Can query using jdbc session in constructor`() {
+        nodeA.services.cordaService(JdbcSessionQueryService::class.java)
+    }
+
+    @Test
+    fun `Can use entity manager in constructor`() {
+        nodeA.services.cordaService(EntityManagerService::class.java)
+    }
+
     @StartableByService
     class DummyServiceFlow : FlowLogic<InvocationContext>() {
         companion object {
@@ -158,6 +168,22 @@ class CordaServiceTest {
 
         fun thatWeCanAccessClassLoader() {
             assertNotNull(Thread.currentThread().contextClassLoader, "thread context classloader should not be null during service initialisation")
+        }
+    }
+
+    @CordaService
+    class JdbcSessionQueryService(val serviceHub: AppServiceHub): SingletonSerializeAsToken() {
+        init {
+            serviceHub.jdbcSession().prepareStatement("SELECT * FROM VAULT_STATES").execute()
+        }
+    }
+
+    @CordaService
+    class EntityManagerService(val serviceHub: AppServiceHub): SingletonSerializeAsToken() {
+        init {
+            serviceHub.withEntityManager {
+                createNativeQuery("SELECT * FROM VAULT_STATES").resultList
+            }
         }
     }
 }


### PR DESCRIPTION
I couldnt find any other servicehub functions that were not using transactions from the testing i did. The only ones that weren't were `jdbcSession` and `withEntityManager`.

After talking to Tudor and Stefano, I get the impression that there shouldn't really be any situations where devs are calling code inside of a service that don't already have a db transaction (provided by a flow or trackby). Therefore the only other situation where devs can do this is in the constructor of the service itself. 

This situation is already handled with a db transaction. Therefore only tests were added.

* Add tests to check that `jdbcSession` and `withEntityManager` work inside of Corda Service constructors using the db transaction provided by the `AbstractNode`s initialisation code.