### PR TITLE
DOCS - Fix network bootstrapper link to download (BACKPORT)

### DIFF
--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -24,7 +24,7 @@ You can find out more about network maps and network parameters from :doc:`netwo
 Bootstrapping a test network
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Corda Network Bootstrapper can be downloaded from `here <https://www.corda.net/resources>`__.
+The Corda Network Bootstrapper can be downloaded from `here <https://software.r3.com/artifactory/corda-releases/net/corda/corda-tools-network-bootstrapper>`__.
 
 Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. "devMode" must be set to true. Then run the
 following command:


### PR DESCRIPTION
Point network bootstrapper url to the artifactory download location

(cherry picked from commit 41634d1fda740a75961f53582370e6040e90026b)

No related jira. 
Docs change only.