### PR TITLE
CORDA-2333: Upgrade jackson version to 2.9.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript {
     ext.asm_version = '7.1'
     ext.artemis_version = '2.6.2'
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.9.5'
+    ext.jackson_version = '2.9.7'
     ext.jetty_version = '9.4.19.v20190610'
     ext.jersey_version = '2.25'
     ext.servlet_version = '4.0.1'


### PR DESCRIPTION
`jackson-module-kotlin` version `2.9.5` was causing runtime errors. Updating to `2.9.7` resolved these errors. The dependency was not updated to a more recent version as they require kotlin 1.3.