### PR TITLE
CORDA-2892 Add a `TransactionBuilder.addOutputState` overload

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -625,7 +625,9 @@ open class TransactionBuilder(
         contract: ContractClassName = requireNotNullContractClassName(state),
         notary: Party, encumbrance: Int? = null,
         constraint: AttachmentConstraint = AutomaticPlaceholderConstraint
-    ) = addOutputState(TransactionState(state, contract, notary, encumbrance, constraint))
+    ): TransactionBuilder {
+        return addOutputState(TransactionState(state, contract, notary, encumbrance, constraint))
+    }
 
     /** Adds an output state. A default notary must be specified during builder construction to use this method */
     @JvmOverloads
@@ -633,16 +635,16 @@ open class TransactionBuilder(
         state: ContractState,
         contract: ContractClassName = requireNotNullContractClassName(state),
         constraint: AttachmentConstraint = AutomaticPlaceholderConstraint
-    ) = apply {
-        checkNotNull(notary) {
-            "Need to specify a notary for the state, or set a default one on TransactionBuilder initialisation"
-        }
+    ): TransactionBuilder {
+        checkNotNull(notary) { "Need to specify a notary for the state, or set a default one on TransactionBuilder initialisation" }
         addOutputState(state, contract, notary!!, constraint = constraint)
+        return this
     }
 
     /** Adds an output state with the specified constraint. */
-    fun addOutputState(state: ContractState, constraint: AttachmentConstraint) =
-        addOutputState(state, requireNotNullContractClassName(state), constraint)
+    fun addOutputState(state: ContractState, constraint: AttachmentConstraint): TransactionBuilder {
+        return addOutputState(state, requireNotNullContractClassName(state), constraint)
+    }
 
     private fun requireNotNullContractClassName(state: ContractState) = requireNotNull(state.requiredContractClassName) {
         //TODO: add link to docsite page, when there is one.

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -621,37 +621,36 @@ open class TransactionBuilder(
     /** Adds an output state, with associated contract code (and constraints), and notary, to the transaction. */
     @JvmOverloads
     fun addOutputState(
-            state: ContractState,
-            contract: ContractClassName = requireNotNull(state.requiredContractClassName) {
-                //TODO: add link to docsite page, when there is one.
-                """
-Unable to infer Contract class name because state class ${state::class.java.name} is not annotated with
-@BelongsToContract, and does not have an enclosing class which implements Contract. Either annotate ${state::class.java.name}
-with @BelongsToContract, or supply an explicit contract parameter to addOutputState().
-""".trimIndent().replace('\n', ' ')
-            },
-            notary: Party, encumbrance: Int? = null,
-            constraint: AttachmentConstraint = AutomaticPlaceholderConstraint
+        state: ContractState,
+        contract: ContractClassName = requireNotNullContractClassName(state),
+        notary: Party, encumbrance: Int? = null,
+        constraint: AttachmentConstraint = AutomaticPlaceholderConstraint
     ) = addOutputState(TransactionState(state, contract, notary, encumbrance, constraint))
 
-    /** A default notary must be specified during builder construction to use this method */
+    /** Adds an output state. A default notary must be specified during builder construction to use this method */
     @JvmOverloads
     fun addOutputState(
-            state: ContractState,
-            contract: ContractClassName = requireNotNull(state.requiredContractClassName) {
-                //TODO: add link to docsite page, when there is one.
-                """
-Unable to infer Contract class name because state class ${state::class.java.name} is not annotated with
-@BelongsToContract, and does not have an enclosing class which implements Contract. Either annotate ${state::class.java.name}
-with @BelongsToContract, or supply an explicit contract parameter to addOutputState().
-""".trimIndent().replace('\n', ' ')
-            },
-            constraint: AttachmentConstraint = AutomaticPlaceholderConstraint
+        state: ContractState,
+        contract: ContractClassName = requireNotNullContractClassName(state),
+        constraint: AttachmentConstraint = AutomaticPlaceholderConstraint
     ) = apply {
         checkNotNull(notary) {
             "Need to specify a notary for the state, or set a default one on TransactionBuilder initialisation"
         }
         addOutputState(state, contract, notary!!, constraint = constraint)
+    }
+
+    /** Adds an output state with the specified constraint. */
+    fun addOutputState(state: ContractState, constraint: AttachmentConstraint) =
+        addOutputState(state, requireNotNullContractClassName(state), constraint)
+
+    private fun requireNotNullContractClassName(state: ContractState) = requireNotNull(state.requiredContractClassName) {
+        //TODO: add link to docsite page, when there is one.
+        """
+        Unable to infer Contract class name because state class ${state::class.java.name} is not annotated with
+        @BelongsToContract, and does not have an enclosing class which implements Contract. Either annotate ${state::class.java.name}
+        with @BelongsToContract, or supply an explicit contract parameter to addOutputState().
+        """.trimIndent().replace('\n', ' ')
     }
 
     /** Adds a [Command] to the transaction. */


### PR DESCRIPTION
To allow better usage in Java, a new `addOutputState` overload has
been added.

It does not use the `@JvmOverloads` annotation as other overloads
already provide the same functionality.

Tidied up the `requireNotNull` code that was duplicated between the
overloads and moved to `requireNotNullContractClassName`.