### PR TITLE
CORDA-3092: Exception is logged if flow session message can't be deserialised

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -274,7 +274,7 @@ class StateMachineManagerImpl(
         val sessionMessage = try {
             message.data.deserialize<SessionMessage>()
         } catch (ex: Exception) {
-            logger.error("Received corrupt SessionMessage data from $peer")
+            logger.error("Unable to deserialize SessionMessage data from $peer", ex)
             return
         }
         val sender = serviceHub.networkMapCache.getPeerByLegalName(peer)


### PR DESCRIPTION
Port of https://github.com/corda/corda/pull/5308