### PR TITLE
CORDA-2975 Remove version uniqueness check

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -342,15 +342,12 @@ class NodeAttachmentServiceTest {
     }
 
     @Test
-    fun `cannot import jar with duplicated contract class, version and signers for trusted uploader`() {
+    fun `can import jar with duplicated contract class, version and signers for trusted uploader`() {
         SelfCleaningDir().use { file ->
             val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
             contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
-
-            assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
-                anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
-            }
+            anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
         }
     }
 
@@ -376,30 +373,23 @@ class NodeAttachmentServiceTest {
     }
 
     @Test
-    fun `cannot promote to trusted uploader if other trusted attachment already has duplicated contract class, version and signers`() {
+    fun `can promote to trusted uploader if other trusted attachment already has duplicated contract class, version and signers`() {
         SelfCleaningDir().use { file ->
             val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             contractJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
             anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
-
-            assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
-                contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
-            }
-
+            contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
         }
     }
 
     @Test
-    fun `cannot promote to trusted uploder the same jar if other trusted uplodaer `() {
+    fun `can promote to trusted uploder the same jar if other trusted uplodaer `() {
         SelfCleaningDir().use { file ->
             val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
             contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
-
-            assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
-                anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
-            }
+            anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
         }
     }
 


### PR DESCRIPTION
see: https://r3-cev.atlassian.net/browse/CORDA-2975

This removes the contract version uniqueness check.
The version field is no longer used anywhere.
Follow-up PR should remove all other traces.