### PR TITLE
CORDA-2920 Hash to Signature Constraint automatic propagation

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
@@ -146,7 +146,7 @@ class TransactionBuilderTest {
     }, DummyContract.PROGRAM_ID)
 
     private fun signedAttachment(vararg parties: Party) = ContractAttachment.create(object : AbstractAttachment({ byteArrayOf() }, "test") {
-        override val id: SecureHash get() = throw UnsupportedOperationException()
+        override val id: SecureHash get() = contractAttachmentId
 
         override val signerKeys: List<PublicKey> get() = parties.map { it.owningKey }
     }, DummyContract.PROGRAM_ID, signerKeys = parties.map { it.owningKey })

--- a/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
@@ -7,10 +7,12 @@ import net.corda.core.contracts.*
 import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.*
 import net.corda.core.messaging.startFlow
+import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.CoreTransaction
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
@@ -19,8 +21,6 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.flows.isQuasarAgentSpecified
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
-import net.corda.testMessage.Message
-import net.corda.testMessage.MessageState
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverDSL
@@ -46,6 +46,7 @@ class SignatureConstraintVersioningTests {
     private val oldUnsignedCordapp = baseUnsigned.copy(versionId = 2)
     private val oldCordapp = base.copy(versionId = 2)
     private val newCordapp = base.copy(versionId = 3)
+    private val newUnsignedCordapp = baseUnsigned.copy(versionId = 3)
     private val user = User("mark", "dadada", setOf(startFlow<CreateMessage>(), startFlow<ConsumeMessage>(), invokeRpc("vaultQuery")))
     private val message = Message("Hello world!")
     private val transformedMessage = Message(message.value + "A")
@@ -55,9 +56,9 @@ class SignatureConstraintVersioningTests {
         assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
 
         val stateAndRef: StateAndRef<MessageState>? = internalDriver(
-            inMemoryDB = false,
-            startNodesInProcess = isQuasarAgentSpecified(),
-            networkParameters = testNetworkParameters(notaries = emptyList(), minimumPlatformVersion = 4)
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                networkParameters = testNetworkParameters(notaries = emptyList(), minimumPlatformVersion = 4)
         ) {
             val nodeName = {
                 val nodeHandle = startNode(NodeParameters(rpcUsers = listOf(user), additionalCordapps = listOf(oldCordapp))).getOrThrow()
@@ -71,18 +72,18 @@ class SignatureConstraintVersioningTests {
             val result = {
                 (baseDirectory(nodeName) / "cordapps").deleteRecursively()
                 val nodeHandle = startNode(
-                    NodeParameters(
-                        providedName = nodeName,
-                        rpcUsers = listOf(user),
-                        additionalCordapps = listOf(newCordapp)
-                    )
+                        NodeParameters(
+                                providedName = nodeName,
+                                rpcUsers = listOf(user),
+                                additionalCordapps = listOf(newCordapp)
+                        )
                 ).getOrThrow()
                 var result: StateAndRef<MessageState>? = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
                     val page = it.proxy.vaultQuery(MessageState::class.java)
                     page.states.singleOrNull()
                 }
                 CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-                    it.proxy.startFlow(::ConsumeMessage, result!!, defaultNotaryIdentity).returnValue.getOrThrow()
+                    it.proxy.startFlow(::ConsumeMessage, result!!, defaultNotaryIdentity, false, false).returnValue.getOrThrow()
                 }
                 result = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
                     val page = it.proxy.vaultQuery(MessageState::class.java)
@@ -100,18 +101,182 @@ class SignatureConstraintVersioningTests {
     @Test
     fun `auto migration from WhitelistConstraint to SignatureConstraint`() {
         assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
-        val transaction =
-            upgradeCorDappBetweenTransactions(oldUnsignedCordapp, newCordapp, listOf(oldUnsignedCordapp, newCordapp))
-        assertEquals(1, transaction.outputs.size)
-        assertTrue(transaction.outputs.single().constraint is SignatureAttachmentConstraint)
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newCordapp,
+            whiteListedCordapps = mapOf(
+                TEST_MESSAGE_CONTRACT_PROGRAM_ID to listOf(
+                    oldUnsignedCordapp,
+                    newCordapp
+                )
+            ),
+            systemProperties = emptyMap(),
+            startNodesInProcess = false
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is WhitelistedByZoneAttachmentConstraint)
+        assertEquals(1, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs.single().constraint is SignatureAttachmentConstraint)
     }
 
     @Test
-    fun `auto migration from WhitelistConstraint to SignatureConstraint fail for not whitelisted signed JAR`() {
+    fun `WhitelistConstraint cannot be migrated to SignatureConstraint if platform version is not 4 or greater`() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newCordapp,
+            whiteListedCordapps = mapOf(
+                TEST_MESSAGE_CONTRACT_PROGRAM_ID to listOf(
+                    oldUnsignedCordapp,
+                    newCordapp
+                )
+            ),
+            systemProperties = emptyMap(),
+            startNodesInProcess = false,
+            minimumPlatformVersion = 3
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is WhitelistedByZoneAttachmentConstraint)
+        assertEquals(1, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs.single().constraint is WhitelistedByZoneAttachmentConstraint)
+    }
+
+    @Test
+    fun `WhitelistConstraint cannot be migrated to SignatureConstraint if signed JAR is not whitelisted`() {
         assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
         assertThatExceptionOfType(CordaRuntimeException::class.java).isThrownBy {
-            upgradeCorDappBetweenTransactions(oldUnsignedCordapp, newCordapp, emptyList())
-        }.withMessageContaining("Selected output constraint: $WhitelistedByZoneAttachmentConstraint not satisfying")
+            upgradeCorDappBetweenTransactions(
+                cordapp = oldUnsignedCordapp,
+                newCordapp = newCordapp,
+                whiteListedCordapps = mapOf(TEST_MESSAGE_CONTRACT_PROGRAM_ID to emptyList()),
+                systemProperties = emptyMap(),
+                startNodesInProcess = true
+            )
+        }
+            .withMessageContaining("Selected output constraint: $WhitelistedByZoneAttachmentConstraint not satisfying")
+    }
+
+    @Test
+    fun `auto migration from WhitelistConstraint to SignatureConstraint will only transition states that do not have a constraint specified`() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newCordapp,
+            whiteListedCordapps = mapOf(
+                TEST_MESSAGE_CONTRACT_PROGRAM_ID to listOf(
+                    oldUnsignedCordapp,
+                    newCordapp
+                )
+            ),
+            systemProperties = emptyMap(),
+            startNodesInProcess = true,
+            specifyExistingConstraint = true,
+            addAnotherAutomaticConstraintState = true
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is WhitelistedByZoneAttachmentConstraint)
+        assertEquals(2, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs[0].constraint is WhitelistedByZoneAttachmentConstraint)
+        assertTrue(consumingTransaction.outputs[1].constraint is SignatureAttachmentConstraint)
+        assertEquals(
+            issuanceTransaction.outputs.single().constraint,
+            consumingTransaction.outputs.first().constraint,
+            "The constraint from the issuance transaction should be the same constraint used in the consuming transaction for the first state"
+        )
+    }
+
+    @Test
+    fun `auto migration from HashConstraint to SignatureConstraint`() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newCordapp,
+            whiteListedCordapps = emptyMap(),
+            systemProperties = mapOf("net.corda.node.disableHashConstraints" to true.toString()),
+            startNodesInProcess = false
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is HashAttachmentConstraint)
+        assertEquals(1, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs.single().constraint is SignatureAttachmentConstraint)
+    }
+
+    @Test
+    fun `HashConstraint cannot be migrated if 'disableHashConstraints' system property is not set to true`() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newCordapp,
+            whiteListedCordapps = emptyMap(),
+            systemProperties = emptyMap(),
+            startNodesInProcess = false
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is HashAttachmentConstraint)
+        assertEquals(1, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs.single().constraint is HashAttachmentConstraint)
+    }
+
+    @Test
+    fun `HashConstraint cannot be migrated to SignatureConstraint if new jar is not signed`() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newUnsignedCordapp,
+            whiteListedCordapps = emptyMap(),
+            systemProperties = mapOf("net.corda.node.disableHashConstraints" to true.toString()),
+            startNodesInProcess = false
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is HashAttachmentConstraint)
+        assertEquals(1, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs.single().constraint is HashAttachmentConstraint)
+    }
+
+    @Test
+    fun `HashConstraint cannot be migrated to SignatureConstraint if platform version is not 4 or greater`() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newCordapp,
+            whiteListedCordapps = emptyMap(),
+            systemProperties = mapOf("net.corda.node.disableHashConstraints" to true.toString()),
+            startNodesInProcess = false,
+            minimumPlatformVersion = 3
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is HashAttachmentConstraint)
+        assertEquals(1, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs.single().constraint is HashAttachmentConstraint)
+    }
+
+    @Test
+    fun `HashConstraint cannot be migrated to SignatureConstraint if a HashConstraint is specified for one state and another uses an AutomaticPlaceholderConstraint`() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
+        val (issuanceTransaction, consumingTransaction) = upgradeCorDappBetweenTransactions(
+            cordapp = oldUnsignedCordapp,
+            newCordapp = newCordapp,
+            whiteListedCordapps = emptyMap(),
+            systemProperties = mapOf("net.corda.node.disableHashConstraints" to true.toString()),
+            startNodesInProcess = false,
+            specifyExistingConstraint = true,
+            addAnotherAutomaticConstraintState = true
+        )
+        assertEquals(1, issuanceTransaction.outputs.size)
+        assertTrue(issuanceTransaction.outputs.single().constraint is HashAttachmentConstraint)
+        assertEquals(2, consumingTransaction.outputs.size)
+        assertTrue(consumingTransaction.outputs[0].constraint is HashAttachmentConstraint)
+        assertTrue(consumingTransaction.outputs[1].constraint is HashAttachmentConstraint)
+        assertEquals(
+            issuanceTransaction.outputs.single().constraint,
+            consumingTransaction.outputs.first().constraint,
+            "The constraint from the issuance transaction should be the same constraint used in the consuming transaction"
+        )
+        assertEquals(
+            consumingTransaction.outputs[0].constraint,
+            consumingTransaction.outputs[1].constraint,
+            "The AutomaticPlaceholderConstraint of the second state should become the same HashConstraint used in other state"
+        )
     }
 
     /**
@@ -121,44 +286,73 @@ class SignatureConstraintVersioningTests {
     private fun upgradeCorDappBetweenTransactions(
         cordapp: CustomCordapp,
         newCordapp: CustomCordapp,
-        whiteListedCordapps: List<CustomCordapp>
-    ): CoreTransaction {
+        whiteListedCordapps: Map<ContractClassName, List<CustomCordapp>>,
+        systemProperties: Map<String, String>,
+        startNodesInProcess: Boolean,
+        minimumPlatformVersion: Int = 4,
+        specifyExistingConstraint: Boolean = false,
+        addAnotherAutomaticConstraintState: Boolean = false
+    ): Pair<CoreTransaction, CoreTransaction> {
 
-        val attachmentHashes = whiteListedCordapps.map { Files.newInputStream(it.jarFile).readFully().sha256() }
+        val whitelistedAttachmentHashes = whiteListedCordapps.mapValues { (_, cordapps) ->
+            cordapps.map {
+                Files.newInputStream(it.jarFile).readFully().sha256()
+            }
+        }
 
         return internalDriver(
             inMemoryDB = false,
-            startNodesInProcess = isQuasarAgentSpecified(),
+            startNodesInProcess = startNodesInProcess,
             networkParameters = testNetworkParameters(
                 notaries = emptyList(),
-                minimumPlatformVersion = 4, whitelistedContractImplementations = mapOf(TEST_MESSAGE_CONTRACT_PROGRAM_ID to attachmentHashes)
-            )
+                minimumPlatformVersion = minimumPlatformVersion,
+                whitelistedContractImplementations = whitelistedAttachmentHashes
+            ),
+            systemProperties = systemProperties
         ) {
             // create transaction using first Cordapp
-            val (nodeName, baseDirectory) = createIssuanceTransaction(cordapp)
+            val (nodeName, baseDirectory, issuanceTransaction) = createIssuanceTransaction(cordapp)
             // delete the first cordapp
             deleteCorDapp(baseDirectory, cordapp)
             // create transaction using the upgraded cordapp resuing   input for transaction
-            createConsumingTransaction(nodeName, newCordapp).coreTransaction
+            val consumingTransaction = createConsumingTransaction(
+                nodeName,
+                newCordapp,
+                specifyExistingConstraint,
+                addAnotherAutomaticConstraintState
+            ).coreTransaction
+            issuanceTransaction to consumingTransaction
         }
     }
 
-    private fun DriverDSL.createIssuanceTransaction(cordapp: CustomCordapp): Pair<CordaX500Name, Path> {
-        val nodeHandle = startNode(NodeParameters(rpcUsers = listOf(user), additionalCordapps = listOf(cordapp))).getOrThrow()
+    private fun DriverDSL.createIssuanceTransaction(cordapp: CustomCordapp): Triple<CordaX500Name, Path, CoreTransaction> {
+        val nodeHandle = startNode(
+            NodeParameters(
+                rpcUsers = listOf(user),
+                additionalCordapps = listOf(cordapp)
+            )
+        ).getOrThrow()
         val nodeName = nodeHandle.nodeInfo.singleIdentity().name
-        CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-            it.proxy.startFlow(::CreateMessage, message, defaultNotaryIdentity).returnValue.getOrThrow()
+        val tx = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+            it.proxy.startFlow(::CreateMessage, message, defaultNotaryIdentity)
+                .returnValue.getOrThrow().coreTransaction
         }
         nodeHandle.stop()
-        return Pair(nodeName, nodeHandle.baseDirectory)
+        return Triple(nodeName, nodeHandle.baseDirectory, tx)
     }
 
     private fun deleteCorDapp(baseDirectory: Path, cordapp: CustomCordapp) {
-        val cordappPath = baseDirectory.resolve(Paths.get("cordapps")).resolve(cordapp.jarFile.fileName)
+        val cordappPath =
+            baseDirectory.resolve(Paths.get("cordapps")).resolve(cordapp.jarFile.fileName)
         cordappPath.delete()
     }
 
-    private fun DriverDSL.createConsumingTransaction(nodeName: CordaX500Name, cordapp: CustomCordapp): SignedTransaction {
+    private fun DriverDSL.createConsumingTransaction(
+        nodeName: CordaX500Name,
+        cordapp: CustomCordapp,
+        specifyExistingConstraint: Boolean,
+        addAnotherAutomaticConstraintState: Boolean
+    ): SignedTransaction {
         val nodeHandle = startNode(
             NodeParameters(
                 providedName = nodeName,
@@ -166,26 +360,43 @@ class SignatureConstraintVersioningTests {
                 additionalCordapps = listOf(cordapp)
             )
         ).getOrThrow()
-        val result: StateAndRef<MessageState>? = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-            val page = it.proxy.vaultQuery(MessageState::class.java)
-            page.states.singleOrNull()
-        }
-        val transaction = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-            it.proxy.startFlow(::ConsumeMessage, result!!, defaultNotaryIdentity).returnValue.getOrThrow()
-        }
+        val result: StateAndRef<MessageState>? =
+            CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                val page = it.proxy.vaultQuery(MessageState::class.java)
+                page.states.singleOrNull()
+            }
+        val transaction =
+            CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::ConsumeMessage,
+                    result!!,
+                    defaultNotaryIdentity,
+                    specifyExistingConstraint,
+                    addAnotherAutomaticConstraintState
+                )
+                    .returnValue.getOrThrow()
+            }
         nodeHandle.stop()
         return transaction
     }
 }
 
 @StartableByRPC
-class CreateMessage(private val message: Message, private val notary: Party) : FlowLogic<SignedTransaction>() {
+class CreateMessage(private val message: Message, private val notary: Party) :
+    FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call(): SignedTransaction {
         val messageState = MessageState(message = message, by = ourIdentity)
-        val txCommand = Command(DummyMessageContract.Commands.Send(), messageState.participants.map { it.owningKey })
-        val txBuilder = TransactionBuilder(notary).withItems(StateAndContract(messageState, TEST_MESSAGE_CONTRACT_PROGRAM_ID), txCommand)
-        txBuilder.toWireTransaction(serviceHub).toLedgerTransaction(serviceHub).verify()
+        val txCommand = Command(
+            DummyMessageContract.Commands.Send(),
+            messageState.participants.map { it.owningKey })
+        val txBuilder = TransactionBuilder(notary).withItems(
+            StateAndContract(
+                messageState,
+                TEST_MESSAGE_CONTRACT_PROGRAM_ID
+            ), txCommand
+        )
+        txBuilder.toLedgerTransaction(serviceHub).verify()
         val signedTx = serviceHub.signInitialTransaction(txBuilder)
         serviceHub.recordTransactions(signedTx)
         return signedTx
@@ -194,19 +405,58 @@ class CreateMessage(private val message: Message, private val notary: Party) : F
 
 //TODO merge both flows?
 @StartableByRPC
-class ConsumeMessage(private val stateRef: StateAndRef<MessageState>, private val notary: Party) : FlowLogic<SignedTransaction>() {
+class ConsumeMessage(
+    private val stateRef: StateAndRef<MessageState>,
+    private val notary: Party,
+    private val specifyExistingConstraint: Boolean,
+    private val addAnotherAutomaticConstraintState: Boolean
+) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call(): SignedTransaction {
         val oldMessageState = stateRef.state.data
-        val messageState = MessageState(Message(oldMessageState.message.value + "A"), ourIdentity, stateRef.state.data.linearId)
-        val txCommand = Command(DummyMessageContract.Commands.Send(), messageState.participants.map { it.owningKey })
-        val txBuilder =
-            TransactionBuilder(notary).withItems(StateAndContract(messageState, TEST_MESSAGE_CONTRACT_PROGRAM_ID), txCommand, stateRef)
+        val messageState = MessageState(
+            Message(oldMessageState.message.value + "A"),
+            ourIdentity,
+            stateRef.state.data.linearId
+        )
+        val txCommand = Command(
+            DummyMessageContract.Commands.Send(),
+            messageState.participants.map { it.owningKey })
+        val txBuilder = TransactionBuilder(notary).apply {
+            if (specifyExistingConstraint) {
+                addOutputState(messageState, stateRef.state.constraint)
+            } else {
+                addOutputState(messageState)
+            }
+            if (addAnotherAutomaticConstraintState) {
+                addOutputState(
+                    MessageState(
+                        Message("Another message"),
+                        ourIdentity,
+                        UniqueIdentifier()
+                    )
+                )
+            }
+            addInputState(stateRef)
+            addCommand(txCommand)
+        }
         txBuilder.toWireTransaction(serviceHub).toLedgerTransaction(serviceHub).verify()
         val signedTx = serviceHub.signInitialTransaction(txBuilder)
         serviceHub.recordTransactions(signedTx)
         return signedTx
     }
+}
+
+@CordaSerializable
+data class Message(val value: String)
+
+@BelongsToContract(DummyMessageContract::class)
+data class MessageState(
+    val message: Message,
+    val by: Party,
+    override val linearId: UniqueIdentifier = UniqueIdentifier()
+) : LinearState {
+    override val participants: List<AbstractParty> = listOf(by)
 }
 
 //TODO enrich original MessageContract for new command
@@ -216,9 +466,7 @@ open class DummyMessageContract : Contract {
     override fun verify(tx: LedgerTransaction) {
         val command = tx.commands.requireSingleCommand<Commands.Send>()
         requireThat {
-            // Generic constraints around the IOU transaction.
-            "Only one output state should be created." using (tx.outputs.size == 1)
-            val out = tx.outputsOfType<MessageState>().single()
+            val out = tx.outputsOfType<MessageState>().first()
             "Message sender must sign." using (command.signers.containsAll(out.participants.map { it.owningKey }))
             "Message value must not be empty." using (out.message.value.isNotBlank())
         }


### PR DESCRIPTION
Allow Hash Constraints to propagate to Signature Constraints. When
propagating, the new jar is added to the transaction instead of the
original contract attachment (jar).

The following requirements must be met to do so:
- System property "net.corda.node.disableHashConstraints" must be set
  to `true`
- The min platform version must be 4 or greater
- There must be an input state with a hash constraint
- There must be no output states with a hash constraint
- The new jar must be signed

If these requirements are not met, the original Hash
Constraint will be kept and the contract attachment related to it is
also used.

This transition is done at the start of `handleContract` as it is not
the normal path a transition would follow. It is considered a backdoor
and should be treated separately from the rest of the attachment and
constraint logic. Furthermore, it will only work in private network
since all nodes must set the special `disableHashConstraints` flag.