### PR TITLE
CORDA-2999: Corrected network builder JAR url in docs

### DIFF
--- a/docs/source/network-builder.rst
+++ b/docs/source/network-builder.rst
@@ -12,7 +12,7 @@ The network you build will either be made up of local ``docker`` nodes *or* of n
 containers. More backends may be added in future. The tool is open source, so contributions to add more
 destinations for the containers are welcome!
 
-`Download the Corda Network Builder <https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-network-builder/4.0-corda/corda-network-builder-4.0-corda-executable.jar>`_.
+`Download the Corda Network Builder <https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-network-builder/3.2.1847-corda/corda-network-builder-3.2.1847-corda-executable.jar>`_.
 
 .. _pre-requisites:
 


### PR DESCRIPTION
The link to the network builder executable JAR was incorrect in the documentation file network-builder.rst
It was pointing to a version 4.0 of the network builder JAR which does not exist. The link was changed to point to the most recent version, which is 3.2.1847.