### PR TITLE
Bump ClassGraph version to fix classpath manifest parsing bug

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -125,7 +125,7 @@ see changes to this list.
 * Lee Braine (Barclays)
 * Lucas Salmen (Itau)
 * Lulu Ren (Monad-Labs)
-* Maksymilian Pawlak (R3)
+* Maksymilian Pawlak (R3, B3i)
 * Manila Gauns (Persistent Systems Limited)
 * Manos Batsis
 * Marek Scocovsky (ABSA)

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ buildscript {
     ext.commons_cli_version = '1.4'
     ext.protonj_version = '0.33.0' // Overide Artemis version
     ext.snappy_version = '0.4'
-    ext.class_graph_version = '4.6.12'
+    ext.class_graph_version = '4.6.23'
     ext.jcabi_manifests_version = '1.1'
     ext.picocli_version = '3.8.0'
     ext.commons_io_version = '2.6'


### PR DESCRIPTION
Fixed bug https://github.com/classgraph/classgraph/issues/305 which occurs mostly on Windows with classpath shortening enabled.

I confirm that PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).