### PR TITLE
CORDA-1937: Do not ignore `alias` parameter passed in.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/CertificateStore.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/CertificateStore.kt
@@ -41,9 +41,8 @@ interface CertificateStore : Iterable<Pair<String, X509Certificate>> {
     }
 
     operator fun set(alias: String, certificate: X509Certificate) {
-
         update {
-            internal.addOrReplaceCertificate(X509Utilities.CORDA_ROOT_CA, certificate)
+            internal.addOrReplaceCertificate(alias, certificate)
         }
     }
 


### PR DESCRIPTION
By now we were lucky because all the time `X509Utilities.CORDA_ROOT_CA` been used as an input parameter.
