### PR TITLE
EXPERIMENT: Deactivate JUnit 5 platform - revert to using original JUnit 4 test runner.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,8 +208,6 @@ allprojects {
     }
 
     tasks.withType(Test) {
-        useJUnitPlatform()
-
         failFast = project.hasProperty('tests.failFast') ? project.property('tests.failFast').toBoolean() : false
 
         // Prevent the project from creating temporary files outside of the build directory.


### PR DESCRIPTION
I am expecting that this change _alone_ will result in the Unit Test build containing 2828 tests and taking sub 45 minutes again.

And indeed it does, the flaky unit tests notwithstanding.