### PR TITLE
CORDA-2934 disable hibernate validator integration with hibernate

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,12 @@ Version 4.2
 * :doc:`design/data-model-upgrades/package-namespace-ownership` configurations can be now be set as described in
   :ref:`node_package_namespace_ownership`, when using the Cordformation plugin version 4.0.43.
 
+* Disabled the default loading of ``hibernate-validator`` as a plugin by hibernate when a CorDapp depends on it. This change will in turn fix the
+  (https://github.com/corda/corda/issues/4444) issue, because nodes will no longer need to add ``hibernate-validator`` to the ``\libs`` folder.
+  For nodes that already did that, it can be safely removed when the latest Corda is installed.
+  One thing to keep in mind is that if any CorDapp relied on hibernate-validator to validate Querayable JPA Entities via annotations, that will no longer happen.
+  That was a bad practice anyway, because the ``ContractState`` should be validated in the Contract verify method.
+
 .. _changelog_v4.0:
 
 Version 4.0

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt
@@ -89,6 +89,7 @@ class HibernateConfiguration(
         val config = Configuration(metadataSources).setProperty("hibernate.connection.provider_class", NodeDatabaseConnectionProvider::class.java.name)
                 .setProperty("hibernate.format_sql", "true")
                 .setProperty("hibernate.hbm2ddl.auto", hbm2dll)
+                .setProperty("javax.persistence.validation.mode", "none")
                 .setProperty("hibernate.connection.isolation", databaseConfig.transactionIsolationLevel.jdbcValue.toString())
 
         schemas.forEach { schema ->


### PR DESCRIPTION
see https://r3-cev.atlassian.net/browse/CORDA-2934

I've tested manually, and the node can be started without hibernate validator in the "lib" folder