### PR TITLE
[CORDA-2923] Ensure the RPC connection is closed in Reconnection test

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientReconnectionTest.kt
@@ -49,24 +49,24 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            val connection = client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true)
-            val rpcOps = connection.proxy
-            val networkParameters = rpcOps.networkParameters
-            val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
-            cashStatesFeed.updates.subscribe { latch.countDown() }
-            rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
+            client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true).use {
+                val rpcOps = it.proxy
+                val networkParameters = rpcOps.networkParameters
+                val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
+                cashStatesFeed.updates.subscribe { latch.countDown() }
+                rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
 
-            node.stop()
-            startNode()
+                node.stop()
+                startNode()
 
-            rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
+                rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
 
-            val networkParametersAfterCrash = rpcOps.networkParameters
-            assertThat(networkParameters).isEqualTo(networkParametersAfterCrash)
-            assertTrue {
-                latch.await(2, TimeUnit.SECONDS)
+                val networkParametersAfterCrash = rpcOps.networkParameters
+                assertThat(networkParameters).isEqualTo(networkParametersAfterCrash)
+                assertTrue {
+                    latch.await(2, TimeUnit.SECONDS)
+                }
             }
-            connection.close()
         }
     }
 
@@ -89,23 +89,23 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            val connection = client.start(rpcUser.username, rpcUser.password, true)
-            val rpcOps = connection.proxy
-            val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
-            val subscription = cashStatesFeed.updates.subscribe { latch.countDown() }
-            rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
+            client.start(rpcUser.username, rpcUser.password, true).use {
+                val rpcOps = it.proxy
+                val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
+                val subscription = cashStatesFeed.updates.subscribe { latch.countDown() }
+                rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
 
-            node.stop()
-            startNode()
+                node.stop()
+                startNode()
 
-            subscription.unsubscribe()
+                subscription.unsubscribe()
 
-            rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
+                rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
 
-            assertFalse {
-                latch.await(4, TimeUnit.SECONDS)
+                assertFalse {
+                    latch.await(4, TimeUnit.SECONDS)
+                }
             }
-            connection.close()
         }
     }
 
@@ -129,24 +129,24 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            val connection = client.start(rpcUser.username, rpcUser.password, true)
-            val rpcOps = connection.proxy
-            val networkParameters = rpcOps.networkParameters
-            val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
-            cashStatesFeed.updates.subscribe { latch.countDown() }
-            rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
+            client.start(rpcUser.username, rpcUser.password, true).use {
+                val rpcOps = it.proxy
+                val networkParameters = rpcOps.networkParameters
+                val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
+                cashStatesFeed.updates.subscribe { latch.countDown() }
+                rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
 
-            node.stop()
-            startNode(addresses[1])
+                node.stop()
+                startNode(addresses[1])
 
-            rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
+                rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
 
-            val networkParametersAfterCrash = rpcOps.networkParameters
-            assertThat(networkParameters).isEqualTo(networkParametersAfterCrash)
-            assertTrue {
-                latch.await(2, TimeUnit.SECONDS)
+                val networkParametersAfterCrash = rpcOps.networkParameters
+                assertThat(networkParameters).isEqualTo(networkParametersAfterCrash)
+                assertTrue {
+                    latch.await(2, TimeUnit.SECONDS)
+                }
             }
-            connection.close()
         }
     }
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientReconnectionTest.kt
@@ -1,5 +1,6 @@
 package net.corda.client.rpc
 
+import net.corda.client.rpc.internal.ReconnectingCordaRPCOps
 import net.corda.core.messaging.startTrackedFlow
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.OpaqueBytes
@@ -49,8 +50,8 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true).use {
-                val rpcOps = it.proxy
+            (client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true).proxy as ReconnectingCordaRPCOps).use {
+                val rpcOps = it
                 val networkParameters = rpcOps.networkParameters
                 val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
                 cashStatesFeed.updates.subscribe { latch.countDown() }
@@ -89,8 +90,8 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            client.start(rpcUser.username, rpcUser.password, true).use {
-                val rpcOps = it.proxy
+            (client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true).proxy as ReconnectingCordaRPCOps).use {
+                val rpcOps = it
                 val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
                 val subscription = cashStatesFeed.updates.subscribe { latch.countDown() }
                 rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
@@ -129,8 +130,8 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            client.start(rpcUser.username, rpcUser.password, true).use {
-                val rpcOps = it.proxy
+            (client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true).proxy as ReconnectingCordaRPCOps).use {
+                val rpcOps = it
                 val networkParameters = rpcOps.networkParameters
                 val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
                 cashStatesFeed.updates.subscribe { latch.countDown() }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientReconnectionTest.kt
@@ -49,7 +49,8 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            val rpcOps = client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true).proxy
+            val connection = client.start(rpcUser.username, rpcUser.password, gracefulReconnect = true)
+            val rpcOps = connection.proxy
             val networkParameters = rpcOps.networkParameters
             val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
             cashStatesFeed.updates.subscribe { latch.countDown() }
@@ -65,6 +66,7 @@ class CordaRPCClientReconnectionTest {
             assertTrue {
                 latch.await(2, TimeUnit.SECONDS)
             }
+            connection.close()
         }
     }
 
@@ -87,7 +89,8 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            val rpcOps = client.start(rpcUser.username, rpcUser.password, true).proxy
+            val connection = client.start(rpcUser.username, rpcUser.password, true)
+            val rpcOps = connection.proxy
             val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
             val subscription = cashStatesFeed.updates.subscribe { latch.countDown() }
             rpcOps.startTrackedFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue.get()
@@ -102,6 +105,7 @@ class CordaRPCClientReconnectionTest {
             assertFalse {
                 latch.await(4, TimeUnit.SECONDS)
             }
+            connection.close()
         }
     }
 
@@ -125,7 +129,8 @@ class CordaRPCClientReconnectionTest {
                     maxReconnectAttempts = 5
             ))
 
-            val rpcOps = client.start(rpcUser.username, rpcUser.password, true).proxy
+            val connection = client.start(rpcUser.username, rpcUser.password, true)
+            val rpcOps = connection.proxy
             val networkParameters = rpcOps.networkParameters
             val cashStatesFeed = rpcOps.vaultTrack(Cash.State::class.java)
             cashStatesFeed.updates.subscribe { latch.countDown() }
@@ -141,6 +146,7 @@ class CordaRPCClientReconnectionTest {
             assertTrue {
                 latch.await(2, TimeUnit.SECONDS)
             }
+            connection.close()
         }
     }
 


### PR DESCRIPTION
The `CordaRPCClientReconnectionTests` do not close the RPC connection once they are done with it. This appears to result in a serialization environment leak, causing tests run after this set to fail due to multiple serialization environments being set. This PR ensures that these connections are closed at the end of the tests.
