### PR TITLE
CORDA-2870 improve error messages for non composable types

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt
@@ -97,5 +97,6 @@ class CorDappCustomSerializer(
     override fun isSerializerFor(clazz: Class<*>) =
         TypeToken.of(type.asClass()) == TypeToken.of(clazz)
 
+    override fun toString(): String = "${this::class.java}(${serializer::class.java})"
 }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -26,6 +26,12 @@ class DuplicateCustomSerializerException(serializers: List<AMQPSerializer<*>>, c
                 " registered to serialize type $clazz")
 
 interface CustomSerializerRegistry {
+
+    /**
+     * Retrieves the names of the registered custom serializers.
+     */
+    val customSerializerNames: List<String>
+
     /**
      * Register a custom serializer for any type that cannot be serialized or deserialized by the default serializer
      * that expects to find getters and a constructor with a parameter for each property.
@@ -58,6 +64,12 @@ class CachingCustomSerializerRegistry(
         val logger = contextLogger()
     }
 
+    override val customSerializerNames: List<String>
+        get() = customSerializers.map { serializer ->
+            if (serializer is CorDappCustomSerializer) serializer.toString()
+            else "${serializer::class.java} - Classloader: ${serializer::class.java.classLoader}"
+        }
+
     private data class CustomSerializerIdentifier(val actualTypeIdentifier: TypeIdentifier, val declaredTypeIdentifier: TypeIdentifier)
 
     private sealed class CustomSerializerLookupResult {
@@ -72,8 +84,7 @@ class CachingCustomSerializerRegistry(
     }
 
     private val customSerializersCache: MutableMap<CustomSerializerIdentifier, CustomSerializerLookupResult> = DefaultCacheProvider.createCache()
-    var customSerializers: List<SerializerFor> = emptyList()
-        private set
+    private var customSerializers: List<SerializerFor> = emptyList()
 
     /**
      * Register a custom serializer for any type that cannot be serialized or deserialized by the default serializer

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -72,7 +72,8 @@ class CachingCustomSerializerRegistry(
     }
 
     private val customSerializersCache: MutableMap<CustomSerializerIdentifier, CustomSerializerLookupResult> = DefaultCacheProvider.createCache()
-    private var customSerializers: List<SerializerFor> = emptyList()
+    var customSerializers: List<SerializerFor> = emptyList()
+        private set
 
     /**
      * Register a custom serializer for any type that cannot be serialized or deserialized by the default serializer

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -82,7 +82,7 @@ class DefaultLocalSerializerFactory(
         private val fingerPrinter: FingerPrinter,
         override val classloader: ClassLoader,
         private val descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry,
-        private val customSerializerRegistry: CustomSerializerRegistry,
+        val customSerializerRegistry: CustomSerializerRegistry,
         private val onlyCustomSerializers: Boolean)
     : LocalSerializerFactory {
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -32,6 +32,11 @@ interface LocalSerializerFactory {
     val classloader: ClassLoader
 
     /**
+     * Retrieves the names of the registered custom serializers.
+     */
+    val customSerializerNames: List<String>
+
+    /**
      * Obtain an [AMQPSerializer] for an object of actual type [actualClass], and declared type [declaredType].
      */
     fun get(actualClass: Class<*>, declaredType: Type): AMQPSerializer<Any>
@@ -82,13 +87,16 @@ class DefaultLocalSerializerFactory(
         private val fingerPrinter: FingerPrinter,
         override val classloader: ClassLoader,
         private val descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry,
-        val customSerializerRegistry: CustomSerializerRegistry,
+        private val customSerializerRegistry: CustomSerializerRegistry,
         private val onlyCustomSerializers: Boolean)
     : LocalSerializerFactory {
 
     companion object {
         val logger = contextLogger()
     }
+
+    override val customSerializerNames: List<String>
+        get() = customSerializerRegistry.customSerializerNames
 
     private data class ActualAndDeclaredType(val actualType: Class<*>, val declaredType: Type)
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
@@ -15,9 +15,17 @@ interface ObjectSerializer : AMQPSerializer<Any> {
     companion object {
         fun make(typeInformation: LocalTypeInformation, factory: LocalSerializerFactory): ObjectSerializer {
             if (typeInformation is LocalTypeInformation.NonComposable) {
+                val serializerInformation = (factory as? DefaultLocalSerializerFactory)?.let {
+                    (it.customSerializerRegistry as? CachingCustomSerializerRegistry)?.customSerializers?.map {
+                        "Serializer: ${(it as? CorDappCustomSerializer)?.toString()
+                            ?: it::class.java} - Classloader: ${it::class.java.classLoader}"
+                    }
+                } ?: emptyList()
                 throw NotSerializableException(
                     "Unable to create an object serializer for type ${typeInformation.observedType}:\n" +
-                            "${typeInformation.reason}\n\n${typeInformation.remedy}"
+                            "${typeInformation.reason}\n\n" +
+                            "${typeInformation.remedy}\n\n" +
+                            "Registered custom serializers:\n ${serializerInformation.joinToString("\n    ")}\n"
                 )
             }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
@@ -35,21 +35,16 @@ interface ObjectSerializer : AMQPSerializer<Any> {
             typeInformation: LocalTypeInformation.NonComposable,
             factory: LocalSerializerFactory
         ): String {
-            val serializerInformation = (factory as? DefaultLocalSerializerFactory)?.let {
-                (it.customSerializerRegistry as? CachingCustomSerializerRegistry)?.customSerializers?.map {
-                    "Serializer: ${(it as? CorDappCustomSerializer)?.toString()
-                        ?: it::class.java} - Classloader: ${it::class.java.classLoader}"
+            val serializerInformation = factory.customSerializerNames.map { "Serializer: $it" }.let { serializers ->
+                when {
+                    serializers.isNotEmpty() -> "Registered custom serializers:\n    ${serializers.joinToString("\n    ")}"
+                    else -> "No custom serializers registered."
                 }
-            } ?: emptyList()
-            val registeredSerializersString = if (serializerInformation.isNotEmpty()) {
-                "Registered custom serializers:\n    ${serializerInformation.joinToString("\n    ")}"
-            } else {
-                "No custom serializers registered."
             }
             return "Unable to create an object serializer for type ${typeInformation.observedType}:\n" +
                     "${typeInformation.reason}\n\n" +
                     "${typeInformation.remedy}\n\n" +
-                    "$registeredSerializersString\n"
+                    "$serializerInformation\n"
         }
 
         private fun makeForAbstract(typeNotation: CompositeType,

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
@@ -14,10 +14,12 @@ interface ObjectSerializer : AMQPSerializer<Any> {
 
     companion object {
         fun make(typeInformation: LocalTypeInformation, factory: LocalSerializerFactory): ObjectSerializer {
-            if (typeInformation is LocalTypeInformation.NonComposable)
+            if (typeInformation is LocalTypeInformation.NonComposable) {
                 throw NotSerializableException(
-                        "Trying to build an object serializer for ${typeInformation.typeIdentifier.prettyPrint(false)}, " +
-                        "but it is not constructable from its public properties, and so requires a custom serialiser.")
+                    "Unable to create an object serializer for type ${typeInformation.observedType}:\n" +
+                            "${typeInformation.reason}\n\n${typeInformation.remedy}"
+                )
+            }
 
             val typeDescriptor = factory.createDescriptor(typeInformation)
             val typeNotation = TypeNotationGenerator.getTypeNotation(typeInformation, typeDescriptor)

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
@@ -4,7 +4,6 @@ import com.google.common.reflect.TypeToken
 import net.corda.core.KeepForDJVM
 import net.corda.core.internal.isPublic
 import net.corda.core.serialization.SerializableCalculatedProperty
-import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.amqp.MethodClassifier.*
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -88,7 +87,7 @@ private val propertyMethodRegex = Regex("(?<type>get|set|is)(?<var>\\p{Lu}.*)")
  * take a single parameter of a type compatible with exampleProperty and isExampleProperty must
  * return a boolean
  */
-internal fun Class<out Any?>.propertyDescriptors(warnInvalid: Boolean = true): Map<String, PropertyDescriptor> {
+internal fun Class<out Any?>.propertyDescriptors(validateProperties: Boolean = true): Map<String, PropertyDescriptor> {
     val fieldProperties = superclassChain().declaredFields().byFieldName()
 
     return superclassChain().declaredMethods()
@@ -97,7 +96,7 @@ internal fun Class<out Any?>.propertyDescriptors(warnInvalid: Boolean = true): M
             .withValidSignature()
             .byNameAndClassifier(fieldProperties.keys)
             .toClassProperties(fieldProperties).run {
-                if (warnInvalid) validated() else this
+                if (validateProperties) validated() else this
             }
 }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt
@@ -27,4 +27,8 @@ class ComposedSerializerFactory(
 ) : SerializerFactory,
         LocalSerializerFactory by localSerializerFactory,
         RemoteSerializerFactory by remoteSerializerFactory,
-        CustomSerializerRegistry by customSerializerRegistry
+        CustomSerializerRegistry by customSerializerRegistry {
+
+        override val customSerializerNames: List<String>
+                get() = customSerializerRegistry.customSerializerNames
+}

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
@@ -259,7 +259,9 @@ sealed class LocalTypeInformation {
             val properties: Map<PropertyName, LocalPropertyInformation>,
             val superclass: LocalTypeInformation,
             val interfaces: List<LocalTypeInformation>,
-            val typeParameters: List<LocalTypeInformation>) : LocalTypeInformation()
+            val typeParameters: List<LocalTypeInformation>,
+            val reason: String,
+            val remedy: String) : LocalTypeInformation()
 
     /**
      * Represents a type whose underlying class is a collection class such as [List] with a single type parameter.

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -312,14 +312,11 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
     }
 
     private fun nonComposablePropertiesErrorReason(nonComposableProperties: Map<PropertyName, LocalPropertyInformation>): String {
-        val reason = StringBuilder("Has properties ${nonComposableProperties.keys} of types that are not serializable:\n")
-        for ((key, value) in nonComposableProperties) {
-            reason.appendln(
-                "$key [${value.type.observedType}]: ${(value.type as LocalTypeInformation.NonComposable).reason}"
-                    .replace("\n", "\n    ")
-            )
+        val reasons = nonComposableProperties.entries.joinToString("\n") { (key, value) ->
+            "$key [${value.type.observedType}]: ${(value.type as LocalTypeInformation.NonComposable).reason}"
+                .replace("\n", "\n    ")
         }
-        return reason.removeSuffix("\n").toString()
+        return "Has properties ${nonComposableProperties.keys} of types that are not serializable:\n" + reasons
     }
 
     private fun buildSuperclassInformation(type: Type): LocalTypeInformation =

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
@@ -549,16 +549,31 @@ class DeserializeSimpleTypesTests {
 
     @Test
     fun classHasNoPublicConstructor() {
-        assertFailsWithMessage("Trying to build an object serializer for ${Garbo::class.java.name}, " +
-                "but it is not constructable from its public properties, and so requires a custom serialiser.") {
+        assertFailsWithMessage(
+            """Unable to create an object serializer for type class ${Garbo::class.java.name}:
+Mandatory constructor parameters [value] are missing from the readable properties []
+
+Either provide getters or readable fields for [value], or provide a custom serializer for this type
+
+No custom serializers registered.
+"""
+        ) {
             TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(Garbo.make(1))
         }
     }
 
     @Test
     fun propertyClassHasNoPublicConstructor() {
-        assertFailsWithMessage("Trying to build an object serializer for ${Greta::class.java.name}, " +
-                "but it is not constructable from its public properties, and so requires a custom serialiser.") {
+        assertFailsWithMessage(
+            """Unable to create an object serializer for type class ${Greta::class.java.name}:
+Has properties [garbo] of types that are not serializable:
+garbo [class ${Garbo::class.java.name}]: Mandatory constructor parameters [value] are missing from the readable properties []
+
+Either ensure that the properties [garbo] are serializable, or provide a custom serializer for this type
+
+No custom serializers registered.
+"""
+        ) {
             TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(Greta(Garbo.make(1)))
         }
     }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
@@ -8,7 +8,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.lang.reflect.Type
-import java.time.LocalDateTime
 import java.util.*
 
 class LocalTypeModelTests {
@@ -16,6 +15,12 @@ class LocalTypeModelTests {
     private val descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry()
     private val customSerializerRegistry: CustomSerializerRegistry = CachingCustomSerializerRegistry(descriptorBasedSerializerRegistry)
     private val model = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, customSerializerRegistry))
+    private val emptyCustomSerializerRegistry = object: CustomSerializerRegistry {
+        override fun register(customSerializer: CustomSerializer<out Any>) {}
+        override fun registerExternal(customSerializer: CorDappCustomSerializer) {}
+        override fun findCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? = null
+    }
+    private val modelWithoutOpacity = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, emptyCustomSerializerRegistry))
 
     interface CollectionHolder<K, V> {
         val list: List<V>
@@ -134,20 +139,70 @@ class LocalTypeModelTests {
         """)
     }
 
-    class TransitivelyNonComposable(val a: String, val b: Exception)
+    class TransitivelyNonComposable(
+        val a: String,
+        val b: Exception,
+        val c: MissingConstructorParameter,
+        val d: AnotherTransitivelyNonComposable
+    )
+
+    class AnotherTransitivelyNonComposable(val e: String, val f: Exception, val g: OneMoreTransitivelyNonComposable)
+    class OneMoreTransitivelyNonComposable(val h: String, val i: Exception)
+    class MissingConstructorParameter(val a: String, b: Exception)
 
     @Test
-    fun `non-composable types`() {
-        val serializerRegistry = object: CustomSerializerRegistry {
-            override fun register(customSerializer: CustomSerializer<out Any>) {}
-
-            override fun registerExternal(customSerializer: CorDappCustomSerializer) {}
-
-            override fun findCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? = null
+    fun `no unique deserialization constructor creates non-composable type`() {
+        modelWithoutOpacity.inspect(typeOf<Exception>()).let { typeInformation ->
+            assertTrue(typeInformation is LocalTypeInformation.NonComposable)
+            typeInformation as LocalTypeInformation.NonComposable
+            assertEquals(
+                "No unique deserialization constructor can be identified",
+                typeInformation.reason
+            )
+            assertEquals(
+                "Either annotate a constructor for this type with @ConstructorForDeserialization, or provide a custom serializer for it",
+                typeInformation.remedy
+            )
         }
-        val modelWithoutOpacity = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, serializerRegistry) )
-        assertTrue(modelWithoutOpacity.inspect(typeOf<Exception>()) is LocalTypeInformation.NonComposable)
-        assertTrue(modelWithoutOpacity.inspect(typeOf<TransitivelyNonComposable>()) is LocalTypeInformation.NonComposable)
+    }
+
+    @Test
+    fun `missing constructor parameters creates non-composable type`() {
+        modelWithoutOpacity.inspect(typeOf<MissingConstructorParameter>()).let { typeInformation ->
+            assertTrue(typeInformation is LocalTypeInformation.NonComposable)
+            typeInformation as LocalTypeInformation.NonComposable
+            assertEquals(
+                "Mandatory constructor parameters [b] are missing from the readable properties [a]",
+                typeInformation.reason
+            )
+            assertEquals(
+                "Either provide getters or readable fields for [b], or provide a custom serializer for this type",
+                typeInformation.remedy
+            )
+        }
+    }
+
+    @Test
+    fun `transitive types are non-composable creates non-composable type`() {
+        modelWithoutOpacity.inspect(typeOf<TransitivelyNonComposable>()).let { typeInformation ->
+            assertTrue(typeInformation is LocalTypeInformation.NonComposable)
+            typeInformation as LocalTypeInformation.NonComposable
+            assertEquals(
+                """
+                Has properties [b, c, d] of types that are not serializable:
+                b [${Exception::class.java}]: No unique deserialization constructor can be identified
+                c [${MissingConstructorParameter::class.java}]: Mandatory constructor parameters [b] are missing from the readable properties [a]
+                d [${AnotherTransitivelyNonComposable::class.java}]: Has properties [f, g] of types that are not serializable:
+                    f [${Exception::class.java}]: No unique deserialization constructor can be identified
+                    g [${OneMoreTransitivelyNonComposable::class.java}]: Has properties [i] of types that are not serializable:
+                        i [${Exception::class.java}]: No unique deserialization constructor can be identified
+                """.trimIndent(), typeInformation.reason
+            )
+            assertEquals(
+                "Either ensure that the properties [b, c, d] are serializable, or provide a custom serializer for this type",
+                typeInformation.remedy
+            )
+        }
     }
 
     private inline fun <reified T> assertInformation(expected: String) {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
@@ -16,6 +16,7 @@ class LocalTypeModelTests {
     private val customSerializerRegistry: CustomSerializerRegistry = CachingCustomSerializerRegistry(descriptorBasedSerializerRegistry)
     private val model = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, customSerializerRegistry))
     private val emptyCustomSerializerRegistry = object: CustomSerializerRegistry {
+        override val customSerializerNames: List<String> = emptyList()
         override fun register(customSerializer: CustomSerializer<out Any>) {}
         override fun registerExternal(customSerializer: CorDappCustomSerializer) {}
         override fun findCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? = null


### PR DESCRIPTION
Raised for https://r3-cev.atlassian.net/browse/CORDA-2870 . I have followed the recommendations of information to include in this change that Dom mentioned in the Jira ticket. I think the format of the error messages is quite good and useful now, but the classloader information probably needs a little more work on it.

Below are the main changes:

When creating `LocalTypeInformation.NonComposable` pass in the `reason`
a type was not composable and the `remedy` to fix it. This required
changes in `LocalTypeInformationBuilder` to pass in this extra
information so that it can be used later.

The message that the `ObjectSerializer` includes in its
`NotSerializableException` now includes the extra information about the
non composable type.

In `ObjectSerializer`, when a serialization exception is thrown,
include the registered custom serializers + their classloaders as part
of the error message.

Tidy up `LocalTypeInformationBuilder` error message text for
transitive non-composable types.

Expose `customSerializerNames` in `LocalSerializerFactory` and
`CustomSerializerFactory`.