### PR TITLE
CORDA-2216 Restrict extended key usage of certificate types

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -396,9 +396,6 @@ class X509CertificateFactory {
 enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurposeId, val isCA: Boolean, val role: CertRole?) {
     ROOT_CA(
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyCertSign or KeyUsage.cRLSign),
-            KeyPurposeId.id_kp_serverAuth,
-            KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = true,
             role = null
     ),
@@ -407,7 +404,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyCertSign or KeyUsage.cRLSign),
             KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = true,
             role = CertRole.DOORMAN_CA
     ),
@@ -416,7 +412,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
             KeyUsage(KeyUsage.digitalSignature),
             KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = false,
             role = CertRole.NETWORK_MAP
     ),
@@ -425,7 +420,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
             KeyUsage(KeyUsage.digitalSignature),
             KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = false,
             role = CertRole.SERVICE_IDENTITY
     ),
@@ -434,7 +428,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyCertSign or KeyUsage.cRLSign),
             KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = true,
             role = CertRole.NODE_CA
     ),
@@ -443,7 +436,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyEncipherment or KeyUsage.keyAgreement),
             KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = false,
             role = CertRole.TLS
     ),
@@ -451,18 +443,12 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
     // TODO: Identity certs should have tight name constraints on child certificates
     LEGAL_IDENTITY(
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyCertSign),
-            KeyPurposeId.id_kp_serverAuth,
-            KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = true,
             role = CertRole.LEGAL_IDENTITY
     ),
 
     CONFIDENTIAL_LEGAL_IDENTITY(
             KeyUsage(KeyUsage.digitalSignature),
-            KeyPurposeId.id_kp_serverAuth,
-            KeyPurposeId.id_kp_clientAuth,
-            KeyPurposeId.anyExtendedKeyUsage,
             isCA = false,
             role = CertRole.CONFIDENTIAL_LEGAL_IDENTITY
     ),

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -2,7 +2,6 @@ package net.corda.nodeapi.internal.crypto
 
 import net.corda.core.CordaOID
 import net.corda.core.crypto.Crypto
-import net.corda.core.crypto.SignatureScheme
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.*
 import net.corda.core.utilities.days
@@ -402,7 +401,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
 
     INTERMEDIATE_CA(
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyCertSign or KeyUsage.cRLSign),
-            KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
             isCA = true,
             role = CertRole.DOORMAN_CA
@@ -410,7 +408,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
 
     NETWORK_MAP(
             KeyUsage(KeyUsage.digitalSignature),
-            KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
             isCA = false,
             role = CertRole.NETWORK_MAP
@@ -418,7 +415,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
 
     SERVICE_IDENTITY(
             KeyUsage(KeyUsage.digitalSignature),
-            KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
             isCA = false,
             role = CertRole.SERVICE_IDENTITY
@@ -426,7 +422,6 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
 
     NODE_CA(
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyCertSign or KeyUsage.cRLSign),
-            KeyPurposeId.id_kp_serverAuth,
             KeyPurposeId.id_kp_clientAuth,
             isCA = true,
             role = CertRole.NODE_CA
@@ -443,18 +438,21 @@ enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurpo
     // TODO: Identity certs should have tight name constraints on child certificates
     LEGAL_IDENTITY(
             KeyUsage(KeyUsage.digitalSignature or KeyUsage.keyCertSign),
+            KeyPurposeId.id_kp_clientAuth,
             isCA = true,
             role = CertRole.LEGAL_IDENTITY
     ),
 
     CONFIDENTIAL_LEGAL_IDENTITY(
             KeyUsage(KeyUsage.digitalSignature),
+            KeyPurposeId.id_kp_clientAuth,
             isCA = false,
             role = CertRole.CONFIDENTIAL_LEGAL_IDENTITY
     ),
 
     NETWORK_PARAMETERS(
             KeyUsage(KeyUsage.digitalSignature),
+            KeyPurposeId.id_kp_clientAuth,
             isCA = false,
             role = CertRole.NETWORK_PARAMETERS
     )


### PR DESCRIPTION
- Remove `anyExtendedKeyUsage` from all certificates
- Restrict to server and client auth for all certificates except `ROOT_CA` which has had all extended key usages removed

In regards to https://r3-cev.atlassian.net/browse/CORDA-2216