### PR TITLE
ENT-3444 define RequiresDB annotation and junit5 extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -373,6 +373,7 @@ bintrayConfig {
             'corda-node-api',
             'corda-test-common',
             'corda-test-utils',
+            'corda-test-db',
             'corda-jackson',
             'corda-webserver-impl',
             'corda-webserver',

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,10 +28,11 @@ include 'jdk8u-deterministic'
 include 'test-common'
 include 'test-cli'
 include 'test-utils'
+include 'test-db'
 include 'smoke-test-utils'
 include 'node-driver'
 // Avoid making 'testing' a project, and allow build.gradle files to refer to these by their simple names:
-['test-common', 'test-utils', 'test-cli', 'smoke-test-utils', 'node-driver'].each {
+['test-common', 'test-utils', 'test-cli', 'test-db', 'smoke-test-utils', 'node-driver'].each {
     project(":$it").projectDir = new File("$settingsDir/testing/$it")
 }
 include 'tools:explorer'

--- a/testing/test-db/build.gradle
+++ b/testing/test-db/build.gradle
@@ -1,0 +1,26 @@
+apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'net.corda.plugins.api-scanner'
+apply plugin: 'com.jfrog.artifactory'
+
+dependencies {
+    compile "org.slf4j:slf4j-api:$slf4j_version"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
+    
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+
+    testRuntime "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntime "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+
+    compile "org.assertj:assertj-core:$assertj_version"
+}
+
+jar {
+    baseName 'corda-test-db'
+}
+
+publish {
+    name jar.baseName
+}

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/DBRunnerExtension.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/DBRunnerExtension.kt
@@ -1,0 +1,79 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.extension.*
+
+/***
+ * A JUnit 5 [Extension] which invokes a [TestDatabaseContext] to manage database state across three scopes:
+ *
+ * * Test run (defined across multiple classes)
+ * * Test suite (defined in a single class)
+ * * Test instance (defined in a single method)
+ *
+ * A test class will not ordinarily register this extension directly: instead, it is registered for any class having the [RequiresDb]
+ * annotation, which it consults to discover which group of tests the test class belongs to (`"default"`, if not stated).
+ *
+ * The class of the [TestDatabaseContext] used is selected by a system property, `test.db.context./groupName/`, where `groupName` is the
+ * name of the group of tests to which the test using this extension belongs. If this system property is not set, the class name defaults
+ * to the [RequiresDb.defaultContextClassName] stated in the annotation, which in turn defaults to the class of [NoOpTestDatabaseContext].
+ *
+ * When [BeforeAllCallback.beforeAll] is called prior to executing any test methods in a given class, the [ExtensionContext.Store] of the
+ * root extension context is used to look up the [TestDatabaseContext] for the class's declared `groupName`, creating and initialising it
+ * if it does not already exist. This ensures that a [TestDatabaseContext] is created exactly once during each test run for every named
+ * group of tests using this extension. This context will be closed with a call to [ExtensionContext.Store.CloseableResource.close] once
+ * the test run completes, tearing down the database state created at the beginning.
+ *
+ * For each test suite and test instance, this extension looks at the corresponding class or method to see if it is annotated with
+ * [RequiresSql], indicating that further SQL setup/teardown is required around the current scope. If it is, then appropriate calls are made
+ * to [TestDatabaseContext.beforeClass], [TestDatabaseContext.beforeTest], [TestDatabaseContext.afterTest] and
+ * [TestDatabaseContext.afterClass], passing through the name of the SQL script to be run. (Note that the same name is used for setup and
+ * teardown, and it is up to the [TestDatabaseContext] to map this to the appropriate SQL script for each case).
+ */
+class DBRunnerExtension : Extension, BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
+
+    override fun beforeAll(context: ExtensionContext?) {
+        // Always obtain/create a database context
+        val dbContext = getDatabaseContext(context) ?: return
+        val testSql = context?.testClass?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        dbContext.beforeClass(testSql)
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        val testSql = context?.testClass?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        getDatabaseContext(context)?.afterClass(testSql)
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        val testSql = context?.testMethod?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        getDatabaseContext(context)?.beforeTest(testSql)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        val testSql = context?.testMethod?.orElse(null)?.getAnnotation(RequiresSql::class.java)?.name ?: return
+        getDatabaseContext(context)?.afterTest(testSql)
+    }
+
+    private fun getDatabaseContext(context: ExtensionContext?): TestDatabaseContext? {
+        val rootContext = context?.root ?: return null
+
+        val testClass = context.testClass.orElse(null) ?: return null
+        val annotation = testClass.getAnnotation(RequiresDb::class.java) ?:
+            throw IllegalStateException("Test run with DBRunnerExtension is not annotated with @RequiresDb")
+        val groupName = annotation.group
+        val defaultContextClassName = annotation.defaultContextClassName
+
+        val store = rootContext.getStore(ExtensionContext.Namespace.create(DBRunnerExtension::class.java.simpleName, groupName))
+        return store.getOrComputeIfAbsent(
+                TestDatabaseContext::class.java.simpleName,
+                { createDatabaseContext(groupName, defaultContextClassName) },
+                TestDatabaseContext::class.java)
+    }
+
+    private fun createDatabaseContext(groupName: String, defaultContextClassName: String): TestDatabaseContext {
+        val propertyKey = "test.db.context.$groupName"
+        val className = System.getProperty(propertyKey) ?: defaultContextClassName
+
+        val ctx = Class.forName(className).newInstance() as TestDatabaseContext
+        ctx.initialize(groupName)
+        return ctx
+    }
+}

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/NoOpTestDatabaseContext.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/NoOpTestDatabaseContext.kt
@@ -1,0 +1,41 @@
+package net.corda.testing.db
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * An implementation of [TestDatabaseContext] which does nothing besides logging the calls made to it.
+ */
+class NoOpTestDatabaseContext : TestDatabaseContext {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(NoOpTestDatabaseContext::class.java)
+    }
+
+    private lateinit var groupName: String
+
+    override fun initialize(groupName: String) {
+        logger.info("[NO-OP] Initializing database group $groupName")
+        this.groupName = groupName
+    }
+
+    override fun beforeClass(setupSql: String) {
+        logger.info("[NO-OP] Running SQL setup script $setupSql in group $groupName")
+    }
+
+    override fun afterClass(teardownSql: String) {
+        logger.info("[NO-OP] Running SQL teardown script $teardownSql in group $groupName")
+    }
+
+    override fun beforeTest(setupSql: String) {
+        logger.info("[NO-OP] Running SQL setup script $setupSql in group $groupName")
+    }
+
+    override fun afterTest(teardownSql: String) {
+        logger.info("[NO-OP] Running SQL teardown script $teardownSql in group $groupName")
+    }
+
+    override fun close() {
+        logger.info("[NO-OP] Cleaning up database group $groupName")
+    }
+}

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/RequiresDb.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/RequiresDb.kt
@@ -1,0 +1,32 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * An annotation which is applied to test classes to indicate that they belong to a group of tests which require a common database
+ * environment, which is initialized before any of the tests in any of the classes in that group are run, and cleaned up after all of them
+ * have completed.
+ *
+ * @param group The name of the group of tests to which the annotated test belongs, or `"default"` if unstated.
+ * @param defaultContextClassName The class name of the [TestDatabaseContext] which should be instantiated to manage the database
+ * environment for these tests, if none is given in the system property `test.db.context./groupName/`. This defaults to the class name of
+ * [NoOpTestDatabaseContext].
+ */
+@ExtendWith(DBRunnerExtension::class)
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class RequiresDb(
+        val group: String = "default",
+        val defaultContextClassName: String = "net.corda.testing.db.NoOpTestDatabaseContext")
+
+/**
+ * An annotation which is applied to test classes and methods to indicate that the corresponding test suite  / instance requires SQL scripts
+ * to be run against its database as part of its setup / teardown.
+ *
+ * @param name The name of the SQL script to run. The same name will be used for setup and teardown: it is up to the [TestDatabaseContext] to
+ * select the actual SQL script based on the context, e.g. `"specialSql"` may be translated to `"/groupName/-specialSql-setup.sql"` or to
+ * `"/groupName/-specialSql-teardown.sql"` depending on which operation is being performed.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class RequiresSql(val name: String)

--- a/testing/test-db/src/main/kotlin/net/corda/testing/db/TestDatabaseContext.kt
+++ b/testing/test-db/src/main/kotlin/net/corda/testing/db/TestDatabaseContext.kt
@@ -1,0 +1,53 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Interface which must be implemented by any class offering to manage test database environments for tests annotated with [RequiresDb].
+ *
+ * A separate instance of [TestDatabaseContext] will be created and initialised for each group of tests, identified by [RequiresDb.group].
+ *
+ * Once all tests in the group have been run, [ExtensionContext.Store.CloseableResource.close] will be called; implementations should use
+ * this method to tear down the database context.
+ */
+interface TestDatabaseContext : ExtensionContext.Store.CloseableResource {
+
+    /**
+     * Called once when the context is first instantiated, i.e. at the start of the test run, before any tests at all have been executed.
+     *
+     * @param groupName The name of the group of tests whose database environment is to be managed by this context.
+     */
+    fun initialize(groupName: String)
+
+    /**
+     * Called once if some setup SQL needs to be run before a suite of tests is executed, as indicated by a [RequiresSql] annotation on the
+     * class containing the test suite.
+     *
+     * @param setupSql The name of the SQL script to be run prior to running the suite of tests.
+     */
+    fun beforeClass(setupSql: String)
+
+    /**
+     * Called once if some setup SQL needs to be run after a suite of tests is executed, as indicated by a [RequiresSql] annotation on the
+     * class containing the test suite.
+     *
+     * @param teardownSql The name of the SQL script to be run after running the suite of tests.
+     */
+    fun afterClass(teardownSql: String)
+
+    /**
+     * Called once if some setup SQL needs to be run before a given test is executed, as indicated by a [RequiresSql] annotation on the
+     * method defining the test
+     *
+     * @param setUpSql The name of the SQL script to be run before running the test.
+     */
+    fun beforeTest(setupSql: String)
+
+    /**
+     * Called once if some setup SQL needs to be run after a given test is executed, as indicated by a [RequiresSql] annotation on the
+     * method defining the test
+     *
+     * @param teardownSql The name of the SQL script to be run after running the test.
+     */
+    fun afterTest(teardownSql: String)
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/AssertingTestDatabaseContext.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/AssertingTestDatabaseContext.kt
@@ -1,0 +1,61 @@
+package net.corda.testing.db
+
+import org.assertj.core.api.Assertions.assertThat
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.lang.IllegalStateException
+
+class AssertingTestDatabaseContext : TestDatabaseContext {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(AssertingTestDatabaseContext::class.java)
+        private val expectations = mutableMapOf<String, List<String>>()
+
+        fun addExpectations(groupName: String, vararg scripts: String) {
+            expectations.compute(groupName) { _, expected ->
+                (expected ?: emptyList()) + scripts.toList()
+            }
+        }
+    }
+
+    private lateinit var groupName: String
+    private val scriptsRun = mutableListOf<String>()
+
+    override fun initialize(groupName: String) {
+        this.groupName = groupName
+        scriptsRun += "${groupName}-db-setup.sql"
+    }
+
+    override fun beforeClass(setupSql: String) {
+        scriptsRun += "$groupName-$setupSql-setup.sql"
+    }
+
+    override fun afterClass(teardownSql: String) {
+        scriptsRun += "$groupName-$teardownSql-teardown.sql"
+    }
+
+    override fun beforeTest(setupSql: String) {
+        scriptsRun += "$groupName-$setupSql-setup.sql"
+    }
+
+    override fun afterTest(teardownSql: String) {
+        scriptsRun += "$groupName-$teardownSql-teardown.sql"
+    }
+
+    override fun close() {
+        scriptsRun += "${groupName}-db-teardown.sql"
+
+        logger.info("SQL scripts run for group $groupName:\n" + scriptsRun.joinToString("\n"))
+
+        val expectedScripts = (listOf("db-setup") + (expectations[groupName] ?: emptyList()) + listOf("db-teardown"))
+                .map { "$groupName-$it.sql" }
+                .toTypedArray()
+
+        try {
+            assertThat(scriptsRun).containsExactlyInAnyOrder(*expectedScripts)
+        } catch (e: AssertionError) {
+            throw IllegalStateException("Assertion failed: ${e.message}")
+        }
+    }
+
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupAMoreTests.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupAMoreTests.kt
@@ -1,0 +1,20 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.Test
+
+@RequiresDb("groupA", "net.corda.testing.db.AssertingTestDatabaseContext")
+class GroupAMoreTests {
+
+    @Test
+    fun setExpectations() {
+        AssertingTestDatabaseContext.addExpectations("groupA",
+                "specialSql2-setup", "specialSql2-teardown")
+    }
+
+    @Test
+    @RequiresSql("specialSql2")
+    fun moreSpecialSqlRequired() {
+
+    }
+
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupATests.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupATests.kt
@@ -1,0 +1,26 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.Test
+
+@RequiresDb("groupA", "net.corda.testing.db.AssertingTestDatabaseContext")
+@RequiresSql("forClassGroupATests")
+class GroupATests {
+
+    @Test
+    fun setExpectations() {
+        AssertingTestDatabaseContext.addExpectations("groupA",
+                "forClassGroupATests-setup", "specialSql1-setup", "specialSql1-teardown", "forClassGroupATests-teardown")
+    }
+
+    @Test
+    fun noSpecialSqlRequired() {
+
+    }
+
+    @Test
+    @RequiresSql("specialSql1")
+    fun someSpecialSqlRequired() {
+
+    }
+
+}

--- a/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupBTests.kt
+++ b/testing/test-db/src/test/kotlin/net/corda/testing/db/GroupBTests.kt
@@ -1,0 +1,26 @@
+package net.corda.testing.db
+
+import org.junit.jupiter.api.Test
+
+@RequiresDb("groupB", "net.corda.testing.db.AssertingTestDatabaseContext")
+@RequiresSql("forClassGroupBTests")
+class GroupBTests {
+
+    @Test
+    fun setExpectations() {
+        AssertingTestDatabaseContext.addExpectations("groupB",
+                "forClassGroupBTests-setup", "specialSql1-setup", "specialSql1-teardown", "forClassGroupBTests-teardown")
+    }
+
+    @Test
+    fun noSpecialSqlRequired() {
+
+    }
+
+    @Test
+    @RequiresSql("specialSql1")
+    fun someSpecialSqlRequired() {
+
+    }
+
+}

--- a/testing/test-db/src/test/resources/log4j2-test.xml
+++ b/testing/test-db/src/test/resources/log4j2-test.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info" packages="net.corda.common.logging">
+
+    <Properties>
+        <Property name="log-path">${sys:log-path:-logs}</Property>
+        <Property name="log-name">node-${hostName}</Property>
+        <Property name="archive">${log-path}/archive</Property>
+        <Property name="defaultLogLevel">${sys:defaultLogLevel:-info}</Property>
+    </Properties>
+
+    <ThresholdFilter level="trace"/>
+
+    <Appenders>
+        <Console name="Console-Appender" target="SYSTEM_OUT">
+            <PatternLayout>
+                <ScriptPatternSelector defaultPattern="%highlight{[%level{length=5}] %date{HH:mm:ss,SSS} [%t] %c{2}.%method - %msg%n}{INFO=white,WARN=red,FATAL=bright red}">
+                    <Script name="MDCSelector" language="javascript"><![CDATA[
+                    result = null;
+                    if (!logEvent.getContextData().size() == 0) {
+                        result = "WithMDC";
+                    } else {
+                        result = null;
+                    }
+                    result;
+               ]]>
+                    </Script>
+                    <PatternMatch key="WithMDC" pattern="%highlight{[%level{length=5}] %date{HH:mm:ss,SSS} [%t] %c{2}.%method - %msg %X%n}{INFO=white,WARN=red,FATAL=bright red}"/>
+                </ScriptPatternSelector>
+            </PatternLayout>
+            <ThresholdFilter level="trace"/>
+        </Console>
+
+        <!-- Required for printBasicInfo -->
+        <Console name="Console-Appender-Println" target="SYSTEM_OUT">
+            <PatternLayout pattern="%msg%n" />
+        </Console>
+
+        <!-- Will generate up to 100 log files for a given day. During every rollover it will delete
+             those that are older than 60 days, but keep the most recent 10 GB -->
+        <RollingRandomAccessFile name="RollingFile-Appender"
+                     fileName="${log-path}/${log-name}.log"
+                     filePattern="${archive}/${log-name}.%date{yyyy-MM-dd}-%i.log.gz">
+
+            <PatternLayout pattern="[%-5level] %date{ISO8601}{UTC}Z [%t] %c{2}.%method - %msg %X%n"/>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10MB"/>
+            </Policies>
+
+            <DefaultRolloverStrategy min="1" max="100">
+                <Delete basePath="${archive}" maxDepth="1">
+                    <IfFileName glob="${log-name}*.log.gz"/>
+                    <IfLastModified age="60d">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="10 GB"/>
+                        </IfAny>
+                    </IfLastModified>
+                </Delete>
+            </DefaultRolloverStrategy>
+
+        </RollingRandomAccessFile>
+
+        <Rewrite name="Console-ErrorCode-Appender">
+            <AppenderRef ref="Console-Appender"/>
+            <ErrorCodeRewritePolicy/>
+        </Rewrite>
+
+        <Rewrite name="Console-ErrorCode-Appender-Println">
+            <AppenderRef ref="Console-Appender-Println"/>
+            <ErrorCodeRewritePolicy/>
+        </Rewrite>
+
+        <Rewrite name="RollingFile-ErrorCode-Appender">
+            <AppenderRef ref="RollingFile-Appender"/>
+            <ErrorCodeRewritePolicy/>
+        </Rewrite>
+    </Appenders>
+
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console-ErrorCode-Appender"/>
+        </Root>
+        <Logger name="net.corda" level="${defaultLogLevel}" additivity="false">
+            <AppenderRef ref="Console-ErrorCode-Appender"/>
+            <AppenderRef ref="RollingFile-ErrorCode-Appender" />
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Define a mechanism for flagging tests as requiring a database environment, and a JUnit 5 extension for managing database environments across three scopes:

* Test run - all tests defined as belonging to the same "group" of tests
* Test suite - all tests defined in the same class
* Test instance - the test defined in a single test method

Each of these scopes can have custom setup/teardown behaviour, enacted by a class implementing the [TestDatabaseContext] interface. The class used during a given test run is controlled via a system property.