### PR TITLE
CORDA-2974 Fixing x500Prinicipal matching

### DIFF
--- a/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
@@ -83,12 +83,12 @@ data class CordaX500Name(val commonName: String?,
         @JvmStatic
         fun build(principal: X500Principal): CordaX500Name {
             val attrsMap = principal.toAttributesMap(supportedAttributes)
-            val CN = attrsMap[BCStyle.CN]?.toString()
-            val OU = attrsMap[BCStyle.OU]?.toString()
-            val O = requireNotNull(attrsMap[BCStyle.O]?.toString()) { "Corda X.500 names must include an O attribute" }
-            val L = requireNotNull(attrsMap[BCStyle.L]?.toString()) { "Corda X.500 names must include an L attribute" }
-            val ST = attrsMap[BCStyle.ST]?.toString()
-            val C = requireNotNull(attrsMap[BCStyle.C]?.toString()) { "Corda X.500 names must include an C attribute" }
+            val CN = attrsMap[BCStyle.CN]
+            val OU = attrsMap[BCStyle.OU]
+            val O = requireNotNull(attrsMap[BCStyle.O]) { "Corda X.500 names must include an O attribute" }
+            val L = requireNotNull(attrsMap[BCStyle.L]) { "Corda X.500 names must include an L attribute" }
+            val ST = attrsMap[BCStyle.ST]
+            val C = requireNotNull(attrsMap[BCStyle.C]) { "Corda X.500 names must include an C attribute" }
             return CordaX500Name(CN, OU, O, L, ST, C)
         }
 

--- a/core/src/main/kotlin/net/corda/core/internal/X500Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/X500Utils.kt
@@ -41,14 +41,14 @@ fun X500Principal.toX500Name(): X500Name = X500Name.getInstance(this.encoded)
  * @throws IllegalArgumentException if this principal consists of duplicated attributes or the attribute is not supported.
  *
  */
-fun X500Principal.toAttributesMap(supportedAttributes: Set<ASN1ObjectIdentifier> = emptySet()): Map<ASN1ObjectIdentifier, ASN1Encodable> {
+fun X500Principal.toAttributesMap(supportedAttributes: Set<ASN1ObjectIdentifier> = emptySet()): Map<ASN1ObjectIdentifier, String> {
     val x500Name = this.toX500Name()
-    val attrsMap: Map<ASN1ObjectIdentifier, ASN1Encodable> = x500Name.rdNs
+    val attrsMap: Map<ASN1ObjectIdentifier, String> = x500Name.rdNs
             .flatMap { it.typesAndValues.asList() }
             .groupBy(AttributeTypeAndValue::getType, AttributeTypeAndValue::getValue)
             .mapValues {
                 require(it.value.size == 1) { "Duplicate attribute ${it.key}" }
-                it.value[0]
+                it.value[0].toString()
             }
     if (supportedAttributes.isNotEmpty()) {
         (attrsMap.keys - supportedAttributes).let { unsupported ->


### PR DESCRIPTION
This fixes the issue with the x500Principal decoding from the certificate in the JKS store. It turns out that some parts of the x500Principal are either instances of DERPrintableString or DERUTF8String.
