### PR TITLE
Add MockNet support for custom Notary class

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,6 +35,8 @@ Version 5.0
 Version 4.2
 -----------
 
+* The MockNet now supports setting a custom Notary class name, as was already supported by normal node config. See :doc:`tutorial-custom-notary`.
+
 * Contract attachments are now automatically whitelisted by the node if another contract attachment is present with the same contract classes,
   signed by the same public keys, and uploaded by a trusted uploader. This allows the node to resolve transactions that use earlier versions
   of a contract without having to manually install that version, provided a newer version is installed. Similarly, non-contract attachments

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,8 @@ release, see :doc:`app-upgrade-notes`.
 Version 5.0
 -----------
 
+* The MockNet now supports setting a custom Notary class name, as was already supported by normal node config. See :doc:`tutorial-custom-notary`.
+
 * Introduced a new ``Destination`` abstraction for communicating with non-Party destinations using the new ``FlowLogic.initateFlow(Destination)``
   method. ``Party`` and ``AnonymousParty`` have been retrofitted to implement ``Destination``. Initiating a flow to an ``AnonymousParty``
   means resolving to the well-known identity ``Party`` and then communicating with that.
@@ -34,8 +36,6 @@ Version 5.0
 
 Version 4.2
 -----------
-
-* The MockNet now supports setting a custom Notary class name, as was already supported by normal node config. See :doc:`tutorial-custom-notary`.
 
 * Contract attachments are now automatically whitelisted by the node if another contract attachment is present with the same contract classes,
   signed by the same public keys, and uploaded by a trusted uploader. This allows the node to resolve transactions that use earlier versions

--- a/docs/source/tutorial-custom-notary.rst
+++ b/docs/source/tutorial-custom-notary.rst
@@ -33,3 +33,16 @@ To enable the service, add the following to the node configuration:
         validating : true # Set to false if your service is non-validating
         className : "net.corda.notarydemo.MyCustomValidatingNotaryService" # The fully qualified name of your service class
     }
+
+Testing your custom notary service
+---------------------------------
+
+To create a flow test that uses your custom notary service, you can set the class name of the custom notary service as follows in your flow test:
+
+.. literalinclude:: ../../testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt
+   :language: kotlin
+   :start-after: START 1
+   :end-before: END 1
+
+After this, your custom notary will be the default notary on the mock network, and can be used in the same way as described in :doc:`flow-testing`.
+

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -125,9 +125,7 @@ data class MockNetworkParameters(
  * @property validating Boolean for whether the notary is validating or non-validating.
  * @property className String the optional name of a notary service class to load. If null, a builtin notary is loaded.
  */
-data class MockNetworkNotarySpec(val name: CordaX500Name, val validating: Boolean = true, val className: String? = null) {
-    constructor(name: CordaX500Name) : this(name, validating = true)
-}
+data class MockNetworkNotarySpec @JvmOverloads constructor(val name: CordaX500Name, val validating: Boolean = true, val className: String? = null)
 
 /** A class that represents an unstarted mock node for testing. */
 class UnstartedMockNode private constructor(private val node: InternalMockNetwork.MockNode) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -104,6 +104,7 @@ data class MockNetworkParameters(
     fun withServicePeerAllocationStrategy(servicePeerAllocationStrategy: InMemoryMessagingNetwork.ServicePeerAllocationStrategy): MockNetworkParameters {
         return copy(servicePeerAllocationStrategy = servicePeerAllocationStrategy)
     }
+
     fun withNotarySpecs(notarySpecs: List<MockNetworkNotarySpec>): MockNetworkParameters = copy(notarySpecs = notarySpecs)
     fun withCordappsForAllNodes(cordappsForAllNodes: Collection<TestCordapp>): MockNetworkParameters = copy(cordappsForAllNodes = cordappsForAllNodes)
 
@@ -125,7 +126,13 @@ data class MockNetworkParameters(
  * @property validating Boolean for whether the notary is validating or non-validating.
  * @property className String the optional name of a notary service class to load. If null, a builtin notary is loaded.
  */
-data class MockNetworkNotarySpec @JvmOverloads constructor(val name: CordaX500Name, val validating: Boolean = true, val className: String? = null)
+data class MockNetworkNotarySpec @JvmOverloads constructor(val name: CordaX500Name, val validating: Boolean = true) {
+    var className: String? = null
+
+    constructor(name: CordaX500Name, validating: Boolean = true, className: String? = null) : this(name, validating) {
+        this.className = className
+    }
+}
 
 /** A class that represents an unstarted mock node for testing. */
 class UnstartedMockNode private constructor(private val node: InternalMockNetwork.MockNode) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -123,8 +123,9 @@ data class MockNetworkParameters(
  *
  * @property name The name of the notary node.
  * @property validating Boolean for whether the notary is validating or non-validating.
+ * @property className String the optional name of a notary service class to load. If null, a builtin notary is loaded.
  */
-data class MockNetworkNotarySpec(val name: CordaX500Name, val validating: Boolean = true) {
+data class MockNetworkNotarySpec(val name: CordaX500Name, val validating: Boolean = true, val className: String? = null) {
     constructor(name: CordaX500Name) : this(name, validating = true)
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -249,10 +249,10 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
 
     @VisibleForTesting
     internal open fun createNotaries(): List<TestStartedNode> {
-        return notarySpecs.map { (name, validating) ->
+        return notarySpecs.map { (name, validating, className) ->
             createNode(InternalMockNodeParameters(
                     legalName = name,
-                    configOverrides = { doReturn(NotaryConfig(validating)).whenever(it).notary }
+                    configOverrides = { doReturn(NotaryConfig(validating, className = className)).whenever(it).notary }
             ))
         }
     }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -249,10 +249,10 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
 
     @VisibleForTesting
     internal open fun createNotaries(): List<TestStartedNode> {
-        return notarySpecs.map { (name, validating, className) ->
+        return notarySpecs.map { spec ->
             createNode(InternalMockNodeParameters(
-                    legalName = name,
-                    configOverrides = { doReturn(NotaryConfig(validating, className = className)).whenever(it).notary }
+                    legalName = spec.name,
+                    configOverrides = { doReturn(NotaryConfig(spec.validating, className = spec.className)).whenever(it).notary }
             ))
         }
     }

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt
@@ -1,0 +1,77 @@
+package net.corda.testing.node
+
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.NotaryFlow
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.internal.notary.NotaryService
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.api.ServiceHubInternal
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.enclosedCordapp
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.security.PublicKey
+import java.util.*
+
+class CustomNotaryTest {
+    private lateinit var mockNet: MockNetwork
+    private lateinit var notaryNode: StartedMockNode
+    private lateinit var aliceNode: StartedMockNode
+    private lateinit var notary: Party
+    private lateinit var alice: Party
+
+    @Before
+    fun setup() {
+        // START 1
+        mockNet = MockNetwork(MockNetworkParameters(
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
+                notarySpecs = listOf(MockNetworkNotarySpec(
+                        name = CordaX500Name("Custom Notary", "Amsterdam", "NL"),
+                        className = "net.corda.testing.node.CustomNotaryTest\$CustomNotaryService",
+                        validating = false // Can also be validating if preferred.
+                ))
+        ))
+        // END 1
+        aliceNode = mockNet.createPartyNode(ALICE_NAME)
+        notaryNode = mockNet.defaultNotaryNode
+        notary = mockNet.defaultNotaryIdentity
+        alice = aliceNode.info.singleIdentity()
+    }
+
+    @After
+    fun tearDown() {
+        mockNet.stopNodes()
+    }
+
+    @Test(expected = CustomNotaryException::class)
+    fun `custom notary service is active`() {
+        val tx = DummyContract.generateInitial(Random().nextInt(), notary, alice.ref(0))
+        val stx = aliceNode.services.signInitialTransaction(tx)
+        val future = aliceNode.startFlow(NotaryFlow.Client(stx))
+        mockNet.runNetwork()
+        future.getOrThrow()
+    }
+
+    class CustomNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : NotaryService() {
+
+        override fun createServiceFlow(otherPartySession: FlowSession): FlowLogic<Void?> =
+                object : FlowLogic<Void?>() {
+                    override fun call(): Void? {
+                        throw CustomNotaryException("Proof that a custom notary service is running!")
+                    }
+                }
+
+        override fun start() {}
+        override fun stop() {}
+    }
+
+    class CustomNotaryException(message: String) : FlowException(message)
+}
+


### PR DESCRIPTION
Currently it is possible to run a notary with a custom service class as described here: https://docs.corda.net/tutorial-custom-notary.html. What that page does **not** describe is how to write a flow test using your custom notary. This is because that is currently not possible (or at least not in an elegant way). This PR makes it possible to set the className property in the MockNetworkNotarySpec like so:

```kotlin
MockNetworkNotarySpec(
        name = CordaX500Name("Custom Notary", "Amsterdam", "NL"),
        className = "net.corda.testing.node.CustomNotaryTest\$CustomNotaryService"
)
```

# PR Checklist:

- [X] Tests are ok, new test added that proves that the custom notary is actually the one responding to notarisation requests.
- [X] JavaDoc amended.
- [X] One line added to changelog for 4.2.
- [X] This is not my first PR. (see https://github.com/corda/corda/blob/master/CONTRIBUTORS.md). But since it has been a long time: I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/).
