### PR TITLE
CORDA-2964: Update OWASP dependency checker to v4.0.2 to fix clash with Gradle 5 …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ buildscript {
     ext.rxjava_version = '1.3.8'
     ext.dokka_version = '0.9.17'
     ext.eddsa_version = '0.2.0'
-    ext.dependency_checker_version = '4.0.0'
+    ext.dependency_checker_version = '4.0.2'
     ext.commons_collections_version = '4.1'
     ext.beanutils_version = '1.9.3'
     ext.crash_version = '810d2b774b85d4938be01b9b65e29e4fddbc450b'


### PR DESCRIPTION
Fix OWASP dependency checker 

v4.0.0 fails with Gradle 5 as it is using an internal API. v4.0.2 does not seem to have this issue.