### PR TITLE
CORDA-3127: Move evaluationDependsOn() from core to core-tests.

### DIFF
--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -14,6 +14,8 @@ configurations {
     smokeTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
+evaluationDependsOn(':node:capsule')
+
 sourceSets {
     integrationTest {
         kotlin {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,8 +7,6 @@ apply plugin: 'com.jfrog.artifactory'
 
 description 'Corda core'
 
-evaluationDependsOn(':node:capsule')
-
 configurations {
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntimeOnly.extendsFrom testRuntimeOnly

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -209,7 +209,7 @@ tasks.withType(JavaCompile) {
 }
 
 test {
-    maxHeapSize = "2g"
+    maxHeapSize = "3g"
     maxParallelForks = (System.env.CORDA_NODE_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_TESTING_FORKS".toInteger()
 }
 


### PR DESCRIPTION
The `core-tests` module requires the Node's capsule for the smoke tests, i.e.
```gradle
processSmokeTestResources {
    // Bring in the fully built corda.jar for use by NodeFactory in the smoke tests
    from(project(':node:capsule').tasks['buildCordaJAR']) {
    ...
}
```