### PR TITLE
Flaky test fix in SchedulerService tests

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -312,15 +312,13 @@ class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
 
             // Force the thread to shut down with operations waiting
             scheduler.cancelAndWait()
-        }
 
-        val flowLogic = rigorousMock<FlowLogic<*>>()
-        val logicRef = rigorousMock<FlowLogicRef>()
+            val flowLogic = rigorousMock<FlowLogic<*>>()
+            val logicRef = rigorousMock<FlowLogicRef>()
 
-        transactionStates[stateRef] = transactionStateMock(logicRef, timeInTheFuture)
-        flows[logicRef] = flowLogic
+            transactionStates[stateRef] = transactionStateMock(logicRef, timeInTheFuture)
+            flows[logicRef] = flowLogic
 
-        configureDatabase(dataSourceProps, DatabaseConfig(), { null }, { null }).use { database ->
             val newScheduler = database.transaction {
                 createScheduler(database)
             }
@@ -328,6 +326,7 @@ class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
             assertStarted(flowLogic)
 
             newScheduler.close()
+
         }
     }
 


### PR DESCRIPTION
Test the scheduler picking up a persisted scheduled state without shutting down/restart the db.
