### PR TITLE
CORDA-2991 (Cont): set node info polling interval to 1 second in DriverDSL Node Startup

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt
@@ -3,6 +3,7 @@ package net.corda.nodeapi.internal.network
 import net.corda.core.internal.*
 import net.corda.core.utilities.contextLogger
 import net.corda.core.internal.NODE_INFO_DIRECTORY
+import net.corda.core.utilities.debug
 import rx.Observable
 import rx.Scheduler
 import rx.Subscription
@@ -94,7 +95,6 @@ class NodeInfoFilesCopier(private val scheduler: Scheduler = Schedulers.io()) : 
     private fun allPreviouslySeenFiles() = nodeDataMapBox.alreadyLocked { values.flatMap { it.previouslySeenFiles.keys } }
 
     private fun poll() {
-//        println("[${scheduler.now()}] poll")
         nodeDataMapBox.locked {
             for (nodeData in values) {
                 nodeData.nodeDir.list { paths ->
@@ -110,9 +110,7 @@ class NodeInfoFilesCopier(private val scheduler: Scheduler = Schedulers.io()) : 
     // Takes a path under nodeData config dir and decides whether the file represented by that path needs to
     // be copied.
     private fun processPath(nodeData: NodeData, path: Path) {
-//        println("[${scheduler.now()}] processPath ($path)")
         nodeDataMapBox.alreadyLocked {
-//            println("${path.fileName} (${path.lastModifiedTime()}: ${nodeData.previouslySeenFiles}")
             val newTimestamp = path.lastModifiedTime()
             val previousTimestamp = nodeData.previouslySeenFiles.put(path, newTimestamp) ?: FileTime.fromMillis(-1)
             if (newTimestamp > previousTimestamp) {
@@ -125,8 +123,7 @@ class NodeInfoFilesCopier(private val scheduler: Scheduler = Schedulers.io()) : 
     }
 
     private fun atomicCopy(source: Path, destination: Path) {
-        log.warn("[${scheduler.now()}] Copying ... $source -> $destination")
-
+        log.debug { "[${scheduler.now()}] Copying ... $source -> $destination" }
         val tempDestination = try {
             Files.createTempFile(destination.parent, "", null)
         } catch (exception: IOException) {

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -78,11 +78,11 @@ class NodeInfoWatcher(private val nodePath: Path,
     }
 
     private fun pollDirectory(): List<NodeInfoUpdate> {
-        logger.info("pollDirectory $nodeInfosDir")
+        logger.debug { "pollDirectory $nodeInfosDir" }
         val processedPaths = HashSet<Path>()
         val result = nodeInfosDir.list { paths ->
             paths
-                    .filter { logger.warn("Examining $it")
+                    .filter { logger.debug { "Examining $it" }
                             true}
                     .filter { it.isRegularFile() }
                     .filter { file ->
@@ -93,7 +93,7 @@ class NodeInfoWatcher(private val nodePath: Path,
                         newOrChangedFile
                     }
                     .mapNotNull { file ->
-                        logger.warn("Reading SignedNodeInfo from $file")
+                        logger.debug { "Reading SignedNodeInfo from $file" }
                         try {
                             val nodeInfoSigned = NodeInfoAndSigned(file.readObject())
                             nodeInfoFilesMap[file] = NodeInfoFromFile(nodeInfoSigned.signed.raw.hash, file.lastModifiedTime())
@@ -109,8 +109,8 @@ class NodeInfoWatcher(private val nodePath: Path,
         val removedHashes = removedFiles.map { file ->
             NodeInfoUpdate.Remove(nodeInfoFilesMap.remove(file)!!.nodeInfohash)
         }
-        logger.warn("Read ${result.size} NodeInfo files from $nodeInfosDir")
-        logger.warn("Number of removed NodeInfo files ${removedHashes.size}")
+        logger.debug { "Read ${result.size} NodeInfo files from $nodeInfosDir" }
+        logger.debug { "Number of removed NodeInfo files ${removedHashes.size}" }
         return result.map { NodeInfoUpdate.Add(it.nodeInfo) } + removedHashes
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -78,9 +78,12 @@ class NodeInfoWatcher(private val nodePath: Path,
     }
 
     private fun pollDirectory(): List<NodeInfoUpdate> {
+        logger.info("pollDirectory $nodeInfosDir")
         val processedPaths = HashSet<Path>()
         val result = nodeInfosDir.list { paths ->
             paths
+                    .filter { logger.warn("Examining $it")
+                            true}
                     .filter { it.isRegularFile() }
                     .filter { file ->
                         val lastModifiedTime = file.lastModifiedTime()
@@ -90,7 +93,7 @@ class NodeInfoWatcher(private val nodePath: Path,
                         newOrChangedFile
                     }
                     .mapNotNull { file ->
-                        logger.debug { "Reading SignedNodeInfo from $file" }
+                        logger.warn("Reading SignedNodeInfo from $file")
                         try {
                             val nodeInfoSigned = NodeInfoAndSigned(file.readObject())
                             nodeInfoFilesMap[file] = NodeInfoFromFile(nodeInfoSigned.signed.raw.hash, file.lastModifiedTime())
@@ -106,8 +109,8 @@ class NodeInfoWatcher(private val nodePath: Path,
         val removedHashes = removedFiles.map { file ->
             NodeInfoUpdate.Remove(nodeInfoFilesMap.remove(file)!!.nodeInfohash)
         }
-        logger.debug { "Read ${result.size} NodeInfo files from $nodeInfosDir" }
-        logger.debug { "Number of removed NodeInfo files ${removedHashes.size}" }
+        logger.warn("Read ${result.size} NodeInfo files from $nodeInfosDir")
+        logger.warn("Number of removed NodeInfo files ${removedHashes.size}")
         return result.map { NodeInfoUpdate.Add(it.nodeInfo) } + removedHashes
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -239,7 +239,8 @@ class DriverDSLImpl(
                 NodeConfiguration::useTestClock.name to useTestClock,
                 NodeConfiguration::rpcUsers.name to if (users.isEmpty()) defaultRpcUserList else users.map { it.toConfig().root().unwrapped() },
                 NodeConfiguration::verifierType.name to parameters.verifierType.name,
-                NodeConfiguration::flowOverrides.name to flowOverrideConfig.toConfig().root().unwrapped()
+                NodeConfiguration::flowOverrides.name to flowOverrideConfig.toConfig().root().unwrapped(),
+                NodeConfiguration::additionalNodeInfoPollingFrequencyMsec.name to 1000
         ) + czUrlConfig + jmxConfig + parameters.customOverrides
         val config = NodeConfig(ConfigHelper.loadConfig(
                 baseDirectory = baseDirectory(name),

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -112,9 +112,6 @@ class DriverDSLImpl(
     private lateinit var _notaries: CordaFuture<List<NotaryHandle>>
     override val notaryHandles: List<NotaryHandle> get() = _notaries.getOrThrow()
 
-    // While starting with inProcess mode, we need to have different names to avoid clashes
-    private val inMemoryCounter = AtomicInteger()
-
     interface Waitable {
         @Throws(InterruptedException::class)
         fun waitFor()
@@ -678,6 +675,9 @@ class DriverDSLImpl(
 
     companion object {
         internal val log = contextLogger()
+
+        // While starting with inProcess mode, we need to have different names to avoid clashes
+        private val inMemoryCounter = AtomicInteger()
 
         private val notaryHandleTimeout = Duration.ofMinutes(1)
         private val defaultRpcUserList = listOf(InternalUser("default", "default", setOf("ALL")).toConfig().root().unwrapped())


### PR DESCRIPTION
Fix flakiness in test execution on fast hardware.
 Follow-up to https://github.com/corda/corda/pull/5240

Continuation of [CORDA-2991 shorten poll intervals for node info file propagation](https://r3-cev.atlassian.net/browse/CORDA-2991)