### PR TITLE
CORDA-2774 Fix for liquibase changelog warnings.

### DIFF
--- a/node/src/main/resources/migration/common.changelog-init.xml
+++ b/node/src/main/resources/migration/common.changelog-init.xml
@@ -11,9 +11,8 @@
         <createSequence sequenceName="hibernate_sequence"/>
     </changeSet>
 
-   <changeSet author="R3.Corda" id="1511451595465-1.3" onValidationFail="MARK_RAN">
+   <changeSet author="R3.Corda" id="1511451595465-1.3" onValidationFail="MARK_RAN" dbms="postgres,mssql">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <not><dbms type="h2"/></not>
             <not><sequenceExists sequenceName="hibernate_sequence"/></not>
         </preConditions>
         <createSequence sequenceName="hibernate_sequence" minValue="1"/>


### PR DESCRIPTION
This fixes the wanings arising from database not being h2, even if there is a precondition about it. This does not touch upon the other skipping changeset about clustered changes. (as the fix there would be to mention non existing db for OS)