### PR TITLE
[CORDA-2473] - Remove AMQP system property

### DIFF
--- a/docs/source/cordapp-custom-serializers.rst
+++ b/docs/source/cordapp-custom-serializers.rst
@@ -27,10 +27,7 @@ Serializers must
  * Inherit from ``net.corda.core.serialization.SerializationCustomSerializer``
  * Provide a proxy class to transform the object to and from
  * Implement the ``toProxy`` and ``fromProxy`` methods
- * Be either included into the CorDapp Jar or made known to the running process via the ``amqp.custom.serialization.scanSpec``
-   system property. This system property may be necessary to be able to discover custom serializer in the classpath.
-   At a minimum the value of the property should include comma separated set of packages where custom serializers located.
-   Full syntax includes scanning specification as defined by: `<http://github.com/lukehutch/fast-classpath-scanner/wiki/2.-Constructor#scan-spec>`
+ * Be either included into the CorDapp Jar or made available in the class path of the running process
 
 Serializers inheriting from ``SerializationCustomSerializer`` have to implement two methods and two types.
 

--- a/docs/source/cordapp-custom-serializers.rst
+++ b/docs/source/cordapp-custom-serializers.rst
@@ -27,7 +27,7 @@ Serializers must
  * Inherit from ``net.corda.core.serialization.SerializationCustomSerializer``
  * Provide a proxy class to transform the object to and from
  * Implement the ``toProxy`` and ``fromProxy`` methods
- * Be either included into the CorDapp Jar or made available in the class path of the running process
+ * Be either included into the CorDapp Jar or made available in the system class path of the running process
 
 Serializers inheriting from ``SerializationCustomSerializer`` have to implement two methods and two types.
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
@@ -58,7 +58,7 @@ abstract class AbstractAMQPSerializationScheme(
     // TODO: This method of initialisation for the Whitelist and plugin serializers will have to change
     //       when we have per-cordapp contexts and dynamic app reloading but for now it's the easiest way
     companion object {
-        private val serializationWhitelists: List<SerializationWhitelist> = listOf(DefaultWhitelist)
+        private val serializationWhitelists: List<SerializationWhitelist> by lazy { listOf(DefaultWhitelist) }
 
         @DeleteForDJVM
         val List<Cordapp>.customSerializers

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
@@ -55,8 +55,6 @@ abstract class AbstractAMQPSerializationScheme(
         maybeNotConcurrentSerializerFactoriesForContexts
     }
 
-    // TODO: This method of initialisation for the Whitelist and plugin serializers will have to change
-    //       when we have per-cordapp contexts and dynamic app reloading but for now it's the easiest way
     companion object {
         private val serializationWhitelists: List<SerializationWhitelist> by lazy { listOf(DefaultWhitelist) }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -802,7 +802,7 @@ class DriverDSLImpl(
             )
         }
 
-        private val propertiesInScope = setOf("java.io.tmpdir", AbstractAMQPSerializationScheme.SCAN_SPEC_PROP_NAME)
+        private val propertiesInScope = setOf("java.io.tmpdir")
 
         private fun inheritFromParentProcess(): Iterable<Pair<String, String>> {
             return propertiesInScope.flatMap { propName ->


### PR DESCRIPTION
With the recent changes in C4, the AMQP system property is effectively not used anymore, since Cordapps are loaded as attachments & the RPC client scans the classpath for any custom serializers/whitelists. This change removes this property and the scanning performed in AbstractAMQPSerializationScheme which is dead code currently, in an effort to simplify this part of the code base a bit.

Refer to the JIRA for more details.