### PR TITLE
Quickstart changes for usability

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -146,8 +146,13 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
 
+html_theme_options = {
+    'includehidden':True,
+    'collapse_navigation':False,
+    'sticky_navigation':True,
+    'titles_only':True
+}
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 
@@ -285,4 +290,3 @@ latex_elements = {
 
     'extraclassoptions' : 'openany',
 }
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,8 @@ We look forward to seeing what you can do with Corda!
 
 .. toctree::
    :maxdepth: 1
+   :hidden:
+   :titlesonly:
 
    release-notes
    app-upgrade-notes
@@ -40,6 +42,8 @@ We look forward to seeing what you can do with Corda!
 .. toctree::
    :caption: Development
    :maxdepth: 1
+   :hidden:
+   :titlesonly:
 
    quickstart-index.rst
    key-concepts.rst
@@ -55,6 +59,8 @@ We look forward to seeing what you can do with Corda!
 .. toctree::
    :caption: Operations
    :maxdepth: 2
+   :hidden:
+   :titlesonly:
 
    corda-nodes-index.rst
    corda-networks-index.rst
@@ -70,6 +76,8 @@ We look forward to seeing what you can do with Corda!
    :caption: Corda Network
    :maxdepth: 2
    :if_tag: htmlmode
+   :hidden:
+   :titlesonly:
 
    corda-network/index.md
    corda-network/UAT.md
@@ -87,9 +95,10 @@ We look forward to seeing what you can do with Corda!
    :caption: Participate
    :maxdepth: 2
    :if_tag: htmlmode
+   :hidden:
+   :titlesonly:
 
    contributing-index.rst
    deterministic-modules.rst
    design/design-docs-index.rst
    changelog
-

--- a/docs/source/quickstart-build.rst
+++ b/docs/source/quickstart-build.rst
@@ -1,0 +1,416 @@
+.. highlight:: kotlin
+.. raw:: html
+
+   <script type="text/javascript" src="_static/jquery.js"></script>
+   <script type="text/javascript" src="_static/codesets.js"></script>
+
+Building your own CorDapp
+=========================
+
+After examining a functioning CorDapp, the next challenge is to create one of your own. We're going to build a simple supply chain CorDapp representing a network between a car dealership, a car manufacturer, and a bank.
+
+To model this network, you need to create one state (representing cars), one contract (to control the rules governing cars), and one flow (to create cars). This CorDapp will be very basic, but entirely functional and deployable.
+
+Step One: Download a template CorDapp
+-------------------------------------
+
+The first thing you need to do is clone a CorDapp template to modify.
+
+1. Open a terminal and navigate to a directory to store the new project.
+
+2. Run the following command to clone the template CorDapp: ``git clone https://github.com/corda/cordapp-template-kotlin.git``
+
+3. Open IntelliJ and open the CorDapp template project.
+
+Step Two: Creating states
+-------------------------
+
+Since the CorDapp models a car dealership network, a state must be created to represent cars.
+
+1. From IntelliJ expand the source files and navigate to ``contracts > src > main > kotlin > com.template > states > TemplateState.kt``.
+
+  This file contains a skeleton state definition.
+
+2. Right-click on **TemplateState.kt** in the project navigation on the left. Select **Refactor > Copy**.
+
+3. Rename the file to ``CarState`` and click **OK**.
+
+4. Double-click the new state file to open it. Add the following fields to the state:
+  * ``owningBank`` of type ``Party``
+  * ``holdingDealer`` of type ``Party``
+  * ``manufacturer`` of type ``Party``
+  * ``vin`` of type ``String``
+  * ``licensePlateNumber`` of type ``String``
+  * ``make`` of type ``String``
+  * ``model`` of type ``String``
+  * ``dealershipLocation`` of type ``String``
+  * ``linearId`` of type ``UniqueIdentifier``
+
+5. Remove the ``data`` and ``participants`` parameters.
+
+6. Add a body to the ``CarState`` class that overrides participants to contain a list of ``owningBank``, ``holdingDealer``, and ``manufacturer``.
+
+7. The ``CarState`` file should now appear as follows:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        @BelongsToContract(TemplateContract::class)
+        data class CarState(val owningbank: Party,
+                            val holdingDealer: Party,
+                            val manufacturer: Party,
+                            val vin: String,
+                            val licensePlateNumber: String,
+                            val make: String,
+                            val model: String,
+                            val dealershipLocation: String,
+                            val linearId: UniqueIdentifier) : ContractState {
+            override val participants: List<AbstractParty> = listOf(owningBank, holdingDealer, manufacturer)
+        }
+
+8. Save the ``CarState.kt`` file.
+
+The ``CarState`` definition has now been created. It lists the properties required of all instances of this state and their types.
+
+
+Step Three: Creating contracts
+------------------------------
+
+After creating a state, you must create a contract to dictate how the state can operate.
+
+1. From IntelliJ, expand the project source and navigate to: ``contracts > src > main > kotlin > com.template > contracts > TemplateContract.kt``
+
+2. Right-click on **TemplateContract.kt** in the project navigation on the left. Select **Refactor > Copy**.
+
+3. Rename the file to ``CarContract`` and click **OK**.
+
+4. Double-click the new contract file to open it.
+
+5. Update the ID field to ``com.template.contracts.CarContract``. This ID field is used to identify contracts when building a transaction.
+
+6. Update the ``Action`` command to an ``Issue`` command. This represents an issuance of an instance of the ``CarState`` state.
+
+7. Add ``val command=tx.commands.requireSingleCommand<Commands.Issue>()`` at the beginning of the ``verify()`` method. This line ensures that the command to issue a car state is called.
+
+8. The final function of the contract is to prevent unwanted behaviour during the flow. Add the following requirements to the contract:
+
+  * There should be no input state to the transaction.
+  * There should be one output state.
+  * The output state must be of the type ``CarState``.
+  * The ``licensePlateNumber`` must be seven characters long.
+
+9. The ``CarContract.kt`` file should look as follows:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        class CarContract : Contract {
+            companion object {
+                const val ID = "com.template.contracts.CarContract"
+            }
+
+            override fun verify(tx: LedgerTransaction) {
+
+                val command = tx.commands.requireSingleCommand<Commands.Issue>()
+                requireThat {
+                    "There should be no input state" using (tx.inputs.isEmpty())
+                    "There should be one input state" using (tx.outputs.size == 1)
+                    "The output state must be of type CarState" using (tx.outputs.get(0).data is CarState)
+                    val outputState = tx.outputs.get(0).data as CarState
+                    "The licensePlateNumber must be seven characters long" using (outputState.licensePlateNumber.length == 7)
+                }
+            }
+
+            interface Commands : CommandData {
+                class Issue : Commands
+            }
+        }
+
+10. Save the ``CarContract.kt`` file.
+
+Step Four: Creating a flow
+--------------------------
+
+1. From IntelliJ, expand the project source and navigate to: ``contracts > src > main > kotlin > com.template > contracts > Flows.kt``
+
+2. Right-click on **Flows.kt** in the project navigation on the left. Select **Refactor > Copy**.
+
+3. Rename the file to ``CarFlow`` and click **OK**.
+
+4. Double-click the new contract file to open it.
+
+5. Update the name of the ``Initiator`` class to ``CarIssueInitiator``.
+
+6. Update the name of the ``Responder`` class to ``CarIssueResponder``.
+
+7. Update the ``@InitiatedBy`` property of ``CarIssueResponder`` to ``CarIssueInitiator::class``.
+
+8. Add parameters to the ``CarIssueInitiator`` class for all the fields of the ``CarState`` definition, except for ``linearId``.
+
+9. Inside the ``call()`` function of the initiator, create a variable for the notary node. **expand this with some code**
+
+10. Create a variable for an ``Issue`` command.
+
+  The first parameter of the command must be the command type, in this case ``Issue``.
+
+  The second parameter of the command must be a list of keys from the relevant parties, in this case ``owningBank``, ``holdingDealer``, and ``manufacturer``.
+
+11. Create a ``CarState`` object using the parameters of ``CarIssueInitiator``.
+
+  The last parameter for ``CarState`` must be a new ``UniqueIdentifier()`` object.
+
+12. The ``CarFlow.kt`` file should look like this:
+
+  .. container:: codeset
+
+      .. sourcecode:: kotlin
+
+          @InitiatingFlow
+          @StartableByRPC
+          class CarIssueInitiator(val owningBank: Party,
+                                  val holdingDealer: Party,
+                                  val manufacturer: Party,
+                                  val vin: String,
+                                  val licensePlateNumber: String,
+                                  val make: String,
+                                  val model: String,
+                                  val dealershipLocation: String) : FlowLogic<Unit>() {
+              override val progressTracker = ProgressTracker()
+
+              @Suspendable
+              override fun call() {
+                  val notary = serviceHub.networkMapCache.notaryIdentities.single()
+                  val command = Command(CarContract.Commands.Issue(), listOf(owningBank, holdingDealer, manufacturer).map { it.owningKey })
+                  val carState = CarState(owningBank, holdingDealer, manufacturer, vin, licensePlateNumber, make, model, dealershipLocation, UniqueIdentifier())
+              }
+          }
+
+          @InitiatedBy(CarIssueInitiator::class)
+          class CarIssueResponder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
+              @Suspendable
+              override fun call(){
+
+                  }
+              }
+          }
+
+
+  **So far you've...**
+
+  **Next you must...**
+
+13. Update the ``FlowLogic<Unit>`` to ``FlowLogic<SignedTransaction>`` in both the initiator and responder class.
+
+14. Update the return type of both ``call()`` transactions to be of type ``SignedTransaction``.
+
+15. In the ``call()`` function, create a ``TransactionBuilder`` object similarly. The ``TransactionBuilder`` class should take in the notary node. The output state and command must be added to the ``TransactionBuilder``.
+
+16. Verify the transaction by calling ``verify(serviceHub)`` on the ``TransactionBuilder``.
+
+17. Sign the transaction and store the result in a variable.
+
+18. Delete the ``progressTracker`` as it won't be used in this tutorial.
+
+19. The ``CarFlow.kt`` file should now look like this:
+
+    .. container:: codeset
+
+        .. sourcecode:: kotlin
+
+            @InitiatingFlow
+            @StartableByRPC
+            class CarIssueInitiator(val owningBank: Party,
+                                    val holdingDealer: Party,
+                                    val manufacturer: Party,
+                                    val vin: String,
+                                    val licensePlateNumber: String,
+                                    val make: String,
+                                    val model: String,
+                                    val dealershipLocation: String) : FlowLogic<SignedTransaction>() {
+                override val progressTracker = ProgressTracker()
+
+                @Suspendable
+                override fun call(): SignedTransaction {
+
+                    val notary = serviceHub.networkMapCache.notaryIdentities.single()
+                    val command = Command(CarContract.Commands.Issue(), listOf(owningBank, holdingDealer, manufacturer).map { it.owningKey })
+                    val carState = CarState(owningBank, holdingDealer, manufacturer, vin, licensePlateNumber, make, model, dealershipLocation, UniqueIdentifier())
+
+                    val txBuilder = TransactionBuilder(notary)
+                            .addOutputState(carState, CarContract.ID)
+                            .addCommand(command)
+
+                    txBuilder.verify(serviceHub)
+                    val tx = serviceHub.signInitialTransaction(txBuilder)
+                }
+            }
+
+            @InitiatedBy(CarIssueInitiator::class)
+            class CarIssueResponder(val counterpartySession: FlowSession) : FlowLogic<SignedTransaction>() {
+                @Suspendable
+                override fun call(): SignedTransaction {
+
+                    }
+                }
+            }
+
+  **So far you've...**
+
+  **Next you must...**
+
+20. To finish the initiators ``call()`` function, other parties must sign the transaction. Add the following code to send the transaction to the other relevant parties:
+
+    .. container:: codeset
+
+        .. sourcecode:: kotlin
+
+            val sessions = (carState.participants - ourIdentity).map { initiateFlow(it as Party) }
+            val stx = subFlow(CollectSignaturesFlow(tx, sessions))
+            return subFlow(FinalityFlow(stx, sessions))
+
+  The first line creates a ``List<FlowSession>`` object by calling ``initiateFlow()`` for each party. The second line collects signatures from the relevant parties and returns a signed transaction. The third line calls ``FinalityFlow()``, finalizes the transaction using the notary or notary pool.
+
+21. Lastly, the body of the responder flow must be completed. The following code checks the transaction contents, signs it, and sends it back to the initiator:
+
+    .. container:: codeset
+
+        .. sourcecode:: kotlin
+
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val signedTransactionFlow = object : SignTransactionFlow(counterpartySession) {
+                override fun checkTransaction(stx: SignedTransaction) = requireThat {
+                    val output = stx.tx.outputs.single().data
+                    "The output must be a CarState" using (output is CarState)
+                }
+            }
+            val txWeJustSignedId = subFlow(signedTransactionFlow)
+            return subFlow(ReceiveFinalityFlow(counterpartySession, txWeJustSignedId.id))
+        }
+
+22. The completed ``CarFlow.kt`` should look like this:
+
+    .. container:: codeset
+
+        .. sourcecode:: kotlin
+
+            @InitiatingFlow
+            @StartableByRPC
+            class CarIssueInitiator(val owningBank: Party,
+                                    val holdingDealer: Party,
+                                    val manufacturer: Party,
+                                    val vin: String,
+                                    val licensePlateNumber: String,
+                                    val make: String,
+                                    val model: String,
+                                    val dealershipLocation: String) : FlowLogic<SignedTransaction>() {
+                @Suspendable
+                override fun call(): SignedTransaction {
+
+                    val notary = serviceHub.networkMapCache.notaryIdentities.single()
+                    val command = Command(CarContract.Commands.Issue(), listOf(owningBank, holdingDealer, manufacturer).map { it.owningKey })
+                    val carState = CarState(owningBank, holdingDealer, manufacturer, vin, licensePlateNumber, make, model, dealershipLocation, UniqueIdentifier())
+
+                    val txBuilder = TransactionBuilder(notary)
+                            .addOutputState(carState, CarContract.ID)
+                            .addCommand(command)
+
+                    txBuilder.verify(serviceHub)
+                    val tx = serviceHub.signInitialTransaction(txBuilder)
+
+                    val sessions = (carState.participants - ourIdentity).map { initiateFlow(it as Party) }
+                    val stx = subFlow(CollectSignaturesFlow(tx, sessions))
+                    return subFlow(FinalityFlow(stx, sessions))
+                }
+            }
+
+            @InitiatedBy(CarIssueInitiator::class)
+            class CarIssueResponder(val counterpartySession: FlowSession) : FlowLogic<SignedTransaction>() {
+
+                @Suspendable
+                override fun call(): SignedTransaction {
+                    val signedTransactionFlow = object : SignTransactionFlow(counterpartySession) {
+                        override fun checkTransaction(stx: SignedTransaction) = requireThat {
+                            val output = stx.tx.outputs.single().data
+                            "The output must be a CarState" using (output is CarState)
+                        }
+                    }
+                    val txWeJustSignedId = subFlow(signedTransactionFlow)
+                    return subFlow(ReceiveFinalityFlow(counterpartySession, txWeJustSignedId.id))
+                }
+            }
+
+Step Five: Update the Gradle build
+----------------------------------
+
+The Gradle build files must be updated to change how the nodes are deployed.  (**how**)
+
+1. Navigate to the ``build.gradle`` file in the root ``cordapp-template-kotlin`` directory.
+
+2. In the ``deployNodes`` task, update the nodes to read as follows:
+
+    .. container:: codeset
+
+        .. sourcecode:: kotlin
+
+            node {
+                name "O=Notary,L=London,C=GB"
+                notary = [validating : false]
+                p2pPort 10002
+                rpcSettings {
+                    address("localhost:10003")
+                    adminAddress("localhost:10043")
+                }
+            }
+            node {
+                name "O=Dealership,L=London,C=GB"
+                p2pPort 10005
+                rpcSettings {
+                    address("localhost:10006")
+                    adminAddress("localhost:10046")
+                }
+                rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
+            }
+            node {
+                name "O=Manufacturer,L=New York,C=US"
+                p2pPort 10008
+                rpcSettings {
+                    address("localhost:10009")
+                    adminAddress("localhost:10049")
+                }
+                rpcUsers = [[ user:: "user1", "password": "test", "permissions": ["ALL"]]]
+            }
+            node {
+                name "O=BankofAmerica,L=New York,C=US"
+                p2pPort 10010
+                rpcSettings {
+                    address("localhost:10007")
+                    adminAddress("localhost:10047")
+                }
+                rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
+            }
+
+3. Save the updated ``build.gradle`` file and click **Import Changes** when the pop-up message appears in the lower-right corner.
+
+Step Six: Deploying your CorDapp locally
+----------------------------------------
+
+Now that the the CorDapp code has been completed and the build file updated, the CorDapp can be deployed.
+
+1. Open a terminal and navigate to the root directory of the project.
+
+2. Run ``./gradlew clean deployNodes``
+
+3. Run ``build/nodes/runNodes``
+
+  The nodes should open in terminal windows.
+
+4. To run flows in your CorDapp, enter the following flow command from any node terminal window: ``flow start CarIssueInitiator owningBank: Bank of America, holdingDealer: Dealership, manufacturer: Manufacturer, vin:"abc", licensePlateNumber: "abc1234", make: "Honda", model: "Civic", dealershipLocation: "NYC"``
+
+5. To check that the state was correctly issued, query the node using the following command:
+
+  ``run vaultQuery contractStateType: com.template.states.CarState``
+
+  The vault is the node's repository of all information from the ledger that involves that node, stored in a relational model. After running the query, the terminal should display the state created by the flow command. This command can be run from the terminal window of any node, as all parties are participants in this transaction.

--- a/docs/source/quickstart-build.rst
+++ b/docs/source/quickstart-build.rst
@@ -256,6 +256,7 @@ Step Four: Creating a flow
                 }
             }
 
+
   **So far you've...**
 
   **Next you must...**
@@ -278,17 +279,17 @@ Step Four: Creating a flow
 
         .. sourcecode:: kotlin
 
-        @Suspendable
-        override fun call(): SignedTransaction {
-            val signedTransactionFlow = object : SignTransactionFlow(counterpartySession) {
-                override fun checkTransaction(stx: SignedTransaction) = requireThat {
-                    val output = stx.tx.outputs.single().data
-                    "The output must be a CarState" using (output is CarState)
+            @Suspendable
+            override fun call(): SignedTransaction {
+                val signedTransactionFlow = object : SignTransactionFlow(counterpartySession) {
+                    override fun checkTransaction(stx: SignedTransaction) = requireThat {
+                        val output = stx.tx.outputs.single().data
+                        "The output must be a CarState" using (output is CarState)
+                    }
                 }
+                val txWeJustSignedId = subFlow(signedTransactionFlow)
+                return subFlow(ReceiveFinalityFlow(counterpartySession, txWeJustSignedId.id))
             }
-            val txWeJustSignedId = subFlow(signedTransactionFlow)
-            return subFlow(ReceiveFinalityFlow(counterpartySession, txWeJustSignedId.id))
-        }
 
 22. The completed ``CarFlow.kt`` should look like this:
 

--- a/docs/source/quickstart-build.rst
+++ b/docs/source/quickstart-build.rst
@@ -95,15 +95,17 @@ Since the CorDapp models a car dealership network, a state must be created to re
             // *********
 
             @BelongsToContract(CarContract::class)
-            data class CarState(val owningBank: Party,
-                                val holdingDealer: Party,
-                                val manufacturer: Party,
-                                val vin: String,
-                                val licensePlateNumber: String,
-                                val make: String,
-                                val model: String,
-                                val dealershipLocation: String,
-                                val linearId: UniqueIdentifier) : ContractState {
+            data class CarState(
+                    val owningBank: Party,
+                    val holdingDealer: Party,
+                    val manufacturer: Party,
+                    val vin: String,
+                    val licensePlateNumber: String,
+                    val make: String,
+                    val model: String,
+                    val dealershipLocation: String,
+                    val linearId: UniqueIdentifier
+            ) : ContractState {
                 override val participants: List<AbstractParty> = listOf(owningBank, holdingDealer, manufacturer)
             }
 
@@ -264,14 +266,16 @@ Step Four: Creating a flow
 
             @InitiatingFlow
             @StartableByRPC
-            class CarIssueInitiator(val owningBank: Party,
-                                    val holdingDealer: Party,
-                                    val manufacturer: Party,
-                                    val vin: String,
-                                    val licensePlateNumber: String,
-                                    val make: String,
-                                    val model: String,
-                                    val dealershipLocation: String) : FlowLogic<Unit>() {
+            class CarIssueInitiator(
+                    val owningBank: Party,
+                    val holdingDealer: Party,
+                    val manufacturer: Party,
+                    val vin: String,
+                    val licensePlateNumber: String,
+                    val make: String,
+                    val model: String,
+                    val dealershipLocation: String
+            ) : FlowLogic<Unit>() {
 
                 @Suspendable
                 override fun call() {
@@ -310,14 +314,16 @@ Step Four: Creating a flow
 
             @InitiatingFlow
             @StartableByRPC
-            class CarIssueInitiator(val owningBank: Party,
-                                    val holdingDealer: Party,
-                                    val manufacturer: Party,
-                                    val vin: String,
-                                    val licensePlateNumber: String,
-                                    val make: String,
-                                    val model: String,
-                                    val dealershipLocation: String) : FlowLogic<SignedTransaction>() {
+            class CarIssueInitiator(
+                    val owningBank: Party,
+                    val holdingDealer: Party,
+                    val manufacturer: Party,
+                    val vin: String,
+                    val licensePlateNumber: String,
+                    val make: String,
+                    val model: String,
+                    val dealershipLocation: String
+            ) : FlowLogic<SignedTransaction>() {
                 override val progressTracker = ProgressTracker()
 
                 @Suspendable
@@ -325,7 +331,17 @@ Step Four: Creating a flow
 
                     val notary = serviceHub.networkMapCache.notaryIdentities.single()
                     val command = Command(CarContract.Commands.Issue(), listOf(owningBank, holdingDealer, manufacturer).map { it.owningKey })
-                    val carState = CarState(owningBank, holdingDealer, manufacturer, vin, licensePlateNumber, make, model, dealershipLocation, UniqueIdentifier())
+                    val carState = CarState(
+                            owningBank,
+                            holdingDealer,
+                            manufacturer,
+                            vin,
+                            licensePlateNumber,
+                            make,
+                            model,
+                            dealershipLocation,
+                            UniqueIdentifier()
+                    )
 
                     val txBuilder = TransactionBuilder(notary)
                             .addOutputState(carState, CarContract.ID)
@@ -397,20 +413,32 @@ Step Four: Creating a flow
 
             @InitiatingFlow
             @StartableByRPC
-            class CarIssueInitiator(val owningBank: Party,
-                                    val holdingDealer: Party,
-                                    val manufacturer: Party,
-                                    val vin: String,
-                                    val licensePlateNumber: String,
-                                    val make: String,
-                                    val model: String,
-                                    val dealershipLocation: String) : FlowLogic<SignedTransaction>() {
+            class CarIssueInitiator(
+                    val owningBank: Party,
+                    val holdingDealer: Party,
+                    val manufacturer: Party,
+                    val vin: String,
+                    val licensePlateNumber: String,
+                    val make: String,
+                    val model: String,
+                    val dealershipLocation: String
+            ) : FlowLogic<SignedTransaction>() {
                 @Suspendable
                 override fun call(): SignedTransaction {
 
                     val notary = serviceHub.networkMapCache.notaryIdentities.single()
                     val command = Command(CarContract.Commands.Issue(), listOf(owningBank, holdingDealer, manufacturer).map { it.owningKey })
-                    val carState = CarState(owningBank, holdingDealer, manufacturer, vin, licensePlateNumber, make, model, dealershipLocation, UniqueIdentifier())
+                    val carState = CarState(
+                            owningBank,
+                            holdingDealer,
+                            manufacturer,
+                            vin,
+                            licensePlateNumber,
+                            make,
+                            model,
+                            dealershipLocation,
+                            UniqueIdentifier()
+                    )
 
                     val txBuilder = TransactionBuilder(notary)
                             .addOutputState(carState, CarContract.ID)

--- a/docs/source/quickstart-build.rst
+++ b/docs/source/quickstart-build.rst
@@ -150,7 +150,7 @@ After creating a state, you must create a contract. Contracts define the rules t
 
   Commands are the operations that can be performed on a state. A contract will often define command logic for several operations that can be performed on the state in question, for example, issuing a state, changing ownership, and marking the state retired.
 
-9. Add ``val command = tx.commands.requireSingleCommand<Commands>()`` at the beginning of the ``verify()`` method. The ``verify()`` method defines the verification rules that commands must satisfy to be valid.
+9. Add ``val command = tx.commands.requireSingleCommand<Commands>().value`` at the beginning of the ``verify()`` method. The ``verify()`` method defines the verification rules that commands must satisfy to be valid.
 
 10. The final function of the contract is to prevent unwanted behaviour during the flow. After the ``val command = tx.commands...`` line, add the following requirement code:
 
@@ -192,7 +192,7 @@ After creating a state, you must create a contract. Contracts define the rules t
 
                 override fun verify(tx: LedgerTransaction) {
 
-                    val command = tx.commands.requireSingleCommand<Commands>()
+                    val command = tx.commands.requireSingleCommand<Commands>().value
 
                     when(command) {
                       is Commands.Issue -> requireThat {
@@ -311,7 +311,13 @@ Step Four: Creating a flow
 
 17. Verify the transaction by calling ``verify(serviceHub)`` on the ``TransactionBuilder``.
 
-18. Sign the transaction and store the result in a variable, using a method found in the `**serviceHub** <./api-service-hub.html>`_.
+18. Sign the transaction and store the result in a variable, using the following `serviceHub <./api-service-hub.html>`_ method:
+
+    .. container:: codeset
+
+        .. sourcecode:: kotlin
+
+            val notary = serviceHub.networkMapCache.notaryIdentities.first()
 
 19. Delete the ``progressTracker`` as it won't be used in this tutorial.
 
@@ -560,7 +566,11 @@ Now that the CorDapp code has been completed and the build file updated, the Cor
 
 4. To run flows in your CorDapp, enter the following flow command from any non-notary terminal window:
 
-  ``flow start CarIssueInitiator owningBank: BankofAmerica, holdingDealer: Dealership, manufacturer: Manufacturer, vin: "abc", licensePlateNumber: "abc1234", make: "Honda", model: "Civic", dealershipLocation: "NYC"``
+    .. container:: codeset
+
+        .. sourcecode:: kotlin
+
+            ``flow start CarIssueInitiator owningBank: BankofAmerica, holdingDealer: Dealership, manufacturer: Manufacturer, vin: "abc", licensePlateNumber: "abc1234", make: "Honda", model: "Civic", dealershipLocation: "NYC"``
 
 5. To check that the state was correctly issued, query the node using the following command:
 

--- a/docs/source/quickstart-build.rst
+++ b/docs/source/quickstart-build.rst
@@ -463,7 +463,7 @@ The Gradle build files must be updated to change how the nodes are deployed.  (*
 Step Six: Deploying your CorDapp locally
 ----------------------------------------
 
-Now that the the CorDapp code has been completed and the build file updated, the CorDapp can be deployed.
+Now that the CorDapp code has been completed and the build file updated, the CorDapp can be deployed.
 
 1. Open a terminal and navigate to the root directory of the project.
 

--- a/docs/source/quickstart-build.rst
+++ b/docs/source/quickstart-build.rst
@@ -415,3 +415,17 @@ Now that the the CorDapp code has been completed and the build file updated, the
   ``run vaultQuery contractStateType: com.template.states.CarState``
 
   The vault is the node's repository of all information from the ledger that involves that node, stored in a relational model. After running the query, the terminal should display the state created by the flow command. This command can be run from the terminal window of any node, as all parties are participants in this transaction.
+
+Next steps
+----------
+
+The getting started experience is designed to be lightweight and get to code as quickly as possible, for more detail, see the following documentation:
+
+* `CorDapp design best practice <./writing-a-cordapp.html>`_
+* `Testing CorDapp contracts <./tutorial-test-dsl.html>`_
+
+For operational users, see the following documentation:
+
+* `Node structure and configuration </corda-nodes-index.html>`_
+* `Deploying a node to a server <deploying-a-node.html>`_
+* `Notary documentation <running-a-notary.html>`_

--- a/docs/source/quickstart-deploy.rst
+++ b/docs/source/quickstart-deploy.rst
@@ -14,9 +14,13 @@ The first step is to deploy the CorDapp to nodes running locally.
 
 1. Navigate to the root directory of the example CorDapp.
 
-2. Deploy the CorDapp by running the following command: ``./gradlew deployNodes``
+2. To deploy the nodes on Windows run the following command: ``gradlew clean deployNodes``
 
-3. To best understand the deployment process, there are several perspectives it is helpful to see. Run the following command: ``build/nodes/runnodes``
+  To deploy the nodes on Mac or Linux run the following command: ``./gradlew clean deployNodes``
+
+3. To best understand the deployment process, there are several perspectives it is helpful to see. On Windows run the following command: ``build\nodes\runnodes``
+
+  On Mac/Linux run the following command: ``build/nodes/runnodes``
 
   This command opens four terminal windows: the notary, and a node each for PartyA, PartyB, and PartyC. A notary is a validation service that prevents double-spending, enforces timestamping, and may also validate transactions. For more information on notaries, see the `notary documentation <./key-concepts-notaries.html>`_.
 

--- a/docs/source/quickstart-deploy.rst
+++ b/docs/source/quickstart-deploy.rst
@@ -1,0 +1,33 @@
+Deploying an example CorDapp
+============================
+
+At this point we've set up the development environment, and have a sample CorDapp in an IntelliJ project. In this section, we'll deploy an instance of this CorDapp running on local nodes, including one notary, and two nodes, each representing one party in a transaction.
+
+Steps
+-----
+
+Before continuing, ensure that you have
+
+
+1. Navigate to the root directory of the sample CorDapp.
+
+2. Deploy the CorDapp by running the following command: ``./gradlew deployNodes``.
+
+3. To best understand the deployment process, there are several perspectives it is helpful to see. Run the following command: ``build/nodes/runnodes``
+
+  This command opens three terminal windows: the notary, and a node each for PartyA and PartyB. A notary is a validation service that prevents double-spending and
+
+4. Click the second terminal window to see the perspective of PartyA.
+
+5. After the PartyA node has been successfully deployed, flows can be executed from the perspective of PartyA. To execute the **AWBDJAKLJWLDNLAWND** flow, run the following command: ``flow start <name> target: <name2>``
+
+  A flow is the mechanism by which a transaction takes place using Corda. Flows are written as part of the CorDapp, and define the mechanisms by which parties transact.
+
+6. To check whether PartyB has received the transaction, open the terminal window showing PartyB's perspective, and run the following command: ``run vaultQuery contractStateType:net.corda.<STUFF>``
+
+  This command displays all of the STUFF states in the node's vault. States are immutable objects that represent shared facts between the parties. States serve as the inputs and outputs of transactions.
+
+Next steps
+----------
+
+After deploying the sample CorDapp, a useful next step is to look into the contents of a CorDapp in more detail, to better understand the concepts of flow, state, transactions, and contracts, before writing your own CorDapp.

--- a/docs/source/quickstart-deploy.rst
+++ b/docs/source/quickstart-deploy.rst
@@ -1,33 +1,41 @@
-Deploying an example CorDapp
-============================
+Running the example CorDapp
+===========================
 
-At this point we've set up the development environment, and have a sample CorDapp in an IntelliJ project. In this section, we'll deploy an instance of this CorDapp running on local nodes, including one notary, and two nodes, each representing one party in a transaction.
+At this point we've set up the development environment, and have an example CorDapp in an IntelliJ project. In this section, the CorDapp will be deployed to locally running Corda nodes.
 
-Steps
------
+The local Corda network includes one notary, and three nodes, each representing parties in the network. A Corda node is an individual instance of Corda representing one party in a network. For more information on nodes, see the `node documentation <./key-concepts-node.html>`_.
 
-Before continuing, ensure that you have
+Before continuing, ensure that you've `set up your development environment <./quickstart-index.html>`_.
 
+Step One: Deploy the CorDapp locally
+------------------------------------
 
-1. Navigate to the root directory of the sample CorDapp.
+The first step is to deploy the CorDapp to nodes running locally.
 
-2. Deploy the CorDapp by running the following command: ``./gradlew deployNodes``.
+1. Navigate to the root directory of the example CorDapp.
+
+2. Deploy the CorDapp by running the following command: ``./gradlew deployNodes``
 
 3. To best understand the deployment process, there are several perspectives it is helpful to see. Run the following command: ``build/nodes/runnodes``
 
-  This command opens three terminal windows: the notary, and a node each for PartyA and PartyB. A notary is a validation service that prevents double-spending and
+  This command opens four terminal windows: the notary, and a node each for PartyA, PartyB, and PartyC. A notary is a validation service that prevents double-spending, enforces timestamping, and may also validate transactions. For more information on notaries, see the `notary documentation <./key-concepts-notaries.html>`_.
 
-4. Click the second terminal window to see the perspective of PartyA.
+4. Go through the tabs to see the perspectives of other network members.
 
-5. After the PartyA node has been successfully deployed, flows can be executed from the perspective of PartyA. To execute the **AWBDJAKLJWLDNLAWND** flow, run the following command: ``flow start <name> target: <name2>``
+Step Two: Run a CorDapp transaction
+-----------------------------------
 
-  A flow is the mechanism by which a transaction takes place using Corda. Flows are written as part of the CorDapp, and define the mechanisms by which parties transact.
+1. Open the terminal window for PartyA. From this window, any flows executed will be from the perspective of PartyA.
 
-6. To check whether PartyB has received the transaction, open the terminal window showing PartyB's perspective, and run the following command: ``run vaultQuery contractStateType:net.corda.<STUFF>``
+2. To execute the ``ExampleFlow.kt`` flow, run the following command: ``flow start ExampleFlow iouValue: 1, otherParty: PartyB``
 
-  This command displays all of the STUFF states in the node's vault. States are immutable objects that represent shared facts between the parties. States serve as the inputs and outputs of transactions.
+   A flow is the mechanism by which a transaction takes place using Corda. This flow creates an instance of the IOU state, which requires an ``iouValue`` property. Flows are contained in CorDapps, and define the mechanisms by which parties transact. For more information on flows, see the `flow documentation <key-concepts-flows.html>`_.
+
+3. To check whether PartyB has received the transaction, open the terminal window showing PartyB's perspective, and run the following command: ``run vaultQuery contractStateType:net.corda.example.IOUState``
+
+  This command displays all of the IOU states in the node's vault. States are immutable objects that represent shared facts between the parties. States serve as the inputs and outputs of transactions.
 
 Next steps
 ----------
 
-After deploying the sample CorDapp, a useful next step is to look into the contents of a CorDapp in more detail, to better understand the concepts of flow, state, transactions, and contracts, before writing your own CorDapp.
+After deploying the example CorDapp, the next step is to start writing a CorDapp containing your own contract, states, and flows.

--- a/docs/source/quickstart-deploy.rst
+++ b/docs/source/quickstart-deploy.rst
@@ -38,4 +38,4 @@ Step Two: Run a CorDapp transaction
 Next steps
 ----------
 
-After deploying the example CorDapp, the next step is to start writing a CorDapp containing your own contract, states, and flows.
+After deploying the example CorDapp, the next step is to start `writing a CorDapp <./quickstart-build.html>`_ containing your own contract, states, and flows.

--- a/docs/source/quickstart-deploy.rst
+++ b/docs/source/quickstart-deploy.rst
@@ -18,11 +18,15 @@ The first step is to deploy the CorDapp to nodes running locally.
 
   To deploy the nodes on Mac or Linux run the following command: ``./gradlew clean deployNodes``
 
-3. To best understand the deployment process, there are several perspectives it is helpful to see. On Windows run the following command: ``build\nodes\runnodes``
+3. To best understand the deployment process, there are several perspectives it is helpful to see. On Windows run the following command: ``workflows-kotlin\build\nodes\runnodes``
 
-  On Mac/Linux run the following command: ``build/nodes/runnodes``
+  On Mac/Linux run the following command: ``workflows-kotlin/build/nodes/runnodes``
 
   This command opens four terminal windows: the notary, and a node each for PartyA, PartyB, and PartyC. A notary is a validation service that prevents double-spending, enforces timestamping, and may also validate transactions. For more information on notaries, see the `notary documentation <./key-concepts-notaries.html>`_.
+
+  .. note::
+
+    Maintain window focus on the node windows, if the nodes fail to load, close them using ``ctrl + d``. The ``runnodes`` script opens each node directory and runs ``java -jar corda.jar``.
 
 4. Go through the tabs to see the perspectives of other network members.
 
@@ -35,7 +39,7 @@ Step Two: Run a CorDapp transaction
 
    A flow is the mechanism by which a transaction takes place using Corda. This flow creates an instance of the IOU state, which requires an ``iouValue`` property. Flows are contained in CorDapps, and define the mechanisms by which parties transact. For more information on flows, see the `flow documentation <key-concepts-flows.html>`_.
 
-3. To check whether PartyB has received the transaction, open the terminal window showing PartyB's perspective, and run the following command: ``run vaultQuery contractStateType:net.corda.example.IOUState``
+3. To check whether PartyB has received the transaction, open the terminal window showing PartyB's perspective, and run the following command: ``run vaultQuery contractStateType: com.example.state.IOUState``
 
   This command displays all of the IOU states in the node's vault. States are immutable objects that represent shared facts between the parties. States serve as the inputs and outputs of transactions.
 

--- a/docs/source/quickstart-index.rst
+++ b/docs/source/quickstart-index.rst
@@ -15,22 +15,8 @@ Getting started with Corda will walk you through the process of setting up a dev
 2. `Deploying an example CorDapp <./quickstart-deploy.html>`_
 3. `Building your own CorDapp <./quickstart-build.html>`_
 
-The getting started experience is designed to be lightweight and get to code as quickly as possible, for more detail, see the following documentation:
-
-* CorDapp design best practice
-* Testing CorDapps
-
-For a more operations-focused experience, see the following operations documentation:
-
-* Node structure and configuration
-* Deploying a node
-* Notary docs
-* HSM configuration
-
 Setting up a development environment
 ------------------------------------
-
-**write some text here**
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -55,13 +41,13 @@ Step Two: Creating an IntelliJ project
 
 1. Open IntelliJ. From the splash screen, click **Open**, navigate to and select the ``cordapp-example`` folder, and click **Ok**. This creates an IntelliJ project to work from.
 
-2. Once the project is open, click **File**, then **Project Structure**. Under **Project SDK:**, set the project SDK by clicking **New...**, clicking **JDK**, and navigating to ``C:\Program Files\Java\jdk1.8.0_XXX`` on Windows or ``Library/Java/JavaVirtualMachines/jdk1.8.XXX`` on MacOSX, where ``XXX`` is the latest minor version number. Click **Apply** followed by **Ok**. This instructs IntelliJ to use the version of the Java JDK downloaded in the prerequisites.
+2. Once the project is open, click **File** > **Project Structure**. Under **Project SDK:**, set the project SDK by clicking **New...**, clicking **JDK**, and navigating to ``C:\Program Files\Java\jdk1.8.0_XXX`` on Windows or ``Library/Java/JavaVirtualMachines/jdk1.8.XXX`` on MacOSX, where ``XXX`` is the latest minor version number. Click **Ok**. This instructs IntelliJ to use the version of the Java JDK downloaded in the prerequisites.
 
-3. Click **File** then **Project Structure**, select **Modules**. Click **+**, then **Import Module**, then select the ``cordapp-example`` folder and click **Open**. Select **Import module from external model**, select **Gradle**, click **Next** then **Finish** and **Ok**. Gradle will now download all the project dependencies and perform some indexing.
+3. Click **File** > **Project Structure**, select **Modules**. Click **+**, > **Import Module**, then select the ``cordapp-example`` folder and click **Open**. Select **Import module from external model** > **Gradle** > **Next** > **Finish** > **Ok**. Gradle will now download all the project dependencies and perform some indexing.
 
 Your CorDapp development environment is now complete.
 
 Next steps
 ----------
 
-Now that you've successfully set up your CorDapp development environment, we'll cover deploying the example CorDapp locally.
+Now that you've successfully set up your CorDapp development environment, we'll cover deploying an example CorDapp locally, before writing a CorDapp from scratch.

--- a/docs/source/quickstart-index.rst
+++ b/docs/source/quickstart-index.rst
@@ -29,8 +29,8 @@ Step One: Downloading a sample project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Open a command prompt or terminal.
-2. Clone the CorDapp example repo by running: ``git clone https://github.com/corda/cordapp-example``
-3. Move into the ``cordapp-example`` folder by running: ``cd cordapp-example``
+2. Clone the CorDapp example repo by running: ``git clone https://github.com/corda/samples``
+3. Move into the ``cordapp-example`` folder by running: ``cd samples/cordapp-example``
 4. Checkout the corresponding branch by running: ``git checkout release-V4`` in the current directory.
 
 
@@ -41,7 +41,7 @@ Step Two: Creating an IntelliJ project
 
 2. Click **File** >  **Project Structure**. To set the project SDK click **New...** > **JDK**, and navigating to the installation directory of your JDK. Click **Apply**.
 
-3. Select **Modules** > **+** > **Import Module**. Select the ``cordapp-example`` folder and click **Open**. Select **Import module from external model** > **Gradle** > **Next** > **Finish** > **Ok**. Gradle will now download all the project dependencies and perform some indexing.
+3. Select **Modules** > **+** > **Import Module**. Select the ``cordapp-example`` folder and click **Open**. Select **Import module from external model** > **Gradle** > **Next** > tick the **Use auto-import** checkbox > **Finish** > **Ok**. Gradle will now download all the project dependencies and perform some indexing.
 
 Your CorDapp development environment is now complete.
 

--- a/docs/source/quickstart-index.rst
+++ b/docs/source/quickstart-index.rst
@@ -22,10 +22,9 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 * **Java 8 JVK** - We require at least version |java_version|, but do not currently support Java 9 or higher.
-* **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version |kotlin_version|)
-* **Gradle** - Gradle is a build automation tool that we use for dependency management. We use version 4.10 and the ``gradlew`` script in the project/samples directories will download it for you.
+* **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version |kotlin_version|).
 * **Git** - We use Git to host our sample CorDapp and provide version control.
-
+* **Gradle** - Gradle is a build automation tool that we use for dependency management. We use version 4.10 and the ``gradlew`` script in the project/samples directories will download it for you.
 
 Step One: Downloading a sample project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,9 +40,9 @@ Step Two: Creating an IntelliJ project
 
 1. Open IntelliJ. From the splash screen, click **Open**, navigate to and select the ``cordapp-example`` folder, and click **Ok**. This creates an IntelliJ project to work from.
 
-2. Once the project is open, click **File** > **Project Structure**. Under **Project SDK:**, set the project SDK by clicking **New...**, clicking **JDK**, and navigating to ``C:\Program Files\Java\jdk1.8.0_XXX`` on Windows or ``Library/Java/JavaVirtualMachines/jdk1.8.XXX`` on MacOSX, where ``XXX`` is the latest minor version number. Click **Ok**. This instructs IntelliJ to use the version of the Java JDK downloaded in the prerequisites.
+2. Click **File** >  **Project Structure**. To set the project SDK click **New...** > **JDK**, and navigating to the installation directory of your JDK. Click **Apply**.
 
-3. Click **File** > **Project Structure**, select **Modules**. Click **+**, > **Import Module**, then select the ``cordapp-example`` folder and click **Open**. Select **Import module from external model** > **Gradle** > **Next** > **Finish** > **Ok**. Gradle will now download all the project dependencies and perform some indexing.
+3. Select **Modules** > **+** > **Import Module**. Select the ``cordapp-example`` folder and click **Open**. Select **Import module from external model** > **Gradle** > **Next** > **Finish** > **Ok**. Gradle will now download all the project dependencies and perform some indexing.
 
 Your CorDapp development environment is now complete.
 

--- a/docs/source/quickstart-index.rst
+++ b/docs/source/quickstart-index.rst
@@ -24,7 +24,6 @@ Prerequisites
 * **Java 8 JVK** - We require at least version |java_version|, but do not currently support Java 9 or higher.
 * **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version |kotlin_version|).
 * **Git** - We use Git to host our sample CorDapp and provide version control.
-* **Gradle** - Gradle is a build automation tool that we use for dependency management. We use version 4.10 and the ``gradlew`` script in the project/samples directories will download it for you.
 
 Step One: Downloading a sample project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/quickstart-index.rst
+++ b/docs/source/quickstart-index.rst
@@ -11,10 +11,9 @@ Getting started developing CorDapps
 
 Getting started with Corda will walk you through the process of setting up a development environment, deploying an example CorDapp, and building your own CorDapp based on the example.
 
-1. Setting up a development environment
-2. Deploying an example CorDapp
-3. Understanding CorDapp contents
-4. Building your own CorDapp
+1. `Setting up a development environment`_
+2. `Deploying an example CorDapp <./quickstart-deploy.html>`_
+3. `Building your own CorDapp <./quickstart-build.html>`_
 
 The getting started experience is designed to be lightweight and get to code as quickly as possible, for more detail, see the following documentation:
 
@@ -46,9 +45,9 @@ Step One: Downloading a sample project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Open a command prompt or terminal.
-2. Clone the CorDapp example repo by running ``git clone https://github.com/corda/cordapp-example``
-3. Move into the ``cordapp-example`` folder by running ``cd cordapp-example``
-4. Checkout the corresponding branch for Corda Enterprise by running ``git checkout release-enterprise-V3`` in the current directory.
+2. Clone the CorDapp example repo by running: ``git clone https://github.com/corda/cordapp-example``
+3. Move into the ``cordapp-example`` folder by running: ``cd cordapp-example``
+4. Checkout the corresponding branch by running: ``git checkout release-V4`` in the current directory.
 
 
 Step Two: Creating an IntelliJ project

--- a/docs/source/quickstart-index.rst
+++ b/docs/source/quickstart-index.rst
@@ -1,111 +1,68 @@
-Quickstart
-==========
+Getting started developing CorDapps
+===================================
 
-Welcome to the Corda Quickstart Guide. Follow the links below to help get going quickly with Corda.
+.. toctree::
+  :hidden:
+  :titlesonly:
+  :maxdepth: 0
 
-I want to:
+  quickstart-deploy
+  quickstart-build
 
-* :ref:`Learn <quickstart-learn>` about Corda for the first time
-* :ref:`Develop <quickstart-develop>` a CorDapp
-* :ref:`Run <quickstart-run>` and test a CorDapp on a local Corda network
-* :ref:`Add <quickstart-add>` a node to an existing test Corda network
-* :ref:`Add <quickstart-production>` a node to an existing production network
+Getting started with Corda will walk you through the process of setting up a development environment, deploying an example CorDapp, and building your own CorDapp based on the example.
 
-.. _quickstart-learn:
+1. Setting up a development environment
+2. Deploying an example CorDapp
+3. Understanding CorDapp contents
+4. Building your own CorDapp
 
-Learn about Corda for the first time
+The getting started experience is designed to be lightweight and get to code as quickly as possible, for more detail, see the following documentation:
+
+* CorDapp design best practice
+* Testing CorDapps
+
+For a more operations-focused experience, see the following operations documentation:
+
+* Node structure and configuration
+* Deploying a node
+* Notary docs
+* HSM configuration
+
+Setting up a development environment
 ------------------------------------
 
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| Useful links                               | Description                                                                                |
-+============================================+============================================================================================+
-| :doc:`key-concepts`                        | The key concepts and features of the Corda Platform                                        |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`getting-set-up`                      | Set up your machine for running and developing CorDapps                                    |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`tutorial-cordapp`                    | A guide to running a simple CorDapp                                                        |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
+**write some text here**
 
-.. _quickstart-develop:
+Prerequisites
+~~~~~~~~~~~~~
 
-Develop a CorDapp
------------------
+* **Java 8 JVK** - We require at least version |java_version|, but do not currently support Java 9 or higher.
+* **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version |kotlin_version|)
+* **Gradle** - Gradle is a build automation tool that we use for dependency management. We use version 4.10 and the ``gradlew`` script in the project/samples directories will download it for you.
+* **Git** - We use Git to host our sample CorDapp and provide version control.
 
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| Useful links                               | Description                                                                                |
-+============================================+============================================================================================+
-| :doc:`hello-world-introduction`            | A coding walk-through of a basic CorDapp                                                   |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`cordapp-overview`                    | An introduction to CordApps                                                                |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`writing-a-cordapp`                   | How to structure a CorDapp project                                                         |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`cordapp-build-systems`               | How to build a CorDapp                                                                     |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`corda-api`                           | A guide to the CorDapp API                                                                 |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
 
-.. _quickstart-run:
+Step One: Downloading a sample project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run and test a CorDapp on local Corda network
----------------------------------------------
+1. Open a command prompt or terminal.
+2. Clone the CorDapp example repo by running ``git clone https://github.com/corda/cordapp-example``
+3. Move into the ``cordapp-example`` folder by running ``cd cordapp-example``
+4. Checkout the corresponding branch for Corda Enterprise by running ``git checkout release-enterprise-V3`` in the current directory.
 
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| Useful links                                   | Description                                                                            |
-+================================================+========================================================================================+
-| :doc:`generating-a-node`                       | Guidance on creating Corda nodes for development and testing locally and on Docker     |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| :doc:`node-structure`                          | The Corda node folder structure and how to name your node                              |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| :doc:`corda-configuration-file`                | A detailed description of the Corda node configuration file with examples              |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| :doc:`running-a-node`                          | Guidance on running Corda nodes locally and on Docker                                  |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| :doc:`setting-up-a-dynamic-compatibility-zone` | Considerations for setting up a Corda network                                          |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| :doc:`shell`                                   | Guidance on using an embedded command line to control and monitor a node               |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| :doc:`node-administration`                     | How to monitor a Corda node using an RPC interface                                     |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
-| :doc:`node-explorer`                           | A GUI-based tool to view transactional data and transactional history for a node       |
-+------------------------------------------------+----------------------------------------------------------------------------------------+
 
-.. _quickstart-add:
+Step Two: Creating an IntelliJ project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Add a node to an existing test Corda network
---------------------------------------------
+1. Open IntelliJ. From the splash screen, click **Open**, navigate to and select the ``cordapp-example`` folder, and click **Ok**. This creates an IntelliJ project to work from.
 
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| Useful links                               | Description                                                                                |
-+============================================+============================================================================================+
-| :doc:`node-structure`                      | The Corda node folder structure and how to name your node                                  |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`corda-configuration-file`            | A detailed description of the Corda node configuration file with examples                  |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`deploying-a-node`                    | A step-by-step guide on deploying a Corda node to your own server                          |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`azure-vm`                            | A step-by-step guide on creating a Corda Network on Azure                                  |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`aws-vm`                              | A step-by-step guide on creating a Corda Network on AWS                                    |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`shell`                               | Guidance on using an embedded command line to control and monitor a node                   |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`node-administration`                 | How to monitor a Corda node using an RPC interface                                         |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`node-explorer`                       | A GUI-based tool to view transactional data and transactional history for a node           |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
-| :doc:`blob-inspector`                      | A troubleshooting tool allowing you to read the contents of a binary blob file             |
-+--------------------------------------------+--------------------------------------------------------------------------------------------+
+2. Once the project is open, click **File**, then **Project Structure**. Under **Project SDK:**, set the project SDK by clicking **New...**, clicking **JDK**, and navigating to ``C:\Program Files\Java\jdk1.8.0_XXX`` on Windows or ``Library/Java/JavaVirtualMachines/jdk1.8.XXX`` on MacOSX, where ``XXX`` is the latest minor version number. Click **Apply** followed by **Ok**. This instructs IntelliJ to use the version of the Java JDK downloaded in the prerequisites.
 
-.. _quickstart-production:
+3. Click **File** then **Project Structure**, select **Modules**. Click **+**, then **Import Module**, then select the ``cordapp-example`` folder and click **Open**. Select **Import module from external model**, select **Gradle**, click **Next** then **Finish** and **Ok**. Gradle will now download all the project dependencies and perform some indexing.
 
-Add a node to an existing production network
---------------------------------------------
+Your CorDapp development environment is now complete.
 
-+---------------------------------------------------------------------------------------------------------+
-| Corda Network is a global production network of Corda nodes, operated by the independent                |
-| Corda Network Foundation. You can learn more here: https://corda.network/participation/index.html       |
-+---------------------------------------------------------------------------------------------------------+
-| Corda Testnet is a test network, operated for the community by R3. You can learn                        |
-| more here: https://testnet.corda.network                                                                |
-+---------------------------------------------------------------------------------------------------------+
+Next steps
+----------
+
+Now that you've successfully set up your CorDapp development environment, we'll cover deploying the example CorDapp locally.


### PR DESCRIPTION
Changes:

Main index
- Hide the ToC in the topic body, keep it in the sidebar.
- Update main ToC to only show topic titles, rather than topic subheadings.

Quickstart index
- Remove giant list.
- Combine prerequisites into index.
- Refactor for expectation setting.
- Set up development environment.

Quickstart deploy example
- Deploy the example cordapp locally.
- Introduce some Corda concepts with off-ramp links.

Quickstart build CorDapp
- Clone template CorDapp.
- Walk through building state, contract, and flow.
- Introduce more Corda developer concepts.
- Deploy CorDapp locally.
- Run a flow.

\*\*bonus change**

General docs config
- Add html config to set sensible defaults.

---

These docs are draft, I'm looking for both new dev experience feedback (@chrischabot ), technical improvement (@lankydan ), and any other feedback anyone wants to give. 

(There's more than likely still a typo or two in there somewhere.)

---
@gendal tagging you in case you're interested.