### PR TITLE
[CORDA-2923] Prevent connection threads leaking on reconnect

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -91,10 +91,10 @@ class RPCStabilityTests {
                 block()
             }
             val threadsAfter = waitUntilNumberOfThreadsStable(executor)
-            // This is a less than check because threads from other tests may be shutting down while this test is running.
-            // This is therefore a "best effort" check. When this test is run on its own this should be a strict equality.
-            // In case of failure we output the threads along with their stacktraces to get an idea what was running at a time.
-            require(threadsBefore.keys.size >= threadsAfter.keys.size) { "threadsBefore: $threadsBefore\nthreadsAfter: $threadsAfter" }
+            val newThreads = threadsAfter.keys.minus(threadsBefore.keys)
+            require(newThreads.isEmpty()) {
+                "Threads have leaked. New threads created: $newThreads (total before: ${threadsBefore.size}, total after: ${threadsAfter.size})"
+            }
         } finally {
             executor.shutdownNow()
         }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -157,6 +157,8 @@ class ReconnectingCordaRPCOps private constructor(
          */
         @Synchronized
         fun reconnectOnError(e: Throwable) {
+            // Ensure any resources on this side are cleaned up before building a new connection
+            currentRPCConnection?.close()
             currentState = CurrentState.DIED
             //TODO - handle error cases
             log.error("Reconnecting to ${this.nodeHostAndPorts} due to error: ${e.message}")


### PR DESCRIPTION
A flaky set of tests was exposed by #5303. The `CordaRPCClientReconnectionTest` leaves some threads running after completion, which themselves sometimes spawned new threads. A test in the `RPCStabilityTests` checks for leaking threads, and was sometimes detecting that the thread count had gone up.

The issue turned out to be that on reconnect, the `ReconnectingCordaRPCOps` didn't attempt to close resources from the old connection. This PR adds that logic in, and also adjusts the `RPCStabilityTests` to look for new threads, which makes the test more reliably pick up thread leaking issues.
