### PR TITLE
[CORDA-2552] Flow killing improvements [WIP]

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -35,6 +35,8 @@ interface FlowStateMachine<FLOWRETURN> {
 
     fun updateTimedFlowTimeout(timeoutSeconds: Long)
 
+    fun sendFlowKilledNotification()
+
     val logic: FlowLogic<FLOWRETURN>
     val serviceHub: ServiceHub
     val logger: Logger

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -35,8 +35,6 @@ interface FlowStateMachine<FLOWRETURN> {
 
     fun updateTimedFlowTimeout(timeoutSeconds: Long)
 
-    fun sendFlowKilledNotification()
-
     val logic: FlowLogic<FLOWRETURN>
     val serviceHub: ServiceHub
     val logger: Logger

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowKillTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowKillTest.kt
@@ -1,0 +1,110 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.contracts.Command
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.internal.concurrent.transpose
+import net.corda.core.messaging.startFlow
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.Permissions
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.CHARLIE_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.User
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class FlowKillTest {
+
+    @Test
+    fun `Killing a flow causes flows to terminate on counterparties`() {
+        val user = User("test", "test", setOf(Permissions.all()))
+        driver(DriverParameters(
+                startNodesInProcess = isQuasarAgentSpecified()
+        )) {
+            val (alice, bob, charlie) = listOf(
+                    startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)),
+                    startNode(providedName = BOB_NAME, rpcUsers = listOf(user)),
+                    startNode(providedName = CHARLIE_NAME, rpcUsers = listOf(user))
+            ).transpose().getOrThrow()
+
+            val notary = defaultNotaryHandle
+            val charlieParty = charlie.nodeInfo.legalIdentities.first()
+//            charlie.stop()
+
+            val handle = CordaRPCClient(alice.rpcAddress).start(user.username, user.password).use {
+                val h = it.proxy.startFlow(::DummyFlow, notary.identity, bob.nodeInfo.legalIdentities.first(), charlieParty)
+                h
+            }
+
+            bob.rpc.stateMachinesFeed().let { it.updates.map {
+                update -> update.id
+            }.startWith(it.snapshot.map { snapshot -> snapshot.id }) }.toBlocking().first()
+
+//            CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
+//                assertEquals(1, it.proxy.stateMachinesSnapshot().size, "Wrong number of active flows on Bob")
+//                assertEquals(
+//                        DummyResponder::class.java.name,
+//                        it.proxy.stateMachinesSnapshot().first().flowLogicClassName,
+//                        "Unexpected active flow name")
+//            }
+
+            CordaRPCClient(alice.rpcAddress).start(user.username, user.password).use {
+                val stateMachines = it.proxy.stateMachinesSnapshot()
+                assertEquals(1, stateMachines.size, "Couldn't find initiated flow")
+                val killed = it.proxy.killFlow(handle.id)
+                assertEquals(true, killed, "Could not kill flow with id ${handle.id}")
+            }
+//
+//            CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
+//                assertEquals(0, it.proxy.stateMachinesSnapshot().size, "Flow on Bob has not been killed")
+//            }
+        }
+    }
+}
+
+@StartableByRPC
+@InitiatingFlow
+class DummyFlow(val notary: Party, val partyA: Party, val partyB: Party): FlowLogic<Unit>() {
+
+    @Suspendable
+    override fun call() {
+        val parties = listOf(partyA, partyB)
+        val state = DummyContract.MultiOwnerState(owners = parties)
+        val command = Command(DummyContract.Commands.Create(), parties.map { it.owningKey })
+        val txBuilder = TransactionBuilder(notary)
+                .addOutputState(state, DummyContract.PROGRAM_ID)
+                .addCommand(command)
+        val signedTx = serviceHub.signInitialTransaction(txBuilder)
+        val sessions = parties.map { initiateFlow(it) }
+        subFlow(CollectSignaturesFlow(signedTx, sessions))
+        sessions.forEach {
+            it.send(Unit)
+        }
+        sessions[1].receive<Unit>()
+        sessions[0].receive<Unit>()
+    }
+}
+
+@InitiatedBy(DummyFlow::class)
+class DummyResponder(val otherSideSession: FlowSession): FlowLogic<Unit>() {
+
+    @Suspendable
+    override fun call() {
+        val response = object : SignTransactionFlow(otherSideSession) {
+            override fun checkTransaction(stx: SignedTransaction) {
+                // Do nothing
+            }
+        }
+        subFlow(response)
+        otherSideSession.receive<Unit>()
+        otherSideSession.send(Unit)
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowKillTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowKillTest.kt
@@ -6,11 +6,15 @@ import net.corda.core.contracts.Command
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.transpose
+import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.startFlow
+import net.corda.core.toFuture
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions
+import net.corda.node.services.statemachine.FlowKilledException
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
@@ -19,6 +23,8 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertThrows
+import rx.Observable.combineLatest
 import kotlin.test.assertEquals
 
 class FlowKillTest {
@@ -37,42 +43,48 @@ class FlowKillTest {
 
             val notary = defaultNotaryHandle
             val charlieParty = charlie.nodeInfo.legalIdentities.first()
-//            charlie.stop()
+            // Detect when the flow has been killed on Bob by looking for an update that indicates the flow state machine has been removed.
+            val bobEndedFuture = bob.rpc.stateMachinesFeed().updates.filter { it is StateMachineUpdate.Removed }
+                    .map { it as StateMachineUpdate.Removed }.first().toFuture()
+            // By stopping Charlie, the flow cannot complete on Alice
+            charlie.stop()
 
-            val handle = CordaRPCClient(alice.rpcAddress).start(user.username, user.password).use {
-                val h = it.proxy.startFlow(::DummyFlow, notary.identity, bob.nodeInfo.legalIdentities.first(), charlieParty)
-                h
-            }
-
-            bob.rpc.stateMachinesFeed().let { it.updates.map {
-                update -> update.id
-            }.startWith(it.snapshot.map { snapshot -> snapshot.id }) }.toBlocking().first()
-
-//            CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
-//                assertEquals(1, it.proxy.stateMachinesSnapshot().size, "Wrong number of active flows on Bob")
-//                assertEquals(
-//                        DummyResponder::class.java.name,
-//                        it.proxy.stateMachinesSnapshot().first().flowLogicClassName,
-//                        "Unexpected active flow name")
-//            }
+            // Detect when the flow has started on both nodes
+            val startedFuture = combineLatest(
+                    alice.rpc.stateMachinesFeed().updates.filter { it is StateMachineUpdate.Added }.map { it as StateMachineUpdate.Added },
+                    bob.rpc.stateMachinesFeed().updates.filter { it is StateMachineUpdate.Added }.map { it as StateMachineUpdate.Added }
+            ) { a, b -> Pair(a, b) }.first().toFuture()
 
             CordaRPCClient(alice.rpcAddress).start(user.username, user.password).use {
-                val stateMachines = it.proxy.stateMachinesSnapshot()
-                assertEquals(1, stateMachines.size, "Couldn't find initiated flow")
-                val killed = it.proxy.killFlow(handle.id)
-                assertEquals(true, killed, "Could not kill flow with id ${handle.id}")
+                it.proxy.startFlow(::DummyFlow, notary.identity, bob.nodeInfo.legalIdentities.first(), charlieParty)
+                val (aliceUpdate, bobUpdate) = startedFuture.getOrThrow()
+                val runId = bobUpdate.id
+                // In order for the flow session to be killed on the counterparty node, the session must first be fully initialised. This
+                // check is in place to ensure that the session is initialised before the flow is killed.
+                val progressFeed = aliceUpdate.stateMachineInfo.progressTrackerStepAndUpdates
+                if (progressFeed!!.snapshot != SESSION_STARTED_LABEL) {
+                    progressFeed.updates.filter { update -> update == SESSION_STARTED_LABEL}.first().toFuture().getOrThrow()
+                }
+                it.proxy.killFlow(aliceUpdate.id)
+                val ended = bobEndedFuture.getOrThrow()
+                assertEquals(runId, ended.id)
+                assertThrows(FlowKilledException::class.java) { ended.result.getOrThrow() }
             }
-//
-//            CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
-//                assertEquals(0, it.proxy.stateMachinesSnapshot().size, "Flow on Bob has not been killed")
-//            }
         }
     }
 }
 
+const val SESSION_STARTED_LABEL = "Session started"
+
 @StartableByRPC
 @InitiatingFlow
 class DummyFlow(val notary: Party, val partyA: Party, val partyB: Party): FlowLogic<Unit>() {
+
+    companion object {
+        val SESSION_STARTED = ProgressTracker.Step(SESSION_STARTED_LABEL)
+    }
+
+    override val progressTracker = ProgressTracker(SESSION_STARTED)
 
     @Suspendable
     override fun call() {
@@ -83,13 +95,17 @@ class DummyFlow(val notary: Party, val partyA: Party, val partyB: Party): FlowLo
                 .addOutputState(state, DummyContract.PROGRAM_ID)
                 .addCommand(command)
         val signedTx = serviceHub.signInitialTransaction(txBuilder)
-        val sessions = parties.map { initiateFlow(it) }
+        // The flow from here is written slightly strangely to ensure that the progress tracker update happens after the session to partyA
+        // has been fully initialised.
+        val sessionA = initiateFlow(partyA)
+        sessionA.send(Unit)
+        sessionA.receive<Unit>()
+        progressTracker.currentStep = SESSION_STARTED
+        val sessionB = initiateFlow(partyB)
+        sessionB.send(Unit)
+        sessionB.receive<Unit>()
+        val sessions = listOf(sessionA, sessionB)
         subFlow(CollectSignaturesFlow(signedTx, sessions))
-        sessions.forEach {
-            it.send(Unit)
-        }
-        sessions[1].receive<Unit>()
-        sessions[0].receive<Unit>()
     }
 }
 
@@ -103,8 +119,8 @@ class DummyResponder(val otherSideSession: FlowSession): FlowLogic<Unit>() {
                 // Do nothing
             }
         }
-        subFlow(response)
         otherSideSession.receive<Unit>()
         otherSideSession.send(Unit)
+        subFlow(response)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -47,8 +47,7 @@ class TransientReference<out A>(@Transient val value: A)
 
 class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                               override val logic: FlowLogic<R>,
-                              scheduler: FiberScheduler,
-                              private val flowMessaging: FlowMessaging
+                              scheduler: FiberScheduler
 ) : Fiber<Unit>(id.toString(), scheduler), FlowStateMachine<R>, FlowFiber {
     companion object {
         /**
@@ -489,25 +488,6 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
         // Start time gets serialized along with the fiber when it suspends
         val duration = System.nanoTime() - startTime
         timer.update(duration, TimeUnit.NANOSECONDS)
-    }
-
-    override fun sendFlowKilledNotification() {
-        val sessions = transientState?.value?.checkpoint?.sessions?.values ?: listOf()
-        val errorId = getTransientField(TransientValues::stateMachine).secureRandom.nextLong()
-        val activeSessions = sessions
-                .filter { it is SessionState.Initiated && it.initiatedState is InitiatedSessionState.Live }
-                .map {
-                    val initiatedState = it as SessionState.Initiated
-                    val liveState = initiatedState.initiatedState as InitiatedSessionState.Live
-                    Pair(it, liveState.peerSinkSessionId)
-                }
-        val payload = ErrorSessionMessage(FlowKilledException(), errorId)
-
-        for ((session, sessionId) in activeSessions) {
-            val message = ExistingSessionMessage(sessionId, payload)
-            val deduplicationId = DeduplicationId.createForError(errorId, sessionId)
-            flowMessaging.sendSessionMessage(session.peerParty, message, SenderDeduplicationId(deduplicationId, transientState?.value?.senderUUID))
-        }
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -41,7 +41,7 @@ import kotlin.reflect.KProperty1
 
 class FlowPermissionException(message: String) : FlowException(message)
 
-class FlowKilledException: FlowException("Flow terminated by RPC")
+class FlowKilledException: FlowException("Flow was manually terminated")
 
 class TransientReference<out A>(@Transient val value: A)
 


### PR DESCRIPTION
This PR contains the first attempt at getting flow killed errors propagated to the counterparty nodes. I'd like to get a first look at this now as I'm not sure the approach is quite right. What I've tried to do is send an error message through each of the sessions belonging to the killed flow. If the session is still being initiated, then the error message is sent back when the session confirmation message is received.

Testing
 - Flow framework tests check messages being sent between two parties when a flow is killed after a session is initiated, and before the confirmation message is received
 - Flow kill tests run a driver based test to check flow killing happens across nodes