### PR TITLE
Delete unused DuplicateContractClassException

### DIFF
--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -121,14 +121,10 @@ This is expanded upon in :ref:`contract_constraints_in_transactions`.
 .. note:: Signature Constraints are used by default except when a new transaction contains an input state with a Hash Constraint. In this
           situation the Hash Constraint is used.
 
-.. _app_versioning_with_signature_constraints:
-
 App versioning with Signature Constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Signed apps require a version number to be provided, see :doc:`versioning`. You can't import two different
-JARs that claim to be the same version, provide the same contract classes and which are both signed. At runtime
-the node will throw a ``DuplicateContractClassException`` exception if this condition is violated.
+Signed apps require a version number to be provided, see :doc:`versioning`.
 
 Hash Constraints
 ----------------

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -106,7 +106,7 @@ properly for future releases.
    future not hold true. You should know the platform version of the node releases you want to target.
 
 The new ``versionId`` number is a version code for **your** app, and is unrelated to Corda's own versions.
-It is used to informative purposes only. See ":ref:`app_versioning_with_signature_constraints`" for more information.
+It is used to informative purposes only.
 
 **Split your app into contract and workflow JARs.** The duplication between ``contract`` and ``workflow`` blocks exists because you should split your app into
 two separate JARs/modules, one that contains on-ledger validation code like states and contracts, and one

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -106,7 +106,7 @@ properly for future releases.
    future not hold true. You should know the platform version of the node releases you want to target.
 
 The new ``versionId`` number is a version code for **your** app, and is unrelated to Corda's own versions.
-It is used to informative purposes only.
+It is currently used for informative purposes only.
 
 **Split your app into contract and workflow JARs.** The duplication between ``contract`` and ``workflow`` blocks exists because you should split your app into
 two separate JARs/modules, one that contains on-ledger validation code like states and contracts, and one

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -98,6 +98,6 @@ It's entirely expected and reasonable to have an open source contracts module an
 sophisticated or proprietary business logic, machine learning models, even user interface code. There's nothing that restricts it to just
 being Corda flows or services.
 
-.. important:: The ``versionId`` specified for the JAR manifest is used for informative purposes only.
+.. important:: The ``versionId`` specified for the JAR manifest is currently used for informative purposes only.
 
 .. note:: You can read the original design doc here: :doc:`design/targetversion/design`.

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -98,7 +98,6 @@ It's entirely expected and reasonable to have an open source contracts module an
 sophisticated or proprietary business logic, machine learning models, even user interface code. There's nothing that restricts it to just
 being Corda flows or services.
 
-.. important:: The ``versionId`` specified for the JAR manifest is checked by the platform and is used for informative purposes only.
- See ":ref:`app_versioning_with_signature_constraints`" for more information.
+.. important:: The ``versionId`` specified for the JAR manifest is used for informative purposes only.
 
 .. note:: You can read the original design doc here: :doc:`design/targetversion/design`.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
@@ -12,12 +12,6 @@ import net.corda.core.serialization.CordaSerializable
 class DuplicateAttachmentException(attachmentHash: String) : java.nio.file.FileAlreadyExistsException(attachmentHash), ClientRelevantError
 
 /**
- * Thrown to indicate that a contract class name of the same version was already uploaded to a Corda node.
- */
-class DuplicateContractClassException(contractClassName: String, version: Int, attachmentHashes: List<String>) :
-        Exception("Contract $contractClassName version '$version' already present in the attachments $attachmentHashes"), ClientRelevantError
-
-/**
  * Thrown to indicate that a flow was not designed for RPC and should be started from an RPC client.
  */
 class NonRpcFlowException(logicType: Class<*>) : IllegalArgumentException("${logicType.name} was not designed for RPC"), ClientRelevantError

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -29,7 +29,6 @@ import net.corda.node.utilities.InfrequentlyMutatedCache
 import net.corda.node.utilities.NonInvalidatingCache
 import net.corda.node.utilities.NonInvalidatingWeightBasedCache
 import net.corda.nodeapi.exceptions.DuplicateAttachmentException
-import net.corda.nodeapi.exceptions.DuplicateContractClassException
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
 import net.corda.nodeapi.internal.persistence.currentDBSession

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -21,7 +21,6 @@ import net.corda.core.node.services.vault.Sort
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.nodeapi.exceptions.DuplicateAttachmentException
-import net.corda.nodeapi.exceptions.DuplicateContractClassException
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.common.internal.testNetworkParameters
@@ -384,7 +383,7 @@ class NodeAttachmentServiceTest {
     }
 
     @Test
-    fun `can promote to trusted uploder the same jar if other trusted uplodaer `() {
+    fun `can promote to trusted uploader the same jar if other trusted uploader `() {
         SelfCleaningDir().use { file ->
             val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
@@ -410,7 +409,7 @@ class NodeAttachmentServiceTest {
     }
 
     @Test
-    fun `can import duplicated contract class and version from unsiged attachment if a signed attachment already exists`() {
+    fun `can import duplicated contract class and version from unsigned attachment if a signed attachment already exists`() {
         SelfCleaningDir().use { file ->
             val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), generateManifest = false, jarFileName = "another-sample.jar")
@@ -428,7 +427,7 @@ class NodeAttachmentServiceTest {
     }
 
     @Test
-    fun `can import duplicated contract class and version from siged attachment if an unsigned attachment already exists`() {
+    fun `can import duplicated contract class and version from signed attachment if an unsigned attachment already exists`() {
         SelfCleaningDir().use { file ->
             val contractJar = makeTestContractJar(file.path, "com.example.MyContract")
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")


### PR DESCRIPTION
- Remove exception from code
- Remove reference to it in docs
- Tidy up docs since the versioning checks it mentions are not valid
- Fix spelling mistakes in test names