### PR TITLE
[CORDA-2086] Allow transactions to be re-recorded using StatesToRecord.ALL_VISIBLE

### DIFF
--- a/core/src/test/kotlin/net/corda/core/flows/ReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ReferencedStatesFlowTests.kt
@@ -8,7 +8,6 @@ import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
-import net.corda.core.toFuture
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -77,7 +76,7 @@ class ReferencedStatesFlowTests {
         // 2. Use the "newRefState" a transaction involving another party (nodes[1]) which creates a new state. They should store the new state and the reference state.
         val newTx = nodes[0].services.startFlow(UseRefState(nodes[1].info.legalIdentities.first(), newRefState.state.data.linearId)).resultFuture.getOrThrow()
         // Wait until node 1 stores the new tx.
-        nodes[1].services.validatedTransactions.updates.filter { it.id == newTx.id }.toFuture().getOrThrow()
+        nodes[1].services.validatedTransactions.trackTransaction(newTx.id).getOrThrow()
         // Check that nodes[1] has finished recording the transaction (and updating the vault.. hopefully!).
         // nodes[1] should have two states. The newly created output of type "Regular.State" and the reference state created by nodes[0].
         assertEquals(2, nodes[1].services.vaultService.queryBy<LinearState>().states.size)
@@ -108,7 +107,7 @@ class ReferencedStatesFlowTests {
         // 2. Use the "newRefState" a transaction involving another party (nodes[1]) which creates a new state. They should store the new state and the reference state.
         val newTx = nodes[0].services.startFlow(UseRefState(nodes[1].info.legalIdentities.first(), newRefState.state.data.linearId)).resultFuture.getOrThrow()
         // Wait until node 1 stores the new tx.
-        nodes[1].services.validatedTransactions.updates.filter { it.id == newTx.id }.toFuture().getOrThrow()
+        nodes[1].services.validatedTransactions.trackTransaction(newTx.id).getOrThrow()
         // Check that nodes[1] has finished recording the transaction (and updating the vault.. hopefully!).
         val allRefStates = nodes[1].services.vaultService.queryBy<LinearState>()
         // nodes[1] should have two states. The newly created output and the reference state created by nodes[0].
@@ -125,7 +124,7 @@ class ReferencedStatesFlowTests {
         val newTx = nodes[0].services.startFlow(UseRefState(nodes[1].info.legalIdentities.first(), newRefState.state.data.linearId))
                 .resultFuture.getOrThrow()
         // Wait until node 1 stores the new tx.
-        nodes[1].services.validatedTransactions.updates.filter { it.id == newTx.id }.toFuture().getOrThrow()
+        nodes[1].services.validatedTransactions.trackTransaction(newTx.id).getOrThrow()
         // Check that nodes[1] has finished recording the transaction (and updating the vault.. hopefully!).
         // nodes[1] should have two states. The newly created output of type "Regular.State" and the reference state created by nodes[0].
         assertEquals(2, nodes[1].services.vaultService.queryBy<LinearState>().states.size)
@@ -144,13 +143,13 @@ class ReferencedStatesFlowTests {
         assertEquals(Vault.StateStatus.UNCONSUMED, theReferencedStateOnNodeZero.statesMetadata.single().status)
 
         // 3. Update the reference state but don't share the update.
-        val updatedRefTx = nodes[0].services.startFlow(UpdateRefState(newRefState)).resultFuture.getOrThrow()
+        nodes[0].services.startFlow(UpdateRefState(newRefState)).resultFuture.getOrThrow()
 
         // 4. Use the evolved state as a reference state.
         val updatedTx = nodes[0].services.startFlow(UseRefState(nodes[1].info.legalIdentities.first(), newRefState.state.data.linearId))
                 .resultFuture.getOrThrow()
         // Wait until node 1 stores the new tx.
-        nodes[1].services.validatedTransactions.updates.filter { it.id == updatedTx.id }.toFuture().getOrThrow()
+        nodes[1].services.validatedTransactions.trackTransaction(updatedTx.id).getOrThrow()
         // Check that nodes[1] has finished recording the transaction (and updating the vault.. hopefully!).
         // nodes[1] should have four states. The originals, plus the newly created output of type "Regular.State" and the reference state created by nodes[0].
         assertEquals(4, nodes[1].services.vaultService.queryBy<LinearState>(QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)).states.size)
@@ -178,7 +177,7 @@ class ReferencedStatesFlowTests {
                 .resultFuture.getOrThrow()
 
         // Wait until node 1 stores the new tx.
-        nodes[1].services.validatedTransactions.updates.filter { it.id == newTx.id }.toFuture().getOrThrow()
+        nodes[1].services.validatedTransactions.trackTransaction(newTx.id).getOrThrow()
         // Check that nodes[1] has finished recording the transaction (and updating the vault.. hopefully!).
         // nodes[1] should have two states. The newly created output of type "Regular.State" and the reference state created by nodes[0].
         assertEquals(2, nodes[1].services.vaultService.queryBy<LinearState>().states.size)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,12 @@ Version 5.0
   ``log`` directory. This zip will contain a JSON representation of each checkpointed flow. This information can then be used to determine the
   state of stuck flows or flows that experienced internal errors and were kept in the node for manual intervention.
 
+* It is now possible to re-record transactions if a node wishes to record as an observer a transaction it has participated in. If this is
+  done, then the node may record new output states that are not relevant to the node.
+
+.. warning:: As the node is unable to resolve the forward chain of transactions, the node cannot know if these new output states have been
+   consumed. To resolve this, any consuming transaction must be sent to the node after the transaction that created the state.
+
 .. _changelog_v4.2:
 
 Version 4.2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,8 +23,9 @@ Version 5.0
 * It is now possible to re-record transactions if a node wishes to record as an observer a transaction it has participated in. If this is
   done, then the node may record new output states that are not relevant to the node.
 
-.. warning:: As the node is unable to resolve the forward chain of transactions, the node cannot know if these new output states have been
-   consumed. To resolve this, any consuming transaction must be sent to the node after the transaction that created the state.
+.. warning:: Nodes may re-record transactions if they have previously recorded them as a participant and wish to record them as an observer.
+   However, the node cannot resolve the forward chain of transactions if this is done. This means that if you wish to re-record a chain of
+   transactions and get the new output states to be correctly marked as consumed, the full chain must be sent to the node *in order*.
 
 .. _changelog_v4.2:
 

--- a/docs/source/tutorial-observer-nodes.rst
+++ b/docs/source/tutorial-observer-nodes.rst
@@ -43,12 +43,12 @@ Caveats
   participant/owner. See https://docs.corda.net/api-vault-query.html#example-usage for information on how to do this. 
   This also means that ``Cash.generateSpend`` should not be used when recording ``Cash.State`` states as an observer
 
-* Nodes only record each transaction once. If a node has already recorded a transaction in non-observer mode, it cannot
-  later re-record the same transaction as an observer. This issue is tracked here:
-  https://r3-cev.atlassian.net/browse/CORDA-883
-
 * When an observer node is sent a transaction with the ALL_VISIBLE flag set, any transactions in the transaction history
   that have not already been received will also have ALL_VISIBLE states recorded. This mean a node that is both an observer
   and a participant may have some transactions with all states recorded and some with only relevant states recorded, even
   if those transactions are part of the same chain. As a result, there may be more states present in the vault than would be
   expected if just those transactions sent with the ALL_VISIBLE recording flag were processed in this way.
+
+* Nodes may re-record transaction if they have previously recorded them as a participant and wish to record them as an observer. However,
+  the node cannot resolve a forward chain of transactions if this is done. This means that if you wish to re-record a chain of transactions
+  and get the new output states to be correctly marked as consumed, the full chain must be sent to the node *in order*.

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -59,6 +59,11 @@ interface ServiceHubInternal : ServiceHub {
 
             database.transaction {
                 require(txs.any()) { "No transactions passed in for recording" }
+
+                // Divide transactions into those seen before and those that are new to this node if ALL_VISIBLE states are being recorded.
+                // This allows the node to re-record transactions that have previously only been seen at the ONLY_RELEVANT level. Note that
+                // for transactions being recorded at ONLY_RELEVANT, if this transaction has been seen before its outputs should already
+                // have been recorded at ONLY_RELEVANT, so there shouldn't be anything to re-record here.
                 val (recordedTransactions, previouslySeenTxs) = if (statesToRecord != StatesToRecord.ALL_VISIBLE) {
                     Pair(txs.filter { validatedTransactions.addTransaction(it) }, emptyList())
                 } else {

--- a/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
@@ -17,6 +17,9 @@ interface VaultServiceInternal : VaultService {
      */
     fun notifyAll(statesToRecord: StatesToRecord, txns: Iterable<CoreTransaction>, previouslySeenTxns: Iterable<CoreTransaction> = emptyList())
 
-    /** Same as notifyAll but with a single transaction. */
+    /**
+     * Same as notifyAll but with a single transaction.
+     * This does not allow for passing transactions that have already been seen by the node, as this API is only used in testing.
+     */
     fun notify(statesToRecord: StatesToRecord, tx: CoreTransaction) = notifyAll(statesToRecord, listOf(tx))
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
@@ -15,7 +15,7 @@ interface VaultServiceInternal : VaultService {
      * indicate whether an update consists entirely of regular or notary change transactions, which may require
      * different processing logic.
      */
-    fun notifyAll(statesToRecord: StatesToRecord, txns: Iterable<CoreTransaction>)
+    fun notifyAll(statesToRecord: StatesToRecord, txns: Iterable<CoreTransaction>, previouslySeenTxns: Iterable<CoreTransaction> = emptyList())
 
     /** Same as notifyAll but with a single transaction. */
     fun notify(statesToRecord: StatesToRecord, tx: CoreTransaction) = notifyAll(statesToRecord, listOf(tx))

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -161,7 +161,7 @@ class NodeVaultService(
         }
     }
 
-    private fun recordUpdate(update: Vault.Update<ContractState>): Vault.Update<ContractState> {
+    private fun recordUpdate(update: Vault.Update<ContractState>, previouslySeen: Boolean): Vault.Update<ContractState> {
         if (!update.isEmpty()) {
             val producedStateRefs = update.produced.map { it.ref }
             val producedStateRefsMap = update.produced.associateBy { it.ref }
@@ -214,7 +214,7 @@ class NodeVaultService(
 
         fun flushBatch(previouslySeen: Boolean) {
             val updates = makeUpdates(batch, statesToRecord, previouslySeen)
-            processAndNotify(updates)
+            processAndNotify(updates, previouslySeen)
             batch.clear()
         }
         fun processTransactions(txs: Iterable<CoreTransaction>, previouslySeen: Boolean) {
@@ -362,11 +362,11 @@ class NodeVaultService(
         return states
     }
 
-    private fun processAndNotify(updates: List<Vault.Update<ContractState>>) {
+    private fun processAndNotify(updates: List<Vault.Update<ContractState>>, previouslySeen: Boolean) {
         if (updates.isEmpty()) return
         val netUpdate = updates.reduce { update1, update2 -> update1 + update2 }
         if (!netUpdate.isEmpty()) {
-            recordUpdate(netUpdate)
+            recordUpdate(netUpdate, previouslySeen)
             mutex.locked {
                 // flowId was required by SoftLockManager to perform auto-registration of soft locks for new states
                 val uuid = (Strand.currentStrand() as? FlowStateMachineImpl<*>)?.id?.uuid

--- a/node/src/test/kotlin/net/corda/node/services/persistence/ObserverNodeTransactionTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/ObserverNodeTransactionTests.kt
@@ -66,15 +66,17 @@ class ObserverNodeTransactionTests {
         node.services.startFlow(SendTransaction(regulator.info.singleIdentity(), transactionList[transactionIdx])).resultFuture.getOrThrow()
     }
 
-    fun checkObserverTransactions(expectedMessage: MessageData, regulator: TestStartedNode) {
+    fun checkObserverTransactions(expectedMessage: MessageData, regulator: TestStartedNode, numStates: Int = 1) {
         val regulatorStates = regulator.services.vaultService.queryBy(MessageChainState::class.java).states.filter {
             it.state.data.message.value.startsWith(expectedMessage.value[0])
         }
 
         assertNotNull(regulatorStates, "Could not find any regulator states")
-        assertEquals(1, regulatorStates.size, "Incorrect number of unconsumed regulator states")
-        val retrievedMessage = regulatorStates.singleOrNull()!!.state.data.message
-        assertEquals(expectedMessage, retrievedMessage, "Final unconsumed regulator state is incorrect")
+        assertEquals(numStates, regulatorStates.size, "Incorrect number of unconsumed regulator states")
+        for (state in regulatorStates) {
+            val retrievedMessage = state.state.data.message
+            assertEquals(expectedMessage, retrievedMessage, "Final unconsumed regulator state is incorrect")
+        }
     }
 
 
@@ -108,6 +110,57 @@ class ObserverNodeTransactionTests {
         sendTransactionToObserver(3, node, regulator)
         val outputMessage = MessageData("AAAA")
         checkObserverTransactions(outputMessage, regulator)
+    }
+
+    @Test
+    fun `Re-recording a transaction adds non-relevant states`() {
+        val alice = mockNet.createPartyNode(ALICE_NAME)
+        val bob = mockNet.createPartyNode(BOB_NAME)
+        val notary = mockNet.defaultNotaryIdentity
+        bob.registerInitiatedFlow(ReceiveSplitMessagesFlow::class.java)
+        bob.registerInitiatedFlow(ReceiveReportedTransaction::class.java)
+
+        val message = MessageData("AA")
+        alice.services.startFlow(SplitMessagesFlow(message, bob.info.singleIdentity(), notary)).resultFuture.getOrThrow()
+        checkObserverTransactions(message, bob)
+        sendTransactionToObserver(0, alice, bob)
+        checkObserverTransactions(message, bob, 2)
+    }
+
+    @Test
+    fun `Re-recording a transaction at only relevant does not cause failures`() {
+        val alice = mockNet.createPartyNode(ALICE_NAME)
+        val bob = mockNet.createPartyNode(BOB_NAME)
+        val notary = mockNet.defaultNotaryIdentity
+        bob.registerInitiatedFlow(ReceiveSplitMessagesFlow::class.java)
+        bob.registerInitiatedFlow(ReceiveReportedTransaction::class.java)
+
+        val message = MessageData("AA")
+        alice.services.startFlow(SplitMessagesFlow(message, bob.info.singleIdentity(), notary)).resultFuture.getOrThrow()
+        checkObserverTransactions(message, bob)
+        sendTransactionToObserverOnlyRelevant(0, alice, bob)
+        checkObserverTransactions(message, bob, 1)
+    }
+
+    @Test
+    fun `Recording a transaction twice at all visible works`() {
+        val alice = mockNet.createPartyNode(ALICE_NAME)
+        val bob = mockNet.createPartyNode(BOB_NAME)
+        val notary = mockNet.defaultNotaryIdentity
+        bob.registerInitiatedFlow(ReceiveSplitMessagesFlow::class.java)
+        bob.registerInitiatedFlow(ReceiveReportedTransaction::class.java)
+
+        val message = MessageData("AA")
+        alice.services.startFlow(SplitMessagesFlow(message, bob.info.singleIdentity(), notary)).resultFuture.getOrThrow()
+        checkObserverTransactions(message, bob)
+        sendTransactionToObserverOnlyRelevant(0, alice, bob)
+        checkObserverTransactions(message, bob, 1)
+        sendTransactionToObserver(0, alice, bob)
+        checkObserverTransactions(message, bob, 2)
+        sendTransactionToObserver(0, alice, bob)
+        checkObserverTransactions(message, bob, 2)
+        sendTransactionToObserverOnlyRelevant(0, alice, bob)
+        checkObserverTransactions(message, bob, 2)
     }
 
     @StartableByRPC
@@ -182,6 +235,70 @@ class ObserverNodeTransactionTests {
 
             progressTracker.currentStep = FINALISING_TRANSACTION
             return subFlow(FinalityFlow(signedTx, emptyList(), FINALISING_TRANSACTION.childProgressTracker()))
+        }
+    }
+
+    @StartableByRPC
+    @InitiatingFlow
+    class SplitMessagesFlow(private val message: MessageData,
+                            private val counterparty: Party,
+                            private val notary: Party): FlowLogic<SignedTransaction>() {
+        companion object {
+            object GENERATING_TRANSACTION : ProgressTracker.Step("Generating transaction based on the message.")
+            object VERIFYING_TRANSACTION : ProgressTracker.Step("Verifying contract constraints.")
+            object SIGNING_TRANSACTION : ProgressTracker.Step("Signing transaction with our private key.")
+            object FINALISING_TRANSACTION : ProgressTracker.Step("Obtaining notary signature and recording transaction.") {
+                override fun childProgressTracker() = FinalityFlow.tracker()
+            }
+
+            fun tracker() = ProgressTracker(GENERATING_TRANSACTION, VERIFYING_TRANSACTION, SIGNING_TRANSACTION, FINALISING_TRANSACTION)
+        }
+
+        override val progressTracker = tracker()
+
+        @Suspendable
+        override fun call(): SignedTransaction {
+            progressTracker.currentStep = GENERATING_TRANSACTION
+
+            val messageState = MessageChainState(message = message, by = ourIdentity)
+            val otherPartyState = MessageChainState(message = message, by = counterparty)
+            val txCommand = Command(MessageChainContract.Commands.Split(), listOf(ourIdentity.owningKey, counterparty.owningKey))
+            val txBuilder = TransactionBuilder(notary)
+                    .addOutputState(messageState)
+                    .addOutputState(otherPartyState)
+                    .addCommand(txCommand)
+
+            progressTracker.currentStep = VERIFYING_TRANSACTION
+            txBuilder.toWireTransaction(serviceHub).toLedgerTransaction(serviceHub).verify()
+
+            progressTracker.currentStep = SIGNING_TRANSACTION
+            val signedTx = serviceHub.signInitialTransaction(txBuilder)
+            val session = initiateFlow(counterparty)
+
+            val stx = subFlow(CollectSignaturesFlow(signedTx, listOf(session)))
+
+            progressTracker.currentStep = FINALISING_TRANSACTION
+            val finalStx = subFlow(FinalityFlow(stx, listOf(session), FINALISING_TRANSACTION.childProgressTracker()))
+            session.receive<Unit>()
+            return finalStx
+        }
+    }
+
+    @InitiatedBy(SplitMessagesFlow::class)
+    class ReceiveSplitMessagesFlow(private val otherSideSession: FlowSession): FlowLogic<SignedTransaction>() {
+
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val flow = object : SignTransactionFlow(otherSideSession) {
+                @Suspendable
+                override fun checkTransaction(stx: SignedTransaction) {
+
+                }
+            }
+            subFlow(flow)
+            val stx = subFlow(ReceiveFinalityFlow(otherSideSession))
+            otherSideSession.send(Unit)
+            return stx
         }
     }
 


### PR DESCRIPTION
When recording transactions, the `StatesToRecord` flag is set to indicate what output states should be recorded. Once a transaction has been recorded once, it will be filtered out from further attempts to record it. This is an issue if a node wishes to record the non-relevant states of a transaction after having seen it once already.

This PR introduces a new list of transactions to be passed to the `NodeVaultService`: the `previouslySeenTxs` list. This list is only populated if the transaction list passed to the `ServiceHubInternal` instance should be recorded at `StatesToRecord.ALL_VISIBLE`. This list is processed by the vault by looking up all the outputs for the transaction, and only recording those outputs that are not already present in the vault.

The code is structured such that the vault only needs to be queried if `StatesToRecord.ALL_VISIBLE` is set, and only if the transaction has previously been seen.

Unit tests check the following:
 - Re-recording a transaction at ALL_VISIBLE when it was previously recorded at ONLY_RELEVANT adds the non-relevant states to the vault
 - Re-recording a transaction at ALL_VISIBLE when it was previously recorded at ALL_VISIBLE does nothing (i.e. don't attempt to re-insert a record into the database)
 - Re-recording a transaction at ONLY_RELEVANT does nothing.
