### PR TITLE
ENT-3444 manage test db environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -373,6 +373,7 @@ bintrayConfig {
             'corda-node-api',
             'corda-test-common',
             'corda-test-utils',
+            'corda-test-db',
             'corda-jackson',
             'corda-webserver-impl',
             'corda-webserver',

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,13 @@ buildscript {
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.3'
     ext.junit_version = '4.12'
+    ext.junit4_version = '4.12'
+    // Need this version to access classpath scanning error handling fix -
+    // see https://github.com/junit-team/junit5/commit/389de48c2a18c5a93a7203ef424aa47a8a835a74
+    // Upgrade to 5.5.x when GA release is available.
+    ext.junit_vintage_version = '5.5.0-M1'
+    ext.junit_jupiter_version = '5.5.0-M1'
+    ext.junit_platform_version = '1.4.2'
     ext.mockito_version = '2.18.3'
     ext.mockito_kotlin_version = '1.5.0'
     ext.hamkrest_version = '1.4.2.2'
@@ -460,6 +467,8 @@ if (file('corda-docs-only-build').exists() || (System.getenv('CORDA_DOCS_ONLY_BU
         }
     }
 }
+
+
 
 wrapper {
     gradleVersion = "4.10.1"

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -18,8 +18,16 @@ dependencies {
 
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
+
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
+    
 }
 
 jar {

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -44,7 +44,13 @@ dependencies {
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
 
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     testCompile project(':test-utils')

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -13,8 +13,14 @@ dependencies {
     compile project(':finance:workflows')
     compile project(':finance:contracts')
 
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     testCompile project(':test-utils')

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -74,9 +74,15 @@ dependencies {
     // For caches rather than guava
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     // Unit testing helpers.
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     testCompile project(':node-driver')

--- a/common/configuration-parsing/build.gradle
+++ b/common/configuration-parsing/build.gradle
@@ -10,9 +10,15 @@ dependencies {
     compile group: "com.typesafe", name: "config", version: typesafe_config_version
 
     compile project(":common-validation")
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile group: "org.jetbrains.kotlin", name: "kotlin-test", version: kotlin_version
-    testCompile group: "junit", name: "junit", version: junit_version
     testCompile group: "org.assertj", name: "assertj-core", version: assertj_version
 }
 

--- a/common/validation/build.gradle
+++ b/common/validation/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     testCompile project(":test-utils")
+    
 }
 
 jar {

--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -13,7 +13,12 @@ dependencies {
     cordaCompile project(':core')
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Guava: Google test library (collections test suite)
     testCompile "com.google.guava:guava-testlib:$guava_version"

--- a/core-deterministic/testing/data/build.gradle
+++ b/core-deterministic/testing/data/build.gradle
@@ -12,7 +12,13 @@ dependencies {
 
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testCompile "org.jetbrains.kotlin:kotlin-reflect"
-    testCompile "junit:junit:$junit_version"
+
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 jar.enabled = false

--- a/core-deterministic/testing/verifier/build.gradle
+++ b/core-deterministic/testing/verifier/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     // Compile against the deterministic artifacts to ensure that we use only the deterministic API subset.
     compileOnly configurations.deterministicArtifacts
     api "junit:junit:$junit_version"
+    api "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
 }
 
 jar {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -54,7 +54,14 @@ processSmokeTestResources {
 }
 
 dependencies {
-    testCompile "junit:junit:$junit_version"
+
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+    
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "commons-fileupload:commons-fileupload:$fileupload_version"
 
     // Guava: Google test library (collections test suite)
@@ -87,9 +94,15 @@ dependencies {
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
     // Smoke tests do NOT have any Node code on the classpath!
+    smokeTestCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    smokeTestCompile "junit:junit:${junit4_version}"
+
+    smokeTestRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    smokeTestRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    smokeTestRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     smokeTestCompile project(':smoke-test-utils')
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"
-    smokeTestCompile "junit:junit:$junit_version"
 
     // RxJava: observable streams of events.
     compile "io.reactivex:rxjava:$rxjava_version"

--- a/djvm/djvm/build.gradle
+++ b/djvm/djvm/build.gradle
@@ -34,8 +34,13 @@ dependencies {
     // ClassGraph: classpath scanning
     shadow "io.github.classgraph:classgraph:$class_graph_version"
 
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     // Test utilities
-    testImplementation "junit:junit:$junit_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     jdkRt "net.corda:deterministic-rt:latest.integration"

--- a/experimental/avalanche/build.gradle
+++ b/experimental/avalanche/build.gradle
@@ -8,7 +8,13 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "info.picocli:picocli:$picocli_version"
-    testCompile "junit:junit:$junit_version"
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 jar.enabled = false

--- a/experimental/behave/build.gradle
+++ b/experimental/behave/build.gradle
@@ -64,8 +64,13 @@ dependencies {
     compile project(':client:rpc')
 
     // Unit Tests
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
 
-    testCompile "junit:junit:$junit_version"
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:$assertj_version"
 
     // Scenarios / End-to-End Tests

--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -20,6 +20,11 @@ dependencies {
 
     compile "com.google.guava:guava:$guava_version"
 
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     testCompile project(':node-driver')
 }

--- a/experimental/corda-utils/build.gradle
+++ b/experimental/corda-utils/build.gradle
@@ -23,5 +23,10 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(':node-driver')
 
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -15,7 +15,12 @@ dependencies {
 
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/finance/workflows/build.gradle
+++ b/finance/workflows/build.gradle
@@ -37,7 +37,13 @@ dependencies {
     
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
-    testCompile "junit:junit:$junit_version"
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -41,8 +41,13 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     runtime 'com.mattbertolini:liquibase-slf4j:2.0.0'
 
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile project(':node-driver')

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -128,8 +128,14 @@ dependencies {
     // TypeSafe Config: for simple and human friendly config files.
     compile "com.typesafe:config:$typesafe_config_version"
 
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
     testCompile project(':test-utils')
     testCompile project(':client:jfx')

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -54,7 +54,14 @@ dependencies {
         // and we don't need another one.
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
-    testCompile "junit:junit:$junit_version"
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:$assertj_version"
 
     integrationTestCompile project(':webserver')

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -25,7 +25,12 @@ dependencies {
     compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"
 
     // Test dependencies
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 def nodeTask = tasks.getByPath(':node:capsule:assemble')

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -69,7 +69,14 @@ dependencies {
     }
 
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     integrationTestCompile project(path: ":samples:irs-demo:web", configuration: "demoArtifacts")

--- a/samples/irs-demo/cordapp/contracts-irs/build.gradle
+++ b/samples/irs-demo/cordapp/contracts-irs/build.gradle
@@ -11,7 +11,12 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
 
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 cordapp {

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -24,7 +24,14 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
 
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     cordapp project(':samples:irs-demo:cordapp:contracts-irs')

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -58,7 +58,14 @@ dependencies {
 
     // Test dependencies
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -55,7 +55,14 @@ dependencies {
         // and we don't need another one.
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
-    testCompile "junit:junit:$junit_version"
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/samples/trader-demo/workflows-trader/build.gradle
+++ b/samples/trader-demo/workflows-trader/build.gradle
@@ -11,7 +11,14 @@ dependencies {
     cordapp project(':finance:workflows')
     
     testCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+    
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -28,8 +28,13 @@ dependencies {
     // For caches rather than guava
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
-    // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile project(':node-driver')

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,10 +28,11 @@ include 'jdk8u-deterministic'
 include 'test-common'
 include 'test-cli'
 include 'test-utils'
+include 'test-db'
 include 'smoke-test-utils'
 include 'node-driver'
 // Avoid making 'testing' a project, and allow build.gradle files to refer to these by their simple names:
-['test-common', 'test-utils', 'test-cli', 'smoke-test-utils', 'node-driver'].each {
+['test-common', 'test-utils', 'test-cli', 'test-db', 'smoke-test-utils', 'node-driver'].each {
     project(":$it").projectDir = new File("$settingsDir/testing/$it")
 }
 include 'tools:explorer'

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -29,7 +29,12 @@ dependencies {
 
     // Integration test helpers
     testCompile "org.assertj:assertj-core:$assertj_version"
-    integrationTestCompile "junit:junit:$junit_version"
+    integrationTestCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    integrationTestCompile "junit:junit:${junit4_version}"
+
+    integrationTestRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    integrationTestRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    integrationTestRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Jetty dependencies for NetworkMapClient test.
     // Web stuff: for HTTP[S] servlets

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -7,7 +7,13 @@ dependencies {
     compile group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.9.0"
     compile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.0"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+"
-    compile "junit:junit:$junit_version"
+    
+    compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    compile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
 }
 compileKotlin {

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -9,7 +9,13 @@ dependencies {
     compile project(":common-logging")
 
     // Unit testing helpers.
-    compile "junit:junit:$junit_version"
+    compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    compile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     compile 'org.hamcrest:hamcrest-library:1.3'
     compile "com.nhaarman:mockito-kotlin:$mockito_kotlin_version"
     compile "org.mockito:mockito-core:$mockito_version"

--- a/testing/test-db/build.gradle
+++ b/testing/test-db/build.gradle
@@ -1,0 +1,26 @@
+apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'net.corda.plugins.api-scanner'
+apply plugin: 'com.jfrog.artifactory'
+
+dependencies {
+    compile "org.slf4j:slf4j-api:$slf4j_version"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
+    
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+
+    compile "org.assertj:assertj-core:$assertj_version"
+}
+
+jar {
+    baseName 'corda-test-db'
+}
+
+publish {
+    name jar.baseName
+}

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/DBRunnerExtension.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/DBRunnerExtension.kt
@@ -1,0 +1,79 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.extension.*
+
+/***
+ * A JUnit 5 [Extension] which invokes a [TestDatabaseContext] to manage database state across three scopes:
+ *
+ * * Test run (defined across multiple classes)
+ * * Test suite (defined in a single class)
+ * * Test instance (defined in a single method)
+ *
+ * A test class will not ordinarily register this extension directly: instead, it is registered for any class having the [RequiresDb]
+ * annotation, which it consults to discover which group of tests the test class belongs to (`"default"`, if not stated).
+ *
+ * The class of the [TestDatabaseContext] used is selected by a system property, `test.db.context./groupName/`, where `groupName` is the
+ * name of the group of tests to which the test using this extension belongs. If this system property is not set, the class name defaults
+ * to the [RequiresDb.defaultContextClassName] stated in the annotation, which in turn defaults to the class of [NoOpTestDatabaseContext].
+ *
+ * When [BeforeAllCallback.beforeAll] is called prior to executing any test methods in a given class, the [ExtensionContext.Store] of the
+ * root extension context is used to look up the [TestDatabaseContext] for the class's declared `groupName`, creating and initialising it
+ * if it does not already exist. This ensures that a [TestDatabaseContext] is created exactly once during each test run for every named
+ * group of tests using this extension. This context will be closed with a call to [ExtensionContext.Store.CloseableResource.close] once
+ * the test run completes, tearing down the database state created at the beginning.
+ *
+ * For each test suite and test instance, this extension looks at the corresponding class or method to see if it is annotated with
+ * [RequiresSql], indicating that further SQL setup/teardown is required around the current scope. If it is, then appropriate calls are made
+ * to [TestDatabaseContext.beforeClass], [TestDatabaseContext.beforeTest], [TestDatabaseContext.afterTest] and
+ * [TestDatabaseContext.afterClass], passing through the name of the SQL script to be run. (Note that the same name is used for setup and
+ * teardown, and it is up to the [TestDatabaseContext] to map this to the appropriate SQL script for each case).
+ */
+class DBRunnerExtension : Extension, BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
+
+    override fun beforeAll(context: ExtensionContext?) {
+        // Always obtain/create a database context
+        val dbContext = getDatabaseContext(context) ?: return
+        val testSql = context?.testClass?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        dbContext.beforeClass(testSql)
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        val testSql = context?.testClass?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        getDatabaseContext(context)?.afterClass(testSql)
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        val testSql = context?.testMethod?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        getDatabaseContext(context)?.beforeTest(testSql)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        val testSql = context?.testMethod?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        getDatabaseContext(context)?.afterTest(testSql)
+    }
+
+    private fun getDatabaseContext(context: ExtensionContext?): TestDatabaseContext? {
+        val rootContext = context?.root ?: return null
+
+        val testClass = context.testClass.orElse(null) ?: return null
+        val annotation = testClass.getAnnotation(RequiresDb::class.java) ?:
+            throw IllegalStateException("Test run with DBRunnerExtension is not annotated with @RequiresDb")
+        val groupName = annotation.group
+        val defaultContextClassName = annotation.defaultContextClassName
+
+        val store = rootContext.getStore(ExtensionContext.Namespace.create(DBRunnerExtension::class.java.simpleName, groupName))
+        return store.getOrComputeIfAbsent(
+                TestDatabaseContext::class.java.simpleName,
+                { createDatabaseContext(groupName, defaultContextClassName) },
+                TestDatabaseContext::class.java)
+    }
+
+    private fun createDatabaseContext(groupName: String, defaultContextClassName: String): TestDatabaseContext {
+        val propertyKey = "test.db.context.$groupName"
+        val className = System.getProperty(propertyKey) ?: defaultContextClassName
+
+        val ctx = Class.forName(className).newInstance() as TestDatabaseContext
+        ctx.initialize(groupName)
+        return ctx
+    }
+}

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/NoOpTestDatabaseContext.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/NoOpTestDatabaseContext.kt
@@ -1,0 +1,41 @@
+package net.corda.testing.db
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * An implementation of [TestDatabaseContext] which does nothing besides logging the calls made to it.
+ */
+class NoOpTestDatabaseContext : TestDatabaseContext {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(NoOpTestDatabaseContext::class.java)
+    }
+
+    private lateinit var groupName: String
+
+    override fun initialize(groupName: String) {
+        logger.info("[NO-OP] Initializing database group $groupName")
+        this.groupName = groupName
+    }
+
+    override fun beforeClass(setupSql: String) {
+        logger.info("[NO-OP] Running SQL setup script $setupSql in group $groupName")
+    }
+
+    override fun afterClass(teardownSql: String) {
+        logger.info("[NO-OP] Running SQL teardown script $teardownSql in group $groupName")
+    }
+
+    override fun beforeTest(setupSql: String) {
+        logger.info("[NO-OP] Running SQL setup script $setupSql in group $groupName")
+    }
+
+    override fun afterTest(teardownSql: String) {
+        logger.info("[NO-OP] Running SQL teardown script $teardownSql in group $groupName")
+    }
+
+    override fun close() {
+        logger.info("[NO-OP] Cleaning up database group $groupName")
+    }
+}

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/RequiresDb.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/RequiresDb.kt
@@ -1,0 +1,32 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * An annotation which is applied to test classes to indicate that they belong to a group of tests which require a common database
+ * environment, which is initialized before any of the tests in any of the classes in that group are run, and cleaned up after all of them
+ * have completed.
+ *
+ * @param group The name of the group of tests to which the annotated test belongs, or `"default"` if unstated.
+ * @param defaultContextClassName The class name of the [TestDatabaseContext] which should be instantiated to manage the database
+ * environment for these tests, if none is given in the system property `test.db.context./groupName/`. This defaults to the class name of
+ * [NoOpTestDatabaseContext].
+ */
+@ExtendWith(DBRunnerExtension::class)
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class RequiresDb(
+        val group: String = "default",
+        val defaultContextClassName: String = "net.corda.testing.db.NoOpTestDatabaseContext")
+
+/**
+ * An annotation which is applied to test classes and methods to indicate that the corresponding test suite  / instance requires SQL scripts
+ * to be run against its database as part of its setup / teardown.
+ *
+ * @param name The name of the SQL script to run. The same name will be used for setup and teardown: it is up to the [TestDatabaseContext] to
+ * select the actual SQL script based on the context, e.g. `"specialSql"` may be translated to `"/groupName/-specialSql-setup.sql"` or to
+ * `"/groupName/-specialSql-teardown.sql"` depending on which operation is being performed.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class RequiresSql(val name: String)

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/TestDatabaseContext.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/TestDatabaseContext.kt
@@ -1,0 +1,53 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Interface which must be implemented by any class offering to manage test database environments for tests annotated with [RequiresDb].
+ *
+ * A separate instance of [TestDatabaseContext] will be created and initialised for each group of tests, identified by [RequiresDb.group].
+ *
+ * Once all tests in the group have been run, [ExtensionContext.Store.CloseableResource.close] will be called; implementations should use
+ * this method to tear down the database context.
+ */
+interface TestDatabaseContext : ExtensionContext.Store.CloseableResource {
+
+    /**
+     * Called once when the context is first instantiated, i.e. at the start of the test run, before any tests at all have been executed.
+     *
+     * @param groupName The name of the group of tests whose database environment is to be managed by this context.
+     */
+    fun initialize(groupName: String)
+
+    /**
+     * Called once if some setup SQL needs to be run before a suite of tests is executed, as indicated by a [RequiresSql] annotation on the
+     * class containing the test suite.
+     *
+     * @param setupSql The name of the SQL script to be run prior to running the suite of tests.
+     */
+    fun beforeClass(setupSql: String)
+
+    /**
+     * Called once if some setup SQL needs to be run after a suite of tests is executed, as indicated by a [RequiresSql] annotation on the
+     * class containing the test suite.
+     *
+     * @param teardownSql The name of the SQL script to be run after running the suite of tests.
+     */
+    fun afterClass(teardownSql: String)
+
+    /**
+     * Called once if some setup SQL needs to be run before a given test is executed, as indicated by a [RequiresSql] annotation on the
+     * method defining the test
+     *
+     * @param setUpSql The name of the SQL script to be run before running the test.
+     */
+    fun beforeTest(setupSql: String)
+
+    /**
+     * Called once if some setup SQL needs to be run after a given test is executed, as indicated by a [RequiresSql] annotation on the
+     * method defining the test
+     *
+     * @param teardownSql The name of the SQL script to be run after running the test.
+     */
+    fun afterTest(teardownSql: String)
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/AssertingTestDatabaseContext.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/AssertingTestDatabaseContext.kt
@@ -1,0 +1,61 @@
+package net.corda.testing.db
+
+import org.assertj.core.api.Assertions.assertThat
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.lang.IllegalStateException
+
+class AssertingTestDatabaseContext : TestDatabaseContext {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(AssertingTestDatabaseContext::class.java)
+        private val expectations = mutableMapOf<String, List<String>>()
+
+        fun addExpectations(groupName: String, vararg scripts: String) {
+            expectations.compute(groupName) { _, expected ->
+                (expected ?: emptyList()) + scripts.toList()
+            }
+        }
+    }
+
+    private lateinit var groupName: String
+    private val scriptsRun = mutableListOf<String>()
+
+    override fun initialize(groupName: String) {
+        this.groupName = groupName
+        scriptsRun += "${groupName}-db-setup.sql"
+    }
+
+    override fun beforeClass(setupSql: String) {
+        scriptsRun += "$groupName-$setupSql-setup.sql"
+    }
+
+    override fun afterClass(teardownSql: String) {
+        scriptsRun += "$groupName-$teardownSql-teardown.sql"
+    }
+
+    override fun beforeTest(setupSql: String) {
+        scriptsRun += "$groupName-$setupSql-setup.sql"
+    }
+
+    override fun afterTest(teardownSql: String) {
+        scriptsRun += "$groupName-$teardownSql-teardown.sql"
+    }
+
+    override fun close() {
+        scriptsRun += "${groupName}-db-teardown.sql"
+
+        logger.info("SQL scripts run for group $groupName:\n" + scriptsRun.joinToString("\n"))
+
+        val expectedScripts = (listOf("db-setup") + (expectations[groupName] ?: emptyList()) + listOf("db-teardown"))
+                .map { "$groupName-$it.sql" }
+                .toTypedArray()
+
+        try {
+            assertThat(scriptsRun).containsExactlyInAnyOrder(*expectedScripts)
+        } catch (e: AssertionError) {
+            throw IllegalStateException("Assertion failed: ${e.message}")
+        }
+    }
+
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupAMoreTests.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupAMoreTests.kt
@@ -1,0 +1,20 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.Test
+
+@RequiresDb("groupA", "net.corda.testing.db.AssertingTestDatabaseContext")
+class GroupAMoreTests {
+
+    @Test
+    fun setExpectations() {
+        AssertingTestDatabaseContext.addExpectations("groupA",
+                "specialSql2-setup", "specialSql2-teardown")
+    }
+
+    @Test
+    @RequiresSql("specialSql2")
+    fun moreSpecialSqlRequired() {
+
+    }
+
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupATests.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupATests.kt
@@ -1,0 +1,26 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.Test
+
+@RequiresDb("groupA", "net.corda.testing.db.AssertingTestDatabaseContext")
+@RequiresSql("forClassGroupATests")
+class GroupATests {
+
+    @Test
+    fun setExpectations() {
+        AssertingTestDatabaseContext.addExpectations("groupA",
+                "forClassGroupATests-setup", "specialSql1-setup", "specialSql1-teardown", "forClassGroupATests-teardown")
+    }
+
+    @Test
+    fun noSpecialSqlRequired() {
+
+    }
+
+    @Test
+    @RequiresSql("specialSql1")
+    fun someSpecialSqlRequired() {
+
+    }
+
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupBTests.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupBTests.kt
@@ -1,0 +1,26 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.Test
+
+@RequiresDb("groupB", "net.corda.testing.db.AssertingTestDatabaseContext")
+@RequiresSql("forClassGroupBTests")
+class GroupBTests {
+
+    @Test
+    fun setExpectations() {
+        AssertingTestDatabaseContext.addExpectations("groupB",
+                "forClassGroupBTests-setup", "specialSql1-setup", "specialSql1-teardown", "forClassGroupBTests-teardown")
+    }
+
+    @Test
+    fun noSpecialSqlRequired() {
+
+    }
+
+    @Test
+    @RequiresSql("specialSql1")
+    fun someSpecialSqlRequired() {
+
+    }
+
+}

--- a/testing/test-db/src/test/resources/log4j2-test.xml
+++ b/testing/test-db/src/test/resources/log4j2-test.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info" packages="net.corda.common.logging">
+
+    <Properties>
+        <Property name="log-path">${sys:log-path:-logs}</Property>
+        <Property name="log-name">node-${hostName}</Property>
+        <Property name="archive">${log-path}/archive</Property>
+        <Property name="defaultLogLevel">${sys:defaultLogLevel:-info}</Property>
+    </Properties>
+
+    <ThresholdFilter level="trace"/>
+
+    <Appenders>
+        <Console name="Console-Appender" target="SYSTEM_OUT">
+            <PatternLayout>
+                <ScriptPatternSelector defaultPattern="%highlight{[%level{length=5}] %date{HH:mm:ss,SSS} [%t] %c{2}.%method - %msg%n}{INFO=white,WARN=red,FATAL=bright red}">
+                    <Script name="MDCSelector" language="javascript"><![CDATA[
+                    result = null;
+                    if (!logEvent.getContextData().size() == 0) {
+                        result = "WithMDC";
+                    } else {
+                        result = null;
+                    }
+                    result;
+               ]]>
+                    </Script>
+                    <PatternMatch key="WithMDC" pattern="%highlight{[%level{length=5}] %date{HH:mm:ss,SSS} [%t] %c{2}.%method - %msg %X%n}{INFO=white,WARN=red,FATAL=bright red}"/>
+                </ScriptPatternSelector>
+            </PatternLayout>
+            <ThresholdFilter level="trace"/>
+        </Console>
+
+        <!-- Required for printBasicInfo -->
+        <Console name="Console-Appender-Println" target="SYSTEM_OUT">
+            <PatternLayout pattern="%msg%n" />
+        </Console>
+
+        <!-- Will generate up to 100 log files for a given day. During every rollover it will delete
+             those that are older than 60 days, but keep the most recent 10 GB -->
+        <RollingRandomAccessFile name="RollingFile-Appender"
+                     fileName="${log-path}/${log-name}.log"
+                     filePattern="${archive}/${log-name}.%date{yyyy-MM-dd}-%i.log.gz">
+
+            <PatternLayout pattern="[%-5level] %date{ISO8601}{UTC}Z [%t] %c{2}.%method - %msg %X%n"/>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10MB"/>
+            </Policies>
+
+            <DefaultRolloverStrategy min="1" max="100">
+                <Delete basePath="${archive}" maxDepth="1">
+                    <IfFileName glob="${log-name}*.log.gz"/>
+                    <IfLastModified age="60d">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="10 GB"/>
+                        </IfAny>
+                    </IfLastModified>
+                </Delete>
+            </DefaultRolloverStrategy>
+
+        </RollingRandomAccessFile>
+
+        <Rewrite name="Console-ErrorCode-Appender">
+            <AppenderRef ref="Console-Appender"/>
+            <ErrorCodeRewritePolicy/>
+        </Rewrite>
+
+        <Rewrite name="Console-ErrorCode-Appender-Println">
+            <AppenderRef ref="Console-Appender-Println"/>
+            <ErrorCodeRewritePolicy/>
+        </Rewrite>
+
+        <Rewrite name="RollingFile-ErrorCode-Appender">
+            <AppenderRef ref="RollingFile-Appender"/>
+            <ErrorCodeRewritePolicy/>
+        </Rewrite>
+    </Appenders>
+
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console-ErrorCode-Appender"/>
+        </Root>
+        <Logger name="net.corda" level="${defaultLogLevel}" additivity="false">
+            <AppenderRef ref="Console-ErrorCode-Appender"/>
+            <AppenderRef ref="RollingFile-ErrorCode-Appender" />
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -74,7 +74,13 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(':webserver')
 
-    testCompile "junit:junit:$junit_version"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
 }

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -7,8 +7,15 @@ mainClassName = 'net.corda.explorer.Main'
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
 
     // TornadoFX: A lightweight Kotlin framework for working with JavaFX UI's.
     compile 'no.tornado:tornadofx:1.5.9'

--- a/tools/shell/build.gradle
+++ b/tools/shell/build.gradle
@@ -54,8 +54,14 @@ dependencies {
     // For logging, required for ANSIProgressRenderer.
     compile "org.apache.logging.log4j:log4j-core:$log4j_version"
 
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+    
     // Unit testing helpers.
-    testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile project(':test-utils')
     testCompile project(':finance:contracts')

--- a/tools/worldmap/build.gradle
+++ b/tools/worldmap/build.gradle
@@ -4,5 +4,10 @@ dependencies {
     implementation project(':core')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -61,7 +61,13 @@ dependencies {
     compileOnly "co.paralleluniverse:capsule:$capsule_version"
 
     integrationTestCompile project(':node-driver')
-    testCompile "junit:junit:$junit_version"
+
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testCompile "junit:junit:${junit4_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 task integrationTest(type: Test) {


### PR DESCRIPTION
Define a mechanism for flagging tests as requiring a database environment, and a JUnit 5 extension for managing database environments across three scopes:

* Test run - all tests defined as belonging to the same "group" of tests
* Test suite - all tests defined in the same class
* Test instance - the test defined in a single test method

Each of these scopes can have custom setup/teardown behaviour, enacted by a class implementing the [TestDatabaseContext] interface. The class used during a given test run is controlled via a system property.