### PR TITLE
CORDA-2871: Fine-tune compile vs runtime scopes for published deterministic jars.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -3,7 +3,7 @@
 # their own projects. So don't get fancy with syntax!
 
 cordaVersion=5.0-SNAPSHOT
-gradlePluginsVersion=5.0.1
+gradlePluginsVersion=5.0.2
 kotlinVersion=1.2.71
 java8MinUpdateVersion=171
 # ***************************************************************#

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -3,6 +3,7 @@ description 'Corda core (deterministic)'
 apply from: '../deterministic.gradle'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'java-library'
 apply plugin: 'idea'
 
 evaluationDependsOn(":core")
@@ -11,7 +12,7 @@ def javaHome = System.getProperty('java.home')
 def jarBaseName = "corda-${project.name}".toString()
 
 configurations {
-    deterministicLibraries
+    deterministicLibraries.extendsFrom api
     deterministicArtifacts.extendsFrom deterministicLibraries
 }
 
@@ -20,18 +21,23 @@ dependencies {
 
     // Configure these by hand. It should be a minimal subset of core's dependencies,
     // and without any obviously non-deterministic ones such as Hibernate.
-    deterministicLibraries "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    deterministicLibraries "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    deterministicLibraries "javax.persistence:javax.persistence-api:2.2"
+
+    // These "api" dependencies will become "compile" scoped in our published POM.
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    api "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    api "javax.persistence:javax.persistence-api:2.2"
+    api "com.google.code.findbugs:jsr305:$jsr305_version"
+
+    // These dependencies will become "runtime" scoped in our published POM.
+    // See publish.dependenciesFrom.defaultScope.
     deterministicLibraries "org.bouncycastle:bcprov-jdk15on:$bouncycastle_version"
     deterministicLibraries "org.bouncycastle:bcpkix-jdk15on:$bouncycastle_version"
-    deterministicLibraries "com.google.code.findbugs:jsr305:$jsr305_version"
     deterministicLibraries "net.i2p.crypto:eddsa:$eddsa_version"
     deterministicLibraries "org.slf4j:slf4j-api:$slf4j_version"
 }
 
 jar {
-    baseName 'DOES-NOT-EXIST'
+    archiveBaseName = 'DOES-NOT-EXIST'
     // Don't build a jar here because it would be the wrong one.
     // The jar we really want will be built by the metafix task.
     enabled = false
@@ -41,10 +47,10 @@ def coreJarTask = tasks.getByPath(':core:jar')
 def originalJar = coreJarTask.outputs.files.singleFile
 
 task patchCore(type: Zip, dependsOn: coreJarTask) {
-    destinationDir file("$buildDir/source-libs")
+    destinationDirectory = file("$buildDir/source-libs")
     metadataCharset 'UTF-8'
-    classifier 'transient'
-    extension 'jar'
+    archiveClassifier = 'transient'
+    archiveExtension = 'jar'
 
     from(compileKotlin)
     from(zipTree(originalJar)) {
@@ -65,7 +71,7 @@ task predeterminise(type: ProGuardTask) {
 
     libraryjars file("$javaHome/lib/rt.jar")
     libraryjars file("$javaHome/lib/jce.jar")
-    configurations.compileOnly.forEach {
+    configurations.compileClasspath.forEach {
         if (originalJar != it) {
             libraryjars it, filter: '!META-INF/versions/**'
         }

--- a/core-deterministic/testing/verifier/build.gradle
+++ b/core-deterministic/testing/verifier/build.gradle
@@ -21,11 +21,11 @@ dependencies {
     // Compile against the deterministic artifacts to ensure that we use only the deterministic API subset.
     compileOnly configurations.deterministicArtifacts
     api "junit:junit:$junit_version"
-    runtimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    runtimeOnly "org.junit.vintage:junit-vintage-engine:$junit_vintage_version"
 }
 
 jar {
-    baseName 'corda-deterministic-verifier'
+    archiveBaseName = 'corda-deterministic-verifier'
 }
 
 artifacts {
@@ -36,8 +36,10 @@ artifacts {
 
 publish {
     // Our published POM will contain dependencies on the non-deterministic Corda artifacts.
-    dependenciesFrom configurations.runtimeArtifacts
-    name jar.baseName
+    dependenciesFrom(configurations.runtimeArtifacts) {
+        defaultScope = 'compile'
+    }
+    name jar.archiveBaseName.get()
 }
 
 idea {

--- a/jdk8u-deterministic/build.gradle
+++ b/jdk8u-deterministic/build.gradle
@@ -32,7 +32,7 @@ task copyJdk(type: Copy) {
     into "$jdk_home/jre/lib"
 
     doLast {
-        def eol = System.getProperty('line.separator')
+        def eol = System.lineSeparator()
         file("$jdk_home/release").write "JAVA_VERSION=\"1.8.0_172\"$eol"
         mkdir "$jdk_home/bin"
         file("$jdk_home/bin/javac").with {

--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -3,6 +3,7 @@ description 'Corda serialization (deterministic)'
 apply from: '../deterministic.gradle'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'java-library'
 apply plugin: 'idea'
 
 evaluationDependsOn(":serialization")
@@ -11,7 +12,7 @@ def javaHome = System.getProperty('java.home')
 def jarBaseName = "corda-${project.name}".toString()
 
 configurations {
-    deterministicLibraries
+    deterministicLibraries.extendsFrom implementation
     deterministicArtifacts.extendsFrom deterministicLibraries
 }
 
@@ -20,14 +21,19 @@ dependencies {
 
     // Configure these by hand. It should be a minimal subset of dependencies,
     // and without any obviously non-deterministic ones such as Hibernate.
+
+    // This dependency will become "compile" scoped in our published POM.
+    // See publish.dependenciesFrom.defaultScope.
     deterministicLibraries project(path: ':core-deterministic', configuration: 'deterministicArtifacts')
-    deterministicLibraries "org.apache.qpid:proton-j:$protonj_version"
-    deterministicLibraries "org.iq80.snappy:snappy:$snappy_version"
-    deterministicLibraries "com.google.guava:guava:$guava_version"
+
+    // These "implementation" dependencies will become "runtime" scoped in our published POM.
+    implementation "org.apache.qpid:proton-j:$protonj_version"
+    implementation "org.iq80.snappy:snappy:$snappy_version"
+    implementation "com.google.guava:guava:$guava_version"
 }
 
 jar {
-    baseName 'DOES-NOT-EXIST'
+    archiveBaseName = 'DOES-NOT-EXIST'
     // Don't build a jar here because it would be the wrong one.
     // The jar we really want will be built by the metafix task.
     enabled = false
@@ -37,10 +43,10 @@ def serializationJarTask = tasks.getByPath(':serialization:jar')
 def originalJar = serializationJarTask.outputs.files.singleFile
 
 task patchSerialization(type: Zip, dependsOn: serializationJarTask) {
-    destinationDir file("$buildDir/source-libs")
+    destinationDirectory = file("$buildDir/source-libs")
     metadataCharset 'UTF-8'
-    classifier 'transient'
-    extension 'jar'
+    archiveClassifier = 'transient'
+    archiveExtension = 'jar'
 
     from(compileKotlin)
     from(zipTree(originalJar)) {
@@ -65,7 +71,7 @@ task predeterminise(type: ProGuardTask, dependsOn: project(':core-deterministic'
     libraryjars file("$javaHome/lib/rt.jar")
     libraryjars file("$javaHome/lib/jce.jar")
     libraryjars file("$javaHome/lib/ext/sunec.jar")
-    configurations.compileOnly.forEach {
+    configurations.compileClasspath.forEach {
         if (originalJar != it) {
             libraryjars it, filter: '!META-INF/versions/**'
         }
@@ -168,7 +174,9 @@ artifacts {
 }
 
 publish {
-    dependenciesFrom configurations.deterministicArtifacts
+    dependenciesFrom(configurations.deterministicArtifacts) {
+        defaultScope = 'compile'
+    }
     publishSources = false
     publishJavadoc = false
     name jarBaseName


### PR DESCRIPTION
Use Gradle's `java-library` plugin and `publish-utils` 5.0.2 to publish Corda's deterministic artifacts with appropriate `compile` and `runtime` dependencies. This will allow projects just as Tokens SDK to use `corda-core-deterministic` with its correct transitive dependencies under Gradle 5.x