### PR TITLE
AppendOnlyPersistentMapBase.allPersisted no longer loads everything into memory at once

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -45,12 +45,15 @@ import java.util.*
 import java.util.Spliterator.*
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
+import java.util.stream.Collectors.toCollection
 import java.util.stream.IntStream
 import java.util.stream.Stream
 import java.util.stream.StreamSupport
 import java.util.zip.Deflater
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import kotlin.collections.LinkedHashSet
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 
@@ -272,6 +275,9 @@ inline fun <T, R : Any> Stream<T>.mapNotNull(crossinline transform: (T) -> R?): 
         if (value != null) Stream.of(value) else Stream.empty()
     }
 }
+
+/** Similar to [Collectors.toSet] except the Set is guaranteed to be ordered. */
+fun <T> Stream<T>.toSet(): Set<T> = collect(toCollection { LinkedHashSet<T>() })
 
 fun <T> Class<T>.castIfPossible(obj: Any): T? = if (isInstance(obj)) cast(obj) else null
 

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -4,12 +4,12 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.*
 import net.corda.core.internal.NamedCacheFactory
 import net.corda.core.internal.hash
+import net.corda.core.internal.toSet
 import net.corda.core.node.services.UnknownAnonymousPartyException
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.MAX_HASH_HEX_SIZE
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
-import net.corda.core.utilities.toBase58String
 import net.corda.node.services.api.IdentityServiceInternal
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.nodeapi.internal.crypto.X509CertificateFactory
@@ -25,6 +25,7 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
+import kotlin.streams.toList
 
 /**
  * An identity service that stores parties and their identities to a key value tables in the database. The entries are
@@ -171,8 +172,10 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     // We give the caller a copy of the data set to avoid any locking problems
-    override fun getAllIdentities(): Iterable<PartyAndCertificate> = database.transaction {
-        keyToParties.allPersisted().map { it.second }.asIterable()
+    override fun getAllIdentities(): Iterable<PartyAndCertificate> {
+        return database.transaction {
+            keyToParties.allPersisted.use { it.map { it.second }.toList() }
+        }
     }
 
     override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = certificateFromCordaX500Name(name)?.party
@@ -190,13 +193,9 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
 
     override fun partiesFromName(query: String, exactMatch: Boolean): Set<Party> {
         return database.transaction {
-            val results = LinkedHashSet<Party>()
-            principalToParties.allPersisted().forEach { (x500name, partyId) ->
-                if (x500Matches(query, exactMatch, x500name)) {
-                    results += keyToParties[partyId]!!.party
-                }
+            principalToParties.allPersisted.use {
+                it.filter { x500Matches(query, exactMatch, it.first) }.map { keyToParties[it.second]!!.party }.toSet()
             }
-            results
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.keys
 import net.corda.core.crypto.*
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.NamedCacheFactory
+import net.corda.core.internal.toSet
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.MAX_HASH_HEX_SIZE
 import net.corda.node.services.identity.PersistentIdentityService
@@ -69,7 +70,7 @@ class PersistentKeyManagementService(cacheFactory: NamedCacheFactory, val identi
         initialKeyPairs.forEach { keysMap.addWithDuplicatesAllowed(it.public, it.private) }
     }
 
-    override val keys: Set<PublicKey> get() = database.transaction { keysMap.allPersisted().map { it.first }.toSet() }
+    override val keys: Set<PublicKey> get() = database.transaction { keysMap.allPersisted.use { it.map { it.first }.toSet() } }
 
     override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> = database.transaction {
         identityService.stripNotOurKeys(candidateKeys)

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY
 import rx.Observable
 import rx.subjects.PublishSubject
 import javax.persistence.*
+import kotlin.streams.toList
 
 // cache value type to just store the immutable bits of a signed transaction plus conversion helpers
 typealias TxCacheValue = Pair<SerializedBytes<CoreTransaction>, List<TransactionSignature>>
@@ -88,10 +89,7 @@ class DBTransactionStorage(private val database: CordaPersistence, cacheFactory:
         private const val transactionSignatureOverheadEstimate = 1024
 
         private fun weighTx(tx: AppendOnlyPersistentMapBase.Transactional<TxCacheValue>): Int {
-            val actTx = tx.peekableValue
-            if (actTx == null) {
-                return 0
-            }
+            val actTx = tx.peekableValue ?: return 0
             return actTx.second.sumBy { it.size + transactionSignatureOverheadEstimate } + actTx.first.size
         }
     }
@@ -114,7 +112,7 @@ class DBTransactionStorage(private val database: CordaPersistence, cacheFactory:
     override fun track(): DataFeed<List<SignedTransaction>, SignedTransaction> {
         return database.transaction {
             txStorage.locked {
-                DataFeed(allPersisted().map { it.second.toSignedTx() }.toList(), updates.bufferUntilSubscribed())
+                DataFeed(snapshot(), updates.bufferUntilSubscribed())
             }
         }
     }
@@ -133,6 +131,7 @@ class DBTransactionStorage(private val database: CordaPersistence, cacheFactory:
     }
 
     @VisibleForTesting
-    val transactions: Iterable<SignedTransaction>
-        get() = database.transaction { txStorage.content.allPersisted().map { it.second.toSignedTx() }.toList() }
+    val transactions: List<SignedTransaction> get() = database.transaction { snapshot() }
+
+    private fun snapshot() = txStorage.content.allPersisted.use { it.map { it.second.toSignedTx() }.toList() }
 }

--- a/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmart.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmart.kt
@@ -335,7 +335,7 @@ object BFTSmart {
             // LinkedHashMap for deterministic serialisation
             val committedStates = LinkedHashMap<StateRef, SecureHash>()
             val requests = services.database.transaction {
-                commitLog.allPersisted().forEach { committedStates[it.first] = it.second }
+                commitLog.allPersisted.use { it.forEach { committedStates[it.first] = it.second } }
                 val criteriaQuery = session.criteriaBuilder.createQuery(PersistentUniquenessProvider.Request::class.java)
                 criteriaQuery.select(criteriaQuery.from(PersistentUniquenessProvider.Request::class.java))
                 session.createQuery(criteriaQuery).resultList

--- a/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftTransactionCommitLog.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftTransactionCommitLog.kt
@@ -175,11 +175,13 @@ class RaftTransactionCommitLog<E, EK>(
      */
     override fun snapshot(writer: SnapshotWriter) {
         db.transaction {
-            writer.writeInt(map.size)
-            map.allPersisted().forEach {
-                val bytes = it.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes
-                writer.writeUnsignedShort(bytes.size)
-                writer.writeObject(bytes)
+            writer.writeInt(map.size.toInt())
+            map.allPersisted.use {
+                it.forEach {
+                    val bytes = it.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes
+                    writer.writeUnsignedShort(bytes.size)
+                    writer.writeObject(bytes)
+                }
             }
 
             val criteriaQuery = session.criteriaBuilder.createQuery(PersistentUniquenessProvider.Request::class.java)


### PR DESCRIPTION
As a general purpose API, allPersisted should not be loading the entire contents of the database table into memory. Instead now it returns a Stream for processing one element at a time.


