### PR TITLE
EXPERIMENT: Remove currently unused JUnit 5 "jupiter" engine.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript {
     // Need this version to access classpath scanning error handling fix -
     // see https://github.com/junit-team/junit5/commit/389de48c2a18c5a93a7203ef424aa47a8a835a74
     // Upgrade to 5.5.x when GA release is available.
-    ext.junit_vintage_version = '5.5.0-M1'
+    ext.junit_vintage_version = '5.4.2'
     ext.junit_jupiter_version = '5.5.0-M1'
     ext.junit_platform_version = '1.4.2'
     ext.mockito_version = '2.18.3'

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -19,11 +19,9 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:${assertj_version}"
 

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -44,11 +44,9 @@ dependencies {
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
 
     // Unit testing helpers.
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:${assertj_version}"

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:${assertj_version}"

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -13,11 +13,9 @@ dependencies {
     compile project(':finance:workflows')
     compile project(':finance:contracts')
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Unit testing helpers.

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -77,7 +77,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Unit testing helpers.
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
@@ -97,7 +96,6 @@ dependencies {
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"
     smokeTestImplementation "junit:junit:$junit_version"
     smokeTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    smokeTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 task integrationTest(type: Test) {

--- a/common/configuration-parsing/build.gradle
+++ b/common/configuration-parsing/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile group: "org.jetbrains.kotlin", name: "kotlin-test", version: kotlin_version
     testCompile group: "org.assertj", name: "assertj-core", version: assertj_version

--- a/common/configuration-parsing/build.gradle
+++ b/common/configuration-parsing/build.gradle
@@ -11,11 +11,9 @@ dependencies {
 
     compile project(":common-validation")
     
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile group: "org.jetbrains.kotlin", name: "kotlin-test", version: kotlin_version

--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Guava: Google test library (collections test suite)
     testCompile "com.google.guava:guava-testlib:$guava_version"

--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -12,11 +12,9 @@ dependencies {
     cordaCompile project(':core')
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Guava: Google test library (collections test suite)

--- a/core-deterministic/testing/build.gradle
+++ b/core-deterministic/testing/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     testCompile "org.assertj:assertj-core:$assertj_version"
     testImplementation "junit:junit:$junit_version"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 // This module has no artifact and only contains tests.

--- a/core-deterministic/testing/data/build.gradle
+++ b/core-deterministic/testing/data/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 jar.enabled = false

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,7 +57,6 @@ dependencies {
 
     testImplementation "junit:junit:$junit_version"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "commons-fileupload:commons-fileupload:$fileupload_version"
 
@@ -94,7 +93,6 @@ dependencies {
     smokeTestImplementation "junit:junit:$junit_version"
 
     smokeTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    smokeTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     smokeTestCompile project(':smoke-test-utils')
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -55,10 +55,8 @@ processSmokeTestResources {
 
 dependencies {
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "commons-fileupload:commons-fileupload:$fileupload_version"
@@ -93,11 +91,9 @@ dependencies {
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
     // Smoke tests do NOT have any Node code on the classpath!
-    smokeTestImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     smokeTestImplementation "junit:junit:$junit_version"
 
     smokeTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    smokeTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     smokeTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     smokeTestCompile project(':smoke-test-utils')

--- a/experimental/avalanche/build.gradle
+++ b/experimental/avalanche/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 jar.enabled = false

--- a/experimental/avalanche/build.gradle
+++ b/experimental/avalanche/build.gradle
@@ -9,11 +9,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "info.picocli:picocli:$picocli_version"
     
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 

--- a/experimental/behave/build.gradle
+++ b/experimental/behave/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     
     testCompile "org.assertj:assertj-core:$assertj_version"
 

--- a/experimental/behave/build.gradle
+++ b/experimental/behave/build.gradle
@@ -64,11 +64,9 @@ dependencies {
     compile project(':client:rpc')
 
     // Unit Tests
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -20,11 +20,9 @@ dependencies {
 
     compile "com.google.guava:guava:$guava_version"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     testCompile project(':node-driver')
 }

--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -23,6 +23,5 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     testCompile project(':node-driver')
 }

--- a/experimental/corda-utils/build.gradle
+++ b/experimental/corda-utils/build.gradle
@@ -26,5 +26,4 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/experimental/corda-utils/build.gradle
+++ b/experimental/corda-utils/build.gradle
@@ -23,10 +23,8 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(':node-driver')
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -14,11 +14,9 @@ dependencies {
 
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // AssertJ: for fluent assertions for testing

--- a/finance/workflows/build.gradle
+++ b/finance/workflows/build.gradle
@@ -46,7 +46,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/finance/workflows/build.gradle
+++ b/finance/workflows/build.gradle
@@ -43,11 +43,9 @@ dependencies {
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // AssertJ: for fluent assertions for testing

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -38,11 +38,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     runtime 'com.mattbertolini:liquibase-slf4j:2.0.0'
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -131,7 +131,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:${assertj_version}"

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -128,11 +128,9 @@ dependencies {
     // TypeSafe Config: for simple and human friendly config files.
     compile "com.typesafe:config:$typesafe_config_version"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Unit testing helpers.

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -55,11 +55,9 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
     
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"
 

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 def nodeTask = tasks.getByPath(':node:capsule:assemble')

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -25,11 +25,9 @@ dependencies {
     compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"
 
     // Test dependencies
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -70,11 +70,9 @@ dependencies {
 
     testCompile project(':node-driver')
     
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:${assertj_version}"

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -73,7 +73,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:${assertj_version}"
 

--- a/samples/irs-demo/cordapp/contracts-irs/build.gradle
+++ b/samples/irs-demo/cordapp/contracts-irs/build.gradle
@@ -11,11 +11,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
 
     testCompile project(':node-driver')
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 

--- a/samples/irs-demo/cordapp/contracts-irs/build.gradle
+++ b/samples/irs-demo/cordapp/contracts-irs/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 cordapp {

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -25,11 +25,9 @@ dependencies {
 
     testCompile project(':node-driver')
     
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:${assertj_version}"

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:${assertj_version}"
 

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -59,11 +59,9 @@ dependencies {
     // Test dependencies
     testCompile project(':node-driver')
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"
 }

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -59,7 +59,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"
 }

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -56,11 +56,9 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
     
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/samples/trader-demo/workflows-trader/build.gradle
+++ b/samples/trader-demo/workflows-trader/build.gradle
@@ -12,11 +12,9 @@ dependencies {
     
     testCompile project(':node-driver')
     
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/samples/trader-demo/workflows-trader/build.gradle
+++ b/samples/trader-demo/workflows-trader/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.assertj:assertj-core:$assertj_version"
 }

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -31,8 +31,7 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-    
+
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile project(':node-driver')

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -28,11 +28,9 @@ dependencies {
     // For caches rather than guava
     compile "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -30,10 +30,8 @@ dependencies {
     // Integration test helpers
     testCompile "org.assertj:assertj-core:$assertj_version"
     integrationTestImplementation "junit:junit:$junit_version"
-    integrationTestImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
 
     integrationTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     integrationTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Jetty dependencies for NetworkMapClient test.

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     integrationTestImplementation "junit:junit:$junit_version"
 
     integrationTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    integrationTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Jetty dependencies for NetworkMapClient test.
     // Web stuff: for HTTP[S] servlets

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -8,11 +8,9 @@ dependencies {
     compile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.0"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+"
     
-    compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     compile "junit:junit:${junit_version}"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
 }

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile "junit:junit:${junit_version}"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
 }
 compileKotlin {

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     compile "junit:junit:$junit_version"
 
     runtimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    runtimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     compile 'org.hamcrest:hamcrest-library:1.3'
     compile "com.nhaarman:mockito-kotlin:$mockito_kotlin_version"

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -9,11 +9,9 @@ dependencies {
     compile project(":common-logging")
 
     // Unit testing helpers.
-    compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     compile "junit:junit:$junit_version"
 
     runtimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     runtimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     compile 'org.hamcrest:hamcrest-library:1.3'

--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     testCompile project(':webserver')
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/tools/shell/build.gradle
+++ b/tools/shell/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:$assertj_version"

--- a/tools/worldmap/build.gradle
+++ b/tools/worldmap/build.gradle
@@ -7,5 +7,4 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -62,11 +62,9 @@ dependencies {
 
     integrationTestCompile project(':node-driver')
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
 
 task integrationTest(type: Test) {


### PR DESCRIPTION
Having both JUnit engines on the classpath forces Gradle to check for tests using both `vintage` and `jupiter` APIs. So drop the unused `jupiter` engine to see if this speeds things up.