### PR TITLE
DOCS - Update tutorial docs in "Writing a contract"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -219,3 +219,4 @@ see changes to this list.
 * Wawrzek Niewodniczanski (R3)
 * Wei Wu Zhang (Commonwealth Bank of Australia)
 * Zabrina Smith (Northern Trust)
+* Manish Kumar  (ChainThat)

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -91,10 +91,10 @@ class RPCStabilityTests {
                 block()
             }
             val threadsAfter = waitUntilNumberOfThreadsStable(executor)
-            val newThreads = threadsAfter.keys.minus(threadsBefore.keys)
-            require(newThreads.isEmpty()) {
-                "Threads have leaked. New threads created: $newThreads (total before: ${threadsBefore.size}, total after: ${threadsAfter.size})"
-            }
+            // This is a less than check because threads from other tests may be shutting down while this test is running.
+            // This is therefore a "best effort" check. When this test is run on its own this should be a strict equality.
+            // In case of failure we output the threads along with their stacktraces to get an idea what was running at a time.
+            require(threadsBefore.keys.size >= threadsAfter.keys.size) { "threadsBefore: $threadsBefore\nthreadsAfter: $threadsAfter" }
         } finally {
             executor.shutdownNow()
         }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -1,5 +1,8 @@
-package net.corda.client.rpc
+package net.corda.client.rpcreconnect
 
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.CordaRPCClientConfiguration
+import net.corda.client.rpc.CordaRPCClientTest
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps
 import net.corda.core.messaging.startTrackedFlow
 import net.corda.core.utilities.NetworkHostAndPort

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -157,8 +157,6 @@ class ReconnectingCordaRPCOps private constructor(
          */
         @Synchronized
         fun reconnectOnError(e: Throwable) {
-            // Ensure any resources on this side are cleaned up before building a new connection
-            currentRPCConnection?.close()
             currentState = CurrentState.DIED
             //TODO - handle error cases
             log.error("Reconnecting to ${this.nodeHostAndPorts} due to error: ${e.message}")

--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -24,7 +24,7 @@ You can find out more about network maps and network parameters from :doc:`netwo
 Bootstrapping a test network
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Corda Network Bootstrapper can be downloaded from `here <https://www.corda.net/resources>`__.
+The Corda Network Bootstrapper can be downloaded from `here <https://software.r3.com/artifactory/corda-releases/net/corda/corda-tools-network-bootstrapper>`__.
 
 Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. "devMode" must be set to true. Then run the
 following command:

--- a/docs/source/tutorial-contract.rst
+++ b/docs/source/tutorial-contract.rst
@@ -346,7 +346,7 @@ the owner.
 
 To calculate how much cash is moving, we use the ``sumCashBy`` utility function. Again, this is an extension function,
 so in Kotlin code it appears as if it was a method on the ``List<Cash.State>`` type even though JDK provides no such
-method. In Java we see its true nature: it is actually a static method named ``CashKt.sumCashBy``. This method simply
+method. In Java we see its true nature: it is actually a static method named ``StateSummingUtilities.kt.sumCashBy``. This method simply
 returns an ``Amount`` object containing the sum of all the cash states in the transaction outputs that are owned by
 that given public key, or throws an exception if there were no such states *or* if there were different currencies
 represented in the outputs! So we can see that this contract imposes a limitation on the structure of a redemption

--- a/docs/source/tutorial-contract.rst
+++ b/docs/source/tutorial-contract.rst
@@ -346,7 +346,7 @@ the owner.
 
 To calculate how much cash is moving, we use the ``sumCashBy`` utility function. Again, this is an extension function,
 so in Kotlin code it appears as if it was a method on the ``List<Cash.State>`` type even though JDK provides no such
-method. In Java we see its true nature: it is actually a static method named ``StateSummingUtilities.kt.sumCashBy``. This method simply
+method. In Java we see its true nature: it is actually a static method named ``StateSumming.sumCashBy``. This method simply
 returns an ``Amount`` object containing the sum of all the cash states in the transaction outputs that are owned by
 that given public key, or throws an exception if there were no such states *or* if there were different currencies
 represented in the outputs! So we can see that this contract imposes a limitation on the structure of a redemption


### PR DESCRIPTION
sumCashBy is now present in net.corda.finance.contracts.utils package and  file name is StateSummingUtilities.kt

Example code has been updated but the tutorial-contract.rst still has the old reference to the sumCashBy. I have updated the method name from CashKt to StateSumming.

I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/).

Manish Kumar (Chainthat)