### PR TITLE
CORDA-2871: Restore CompositeKey support to core-deterministic.

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1537,8 +1537,6 @@ public final class net.corda.core.crypto.CordaSecurityProvider extends java.secu
 public static final class net.corda.core.crypto.CordaSecurityProvider$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
-public final class net.corda.core.crypto.CordaSecurityProviderKt extends java.lang.Object
-##
 public final class net.corda.core.crypto.Crypto extends java.lang.Object
   @NotNull
   public static final java.security.PrivateKey decodePrivateKey(String, byte[])

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -1,6 +1,5 @@
 package net.corda.core.crypto
 
-import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.exactAdd
@@ -244,7 +243,7 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
     override fun toString() = "(${children.joinToString()})"
 
     /** A helper class for building a [CompositeKey]. */
-    @DeleteForDJVM
+    @KeepForDJVM
     class Builder {
         private val children: MutableList<NodeAndWeight> = mutableListOf()
 

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKeyFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKeyFactory.kt
@@ -1,6 +1,6 @@
 package net.corda.core.crypto
 
-import net.corda.core.DeleteForDJVM
+import net.corda.core.KeepForDJVM
 import java.security.*
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.KeySpec
@@ -9,7 +9,7 @@ import java.security.spec.X509EncodedKeySpec
 /**
  * Factory for generating composite keys from ASN.1 format key specifications. This is used by [CordaSecurityProvider].
  */
-@DeleteForDJVM
+@KeepForDJVM
 class CompositeKeyFactory : KeyFactorySpi() {
 
     @Throws(InvalidKeySpecException::class)

--- a/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
@@ -15,7 +15,9 @@ class CordaSecurityProvider : Provider(PROVIDER_NAME, 0.1, "$PROVIDER_NAME secur
     }
 
     init {
-        provideNonDeterministic(this)
+        put("KeyFactory.${CompositeKey.KEY_ALGORITHM}", CompositeKeyFactory::class.java.name)
+        put("Alg.Alias.KeyFactory.$COMPOSITE_KEY", CompositeKey.KEY_ALGORITHM)
+        put("Alg.Alias.KeyFactory.OID.$COMPOSITE_KEY", CompositeKey.KEY_ALGORITHM)
         put("Signature.${CompositeSignature.SIGNATURE_ALGORITHM}", CompositeSignature::class.java.name)
         put("Alg.Alias.Signature.$COMPOSITE_SIGNATURE", CompositeSignature.SIGNATURE_ALGORITHM)
         put("Alg.Alias.Signature.OID.$COMPOSITE_SIGNATURE", CompositeSignature.SIGNATURE_ALGORITHM)
@@ -26,16 +28,6 @@ class CordaSecurityProvider : Provider(PROVIDER_NAME, 0.1, "$PROVIDER_NAME secur
     private fun putPlatformSecureRandomService() {
         putService(PlatformSecureRandomService(this))
     }
-}
-
-/**
- * The core-deterministic module is not allowed to generate keys.
- */
-@StubOutForDJVM
-private fun provideNonDeterministic(provider: Provider) {
-    provider["KeyFactory.${CompositeKey.KEY_ALGORITHM}"] = CompositeKeyFactory::class.java.name
-    provider["Alg.Alias.KeyFactory.$COMPOSITE_KEY"] = CompositeKey.KEY_ALGORITHM
-    provider["Alg.Alias.KeyFactory.OID.$COMPOSITE_KEY"] = CompositeKey.KEY_ALGORITHM
 }
 
 @KeepForDJVM


### PR DESCRIPTION
`CompositeKey` support was mistakenly removed from `core-deterministic` and must now be restored.