### PR TITLE
CORDA-2893, ENT-3422: Tweak JUnit 5 configurations to keep vintage engine off compile classpaths.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,8 @@ allprojects {
     }
 
     tasks.withType(Test) {
+        useJUnitPlatform()
+
         failFast = project.hasProperty('tests.failFast') ? project.property('tests.failFast').toBoolean() : false
 
         // Prevent the project from creating temporary files outside of the build directory.

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -20,11 +20,12 @@ dependencies {
     testCompile project(path: ':core', configuration: 'testArtifacts')
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     
 }

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -45,11 +45,12 @@ dependencies {
 
     // Unit testing helpers.
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     testCompile project(':test-utils')

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -14,11 +14,12 @@ dependencies {
     compile project(':finance:contracts')
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:${assertj_version}"
 

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -9,10 +9,10 @@ description 'Corda client RPC modules'
 //noinspection GroovyAssignabilityCheck
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 
     smokeTestCompile.extendsFrom compile
-    smokeTestRuntime.extendsFrom runtime
+    smokeTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
 compileKotlin {
@@ -74,12 +74,11 @@ dependencies {
     // For caches rather than guava
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     // Unit testing helpers.
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
@@ -96,7 +95,9 @@ dependencies {
     smokeTestCompile "org.apache.logging.log4j:log4j-core:$log4j_version"
     smokeTestCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"
-    smokeTestCompile "junit:junit:$junit_version"
+    smokeTestImplementation "junit:junit:$junit_version"
+    smokeTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    smokeTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 task integrationTest(type: Test) {

--- a/common/configuration-parsing/build.gradle
+++ b/common/configuration-parsing/build.gradle
@@ -12,8 +12,9 @@ dependencies {
     compile project(":common-validation")
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 

--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -13,8 +13,9 @@ dependencies {
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 

--- a/core-deterministic/testing/build.gradle
+++ b/core-deterministic/testing/build.gradle
@@ -12,10 +12,13 @@ dependencies {
         transitive = false
     }
 
-    testCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
+    testImplementation "org.slf4j:slf4j-api:$slf4j_version"
+    testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
-    testCompile "junit:junit:$junit_version"
+    testImplementation "junit:junit:$junit_version"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 // This module has no artifact and only contains tests.

--- a/core-deterministic/testing/data/build.gradle
+++ b/core-deterministic/testing/data/build.gradle
@@ -13,10 +13,9 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testCompile "org.jetbrains.kotlin:kotlin-reflect"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 

--- a/core-deterministic/testing/verifier/build.gradle
+++ b/core-deterministic/testing/verifier/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     // Compile against the deterministic artifacts to ensure that we use only the deterministic API subset.
     compileOnly configurations.deterministicArtifacts
     api "junit:junit:$junit_version"
-    api "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    runtimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
 }
 
 jar {

--- a/core-deterministic/testing/verifier/src/main/kotlin/net/corda/deterministic/verifier/LocalSerializationRule.kt
+++ b/core-deterministic/testing/verifier/src/main/kotlin/net/corda/deterministic/verifier/LocalSerializationRule.kt
@@ -1,6 +1,5 @@
 package net.corda.deterministic.verifier
 
-import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationContext.UseCase.P2P
 import net.corda.core.serialization.SerializationCustomSerializer

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,10 +11,10 @@ evaluationDependsOn(':node:capsule')
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 
     smokeTestCompile.extendsFrom compile
-    smokeTestRuntime.extendsFrom runtime
+    smokeTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
 sourceSets {
@@ -56,10 +56,11 @@ processSmokeTestResources {
 dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testImplementation "junit:junit:$junit_version"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "commons-fileupload:commons-fileupload:$fileupload_version"
 
     // Guava: Google test library (collections test suite)
@@ -93,11 +94,12 @@ dependencies {
 
     // Smoke tests do NOT have any Node code on the classpath!
     smokeTestImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    smokeTestImplementation "junit:junit:$junit_version"
 
-    smokeTestCompile "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    smokeTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     smokeTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     smokeTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     smokeTestCompile project(':smoke-test-utils')
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"
 
@@ -138,7 +140,7 @@ jar {
 }
 
 configurations {
-    testArtifacts.extendsFrom testRuntime
+    testArtifacts.extendsFrom testRuntimeClasspath
 }
 
 task testJar(type: Jar) {

--- a/experimental/avalanche/build.gradle
+++ b/experimental/avalanche/build.gradle
@@ -10,8 +10,9 @@ dependencies {
     compile "info.picocli:picocli:$picocli_version"
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/experimental/behave/build.gradle
+++ b/experimental/behave/build.gradle
@@ -65,8 +65,9 @@ dependencies {
 
     // Unit Tests
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     

--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -21,8 +21,9 @@ dependencies {
     compile "com.google.guava:guava:$guava_version"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     testCompile project(':node-driver')

--- a/experimental/corda-utils/build.gradle
+++ b/experimental/corda-utils/build.gradle
@@ -24,8 +24,9 @@ dependencies {
     testCompile project(':node-driver')
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -15,8 +15,9 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
@@ -25,7 +26,7 @@ dependencies {
 }
 
 configurations {
-    testArtifacts.extendsFrom testRuntime
+    testArtifacts.extendsFrom testRuntimeClasspath
 }
 
 jar {

--- a/finance/workflows/build.gradle
+++ b/finance/workflows/build.gradle
@@ -22,6 +22,12 @@ sourceSets {
     }
 }
 
+configurations {
+    testArtifacts.extendsFrom testRuntimeClasspath
+    integrationTestCompile.extendsFrom testCompile
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 dependencies {
     // Note: 3rd party CorDapps should remember to include the relevant Finance CorDapp dependencies using `cordapp`
     // cordapp project(':finance:workflows')
@@ -36,21 +42,16 @@ dependencies {
     
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
-    
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
+
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:$assertj_version"
-}
-
-configurations {
-    testArtifacts.extendsFrom testRuntime
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
 }
 
 task testJar(type: Jar) {
@@ -71,12 +72,6 @@ jar {
     baseName 'corda-finance-workflows'
     preserveFileTimestamps = false
     reproducibleFileOrder = true
-}
-
-configurations {
-    testArtifacts.extendsFrom testRuntime
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
 }
 
 cordapp {

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -39,8 +39,9 @@ dependencies {
     runtime 'com.mattbertolini:liquibase-slf4j:2.0.0'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     // Unit testing helpers.
@@ -55,7 +56,7 @@ dependencies {
 }
 
 configurations {
-    testArtifacts.extendsFrom testRuntime
+    testArtifacts.extendsFrom testRuntimeClasspath
 }
 
 task testJar(type: Jar) {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -24,7 +24,7 @@ description 'Corda node modules'
 //noinspection GroovyAssignabilityCheck
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 sourceSets {
@@ -129,11 +129,12 @@ dependencies {
     compile "com.typesafe:config:$typesafe_config_version"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:${assertj_version}"
     testCompile project(':test-utils')

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -27,7 +27,7 @@ sourceSets {
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 dependencies {
@@ -40,7 +40,7 @@ dependencies {
     // Cordformation needs a SLF4J implementation when executing the Network
     // Bootstrapper, but Log4J doesn't shutdown completely from within Gradle.
     // Use a much simpler SLF4J implementation here instead.
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 
     // Corda integration dependencies
     cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')
@@ -56,11 +56,12 @@ dependencies {
     }
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:$assertj_version"
 
     integrationTestCompile project(':webserver')

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -26,8 +26,9 @@ dependencies {
 
     // Test dependencies
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -48,8 +48,8 @@ sourceSets {
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
-    demoArtifacts.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+    demoArtifacts.extendsFrom testRuntimeClasspath
     systemTestCompile.extendsFrom testCompile
 }
 
@@ -71,11 +71,12 @@ dependencies {
     testCompile project(':node-driver')
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     integrationTestCompile project(path: ":samples:irs-demo:web", configuration: "demoArtifacts")

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     // Corda integration dependencies
     cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 
     cordapp project(':samples:irs-demo:cordapp:contracts-irs')
     cordapp project(':samples:irs-demo:cordapp:workflows-irs')

--- a/samples/irs-demo/cordapp/contracts-irs/build.gradle
+++ b/samples/irs-demo/cordapp/contracts-irs/build.gradle
@@ -12,8 +12,9 @@ dependencies {
 
     testCompile project(':node-driver')
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordapp'
 
 configurations {
-    demoArtifacts.extendsFrom testRuntime
+    demoArtifacts.extendsFrom testRuntimeClasspath
 }
 
 dependencies {
@@ -26,11 +26,12 @@ dependencies {
     testCompile project(':node-driver')
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
     cordapp project(':samples:irs-demo:cordapp:contracts-irs')

--- a/samples/network-verifier/build.gradle
+++ b/samples/network-verifier/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     // Cordformation needs a SLF4J implementation when executing the Network
     // Bootstrapper, but Log4J doesn't shutdown completely from within Gradle.
     // Use a much simpler SLF4J implementation here instead.
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 
     // Corda integration dependencies
     cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')

--- a/samples/notary-demo/build.gradle
+++ b/samples/notary-demo/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     // Cordformation needs a SLF4J implementation when executing the Network
     // Bootstrapper, but Log4J doesn't shutdown completely from within Gradle.
     // Use a much simpler SLF4J implementation here instead.
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 
     // Notary implementations
     cordapp project(':samples:notary-demo:contracts')

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -22,7 +22,7 @@ sourceSets {
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 dependencies {
@@ -60,11 +60,12 @@ dependencies {
     testCompile project(':node-driver')
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -25,7 +25,7 @@ sourceSets {
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 dependencies {
@@ -36,7 +36,7 @@ dependencies {
     // Cordformation needs a SLF4J implementation when executing the Network
     // Bootstrapper, but Log4J doesn't shutdown completely from within Gradle.
     // Use a much simpler SLF4J implementation here instead.
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 
     // We only need this for its DUMMY_BANK constants, and
     // DO NOT want it added to Gradle's runtime classpath.
@@ -57,11 +57,12 @@ dependencies {
     }
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/samples/trader-demo/workflows-trader/build.gradle
+++ b/samples/trader-demo/workflows-trader/build.gradle
@@ -13,11 +13,12 @@ dependencies {
     testCompile project(':node-driver')
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:$assertj_version"
 }
 

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -29,8 +29,9 @@ dependencies {
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     
@@ -40,7 +41,7 @@ dependencies {
 }
 
 configurations {
-    testArtifacts.extendsFrom testRuntime
+    testArtifacts.extendsFrom testRuntimeClasspath
 }
 
 task testJar(type: Jar) {

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -29,9 +29,10 @@ dependencies {
 
     // Integration test helpers
     testCompile "org.assertj:assertj-core:$assertj_version"
+    integrationTestImplementation "junit:junit:$junit_version"
     integrationTestImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
 
-    integrationTestImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    integrationTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     integrationTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -18,7 +18,6 @@ import net.corda.testing.node.internal.addressMustNotBeBound
 import org.assertj.core.api.Assertions.*
 import org.json.simple.JSONObject
 import org.junit.Test
-import java.io.RandomAccessFile
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     compile "junit:junit:${junit_version}"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -10,11 +10,12 @@ dependencies {
 
     // Unit testing helpers.
     compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    compile "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+    runtimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    runtimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+
     compile 'org.hamcrest:hamcrest-library:1.3'
     compile "com.nhaarman:mockito-kotlin:$mockito_kotlin_version"
     compile "org.mockito:mockito-core:$mockito_version"

--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -74,14 +74,12 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(':webserver')
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
-
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
+    testCompile "junit:junit:$junit_version"
 }
 
 tasks.withType(JavaCompile) {

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -8,12 +8,11 @@ mainClassName = 'net.corda.explorer.Main'
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
     // TornadoFX: A lightweight Kotlin framework for working with JavaFX UI's.

--- a/tools/shell/build.gradle
+++ b/tools/shell/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Shell'
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 sourceSets {
@@ -54,10 +54,9 @@ dependencies {
     // For logging, required for ANSIProgressRenderer.
     compile "org.apache.logging.log4j:log4j-core:$log4j_version"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     
     // Unit testing helpers.

--- a/tools/worldmap/build.gradle
+++ b/tools/worldmap/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     implementation project(':core')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -63,8 +63,9 @@ dependencies {
     integrationTestCompile project(':node-driver')
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
 
-    testImplementation "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }


### PR DESCRIPTION
- Put JUnit engines on runtime classpaths.
- Configure `runtimeOnly` configurations for integration and smoke tests.
- Put SLF4J back-ends into `cordaRuntime` configurations.
- Remove some unused imports.
- _Activate Gradle's JUnit 5 support!_