### PR TITLE
[CORDA-2923] Revert previous test fix and workaround other test failures

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -91,10 +91,10 @@ class RPCStabilityTests {
                 block()
             }
             val threadsAfter = waitUntilNumberOfThreadsStable(executor)
-            val newThreads = threadsAfter.keys.minus(threadsBefore.keys)
-            require(newThreads.isEmpty()) {
-                "Threads have leaked. New threads created: $newThreads (total before: ${threadsBefore.size}, total after: ${threadsAfter.size})"
-            }
+            // This is a less than check because threads from other tests may be shutting down while this test is running.
+            // This is therefore a "best effort" check. When this test is run on its own this should be a strict equality.
+            // In case of failure we output the threads along with their stacktraces to get an idea what was running at a time.
+            require(threadsBefore.keys.size >= threadsAfter.keys.size) { "threadsBefore: $threadsBefore\nthreadsAfter: $threadsAfter" }
         } finally {
             executor.shutdownNow()
         }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -1,5 +1,8 @@
-package net.corda.client.rpc
+package net.corda.client.rpcreconnect
 
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.CordaRPCClientConfiguration
+import net.corda.client.rpc.CordaRPCClientTest
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps
 import net.corda.core.messaging.startTrackedFlow
 import net.corda.core.utilities.NetworkHostAndPort

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -157,8 +157,6 @@ class ReconnectingCordaRPCOps private constructor(
          */
         @Synchronized
         fun reconnectOnError(e: Throwable) {
-            // Ensure any resources on this side are cleaned up before building a new connection
-            currentRPCConnection?.close()
             currentState = CurrentState.DIED
             //TODO - handle error cases
             log.error("Reconnecting to ${this.nodeHostAndPorts} due to error: ${e.message}")


### PR DESCRIPTION
#5313 introduced an intermittent test failure in integration tests. This PR reverts that and moves the test case that causes leaking threads to be detected to a different package, which should workaround the issue the previous PR was trying to fix.