### PR TITLE
CORDA-2996: NotaryLoader - improve exception handling

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
@@ -13,6 +13,7 @@ import net.corda.node.services.config.NotaryConfig
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.notary.experimental.bftsmart.BFTSmartNotaryService
 import net.corda.notary.experimental.raft.RaftNotaryService
+import java.lang.reflect.InvocationTargetException
 import java.security.PublicKey
 
 class NotaryLoader(
@@ -61,7 +62,7 @@ class NotaryLoader(
         log.info("Starting notary service: $serviceClass")
 
         val notaryKey = myNotaryIdentity?.owningKey
-                ?: throw IllegalArgumentException("Unable to start notary service $serviceClass: notary identity not found")
+                ?: throw IllegalArgumentException("Unable to start notary service: notary identity not found")
 
         /** Some notary implementations only work with Java serialization. */
         maybeInstallSerializationFilter(serviceClass)
@@ -69,7 +70,12 @@ class NotaryLoader(
         val constructor = serviceClass
                 .getDeclaredConstructor(ServiceHubInternal::class.java, PublicKey::class.java)
                 .apply { isAccessible = true }
-        return constructor.newInstance(services, notaryKey)
+        try {
+            return constructor.newInstance(services, notaryKey)
+        } catch (e: InvocationTargetException) {
+            log.error("Exception occurred when starting notary service")
+            throw e.cause ?: e
+        }
     }
 
     /** Validates that the notary is correctly configured by comparing the configured type against the type advertised in the network map cache */


### PR DESCRIPTION
Ignore InvocationTargetException and only propagate the cause to avoid noise.

Before:

```
[INFO ] 2019-06-10T17:54:10,155Z [main] utilities.NotaryLoader.loadService - Starting notary service: class net.corda.node.services.transactions.SimpleNotaryService
[ERROR] 2019-06-10T17:54:10,178Z [main] internal.NodeStartupLogging.invoke - Exception during node startup [errorCode=1bxlyp, moreInformationAt=https://errors.corda.net/OS/5.0-SNAPSHOT/1bxlyp]
java.lang.reflect.InvocationTargetException: null
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_202]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:1.8.0_202]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_202]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_202]
        at net.corda.node.utilities.NotaryLoader.loadService(NotaryLoader.kt:74) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.AbstractNode.maybeStartNotaryService(AbstractNode.kt:792) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.AbstractNode.access$maybeStartNotaryService(AbstractNode.kt:122) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.AbstractNode$start$8.invoke(AbstractNode.kt:383) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.AbstractNode$start$8.invoke(AbstractNode.kt:122) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.nodeapi.internal.persistence.CordaPersistence.inTopLevelTransaction(CordaPersistence.kt:250) ~[corda-node-api-5.0-SNAPSHOT.jar:?]
        at net.corda.nodeapi.internal.persistence.CordaPersistence.transaction(CordaPersistence.kt:226) ~[corda-node-api-5.0-SNAPSHOT.jar:?]
        at net.corda.nodeapi.internal.persistence.CordaPersistence.transaction(CordaPersistence.kt:236) ~[corda-node-api-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.AbstractNode.start(AbstractNode.kt:373) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.Node.start(Node.kt:434) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartup.startNode(NodeStartup.kt:210) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartupCli$runProgram$2.run(NodeStartup.kt:131) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartup$initialiseAndRun$5.invoke(NodeStartup.kt:187) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartup$initialiseAndRun$5.invoke(NodeStartup.kt:138) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartupLogging$DefaultImpls.attempt(NodeStartup.kt:514) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartup.attempt(NodeStartup.kt:138) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartup.initialiseAndRun(NodeStartup.kt:186) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartupCli.runProgram(NodeStartup.kt:129) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.cliutils.CordaCliWrapper.call(CordaCliWrapper.kt:190) ~[corda-tools-cliutils-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartupCli.call(NodeStartup.kt:84) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at net.corda.node.internal.NodeStartupCli.call(NodeStartup.kt:65) ~[corda-node-5.0-SNAPSHOT.jar:?]
        at picocli.CommandLine.execute(CommandLine.java:1056) ~[picocli-3.8.0.jar:3.8.0]
        at picocli.CommandLine.access$900(CommandLine.java:142) ~[picocli-3.8.0.jar:3.8.0]
        at picocli.CommandLine$RunLast.handle(CommandLine.java:1246) ~[picocli-3.8.0.jar:3.8.0]
        at picocli.CommandLine$RunLast.handle(CommandLine.java:1214) ~[picocli-3.8.0.jar:3.8.0]
        at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:1122) ~[picocli-3.8.0.jar:3.8.0]
        at picocli.CommandLine.parseWithHandlers(CommandLine.java:1405) ~[picocli-3.8.0.jar:3.8.0]
        at net.corda.cliutils.CordaCliWrapperKt.start(CordaCliWrapper.kt:73) ~[corda-tools-cliutils-5.0-SNAPSHOT.jar:?]
        at net.corda.node.Corda.main(Corda.kt:13) ~[corda-node-5.0-SNAPSHOT.jar:?]
Caused by: java.lang.IllegalStateException: Some Exception
        at net.corda.node.services.transactions.SimpleNotaryService.<init>(SimpleNotaryService.kt:18) ~[corda-node-5.0-SNAPSHOT.jar:?]
        ... 33 more
```

After:
```
[INFO ] 2019-06-10T18:05:50,086Z [main] utilities.NotaryLoader.loadService - Starting notary service: class net.corda.node.services.transactions.SimpleNotaryService
[ERROR] 2019-06-10T18:05:50,091Z [main] utilities.NotaryLoader.loadService - Exception occurred when starting notary service
[ERROR] 2019-06-10T18:05:50,102Z [main] internal.NodeStartupLogging.invoke - Exception during node startup: Some Exception [errorCode=3sbx4, moreInformationAt=https://errors.corda.net/OS/5.0-SNAPSHOT/3sbx4]
java.lang.IllegalStateException: Some Exception
        at net.corda.node.services.transactions.SimpleNotaryService.<init>(SimpleNotaryService.kt:18) ~[corda-node-5.0-SNAPSHOT.jar:?]
        ...
```
