### PR TITLE
CORDA-2888 Allow bring-your-own-config to docker image

### DIFF
--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -25,11 +25,8 @@ function generateTestnetConfig() {
 }
 
 function generateGenericCZConfig(){
-
-    if [[ -f /etc/corda/node.conf ]] ; then
-        echo  'WARN: existing config detected, launching corda'
-        run-corda
-    else
+    if ! [[ -f ${CONFIG_FOLDER}/node.conf ]] ; then
+        echo  'INFO: no existing node config detected, generating config skeleton'
         : ${NETWORKMAP_URL:? '$NETWORKMAP_URL, the Compatibility Zone to join must be set as environment variable'}
         : ${DOORMAN_URL:? '$DOORMAN_URL, the Doorman to use when joining must be set as environment variable'}
         : ${MY_LEGAL_NAME:? '$MY_LEGAL_NAME, the X500 name to use when joining must be set as environment variable'}
@@ -47,16 +44,15 @@ function generateGenericCZConfig(){
         MY_RPC_PORT=${MY_RPC_PORT} \
         MY_RPC_ADMIN_PORT=${MY_RPC_ADMIN_PORT} \
         java -jar config-exporter.jar "GENERIC-CZ" "/opt/corda/starting-node.conf" "${CONFIG_FOLDER}/node.conf"
-
-        java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar \
-                --initial-registration \
-                --base-directory /opt/corda \
-                --config-file ${CONFIG_FOLDER}/node.conf \
-                --network-root-truststore-password ${NETWORK_TRUST_PASSWORD} \
-                --network-root-truststore ${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} &&\
-        echo "Succesfully registered with ${DOORMAN_URL}, starting corda" && \
-        run-corda
     fi
+        java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar \
+                initial-registration \
+                --base-directory=/opt/corda \
+                --config-file=/etc/corda/node.conf \
+                --network-root-truststore-password=${NETWORK_TRUST_PASSWORD} \
+                --network-root-truststore=${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} && \
+        echo "Successfully registered with ${DOORMAN_URL}, starting corda" && \
+        run-corda
 }
 
 function downloadTestnetCerts() {
@@ -108,7 +104,6 @@ while :; do
     esac
     shift
 done
-
 
 : ${TRUST_STORE_NAME="network-root-truststore.jks"}
 : ${JVM_ARGS='-Xmx4g -Xms2g -XX:+UseG1GC'}

--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -46,11 +46,11 @@ function generateGenericCZConfig(){
         java -jar config-exporter.jar "GENERIC-CZ" "/opt/corda/starting-node.conf" "${CONFIG_FOLDER}/node.conf"
     fi
         java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar \
-                initial-registration \
-                --base-directory=/opt/corda \
-                --config-file=${CONFIG_FOLDER}/node.conf \
-                --network-root-truststore-password=${NETWORK_TRUST_PASSWORD} \
-                --network-root-truststore=${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} && \
+                --initial-registration \
+                --base-directory /opt/corda \
+                --config-file ${CONFIG_FOLDER}/node.conf \
+                --network-root-truststore-password ${NETWORK_TRUST_PASSWORD} \
+                --network-root-truststore ${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} && \
         echo "Successfully registered with ${DOORMAN_URL}, starting corda" && \
         run-corda
 }

--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -48,7 +48,7 @@ function generateGenericCZConfig(){
         java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar \
                 initial-registration \
                 --base-directory=/opt/corda \
-                --config-file= ${CONFIG_FOLDER}/node.conf \
+                --config-file=${CONFIG_FOLDER}/node.conf \
                 --network-root-truststore-password=${NETWORK_TRUST_PASSWORD} \
                 --network-root-truststore=${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} && \
         echo "Successfully registered with ${DOORMAN_URL}, starting corda" && \

--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -48,7 +48,7 @@ function generateGenericCZConfig(){
         java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar \
                 initial-registration \
                 --base-directory=/opt/corda \
-                --config-file=/etc/corda/node.conf \
+                --config-file= ${CONFIG_FOLDER}/node.conf \
                 --network-root-truststore-password=${NETWORK_TRUST_PASSWORD} \
                 --network-root-truststore=${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} && \
         echo "Successfully registered with ${DOORMAN_URL}, starting corda" && \


### PR DESCRIPTION
modify run logic so that if node config is present, do not generate a new one