### PR TITLE
[CORDA-2866] Adjust RPC test case to prevent failures on non-H2 databases

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
@@ -4,15 +4,14 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.ClientRelevantException
 import net.corda.core.CordaRuntimeException
 import net.corda.core.flows.*
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
 import net.corda.node.services.Permissions
 import net.corda.nodeapi.exceptions.InternalNodeException
-import net.corda.testing.core.ALICE_NAME
-import net.corda.testing.core.BOB_NAME
-import net.corda.testing.core.singleIdentity
+import net.corda.testing.core.*
 import net.corda.testing.driver.*
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.startNode
@@ -125,24 +124,26 @@ class RpcExceptionHandlingTest {
     fun `rpc client handles exceptions thrown on counter-party side`() {
         val params = NodeParameters(rpcUsers = users)
 
-        fun DriverDSL.scenario(devMode: Boolean) {
+        fun DriverDSL.scenario(nameA: CordaX500Name, nameB: CordaX500Name, devMode: Boolean) {
 
-            val nodeA = startNode(ALICE_NAME, devMode, params).getOrThrow()
-            val nodeB = startNode(BOB_NAME, devMode, params).getOrThrow()
+            val nodeA = startNode(nameA, devMode, params).getOrThrow()
+            val nodeB = startNode(nameB, devMode, params).getOrThrow()
 
             nodeA.rpc.startFlow(::InitFlow, nodeB.nodeInfo.singleIdentity()).returnValue.getOrThrow()
         }
 
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
 
-            assertThatThrownBy { scenario(true) }.isInstanceOfSatisfying(CordaRuntimeException::class.java) { exception ->
+            assertThatThrownBy { scenario(ALICE_NAME, BOB_NAME,true) }.isInstanceOfSatisfying(CordaRuntimeException::class.java) { exception ->
 
                 assertThat(exception).hasNoCause()
                 assertThat(exception.stackTrace).isEmpty()
             }
-        }
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
-            assertThatThrownBy { scenario(false) }.isInstanceOfSatisfying(InternalNodeException::class.java) { exception ->
+
+            assertThatThrownBy { scenario(
+                    DUMMY_BANK_A_NAME,
+                    DUMMY_BANK_B_NAME,
+                    false) }.isInstanceOfSatisfying(InternalNodeException::class.java) { exception ->
 
                 assertThat(exception).hasNoCause()
                 assertThat(exception.stackTrace).isEmpty()


### PR DESCRIPTION
CORDA-2866 introduced a check in the database on startup to prevent the node from starting if it has a legal identity but has lost the corresponding key. There is a test case that invokes the driver twice (which causes the key to be lost between invocations). On H2, the database is also destroyed and recreated, which allows the test to pass. On non-H2 databases, however, the database persists, and so on the second invocation the check fails and the nodes fail to start, which fails the test.

This change adjusts the change to use one driver invocation and different nodes for the second part of the test, which should prevent this problem from occurring.
