### PR TITLE
CORDA-2981 Disable slow consumers for RPC since it doesn't work.

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -511,7 +511,6 @@ class RPCStabilityTests {
             val consumer = session.createConsumer(myQueue, null, -1, -1, false)
             consumer.setMessageHandler {
                 Thread.sleep(5000) // Needs to be slower than one per second to get kicked.
-                println("Ack $it")
                 it.acknowledge()
             }
             val producer = session.createProducer(RPCApi.RPC_SERVER_QUEUE_NAME)

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -499,7 +499,7 @@ class RPCStabilityTests {
     }
 
     @Test
-    @Ignore // This is ignored because Artemis slow consumers are broken.  I'm not deleting it in case we can get the feature fixed.
+    @Ignore // TODO: This is ignored because Artemis slow consumers are broken.  I'm not deleting it in case we can get the feature fixed.
     fun `slow consumers are kicked`() {
         rpcDriver {
             val server = startRpcServer(maxBufferedBytesPerClient = 10 * 1024 * 1024, ops = SlowConsumerRPCOpsImpl()).get()

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -21,6 +21,7 @@ import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.junit.After
 import org.junit.Assert.*
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import rx.Observable
@@ -498,6 +499,7 @@ class RPCStabilityTests {
     }
 
     @Test
+    @Ignore // This is ignored because Artemis slow consumers are broken.  I'm not deleting it in case we can get the feature fixed.
     fun `slow consumers are kicked`() {
         rpcDriver {
             val server = startRpcServer(maxBufferedBytesPerClient = 10 * 1024 * 1024, ops = SlowConsumerRPCOpsImpl()).get()
@@ -509,6 +511,7 @@ class RPCStabilityTests {
             val consumer = session.createConsumer(myQueue, null, -1, -1, false)
             consumer.setMessageHandler {
                 Thread.sleep(5000) // Needs to be slower than one per second to get kicked.
+                println("Ack $it")
                 it.acknowledge()
             }
             val producer = session.createProducer(RPCApi.RPC_SERVER_QUEUE_NAME)
@@ -529,7 +532,7 @@ class RPCStabilityTests {
             producer.send(message)
             session.commit()
 
-            // We are consuming slower than the server is producing, so we should be kicked after a while
+            // We are consuming slower than the server is producing, so we should be kicked after a while if slow consumers are enabled.
             pollUntilClientNumber(server, 0)
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
@@ -15,7 +15,6 @@ import org.apache.activemq.artemis.core.config.CoreQueueConfiguration
 import org.apache.activemq.artemis.core.security.Role
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
-import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy
 import java.nio.file.Path
 
 internal class RpcBrokerConfiguration(baseDirectory: Path, maxMessageSize: Int, jmxEnabled: Boolean, address: NetworkHostAndPort, adminAddress: NetworkHostAndPort?, sslOptions: BrokerRpcSslOptions?, useSsl: Boolean, nodeConfiguration: MutualSslConfiguration, shouldStartLocalShell: Boolean) : SecureArtemisConfiguration() {
@@ -42,9 +41,6 @@ internal class RpcBrokerConfiguration(baseDirectory: Path, maxMessageSize: Int, 
                     maxSizeBytes = 5L * maxMessageSize
                     addressFullMessagePolicy = AddressFullMessagePolicy.PAGE
                     pageSizeBytes = 1L * maxMessageSize
-                    slowConsumerPolicy = SlowConsumerPolicy.KILL
-                    slowConsumerThreshold = 1
-                    slowConsumerCheckPeriod = 30
                 }
         )
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -50,7 +50,6 @@ import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
-import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3
 import java.lang.reflect.Method
@@ -207,9 +206,6 @@ data class RPCDriverDSL(
                         maxSizeBytes = maxBufferedBytesPerClient
                         addressFullMessagePolicy = AddressFullMessagePolicy.PAGE
                         pageSizeBytes = maxSizeBytes / 10
-                        slowConsumerPolicy = SlowConsumerPolicy.KILL
-                        slowConsumerThreshold = 1
-                        slowConsumerCheckPeriod = 30
                     }
             )
         }


### PR DESCRIPTION
I've only disabled the test in case we can get the feature fixed.