### PR TITLE
[CORDA-3042] - Revert upgrade of dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ buildscript {
     ext.h2_version = '1.4.199' // Update docs if renamed or removed.
     ext.postgresql_version = '42.2.5'
     ext.rxjava_version = '1.3.8'
-    ext.dokka_version = '0.9.18'
+    ext.dokka_version = '0.9.17'
     ext.eddsa_version = '0.2.0'
     ext.dependency_checker_version = '4.0.2'
     ext.commons_collections_version = '4.3'


### PR DESCRIPTION
Reverting upgrade of dokka. See linked ticket for details.

Change has been tested on the nightly job that was failing.