### PR TITLE
Backport CORDA-2870 Improve error messages for non-composable types

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt
@@ -97,5 +97,6 @@ class CorDappCustomSerializer(
     override fun isSerializerFor(clazz: Class<*>) =
         TypeToken.of(type.asClass()) == TypeToken.of(clazz)
 
+    override fun toString(): String = "${this::class.java}(${serializer::class.java})"
 }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -26,6 +26,12 @@ class DuplicateCustomSerializerException(serializers: List<AMQPSerializer<*>>, c
                 " registered to serialize type $clazz")
 
 interface CustomSerializerRegistry {
+
+    /**
+     * Retrieves the names of the registered custom serializers.
+     */
+    val customSerializerNames: List<String>
+
     /**
      * Register a custom serializer for any type that cannot be serialized or deserialized by the default serializer
      * that expects to find getters and a constructor with a parameter for each property.
@@ -57,6 +63,12 @@ class CachingCustomSerializerRegistry(
     companion object {
         val logger = contextLogger()
     }
+
+    override val customSerializerNames: List<String>
+        get() = customSerializers.map { serializer ->
+            if (serializer is CorDappCustomSerializer) serializer.toString()
+            else "${serializer::class.java} - Classloader: ${serializer::class.java.classLoader}"
+        }
 
     private data class CustomSerializerIdentifier(val actualTypeIdentifier: TypeIdentifier, val declaredTypeIdentifier: TypeIdentifier)
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -32,6 +32,11 @@ interface LocalSerializerFactory {
     val classloader: ClassLoader
 
     /**
+     * Retrieves the names of the registered custom serializers.
+     */
+    val customSerializerNames: List<String>
+
+    /**
      * Obtain an [AMQPSerializer] for an object of actual type [actualClass], and declared type [declaredType].
      */
     fun get(actualClass: Class<*>, declaredType: Type): AMQPSerializer<Any>
@@ -89,6 +94,9 @@ class DefaultLocalSerializerFactory(
     companion object {
         val logger = contextLogger()
     }
+
+    override val customSerializerNames: List<String>
+        get() = customSerializerRegistry.customSerializerNames
 
     private data class ActualAndDeclaredType(val actualType: Class<*>, val declaredType: Type)
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
@@ -4,7 +4,6 @@ import com.google.common.reflect.TypeToken
 import net.corda.core.KeepForDJVM
 import net.corda.core.internal.isPublic
 import net.corda.core.serialization.SerializableCalculatedProperty
-import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.amqp.MethodClassifier.*
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -88,7 +87,7 @@ private val propertyMethodRegex = Regex("(?<type>get|set|is)(?<var>\\p{Lu}.*)")
  * take a single parameter of a type compatible with exampleProperty and isExampleProperty must
  * return a boolean
  */
-internal fun Class<out Any?>.propertyDescriptors(warnInvalid: Boolean = true): Map<String, PropertyDescriptor> {
+internal fun Class<out Any?>.propertyDescriptors(validateProperties: Boolean = true): Map<String, PropertyDescriptor> {
     val fieldProperties = superclassChain().declaredFields().byFieldName()
 
     return superclassChain().declaredMethods()
@@ -97,7 +96,7 @@ internal fun Class<out Any?>.propertyDescriptors(warnInvalid: Boolean = true): M
             .withValidSignature()
             .byNameAndClassifier(fieldProperties.keys)
             .toClassProperties(fieldProperties).run {
-                if (warnInvalid) validated() else this
+                if (validateProperties) validated() else this
             }
 }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt
@@ -27,4 +27,8 @@ class ComposedSerializerFactory(
 ) : SerializerFactory,
         LocalSerializerFactory by localSerializerFactory,
         RemoteSerializerFactory by remoteSerializerFactory,
-        CustomSerializerRegistry by customSerializerRegistry
+        CustomSerializerRegistry by customSerializerRegistry {
+
+        override val customSerializerNames: List<String>
+                get() = customSerializerRegistry.customSerializerNames
+}

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
@@ -259,7 +259,9 @@ sealed class LocalTypeInformation {
             val properties: Map<PropertyName, LocalPropertyInformation>,
             val superclass: LocalTypeInformation,
             val interfaces: List<LocalTypeInformation>,
-            val typeParameters: List<LocalTypeInformation>) : LocalTypeInformation()
+            val typeParameters: List<LocalTypeInformation>,
+            val reason: String,
+            val remedy: String) : LocalTypeInformation()
 
     /**
      * Represents a type whose underlying class is a collection class such as [List] with a single type parameter.

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
@@ -549,16 +549,31 @@ class DeserializeSimpleTypesTests {
 
     @Test
     fun classHasNoPublicConstructor() {
-        assertFailsWithMessage("Trying to build an object serializer for ${Garbo::class.java.name}, " +
-                "but it is not constructable from its public properties, and so requires a custom serialiser.") {
+        assertFailsWithMessage(
+            """Unable to create an object serializer for type class ${Garbo::class.java.name}:
+Mandatory constructor parameters [value] are missing from the readable properties []
+
+Either provide getters or readable fields for [value], or provide a custom serializer for this type
+
+No custom serializers registered.
+"""
+        ) {
             TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(Garbo.make(1))
         }
     }
 
     @Test
     fun propertyClassHasNoPublicConstructor() {
-        assertFailsWithMessage("Trying to build an object serializer for ${Greta::class.java.name}, " +
-                "but it is not constructable from its public properties, and so requires a custom serialiser.") {
+        assertFailsWithMessage(
+            """Unable to create an object serializer for type class ${Greta::class.java.name}:
+Has properties [garbo] of types that are not serializable:
+garbo [class ${Garbo::class.java.name}]: Mandatory constructor parameters [value] are missing from the readable properties []
+
+Either ensure that the properties [garbo] are serializable, or provide a custom serializer for this type
+
+No custom serializers registered.
+"""
+        ) {
             TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(Greta(Garbo.make(1)))
         }
     }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
@@ -8,7 +8,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.lang.reflect.Type
-import java.time.LocalDateTime
 import java.util.*
 
 class LocalTypeModelTests {
@@ -16,6 +15,13 @@ class LocalTypeModelTests {
     private val descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry()
     private val customSerializerRegistry: CustomSerializerRegistry = CachingCustomSerializerRegistry(descriptorBasedSerializerRegistry)
     private val model = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, customSerializerRegistry))
+    private val emptyCustomSerializerRegistry = object: CustomSerializerRegistry {
+        override val customSerializerNames: List<String> = emptyList()
+        override fun register(customSerializer: CustomSerializer<out Any>) {}
+        override fun registerExternal(customSerializer: CorDappCustomSerializer) {}
+        override fun findCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? = null
+    }
+    private val modelWithoutOpacity = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, emptyCustomSerializerRegistry))
 
     interface CollectionHolder<K, V> {
         val list: List<V>
@@ -134,20 +140,70 @@ class LocalTypeModelTests {
         """)
     }
 
-    class TransitivelyNonComposable(val a: String, val b: Exception)
+    class TransitivelyNonComposable(
+        val a: String,
+        val b: Exception,
+        val c: MissingConstructorParameter,
+        val d: AnotherTransitivelyNonComposable
+    )
+
+    class AnotherTransitivelyNonComposable(val e: String, val f: Exception, val g: OneMoreTransitivelyNonComposable)
+    class OneMoreTransitivelyNonComposable(val h: String, val i: Exception)
+    class MissingConstructorParameter(val a: String, b: Exception)
 
     @Test
-    fun `non-composable types`() {
-        val serializerRegistry = object: CustomSerializerRegistry {
-            override fun register(customSerializer: CustomSerializer<out Any>) {}
-
-            override fun registerExternal(customSerializer: CorDappCustomSerializer) {}
-
-            override fun findCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? = null
+    fun `no unique deserialization constructor creates non-composable type`() {
+        modelWithoutOpacity.inspect(typeOf<Exception>()).let { typeInformation ->
+            assertTrue(typeInformation is LocalTypeInformation.NonComposable)
+            typeInformation as LocalTypeInformation.NonComposable
+            assertEquals(
+                "No unique deserialization constructor can be identified",
+                typeInformation.reason
+            )
+            assertEquals(
+                "Either annotate a constructor for this type with @ConstructorForDeserialization, or provide a custom serializer for it",
+                typeInformation.remedy
+            )
         }
-        val modelWithoutOpacity = ConfigurableLocalTypeModel(WhitelistBasedTypeModelConfiguration(AllWhitelist, serializerRegistry) )
-        assertTrue(modelWithoutOpacity.inspect(typeOf<Exception>()) is LocalTypeInformation.NonComposable)
-        assertTrue(modelWithoutOpacity.inspect(typeOf<TransitivelyNonComposable>()) is LocalTypeInformation.NonComposable)
+    }
+
+    @Test
+    fun `missing constructor parameters creates non-composable type`() {
+        modelWithoutOpacity.inspect(typeOf<MissingConstructorParameter>()).let { typeInformation ->
+            assertTrue(typeInformation is LocalTypeInformation.NonComposable)
+            typeInformation as LocalTypeInformation.NonComposable
+            assertEquals(
+                "Mandatory constructor parameters [b] are missing from the readable properties [a]",
+                typeInformation.reason
+            )
+            assertEquals(
+                "Either provide getters or readable fields for [b], or provide a custom serializer for this type",
+                typeInformation.remedy
+            )
+        }
+    }
+
+    @Test
+    fun `transitive types are non-composable creates non-composable type`() {
+        modelWithoutOpacity.inspect(typeOf<TransitivelyNonComposable>()).let { typeInformation ->
+            assertTrue(typeInformation is LocalTypeInformation.NonComposable)
+            typeInformation as LocalTypeInformation.NonComposable
+            assertEquals(
+                """
+                Has properties [b, c, d] of types that are not serializable:
+                b [${Exception::class.java}]: No unique deserialization constructor can be identified
+                c [${MissingConstructorParameter::class.java}]: Mandatory constructor parameters [b] are missing from the readable properties [a]
+                d [${AnotherTransitivelyNonComposable::class.java}]: Has properties [f, g] of types that are not serializable:
+                    f [${Exception::class.java}]: No unique deserialization constructor can be identified
+                    g [${OneMoreTransitivelyNonComposable::class.java}]: Has properties [i] of types that are not serializable:
+                        i [${Exception::class.java}]: No unique deserialization constructor can be identified
+                """.trimIndent(), typeInformation.reason
+            )
+            assertEquals(
+                "Either ensure that the properties [b, c, d] are serializable, or provide a custom serializer for this type",
+                typeInformation.remedy
+            )
+        }
     }
 
     private inline fun <reified T> assertInformation(expected: String) {


### PR DESCRIPTION
backport for https://r3-cev.atlassian.net/browse/CORDA-2870

* CORDA-2870 Add `reason` and `remedy` to `LocalTypeInformation.NonComposable`

When creating `LocalTypeInformation.NonComposable` pass in the `reason`
a type was not composable and the `remedy` to fix it. This required
changes in `LocalTypeInformationBuilder` to pass in this extra
information so that it can be used later.

The message that the `ObjectSerializer` includes in its
`NotSerializableException` now includes the extra information about the
non composable type.

* CORDA-2870 Include custom serializers in serialization error message

In `ObjectSerializer`, when a serialization exception is thrown,
include the registered custom serializers + their classloaders as part
of the error message.

This required making properties on `CustomSerializerRegistry` and
`LocalSerializerFactory` public.

Tidy up `LocalTypeInformationBuilder` error message text for
transitive non-composable types.

* CORDA-2870 Tidy up error thrown for unserializable objects

Fix `DeserializeSimpleTypesTests` and tidy up the code in
`ObjectSerializer` a bit.

* CORDA-2870 Remove non-composable warning logs in `LocalTypeInformationBuilder`

The flag `warnIfNonComposable` and its corresponding log lines are not
needed now that the non-composable error messages contain a lot of
information in them.

The `warnIfNonComposable` flag is now incorrect and has been renamed to
`validateProperties` and the function `suppressWarningsAnd` has been
changed to `suppressValidation`.

`propertyDescriptors` has also had its input boolean changed to
`validateProperties` to better represent what it is doing.

* CORDA-2870 Remove need for casting by moving variable to interface

Expose `customSerializerNames` in `LocalSerializerFactory` and
`CustomSerializerFactory`.

(cherry picked from commit cd73161513b8a07e7c88e5f8b994e2ce2537cb3f)