### PR TITLE
ENT-3540 Reverting jackson - kotlin runtime issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,8 @@ buildscript {
 
     ext.asm_version = '5.0.4'
     ext.artemis_version = '2.6.2'
-    ext.jackson_version = '2.9.8'
+    // upgrade Jackson only when corda is using kotlin 1.3.10
+    ext.jackson_version = '2.9.5'
     ext.jetty_version = '9.4.7.v20170914'
     ext.jersey_version = '2.25'
     ext.assertj_version = '3.8.0'


### PR DESCRIPTION
Jackson was updated to 2.9.8, however this version has a transitive dependency on kotlin 1.3.10 which is incompatible with corda (which uses 1.2 currently).

