### PR TITLE
CORDA-2720: Refactor NodeConfiguration out of NodeRegistrationHelper

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -11,6 +11,7 @@ import net.corda.node.internal.*
 import net.corda.node.internal.NodeStartupLogging.Companion.logger
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.utilities.registration.HTTPNetworkRegistrationService
+import net.corda.node.utilities.registration.NodeRegistrationConfiguration
 import net.corda.node.utilities.registration.NodeRegistrationHelper
 import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
@@ -68,7 +69,7 @@ class InitialRegistration(val baseDirectory: Path, private val networkRootTrustS
                 "*                                                                *\n" +
                 "******************************************************************\n")
 
-        NodeRegistrationHelper(conf,
+        NodeRegistrationHelper(NodeRegistrationConfiguration(conf),
                 HTTPNetworkRegistrationService(
                         requireNotNull(conf.networkServices),
                         versionInfo),

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -9,6 +9,7 @@ import net.corda.node.NodeRegistrationOption
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.nodeapi.internal.cryptoservice.bouncycastle.BCCryptoService
 import net.corda.nodeapi.internal.config.CertificateStore
+import net.corda.nodeapi.internal.config.MutualSslConfiguration
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.NOT_YET_REGISTERED_MARKER_KEYS_AND_CERTS
 import net.corda.nodeapi.internal.crypto.X509KeyStore
@@ -19,6 +20,7 @@ import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_ROOT_CA
 import net.corda.nodeapi.internal.crypto.X509Utilities.DEFAULT_VALIDITY_WINDOW
 import net.corda.nodeapi.internal.cryptoservice.CryptoServiceFactory
 import net.corda.nodeapi.internal.cryptoservice.SupportedCryptoServices
+import net.corda.nodeapi.internal.cryptoservice.CryptoService
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.operator.ContentSigner
@@ -26,6 +28,7 @@ import org.bouncycastle.util.io.pem.PemObject
 import java.io.IOException
 import java.io.StringWriter
 import java.net.ConnectException
+import java.net.URL
 import java.nio.file.Path
 import java.security.KeyPair
 import java.security.PublicKey
@@ -39,7 +42,7 @@ import javax.security.auth.x500.X500Principal
  * needed.
  */
 open class NetworkRegistrationHelper(
-        config: NodeConfiguration,
+        config: NodeRegistrationConfiguration,
         private val certService: NetworkRegistrationService,
         private val networkRootTrustStorePath: Path,
         networkRootTrustStorePassword: String,
@@ -50,6 +53,27 @@ open class NetworkRegistrationHelper(
         protected val logError: (String) -> Unit = System.err::println
 ) {
 
+    constructor(
+            config: NodeConfiguration,
+            certService: NetworkRegistrationService,
+            networkRootTrustStorePath: Path,
+            networkRootTrustStorePassword: String,
+            nodeCaKeyAlias: String,
+            certRole: CertRole,
+            nextIdleDuration: (Duration?) -> Duration? = FixedPeriodLimitedRetrialStrategy(10, Duration.ofMinutes(1)),
+            logProgress: (String) -> Unit = ::println,
+            logError: (String) -> Unit = System.err::println) :this (
+
+            NodeRegistrationConfiguration(config),
+            certService,
+            networkRootTrustStorePath,
+            networkRootTrustStorePassword,
+            nodeCaKeyAlias,
+            certRole,
+            nextIdleDuration,
+            logProgress,
+            logError)
+
     companion object {
         const val SELF_SIGNED_PRIVATE_KEY = "SelfSignedPrivateKey"
         val logger = contextLogger()
@@ -57,8 +81,8 @@ open class NetworkRegistrationHelper(
     private val certificatesDirectory: Path = config.certificatesDirectory
     private val myLegalName: CordaX500Name = config.myLegalName
     private val emailAddress: String = config.emailAddress
-    private val cryptoService = CryptoServiceFactory.makeCryptoService(SupportedCryptoServices.BC_SIMPLE, config.myLegalName, config.signingCertificateStore)
-    private val certificateStore = config.signingCertificateStore.get(true)
+    private val cryptoService = config.cryptoService
+    private val certificateStore = config.certificateStore
     private val requestIdStore = certificatesDirectory / "certificate-request-id.txt"
     protected val rootTrustStore: X509KeyStore
     protected val rootCert: X509Certificate
@@ -268,13 +292,35 @@ open class NetworkRegistrationHelper(
     protected open fun isTlsCrlIssuerCertRequired(): Boolean = false
 }
 
+class NodeRegistrationConfiguration (
+        val p2pSslOptions: MutualSslConfiguration,
+        val myLegalName : CordaX500Name,
+        val tlsCertCrlIssuer : X500Principal?,
+        val tlsCertCrlDistPoint: URL?,
+        val certificatesDirectory: Path,
+        val emailAddress: String,
+        val cryptoService: CryptoService,
+        val certificateStore: CertificateStore) {
+
+    constructor(config: NodeConfiguration) : this(
+            p2pSslOptions = config.p2pSslOptions,
+            myLegalName = config.myLegalName,
+            tlsCertCrlIssuer = config.tlsCertCrlIssuer,
+            tlsCertCrlDistPoint = config.tlsCertCrlDistPoint,
+            certificatesDirectory = config.certificatesDirectory,
+            emailAddress = config.emailAddress,
+            cryptoService = CryptoServiceFactory.makeCryptoService(SupportedCryptoServices.BC_SIMPLE, config.myLegalName, config.signingCertificateStore),
+            certificateStore = config.signingCertificateStore.get(true)
+    )
+}
+
 class NodeRegistrationException(
         message: String?,
         cause: Throwable?
 ) : IOException(message ?: "Unable to contact node registration service", cause)
 
 class NodeRegistrationHelper(
-        private val config: NodeConfiguration,
+        private val config: NodeRegistrationConfiguration,
         certService: NetworkRegistrationService,
         regConfig: NodeRegistrationOption,
         computeNextIdleDoormanConnectionPollInterval: (Duration?) -> Duration? = FixedPeriodLimitedRetrialStrategy(10, Duration.ofMinutes(1)),
@@ -288,6 +334,13 @@ class NodeRegistrationHelper(
                     CORDA_CLIENT_CA,
                     CertRole.NODE_CA,
                     computeNextIdleDoormanConnectionPollInterval, logProgress, logError) {
+
+    @Deprecated("Prefer to use NodeRegistrationConfiguration instead of NodeConfiguration")
+    constructor(
+            config: NodeConfiguration,
+            certService: NetworkRegistrationService,
+            regConfig: NodeRegistrationOption
+    ) : this(NodeRegistrationConfiguration(config), certService, regConfig)
 
     companion object {
         val logger = contextLogger()

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -53,27 +53,6 @@ open class NetworkRegistrationHelper(
         protected val logError: (String) -> Unit = System.err::println
 ) {
 
-    constructor(
-            config: NodeConfiguration,
-            certService: NetworkRegistrationService,
-            networkRootTrustStorePath: Path,
-            networkRootTrustStorePassword: String,
-            nodeCaKeyAlias: String,
-            certRole: CertRole,
-            nextIdleDuration: (Duration?) -> Duration? = FixedPeriodLimitedRetrialStrategy(10, Duration.ofMinutes(1)),
-            logProgress: (String) -> Unit = ::println,
-            logError: (String) -> Unit = System.err::println) :this (
-
-            NodeRegistrationConfiguration(config),
-            certService,
-            networkRootTrustStorePath,
-            networkRootTrustStorePassword,
-            nodeCaKeyAlias,
-            certRole,
-            nextIdleDuration,
-            logProgress,
-            logError)
-
     companion object {
         const val SELF_SIGNED_PRIVATE_KEY = "SelfSignedPrivateKey"
         val logger = contextLogger()

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -249,7 +249,7 @@ class NetworkRegistrationHelperTest {
         }
 
         return when (certRole) {
-            CertRole.NODE_CA -> NodeRegistrationHelper(config, certService, NodeRegistrationOption(config.certificatesDirectory / networkRootTrustStoreFileName, networkRootTrustStorePassword))
+            CertRole.NODE_CA -> NodeRegistrationHelper(NodeRegistrationConfiguration(config), certService, NodeRegistrationOption(config.certificatesDirectory / networkRootTrustStoreFileName, networkRootTrustStorePassword))
             CertRole.SERVICE_IDENTITY -> NetworkRegistrationHelper(
                     config,
                     certService,

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -251,7 +251,7 @@ class NetworkRegistrationHelperTest {
         return when (certRole) {
             CertRole.NODE_CA -> NodeRegistrationHelper(NodeRegistrationConfiguration(config), certService, NodeRegistrationOption(config.certificatesDirectory / networkRootTrustStoreFileName, networkRootTrustStorePassword))
             CertRole.SERVICE_IDENTITY -> NetworkRegistrationHelper(
-                    config,
+                    NodeRegistrationConfiguration(config),
                     certService,
                     config.certificatesDirectory / networkRootTrustStoreFileName,
                     networkRootTrustStorePassword,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -28,6 +28,7 @@ import net.corda.node.internal.clientSslOptionsCompatibleWith
 import net.corda.node.services.Permissions
 import net.corda.node.services.config.*
 import net.corda.node.utilities.registration.HTTPNetworkRegistrationService
+import net.corda.node.utilities.registration.NodeRegistrationConfiguration
 import net.corda.node.utilities.registration.NodeRegistrationHelper
 import net.corda.nodeapi.internal.DevIdentityGenerator
 import net.corda.nodeapi.internal.SignedNodeInfo
@@ -283,7 +284,7 @@ class DriverDSLImpl(
         return if (startNodesInProcess) {
             executorService.fork {
                 NodeRegistrationHelper(
-                        config.corda,
+                        NodeRegistrationConfiguration(config.corda),
                         HTTPNetworkRegistrationService(networkServicesConfig, versionInfo),
                         NodeRegistrationOption(rootTruststorePath, rootTruststorePassword)
                 ).generateKeysAndRegister()


### PR DESCRIPTION
Refactor `NodeRegistrationHelper` to use it's own config class (`NodeRegistrationConfiguration`) rather than the larger (and largely unnecessary) `NodeConfiguration`