### PR TITLE
ENT-3658 - Add TimedCryptoService which enhances a CryptoService with timeouts

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoServiceFactory.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoServiceFactory.kt
@@ -7,12 +7,17 @@ import java.nio.file.Path
 
 class CryptoServiceFactory {
     companion object {
-        fun makeCryptoService(cryptoServiceName: SupportedCryptoServices, legalName: CordaX500Name,  signingCertificateStore: FileBasedCertificateStoreSupplier? = null, cryptoServiceConf: Path? = null): CryptoService {
+        fun makeCryptoService(cryptoServiceName: SupportedCryptoServices,
+                              legalName: CordaX500Name,
+                              signingCertificateStore: FileBasedCertificateStoreSupplier? = null,
+                              cryptoServiceConf: Path? = null,
+                              timeout: Long? = null): CryptoService {
             // The signing certificate store can be null for other services as only BCC requires is at the moment.
             if (cryptoServiceName != SupportedCryptoServices.BC_SIMPLE || signingCertificateStore == null) {
                 throw IllegalArgumentException("Currently only BouncyCastle is used as a crypto service. A valid signing certificate store is required.")
             }
-            return BCCryptoService(legalName.x500Principal, signingCertificateStore)
+            val cryptoService = BCCryptoService(legalName.x500Principal, signingCertificateStore)
+            return if (timeout != null) { TimedCryptoService(cryptoService, timeout) } else { cryptoService }
         }
     }
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/TimedCryptoService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/TimedCryptoService.kt
@@ -1,0 +1,65 @@
+package net.corda.nodeapi.internal.cryptoservice
+
+import net.corda.core.crypto.SignatureScheme
+import org.bouncycastle.operator.ContentSigner
+import java.security.PublicKey
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+open class TimedCryptoServiceException(message: String?, cause: Throwable? = null) : Exception(message, cause)
+
+/**
+ * Provides the mechanism for running code with a timeout.  Uses a single-threaded [ExecutorService]
+ */
+interface Timeout {
+    companion object {
+        private val executor = Executors.newCachedThreadPool()
+    }
+
+    /**
+     * Adds a timeout for the given [func].
+     * @param timeout The time to wait on the function completing (in seconds)
+     * @param func The call that we're waiting on
+     * @return the return value of the function call
+     * @throws TimedCryptoServiceException if we reach the timeout
+     */
+    fun <A> withTimeout(timeout: Long, func: () -> A) : A {
+        try {
+            return executor.invokeAny(listOf( Callable { func.invoke() } ), timeout, TimeUnit.SECONDS)
+        } catch (e: TimeoutException) {
+            throw TimedCryptoServiceException("Timed-out while waiting for $timeout seconds")
+        }
+    }
+}
+
+/**
+ * Timeout decorator implementation of a [CryptoService] that uses the [underlying] real service
+ * wrapped with timeout functionality.  If the [CryptoService] call times out a [TimedCryptoServiceException]
+ * is raised
+ */
+class TimedCryptoService<C : CryptoService>(private val underlying: C, private val timeout: Long) : CryptoService, Timeout {
+
+    override fun generateKeyPair(alias: String, scheme: SignatureScheme): PublicKey =
+        withTimeout(timeout) { underlying.generateKeyPair(alias, scheme) }
+
+    override fun containsKey(alias: String): Boolean =
+        withTimeout(timeout) { underlying.containsKey(alias) }
+
+    override fun getPublicKey(alias: String): PublicKey? =
+        withTimeout(timeout) { underlying.getPublicKey(alias) }
+
+    override fun sign(alias: String, data: ByteArray, signAlgorithm: String?): ByteArray =
+        withTimeout(timeout) { underlying.sign(alias, data, signAlgorithm) }
+
+    override fun getSigner(alias: String): ContentSigner =
+        withTimeout(timeout) { underlying.getSigner(alias) }
+
+    override fun defaultIdentitySignatureScheme(): SignatureScheme =
+        withTimeout(timeout) { underlying.defaultIdentitySignatureScheme() }
+
+    override fun defaultTLSSignatureScheme(): SignatureScheme {
+        return withTimeout(timeout) { underlying.defaultTLSSignatureScheme() }
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/TimedCryptoServiceTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/TimedCryptoServiceTest.kt
@@ -1,52 +1,26 @@
 package net.corda.nodeapi.internal.cryptoservice
 
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doAnswer
+import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.Crypto.RSA_SHA256
-import net.corda.core.crypto.SignatureScheme
-import net.corda.core.utilities.toSHA256Bytes
-import net.corda.nodeapi.internal.crypto.ContentSignerBuilder
+import net.corda.nodeapi.internal.cryptoservice.bouncycastle.BCCryptoService
+import net.corda.testing.internal.rigorousMock
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.bouncycastle.operator.ContentSigner
-import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
 import org.junit.Test
 import java.lang.Thread.sleep
-import java.security.PublicKey
 import java.util.concurrent.TimeUnit.SECONDS
 
 class TimedCryptoServiceTest {
-    class TestService(private val timeout: Long) : CryptoService {
-        private val testKeyPair = Crypto.generateKeyPair()
-
-        override fun generateKeyPair(alias: String, scheme: SignatureScheme): PublicKey {
-            sleep(SECONDS.toMillis(timeout))
-            return testKeyPair.public
-        }
-
-        override fun containsKey(alias: String): Boolean {
-            sleep(SECONDS.toMillis(timeout))
-            return true
-        }
-
-        override fun getPublicKey(alias: String): PublicKey? {
-            sleep(SECONDS.toMillis(timeout))
-            return testKeyPair.public
-        }
-
-        override fun sign(alias: String, data: ByteArray, signAlgorithm: String?): ByteArray {
-            sleep(SECONDS.toMillis(timeout))
-            return testKeyPair.public.toSHA256Bytes() // Just some random bytes...
-        }
-
-        override fun getSigner(alias: String): ContentSigner {
-            sleep(SECONDS.toMillis(timeout))
-            return ContentSignerBuilder.build(RSA_SHA256, testKeyPair.private, BouncyCastlePQCProvider())
-        }
-    }
+    private val testKeyPair = Crypto.generateKeyPair()
 
     @Test
     fun `timeout causes exception to be thrown`() {
         val timeout = 1L
-        val underlying = TestService(timeout * 2)
+        val underlying = rigorousMock<BCCryptoService>().also {
+            doAnswer { sleep(SECONDS.toMillis(timeout * 2)); return@doAnswer testKeyPair.public }.whenever(it).generateKeyPair(any(), any())
+        }
         val service = TimedCryptoService(underlying, timeout)
 
         assertThatExceptionOfType(TimedCryptoServiceException::class.java).isThrownBy {
@@ -57,7 +31,9 @@ class TimedCryptoServiceTest {
     @Test
     fun `when no timeout no exception is thrown`() {
         val timeout = 2L
-        val underlying = TestService(timeout / 2)
+        val underlying = rigorousMock<BCCryptoService>().also {
+            doAnswer { sleep(SECONDS.toMillis(timeout / 2)); return@doAnswer testKeyPair.public }.whenever(it).generateKeyPair(any(), any())
+        }
         val service = TimedCryptoService(underlying, timeout)
 
         service.generateKeyPair("", RSA_SHA256)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/TimedCryptoServiceTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/TimedCryptoServiceTest.kt
@@ -1,0 +1,65 @@
+package net.corda.nodeapi.internal.cryptoservice
+
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.Crypto.RSA_SHA256
+import net.corda.core.crypto.SignatureScheme
+import net.corda.core.utilities.toSHA256Bytes
+import net.corda.nodeapi.internal.crypto.ContentSignerBuilder
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.bouncycastle.operator.ContentSigner
+import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
+import org.junit.Test
+import java.lang.Thread.sleep
+import java.security.PublicKey
+import java.util.concurrent.TimeUnit.SECONDS
+
+class TimedCryptoServiceTest {
+    class TestService(private val timeout: Long) : CryptoService {
+        private val testKeyPair = Crypto.generateKeyPair()
+
+        override fun generateKeyPair(alias: String, scheme: SignatureScheme): PublicKey {
+            sleep(SECONDS.toMillis(timeout))
+            return testKeyPair.public
+        }
+
+        override fun containsKey(alias: String): Boolean {
+            sleep(SECONDS.toMillis(timeout))
+            return true
+        }
+
+        override fun getPublicKey(alias: String): PublicKey? {
+            sleep(SECONDS.toMillis(timeout))
+            return testKeyPair.public
+        }
+
+        override fun sign(alias: String, data: ByteArray, signAlgorithm: String?): ByteArray {
+            sleep(SECONDS.toMillis(timeout))
+            return testKeyPair.public.toSHA256Bytes() // Just some random bytes...
+        }
+
+        override fun getSigner(alias: String): ContentSigner {
+            sleep(SECONDS.toMillis(timeout))
+            return ContentSignerBuilder.build(RSA_SHA256, testKeyPair.private, BouncyCastlePQCProvider())
+        }
+    }
+
+    @Test
+    fun `timeout causes exception to be thrown`() {
+        val timeout = 1L
+        val underlying = TestService(timeout * 2)
+        val service = TimedCryptoService(underlying, timeout)
+
+        assertThatExceptionOfType(TimedCryptoServiceException::class.java).isThrownBy {
+            service.generateKeyPair("", RSA_SHA256)
+        }.withMessage("Timed-out while waiting for $timeout seconds")
+    }
+
+    @Test
+    fun `when no timeout no exception is thrown`() {
+        val timeout = 2L
+        val underlying = TestService(timeout / 2)
+        val service = TimedCryptoService(underlying, timeout)
+
+        service.generateKeyPair("", RSA_SHA256)
+    }
+}


### PR DESCRIPTION
Adds both the new decorator class as well as an exception specifically for timeouts.

Also plumbed into the makeCryptoService call (default is to not use it so we don't interfere with current code)