### PR TITLE
[CORDA-3082] Update app upgrade notes to document source incompatibility

### DIFF
--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -53,10 +53,10 @@ Compiling this code against Platform Version 5 will result in the following erro
 
 `Type mismatch: inferred type is Any but AbstractParty was expected`
 
-The issue here is that a new interface introduced in Platform Version 5 can cause type inference failures when a variable is used as an
-`AbstractParty` but has an actual value that is one of a number of possible subclasses of `AbstractParty`. As these subclasses implement an
-interface that the superclass does not, the Kotlin compiler is unable to infer that both branches result in a subclass of `AbstractParty`,
-and instead infers that the type is `Any`.
+The issue here is that a new `Destination` interface introduced in Platform Version 5 (see the :doc:`changelog` for Platform Version 5) can
+cause type inference failures when a variable is used as an `AbstractParty` but has an actual value that is one of a number of possible
+subclasses of `AbstractParty`. As these subclasses implement an interface that the superclass does not, the Kotlin compiler is unable to
+infer that both branches result in a subclass of `AbstractParty`, and instead infers that the type is `Any`.
 
 To fix this, an explicit type hint must be provided to the compiler:
 

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -62,7 +62,8 @@ ancestor of both ``AbstractParty`` and ``Destination``. This is ``Any``, which i
 (For more information on ``Destination``, see the :doc:`changelog` for Platform Version 5, or the KDocs for the interface
 `here <https://docs.corda.net/head/api/kotlin/corda/net.corda.core.flows/-destination.html>`__)
 
-Note that this is a Kotlin-specific issue. Java has an appropriate type to choose here in ``? extends AbstractParty & Destination``.
+Note that this is a Kotlin-specific issue. Java can instead choose ``? extends AbstractParty & Destination`` here, which can later be used
+as ``AbstractParty``.
 
 To fix this, an explicit type hint must be provided to the compiler:
 

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -4,12 +4,30 @@
    <script type="text/javascript" src="_static/jquery.js"></script>
    <script type="text/javascript" src="_static/codesets.js"></script>
 
+Upgrading CorDapps to newer Platform Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These notes provide instructions for upgrading your CorDapps from previous versions. Corda provides backwards compatibility for public,
+non-experimental APIs that have been committed to. A list can be found in the :doc:`corda-api` page.
+
+This means that you can upgrade your node across versions *without recompiling or adjusting your CorDapps*. You just have to upgrade
+your node and restart.
+
+However, there are usually new features and other opt-in changes that may improve the security, performance or usability of your
+application that are worth considering for any actively maintained software. This guide shows you how to upgrade your app to benefit
+from the new features in the latest release.
+
+.. warning:: The sample apps found in the Corda repository and the Corda samples repository are not intended to be used in production.
+   If you are using them you should re-namespace them to a package namespace you control, and sign/version them yourself.
+
+.. contents::
+   :depth: 3
+
 Upgrading apps to Platform Version 5
 ====================================
 
-These notes provide instructions for upgrading your CorDapps from previous versions to take advantage of features and enhancements introduced
-in platform version 5. Backwards compatibility for public, non-experimental APIs continues to be provided in this release. See the
-:doc: `corda-api` page for details of which APIs are committed to.
+This section provides instructions for upgrading your CorDapps from previous versions to take advantage of features and enhancements introduced
+in platform version 5.
 
 .. note:: If you are upgrading from a platform version older than 4, then the upgrade notes for upgrading to Corda 4 (below) also apply.
 
@@ -67,24 +85,10 @@ and instead picks the most specific common ancestor of both of these. Unfortunat
 is lost. By indicating to the compiler that both branches result in an `AbstractParty`, it can then accept future uses of the variable as
 an `AbstractParty`.
 
-Upgrading apps to Corda 4
-=========================
+Upgrading apps to Platform Version 4
+====================================
 
-These notes provide instructions for upgrading your CorDapps from previous versions. Corda provides backwards compatibility for public,
-non-experimental APIs that have been committed to. A list can be found in the :doc:`corda-api` page.
-
-This means that you can upgrade your node across versions *without recompiling or adjusting your CorDapps*. You just have to upgrade
-your node and restart.
-
-However, there are usually new features and other opt-in changes that may improve the security, performance or usability of your
-application that are worth considering for any actively maintained software. This guide shows you how to upgrade your app to benefit
-from the new features in the latest release.
-
-.. warning:: The sample apps found in the Corda repository and the Corda samples repository are not intended to be used in production.
-   If you are using them you should re-namespace them to a package namespace you control, and sign/version them yourself.
-
-.. contents::
-   :depth: 3
+This section provides instructions for upgrading your CorDapps from previous versions to platform version 4.
 
 Step 1. Switch any RPC clients to use the new RPC library
 ---------------------------------------------------------

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -53,10 +53,11 @@ Compiling this code against Platform Version 5 will result in the following erro
 
 `Type mismatch: inferred type is Any but AbstractParty was expected`
 
-The issue here is that a new `Destination` interface introduced in Platform Version 5 (see the :doc:`changelog` for Platform Version 5) can
-cause type inference failures when a variable is used as an `AbstractParty` but has an actual value that is one of a number of possible
-subclasses of `AbstractParty`. As these subclasses implement an interface that the superclass does not, the Kotlin compiler is unable to
-infer that both branches result in a subclass of `AbstractParty`, and instead infers that the type is `Any`.
+The issue here is that a new `Destination` interface introduced in Platform Version 5 (see the :doc:`changelog` for Platform Version 5, or
+the KDocs for the interface `here <https://docs.corda.net/head/api/kotlin/corda/net.corda.core.flows/-destination.html>`__) can cause type
+inference failures when a variable is used as an `AbstractParty` but has an actual value that is one of a number of possible subclasses of
+`AbstractParty`. As these subclasses implement an interface that the superclass does not, the Kotlin compiler is unable to infer that both
+branches result in a subclass of `AbstractParty`, and instead infers that the type is `Any`.
 
 To fix this, an explicit type hint must be provided to the compiler:
 

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -55,11 +55,11 @@ Compiling this code against Platform Version 5 will result in the following erro
 
 ``Type mismatch: inferred type is Any but AbstractParty was expected``
 
-The issue here is that a new `Destination` interface introduced in Platform Version 5 (see the :doc:`changelog` for Platform Version 5, or
+The issue here is that a new ``Destination`` interface introduced in Platform Version 5 (see the :doc:`changelog` for Platform Version 5, or
 the KDocs for the interface `here <https://docs.corda.net/head/api/kotlin/corda/net.corda.core.flows/-destination.html>`__) can cause type
-inference failures when a variable is used as an `AbstractParty` but has an actual value that is one of a number of possible subclasses of
-`AbstractParty`. As these subclasses implement an interface that the superclass does not, the Kotlin compiler is unable to infer that both
-branches result in a subclass of `AbstractParty`, and instead infers that the type is `Any`.
+inference failures when a variable is used as an ``AbstractParty`` but has an actual value that is one of a number of possible subclasses of
+``AbstractParty``. As these subclasses implement an interface that the superclass does not, the Kotlin compiler is unable to infer that both
+branches result in a subclass of ``AbstractParty``, and instead infers that the type is ``Any``.
 
 Note that this is a Kotlin-specific issue. The Java compiler should be able to handle this case.
 
@@ -83,15 +83,15 @@ To fix this, an explicit type hint must be provided to the compiler:
 
 A more detailed explanation is provided below:
 
-Platform Version 5 introduces a new `Destination` interface to mark parties which a flow can be initiated with. `AbstractParty` does not
-implement this as in the future new subclasses of `AbstractParty` may be introduced that a flow cannot be initiated with. However, the current
-`Party` and `AnonymousParty` do implement this interface.
+Platform Version 5 introduces a new ``Destination`` interface to mark parties which a flow can be initiated with. ``AbstractParty`` does not
+implement this as in the future new subclasses of ``AbstractParty`` may be introduced that a flow cannot be initiated with. However, the current
+``Party`` and ``AnonymousParty`` do implement this interface.
 
-This introduces a type inference failure when a variable could be either of these subclasses of `AbstractParty`. Due to a limitation in the
-Kotlin compiler, it cannot determine that the type of these variables is both a subclass of `AbstractParty` and an implementor of `Destination`,
-and instead picks the most specific common ancestor of both of these. Unfortunately, this is the `Any` type, and so all type information
-is lost. By indicating to the compiler that both branches result in an `AbstractParty`, it can then accept future uses of the variable as
-an `AbstractParty`.
+This introduces a type inference failure when a variable could be either of these subclasses of ``AbstractParty``. Due to a limitation in the
+Kotlin compiler, it cannot determine that the type of these variables is both a subclass of ``AbstractParty`` and an implementor of ``Destination``,
+and instead picks the most specific common ancestor of both of these. Unfortunately, this is the ``Any`` type, and so all type information
+is lost. By indicating to the compiler that both branches result in an ``AbstractParty``, it can then accept future uses of the variable as
+an ``AbstractParty``.
 
 Upgrading apps to Platform Version 4
 ====================================


### PR DESCRIPTION
The introduction of the `Destination` interface has introduced a potential source incompatibility between platform versions 4 and 5. This occurs due to a type inference limitation in the Kotlin compiler. This PR updates the upgrade notes for platform version 5 to describe the possible break and how to fix it.
