### PR TITLE
 Improve docs about extending log4j2 settings (prerequisite for  CORDA-3096)

### DIFF
--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -19,7 +19,7 @@ Also, several other classes have the default log level set above ``INFO`` to pre
 It may be the case that you need to amend the log level of a particular subset of modules (e.g., if you'd like to take a
 closer look at hibernate activity). So, for more bespoke logging configuration, the logger settings can be modified or completely overridden
 with a `Log4j2 <https://logging.apache.org/log4j/2.x>`_ configuration file assigned to the ``log4j.configurationFile`` system property.
-To extend the Corda default logging configuration, the `log4j.configurationFile`` property should list the default ``log4j2.xml`` file
+To extend the Corda default logging configuration, the ``log4j.configurationFile`` property should list the default ``log4j2.xml`` file
 and the additional file with custom settings e.g.
 ``log4j.configurationFile=log4j2.xml,path_to_custom_config.xml``.
 Corda contains default log4j2 settings in the ``log4j2.xml`` embedded file. If ``log4j.configurationFile`` omits the default file then

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -19,9 +19,10 @@ Also few other classes have the default log level set above ``INFO`` to prevent 
 It may be the case that you require to amend the log level of a particular subset of modules (e.g., if you'd like to take a
 closer look at hibernate activity). So, for more bespoke logging configuration, the logger settings can be modified or completely overridden
 with a `Log4j2 <https://logging.apache.org/log4j/2.x>`_ configuration file assigned to the ``log4j.configurationFile`` system property.
-To extend Corda default logging configuration the `log4j.configurationFile`` property should contain also the ``log4j2.xml`` e.g.
+To extend the Corda default logging configuration, the `log4j.configurationFile`` property should list additional list ``log4j2.xml`` e.g.
 ``log4j.configurationFile=log4j2.xml,path_to_custom_config.xml``.
-If you list your custom configuration file only, the default log4j2 file embedded in a Corda node is ignored and replaced by your configuration file.
+Corda contains default log4j2 settings in the ``log4j2.xml`` embedded file. If ``log4j.configurationFile`` omits the default file then
+custom configuration replace the default Corda log4j2 setting entirely.
 
 The node is using log4j2 asynchronous logging by default (configured via log4j2 properties file in its resources)
 to ensure that log message flushing is not slowing down the actual processing.

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -10,14 +10,18 @@ Logging
 By default the node log files are stored to the ``logs`` subdirectory of the working directory and are rotated from time
 to time. You can have logging printed to the console as well by passing the ``--log-to-console`` command line flag.
 The default logging level is ``INFO`` which can be adjusted by the ``--logging-level`` command line argument. This configuration
-option will affect all modules. Hibernate (the JPA provider used by Corda) specific log messages of level ``WARN`` and above 
+option will affect all modules. Hibernate (the JPA provider used by Corda) specific log messages of level ``WARN`` and above
 will be logged to the diagnostic log file, which is stored in the same location as other log files (``logs`` subdirectory 
 by default). This is because Hibernate may log messages at WARN and ERROR that are handled internally by Corda and do not 
 need operator attention. If they do, they will be logged by Corda itself in the main node log file.
+Also few other classes have the default log level set above ``INFO`` to prevent surplus logging.
 
 It may be the case that you require to amend the log level of a particular subset of modules (e.g., if you'd like to take a
-closer look at hibernate activity). So, for more bespoke logging configuration, the logger settings can be completely overridden
+closer look at hibernate activity). So, for more bespoke logging configuration, the logger settings can be modified or completely overridden
 with a `Log4j2 <https://logging.apache.org/log4j/2.x>`_ configuration file assigned to the ``log4j.configurationFile`` system property.
+To extend Corda default logging configuration the `log4j.configurationFile`` property should contain also the ``log4j2.xml`` e.g.
+``log4j.configurationFile=log4j2.xml,path_to_custom_config.xml``.
+If you list your custom configuration file only, the default log4j2 file embedded in a Corda node is ignored and replaced by your configuration file.
 
 The node is using log4j2 asynchronous logging by default (configured via log4j2 properties file in its resources)
 to ensure that log message flushing is not slowing down the actual processing.
@@ -28,7 +32,7 @@ command line or to the ``jvmArgs`` section of the node configuration (see :doc:`
 Example
 +++++++
 
-Create a file ``sql.xml`` in the current working directory. Add the following text :
+Create a file ``sql.xml`` in the current working directory. Add the following text:
 
 .. code-block:: xml
 
@@ -51,9 +55,10 @@ Create a file ``sql.xml`` in the current working directory. Add the following te
 
 Note the addition of a logger named ``org.hibernate`` that has set this particular logger level to ``debug``.
 
-Now start the node as usual but with the additional parameter ``log4j.configurationFile`` set to the filename as above, e.g.
+Now start the node as usual but with the additional parameter ``log4j.configurationFile`` set to both
+the default Corda log4j filename (log4j2.xml) and the filename as above, e.g.
 
-``java <Your existing startup options here> -Dlog4j.configurationFile=sql.xml -jar corda.jar``
+``java <Your existing startup options here> -Dlog4j.configurationFile=log4j2.xml,sql.xml -jar corda.jar``
 
 To determine the name of the logger, for Corda objects, use the fully qualified name (e.g., to look at node output
 in more detail, use ``net.corda.node.internal.Node`` although be aware that as we have marked this class ``internal`` we

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -14,15 +14,16 @@ option will affect all modules. Hibernate (the JPA provider used by Corda) speci
 will be logged to the diagnostic log file, which is stored in the same location as other log files (``logs`` subdirectory 
 by default). This is because Hibernate may log messages at WARN and ERROR that are handled internally by Corda and do not 
 need operator attention. If they do, they will be logged by Corda itself in the main node log file.
-Also few other classes have the default log level set above ``INFO`` to prevent surplus logging.
+Also, several other classes have the default log level set above ``INFO`` to prevent surplus logging.
 
-It may be the case that you require to amend the log level of a particular subset of modules (e.g., if you'd like to take a
+It may be the case that you need to amend the log level of a particular subset of modules (e.g., if you'd like to take a
 closer look at hibernate activity). So, for more bespoke logging configuration, the logger settings can be modified or completely overridden
 with a `Log4j2 <https://logging.apache.org/log4j/2.x>`_ configuration file assigned to the ``log4j.configurationFile`` system property.
-To extend the Corda default logging configuration, the `log4j.configurationFile`` property should list additional list ``log4j2.xml`` e.g.
+To extend the Corda default logging configuration, the `log4j.configurationFile`` property should list the default ``log4j2.xml`` file
+and the additional file with custom settings e.g.
 ``log4j.configurationFile=log4j2.xml,path_to_custom_config.xml``.
 Corda contains default log4j2 settings in the ``log4j2.xml`` embedded file. If ``log4j.configurationFile`` omits the default file then
-custom configuration replace the default Corda log4j2 setting entirely.
+custom configuration replaces the default Corda log4j2 settings entirely.
 
 The node is using log4j2 asynchronous logging by default (configured via log4j2 properties file in its resources)
 to ensure that log message flushing is not slowing down the actual processing.

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -22,8 +22,8 @@ with a `Log4j2 <https://logging.apache.org/log4j/2.x>`_ configuration file assig
 To extend the Corda default logging configuration, the ``log4j.configurationFile`` property should list the default ``log4j2.xml`` file
 and the additional file with custom settings e.g.
 ``log4j.configurationFile=log4j2.xml,path_to_custom_config.xml``.
-Corda contains default log4j2 settings in the ``log4j2.xml`` embedded file. If ``log4j.configurationFile`` omits the default file then
-custom configuration replaces the default Corda log4j2 settings entirely.
+Corda contains default log4j2 settings in the ``log4j2.xml`` file embedded within the corda JAR.
+If ``log4j.configurationFile`` omits the default file then custom configuration replaces the default Corda log4j2 settings entirely.
 
 The node is using log4j2 asynchronous logging by default (configured via log4j2 properties file in its resources)
 to ensure that log message flushing is not slowing down the actual processing.


### PR DESCRIPTION
Fix misleading doc about extending (but not replacing) the default log4j configuration settings.
The improved instruction will be referenced by a database initlisation logs doc in https://github.com/corda/corda/pull/5310.
Tested:
1) ./gradlew samples:tarder-demo:deployNodes
2) ```cd``` to BankOfCorda, ```rm *.db, rm logs/*.log```
3) followed the original doc  ( java -jar -Dlog4j.configurationFile=<path_to_file>/sql.xml corda.jar)
there ar eno logs in logs folder as the configuration was completley replaced
4) stop node
5) ```rm *.db, rm logs/*.log```
6) followed the ned doc.( java -jar -Dlog4j.configurationFile=log4j2.xml,<path_to_file>/sql.xml corda.jar) - the contend is loged to the file inside 'logs' folder