### PR TITLE
BACKPORT - docs reconnecting rpc correct link

### DIFF
--- a/docs/source/clientrpc.rst
+++ b/docs/source/clientrpc.rst
@@ -368,11 +368,11 @@ The only way to confirm is to perform a business-level query and retry according
 In case users require such a functionality to write a resilient RPC client we have a sample that showcases how this can be implemented and also
 a thorough test that demonstrates it works as expected.
 
-The code that performs the reconnecting logic is: `ReconnectingCordaRPCOps.kt <https://github.com/corda/samples/blob/release-V|platform_version|/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt>`_.
+The code that performs the reconnecting logic is: `ReconnectingCordaRPCOps.kt <https://github.com/corda/corda/blob/master/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt>`_.
 
 .. note:: This sample code is not exposed as an official Corda API, and must be included directly in the client codebase and adjusted.
 
-The usage is showcased in the: `RpcReconnectTests.kt <https://github.com/corda/samples/blob/release-V|platform_version|/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcReconnectTests.kt>`_.
+The usage is showcased in the: `RpcReconnectTests.kt <https://github.com/corda/corda/blob/master/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcReconnectTests.kt>`_.
 In case resiliency is a requirement, then it is recommended that users will write a similar test.
 
 How to initialize the `ReconnectingCordaRPCOps`:


### PR DESCRIPTION
(cherry picked from commit 2bfd2c8cb5c8ff894d63f825f58e893c44d3e432)

No related jira. Docs only change.