### PR TITLE
CORDA-2971 - added tests for initialiseSchema configuration option

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/persistence/DbSchemaInitialisationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/DbSchemaInitialisationTest.kt
@@ -1,0 +1,32 @@
+package net.corda.node.persistence
+
+import net.corda.core.utilities.getOrThrow
+import net.corda.nodeapi.internal.persistence.DatabaseIncompatibleException
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeParameters
+import net.corda.testing.driver.driver
+import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class DbSchemaInitialisationTest {
+
+    @Test
+    fun `database is initialised`() {
+        driver(DriverParameters(startNodesInProcess = isQuasarAgentSpecified())) {
+            val nodeHandle = {
+                startNode(NodeParameters(customOverrides = mapOf("database.initialiseSchema" to "true"))).getOrThrow()
+            }()
+            assertNotNull(nodeHandle)
+        }
+    }
+
+    @Test
+    fun `database is not initialised`() {
+        driver(DriverParameters(startNodesInProcess = isQuasarAgentSpecified())) {
+            assertFailsWith(DatabaseIncompatibleException::class) {
+                startNode(NodeParameters(customOverrides = mapOf("database.initialiseSchema" to "false"))).getOrThrow()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add integration tests to check if database.initialiseSchema=false is respected.The expected behaviour is:For a fresh node when the option is set to false Hibernate doesn't create database objects (e.g. tables) upon a node startup and node fails to start beacuse the databse objects defined in JPA annotations can not be found.
This is backport of some test done for Corda Enteprise in ENT-3616 .