### PR TITLE
DOCS - use signInitialTransaction instead of toSignedTransaction in tutorial docs

### DIFF
--- a/docs/source/tutorial-contract.rst
+++ b/docs/source/tutorial-contract.rst
@@ -513,7 +513,7 @@ from the ledger). Finally, we add a Redeem command that should be signed by the 
 
 A ``TransactionBuilder`` is not by itself ready to be used anywhere, so first, we must convert it to something that
 is recognised by the network. The most important next step is for the participating entities to sign it. Typically,
-an initiating flow will create an initial partially signed ``SignedTransaction`` by calling the ``serviceHub.toSignedTransaction`` method.
+an initiating flow will create an initial partially signed ``SignedTransaction`` by calling the ``ServiceHub.signInitialTransaction`` method.
 Then the frozen ``SignedTransaction`` can be passed to other nodes by the flow, these can sign using ``serviceHub.createSignature`` and distribute.
 The ``CollectSignaturesFlow`` provides a generic implementation of this process that can be used as a ``subFlow`` .
 


### PR DESCRIPTION
Correcting the method name in ServiceHub. It is mentioned as serviceHub.toSignedTransaction where toSignedTransaction is a method from TransactionBuilder. 
Optionally this can be changed to TransactionBuilder.toSignedTransaction however as it is an internal function it is of less relevance I suppose.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [x] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
