### PR TITLE
CORDA-3121 - Fix incorrect rendering of Independent Foundation URL (in HTML)

### DIFF
--- a/docs/source/corda-network/UAT.md
+++ b/docs/source/corda-network/UAT.md
@@ -27,11 +27,11 @@ Joining the UAT environment
 * Access to the appropriate environment has been agreed with your project representative with sufficient advance notice (4 weeks standard but may be longer if you have special service requirements) to ensure appropriate SLAs can be in place. Your project representative will be able to supply the booking template.
 
 **Note**: 
-*Corda Network UAT is an R3 owned and operated environment and service designed to support parties intending to join Corda Network proper with realistic network test facilities. In contrast, Corda Network is a production network governed by an [independent Foundation](https://corda.network/governance/index.html) and has no responsibility for Corda Network UAT. Corda Network UAT seeks to provide a test environment which is as close as possible to Corda Network in its make-up and operation.*
+Corda Network UAT is an R3 owned and operated environment and service designed to support parties intending to join Corda Network proper with realistic network test facilities. In contrast, Corda Network is a production network governed by an [Independent Foundation](https://corda.network/governance/index.html) and has no responsibility for Corda Network UAT. Corda Network UAT seeks to provide a test environment which is as close as possible to Corda Network in its make-up and operation.
 
 Steps to join UAT environment
 -----------------------------
 
-Steps to join are outlined on the [Corda Network UAT microsite](http://uat.network.r3.com/pages/joining/joining.html)
+Steps to join are outlined on the [Corda Network UAT microsite](http://uat.network.r3.com/pages/joining/joining.html).
 
 For further questions on this process, please contact us - preferably on the mailing list: https://groups.io/g/corda-network

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -239,7 +239,8 @@ class DriverDSLImpl(
                 NodeConfiguration::useTestClock.name to useTestClock,
                 NodeConfiguration::rpcUsers.name to if (users.isEmpty()) defaultRpcUserList else users.map { it.toConfig().root().unwrapped() },
                 NodeConfiguration::verifierType.name to parameters.verifierType.name,
-                NodeConfiguration::flowOverrides.name to flowOverrideConfig.toConfig().root().unwrapped()
+                NodeConfiguration::flowOverrides.name to flowOverrideConfig.toConfig().root().unwrapped(),
+                NodeConfiguration::additionalNodeInfoPollingFrequencyMsec.name to 1000
         ) + czUrlConfig + jmxConfig + parameters.customOverrides
         val config = NodeConfig(ConfigHelper.loadConfig(
                 baseDirectory = baseDirectory(name),


### PR DESCRIPTION
Independent Foundation URL not currently rendering:

<img width="1153" alt="Screen Shot 2019-07-30 at 11 41 37" src="https://user-images.githubusercontent.com/23558646/62124919-6b4bb000-b2c3-11e9-9095-f98f5c2b88e0.png">
