### PR TITLE
ENT-3504 Statemachine IllegalStateException logging (BACKPORT)

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -452,12 +452,12 @@ class SingleThreadedStateMachineManager(
                     }
                 } else {
                     // It happens when flows restart and the old sessions messages still arrive from a peer.
-                    logger.info("Cannot find flow corresponding to session ID $recipientId.")
+                    logger.info("Cannot find flow corresponding to session ID - $recipientId.")
                 }
             } else {
-                val flow = mutex.locked { flows[flowId] }
-                        ?: throw IllegalStateException("Cannot find fiber corresponding to ID $flowId")
-                flow.fiber.scheduleEvent(Event.DeliverSessionMessage(sessionMessage, deduplicationHandler, sender))
+                mutex.locked { flows[flowId] }?.run {
+                    fiber.scheduleEvent(Event.DeliverSessionMessage(sessionMessage, deduplicationHandler, sender))
+                } ?: logger.info("Cannot find fiber corresponding to flow ID $flowId")
             }
         } catch (exception: Exception) {
             logger.error("Exception while routing $sessionMessage", exception)


### PR DESCRIPTION
Change to `SingleThreadedStateMachineManager`.

Instead of throwing an exception when a flow's fiber cannot be found,
just log the message at info level.

(cherry picked from commit 70b2a94fda4e1b4f4ee7aff2e369d87fb1c9f7f5)

Related jira - https://r3-cev.atlassian.net/browse/ENT-3504