### PR TITLE
CORDA-3094 improvements to checkpoint dumper

### DIFF
--- a/docs/source/checkpoint-tooling.rst
+++ b/docs/source/checkpoint-tooling.rst
@@ -41,7 +41,7 @@ Below are some of the more important fields included in the output:
 
 - ``flowId``: The id of the flow
 - ``topLevelFlowClass``: The name of the original flow that was invoked (by RPC or a service)
-- ``topLevelFlowLogic``: Further information about the top level flow
+- ``topLevelFlowLogic``: Detailed view of the top level flow
 - ``flowCallStackSummary``: A summarised list of the current stack of sub flows along with any progress tracker information
 - ``suspendedOn``: The command that the flow is suspended on (e.g. ``SuspendAndReceive``) which includes the ``suspendedTimestamp``
 - ``flowCallStack`` A detailed view of the of the current stack of sub flows

--- a/docs/source/checkpoint-tooling.rst
+++ b/docs/source/checkpoint-tooling.rst
@@ -96,7 +96,7 @@ Below is an example of the JSON output:
             }
           }
         ],
-        "suspendedTimestamp" : "2019-08-12T15:38:39",
+        "suspendedTimestamp" : "2019-08-12T15:38:39Z",
         "secondsSpentWaiting" : 7
       },
       "flowCallStack" : [
@@ -407,7 +407,7 @@ And two additional files will appear in the nodes logs directory:
                }
              }
            ],
-           "suspendedTimestamp" : "2019-08-12T15:38:39",
+           "suspendedTimestamp" : "2019-08-12T15:38:39Z",
            "secondsSpentWaiting" : 7
          },
          "flowCallStack" : [
@@ -553,7 +553,7 @@ See also :ref:`Flow draining mode <draining-mode>`.
                }
              }
            ],
-           "suspendedTimestamp" : "2019-08-12T15:38:39",
+           "suspendedTimestamp" : "2019-08-12T15:38:39Z",
            "secondsSpentWaiting" : 7
         }
       }

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
@@ -289,7 +289,7 @@ class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private
             val customOperation: FlowIORequest.ExecuteAsyncOperation<*>? = null,
             val forceCheckpoint: FlowIORequest.ForceCheckpoint? = null
     ) {
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "UTC")
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
         lateinit var suspendedTimestamp: Instant
         var secondsSpentWaiting: Long = 0
     }

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
@@ -182,6 +182,7 @@ class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private
             flowId = id,
             topLevelFlowClass = flowLogic.javaClass,
             topLevelFlowLogic = flowLogic,
+            flowCallStackSummary = flowCallStack.toSummary(),
             flowCallStack = flowCallStack,
             suspendedOn = (flowState as? FlowState.Started)?.flowIORequest?.toSuspendedOn(
                 suspendedTimestamp(),
@@ -220,6 +221,19 @@ class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private
         )
     }
 
+    private fun List<FlowCall>.toSummary() = map {
+        FlowCallSummary(
+            it.flowClass,
+            it.progressStep
+        )
+    }
+
+    @Suppress("unused")
+    private class FlowCallSummary(
+        val flowClass: Class<*>,
+        val progressStep: String?
+    )
+
     @Suppress("unused")
     private class FlowCall(
         val flowClass: Class<*>,
@@ -252,8 +266,9 @@ class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private
         val flowId: UUID,
         val topLevelFlowClass: Class<FlowLogic<*>>,
         val topLevelFlowLogic: FlowLogic<*>,
-        val flowCallStack: List<FlowCall>,
+        val flowCallStackSummary: List<FlowCallSummary>,
         val suspendedOn: SuspendedOn?,
+        val flowCallStack: List<FlowCall>,
         val origin: Origin,
         val ourIdentity: Party,
         val activeSessions: List<ActiveSession>,


### PR DESCRIPTION
- Handle errors in Jackson and checkpoint deserialisation. A file notifying the user that the checkpoint dump failed is created when errors occur.

- Handle message deserialisation errors. A string placeholder is used if an error occurs.

- Add more information about subflows (include their `FlowLogic`)

- Increase clarity in checkpoint output field names

- Add `flowCallStackSummary` to the output which contains the same content as `flowCallStack` minus each subflow's `FlowLogic`. The `FlowLogic` contains a ton of info which is normally repeated in each subflow. Adding the summary gives an overview of the steps the flow executed and which step it is currently on.

- The `suspendedOn` field is put underneath the summary and the original
call stack is moved below the suspended info.

- This puts the most useful information towards the top of the json file.