### PR TITLE
CORDA-2991 shorten poll intervals for node info file propagation

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt
@@ -37,7 +37,7 @@ class NodeInfoFilesCopier(scheduler: Scheduler = Schedulers.io()) : AutoCloseabl
     private val subscription: Subscription
 
     init {
-        this.subscription = Observable.interval(5, TimeUnit.SECONDS, scheduler)
+        this.subscription = Observable.interval(1, TimeUnit.SECONDS, scheduler)
                 .subscribe { poll() }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -63,7 +63,7 @@ class NodeInfoWatcher(private val nodePath: Path,
     val processedNodeInfoHashes: Set<SecureHash> get() = nodeInfoFilesMap.values.map { it.nodeInfohash }.toSet()
 
     init {
-        require(pollInterval >= 1.seconds) { "Poll interval must be 5 seconds or longer." }
+        require(pollInterval >= 1.seconds) { "Poll interval must be 1 second or longer." }
         nodeInfosDir.createDirectories()
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -63,7 +63,7 @@ class NodeInfoWatcher(private val nodePath: Path,
     val processedNodeInfoHashes: Set<SecureHash> get() = nodeInfoFilesMap.values.map { it.nodeInfohash }.toSet()
 
     init {
-        //require(pollInterval >= 5.seconds) { "Poll interval must be 5 seconds or longer." }
+        require(pollInterval >= 1.seconds) { "Poll interval must be 5 seconds or longer." }
         nodeInfosDir.createDirectories()
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -63,7 +63,7 @@ class NodeInfoWatcher(private val nodePath: Path,
     val processedNodeInfoHashes: Set<SecureHash> get() = nodeInfoFilesMap.values.map { it.nodeInfohash }.toSet()
 
     init {
-        require(pollInterval >= 5.seconds) { "Poll interval must be 5 seconds or longer." }
+        //require(pollInterval >= 5.seconds) { "Poll interval must be 5 seconds or longer." }
         nodeInfosDir.createDirectories()
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -263,6 +263,7 @@ class DriverDSLImpl(
                         "address" to portAllocation.nextHostAndPort().toString(),
                         "adminAddress" to portAllocation.nextHostAndPort().toString()
                 ),
+                "additionalNodeInfoPollingFrequencyMsec" to 1000,
                 "devMode" to false) + customOverrides
         val config = NodeConfig(ConfigHelper.loadConfig(
                 baseDirectory = baseDirectory,


### PR DESCRIPTION
Shorten the polling interval for propagating node info files between nodes, in the hope of avoiding test failures due to nodes not having received each other's info yet.