### PR TITLE
CORDA-2888 change default dataSource.url to match the docker container structure.

### DIFF
--- a/docker/src/bash/run-corda.sh
+++ b/docker/src/bash/run-corda.sh
@@ -4,4 +4,10 @@ if [[ ${JVM_ARGS} == *"Xmx"* ]]; then
   echo "WARNING: the use of the -Xmx flag is not recommended within docker containers. Use the --memory option passed to the container to limit heap size"
 fi
 
-java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar --base-directory /opt/corda --config-file ${CONFIG_FOLDER}/node.conf ${CORDA_ARGS}
+count=$(grep -c dataSourceProperties ${CONFIG_FOLDER}/node.conf)
+
+if [ "$count" -eq 0 ]; then
+  java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -Dcorda.dataSourceProperties.dataSource.url="jdbc:h2:file:"${PERSISTENCE_FOLDER}"/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000" -jar /opt/corda/bin/corda.jar --base-directory /opt/corda --config-file ${CONFIG_FOLDER}/node.conf ${CORDA_ARGS}
+else
+  java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar --base-directory /opt/corda --config-file ${CONFIG_FOLDER}/node.conf ${CORDA_ARGS}
+fi

--- a/docs/source/docker-image.rst
+++ b/docs/source/docker-image.rst
@@ -6,6 +6,7 @@ Running a node connected to a Compatibility Zone in Docker
 
 .. note:: Requirements: A valid node.conf and a valid set of certificates - (signed by the CZ)
 
+
 In this example, the certificates are stored at ``/home/user/cordaBase/certificates``, the node configuration is in ``/home/user/cordaBase/config/node.conf`` and the CorDapps to run are in ``/path/to/cordapps``
 
 .. code-block:: shell
@@ -32,6 +33,9 @@ As the node runs within a container, several mount points are required:
 If using the H2 database:
 
 5. Persistence - the folder to hold the H2 database files must be mounted at location ``/opt/corda/persistence``
+
+.. note:: If there is no dataSourceProperties key in the node.conf, the docker container overrides the url for H2 to point to the persistence directory by default so that the database can be accessed outside the container
+
 
 Running a node connected to a Bootstrapped Network
 --------------------------------------------------


### PR DESCRIPTION
Added a command line argument for corda.jar when there is no dataSourceProperties in the node.conf file which was mounted for the container. 