### PR TITLE
CORDA-3018 Whitelisting attachments by public key - relax signer restrictions

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/AttachmentsClassLoaderTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/AttachmentsClassLoaderTests.kt
@@ -347,12 +347,12 @@ class AttachmentsClassLoaderTests {
             "/com/example/something/UntrustedClass.class",
             "Signed by someone who inherits trust"
         ).inputStream()
-        inheritedTrustClassJar.use {
+        val inheritedTrustAttachment = inheritedTrustClassJar.use {
             storage.importContractAttachment(
                 listOf("UntrustedClass.class"),
                 "untrusted",
                 it,
-                signers = listOf(keyPairA.public, keyPairB.public)
+                signers = listOf(keyPairB.public, keyPairA.public)
             )
         }
 
@@ -369,6 +369,7 @@ class AttachmentsClassLoaderTests {
             )
         }
 
+        make(arrayOf(inheritedTrustAttachment).map { storage.openAttachment(it)!! })
         assertFailsWith(TransactionVerificationException.UntrustedAttachmentsException::class) {
             make(arrayOf(untrustedAttachment).map { storage.openAttachment(it)!! })
         }

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -185,7 +185,7 @@ fun FlowLogic<*>.checkParameterHash(networkParametersHash: SecureHash?) {
 }
 
 // A cache for caching whether a particular set of signers are trusted
-private val trustedSignersCache: MutableMap<PublicKey, Boolean> =
+private val trustedKeysCache: MutableMap<PublicKey, Boolean> =
     createSimpleCache<PublicKey, Boolean>(100).toSynchronised()
 
 /**
@@ -194,8 +194,8 @@ private val trustedSignersCache: MutableMap<PublicKey, Boolean> =
  *
  * Attachments are trusted if one of the following is true:
  *  - They are uploaded by a trusted uploader
- *  - There is another attachment in the attachment store signed by the same keys (and with the same contract classes if the attachment is a
- *    contract attachment) that is trusted
+ *  - There is another attachment in the attachment store, that is trusted and is signed by at least one key that the input
+ *  attachment is also signed with
  */
 fun isAttachmentTrusted(attachment: Attachment, service: AttachmentStorage?): Boolean {
     val trustedByUploader = when (attachment) {
@@ -208,7 +208,7 @@ fun isAttachmentTrusted(attachment: Attachment, service: AttachmentStorage?): Bo
 
     return if (service != null && attachment.signerKeys.isNotEmpty()) {
         attachment.signerKeys.any { signer ->
-            trustedSignersCache.computeIfAbsent(signer) {
+            trustedKeysCache.computeIfAbsent(signer) {
                 val queryCriteria = AttachmentQueryCriteria.AttachmentsQueryCriteria(
                     signersCondition = Builder.equal(listOf(signer)),
                     uploaderCondition = Builder.`in`(TRUSTED_UPLOADERS)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -909,8 +909,8 @@ class NodeAttachmentServiceTest {
             file.path.signJar(jarSignedByA.toAbsolutePath().toString(), aliasA, password)
 
             val jarSignedByAB = makeTestContractJar(file.path, "foo.bar.DifferentContract", version = 2)
-            file.path.signJar(jarSignedByAB.toAbsolutePath().toString(), aliasA, password)
             file.path.signJar(jarSignedByAB.toAbsolutePath().toString(), aliasB, password)
+            file.path.signJar(jarSignedByAB.toAbsolutePath().toString(), aliasA, password)
 
             val jarSignedByBC = makeTestContractJar(file.path, "foo.bar.AnotherContract", version = 2)
             file.path.signJar(jarSignedByBC.toAbsolutePath().toString(), aliasB, password)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -801,7 +801,7 @@ class NodeAttachmentServiceTest {
     }
 
     @Test
-    fun `jar not trusted if same key but different contract`() {
+    fun `jar trusted if same key but different contract`() {
         SelfCleaningDir().use { file ->
             val alias = "testAlias"
             val password = "testPassword"
@@ -817,7 +817,7 @@ class NodeAttachmentServiceTest {
             // Sanity check.
             assertEquals(key1, key2, "Different public keys used to sign jars")
             assertTrue(isAttachmentTrusted(storage.openAttachment(v1Id)!!, storage), "Initial contract $v1Id should be trusted")
-            assertFalse(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Upgraded contract $v2Id should not be trusted")
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Upgraded contract $v2Id should not be trusted")
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -14,10 +14,8 @@ import net.corda.core.internal.*
 import net.corda.core.internal.cordapp.CordappImpl.Companion.DEFAULT_CORDAPP_VERSION
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.services.AttachmentId
+import net.corda.core.node.services.vault.*
 import net.corda.core.node.services.vault.AttachmentQueryCriteria.AttachmentsQueryCriteria
-import net.corda.core.node.services.vault.AttachmentSort
-import net.corda.core.node.services.vault.Builder
-import net.corda.core.node.services.vault.Sort
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.nodeapi.exceptions.DuplicateAttachmentException
@@ -817,7 +815,82 @@ class NodeAttachmentServiceTest {
             // Sanity check.
             assertEquals(key1, key2, "Different public keys used to sign jars")
             assertTrue(isAttachmentTrusted(storage.openAttachment(v1Id)!!, storage), "Initial contract $v1Id should be trusted")
-            assertTrue(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Upgraded contract $v2Id should not be trusted")
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Upgraded contract $v2Id should be trusted")
+        }
+    }
+
+    @Test
+    fun `jar trusted if the signing keys are a subset of an existing trusted jar's signers`() {
+        SelfCleaningDir().use { file ->
+            val alias = "testAlias"
+            val password = "testPassword"
+            val alias2 = "anotherTestAlias"
+            file.path.generateKey(alias, password)
+            file.path.generateKey(alias2, password)
+
+            val jarV1 = makeTestContractJar(file.path, "foo.bar.DummyContract")
+            file.path.signJar(jarV1.toAbsolutePath().toString(), alias, password)
+            file.path.signJar(jarV1.toAbsolutePath().toString(), alias2, password)
+
+            val jarV2 = makeTestContractJar(file.path, "foo.bar.DifferentContract", version = 2)
+            file.path.signJar(jarV2.toAbsolutePath().toString(), alias, password)
+
+            val v1Id = jarV1.read { storage.privilegedImportAttachment(it, "app", "dummy-contract.jar") }
+            val v2Id = jarV2.read { storage.privilegedImportAttachment(it, "untrusted", "dummy-contract.jar") }
+
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v1Id)!!, storage), "Initial contract $v1Id should be trusted")
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Upgraded contract $v2Id should be trusted")
+        }
+    }
+
+    @Test
+    fun `jar trusted if the signing keys are an intersection of an existing trusted jar's signers`() {
+        SelfCleaningDir().use { file ->
+            val alias = "testAlias"
+            val password = "testPassword"
+            val alias2 = "anotherTestAlias"
+            val alias3 = "yetAnotherTestAlias"
+            file.path.generateKey(alias, password)
+            file.path.generateKey(alias2, password)
+            file.path.generateKey(alias3, password)
+
+            val jarV1 = makeTestContractJar(file.path, "foo.bar.DummyContract")
+            file.path.signJar(jarV1.toAbsolutePath().toString(), alias, password)
+            file.path.signJar(jarV1.toAbsolutePath().toString(), alias2, password)
+
+            val jarV2 = makeTestContractJar(file.path, "foo.bar.DifferentContract", version = 2)
+            file.path.signJar(jarV2.toAbsolutePath().toString(), alias, password)
+            file.path.signJar(jarV2.toAbsolutePath().toString(), alias3, password)
+
+            val v1Id = jarV1.read { storage.privilegedImportAttachment(it, "app", "dummy-contract.jar") }
+            val v2Id = jarV2.read { storage.privilegedImportAttachment(it, "untrusted", "dummy-contract.jar") }
+
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v1Id)!!, storage), "Initial contract $v1Id should be trusted")
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Upgraded contract $v2Id should be trusted")
+        }
+    }
+
+    @Test
+    fun `jar trusted if the signing keys are a superset of an existing trusted jar's signers`() {
+        SelfCleaningDir().use { file ->
+            val alias = "testAlias"
+            val password = "testPassword"
+            val alias2 = "anotherTestAlias"
+            file.path.generateKey(alias, password)
+            file.path.generateKey(alias2, password)
+
+            val jarV1 = makeTestContractJar(file.path, "foo.bar.DummyContract")
+            file.path.signJar(jarV1.toAbsolutePath().toString(), alias, password)
+
+            val jarV2 = makeTestContractJar(file.path, "foo.bar.DifferentContract", version = 2)
+            file.path.signJar(jarV2.toAbsolutePath().toString(), alias, password)
+            file.path.signJar(jarV2.toAbsolutePath().toString(), alias2, password)
+
+            val v1Id = jarV1.read { storage.privilegedImportAttachment(it, "app", "dummy-contract.jar") }
+            val v2Id = jarV2.read { storage.privilegedImportAttachment(it, "untrusted", "dummy-contract.jar") }
+
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v1Id)!!, storage), "Initial contract $v1Id should be trusted")
+            assertTrue(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Upgraded contract $v2Id should be trusted")
         }
     }
 
@@ -937,6 +1010,147 @@ class NodeAttachmentServiceTest {
 
             assertTrue(isAttachmentTrusted(storage.openAttachment(v1Id)!!, storage), "Initial attachment $v1Id should not be trusted")
             assertFalse(isAttachmentTrusted(storage.openAttachment(v2Id)!!, storage), "Other attachment $v2Id should not be trusted")
+        }
+    }
+
+    @Test
+    fun `attachments can be queried by providing a intersection of signers using an EQUAL statement - EQUAL containing a single public key`() {
+        SelfCleaningDir().use { file ->
+            val aliasA = "Luke Skywalker"
+            val aliasB = "Han Solo"
+            val aliasC = "Chewbacca"
+            val aliasD = "Princess Leia"
+            val password = "may the force be with you"
+            file.path.generateKey(aliasA, password)
+            file.path.generateKey(aliasB, password)
+            file.path.generateKey(aliasC, password)
+            file.path.generateKey(aliasD, password)
+
+            val jarSignedByA = makeTestContractJar(file.path, "foo.bar.DummyContract")
+            val keyA = file.path.signJar(jarSignedByA.toAbsolutePath().toString(), aliasA, password)
+
+            val jarSignedByAB = makeTestContractJar(file.path, "foo.bar.DifferentContract")
+            file.path.signJar(jarSignedByAB.toAbsolutePath().toString(), aliasA, password)
+            val keyB = file.path.signJar(jarSignedByAB.toAbsolutePath().toString(), aliasB, password)
+
+            val jarSignedByABC = makeTestContractJar(file.path, "foo.bar.ExpensiveContract")
+            file.path.signJar(jarSignedByABC.toAbsolutePath().toString(), aliasA, password)
+            file.path.signJar(jarSignedByABC.toAbsolutePath().toString(), aliasB, password)
+            val keyC = file.path.signJar(jarSignedByABC.toAbsolutePath().toString(), aliasC, password)
+
+            val jarSignedByABCD = makeTestContractJar(file.path, "foo.bar.DidNotReadThisContract")
+            file.path.signJar(jarSignedByABCD.toAbsolutePath().toString(), aliasA, password)
+            file.path.signJar(jarSignedByABCD.toAbsolutePath().toString(), aliasB, password)
+            file.path.signJar(jarSignedByABCD.toAbsolutePath().toString(), aliasC, password)
+            val keyD = file.path.signJar(jarSignedByABCD.toAbsolutePath().toString(), aliasD, password)
+
+            val attachmentA = jarSignedByA.read { storage.privilegedImportAttachment(it, "app", "A.jar") }
+            val attachmentB = jarSignedByAB.read { storage.privilegedImportAttachment(it, "app", "B.jar") }
+            val attachmentC = jarSignedByABC.read { storage.privilegedImportAttachment(it, "app", "C.jar") }
+            val attachmentD = jarSignedByABCD.read { storage.privilegedImportAttachment(it, "app", "D.jar") }
+
+            assertEquals(
+                listOf(attachmentA, attachmentB, attachmentC, attachmentD),
+                storage.queryAttachments(
+                    AttachmentsQueryCriteria(
+                        signersCondition = Builder.equal(listOf(keyA))
+                    )
+                )
+            )
+
+            assertEquals(
+                listOf(attachmentB, attachmentC, attachmentD),
+                storage.queryAttachments(
+                    AttachmentsQueryCriteria(
+                        signersCondition = Builder.equal(listOf(keyB))
+                    )
+                )
+            )
+
+            assertEquals(
+                listOf(attachmentC, attachmentD),
+                storage.queryAttachments(
+                    AttachmentsQueryCriteria(
+                        signersCondition = Builder.equal(listOf(keyC))
+                    )
+                )
+            )
+
+            assertEquals(
+                listOf(attachmentD),
+                storage.queryAttachments(
+                    AttachmentsQueryCriteria(
+                        signersCondition = Builder.equal(listOf(keyD))
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `attachments can be queried by providing a intersection of signers using an EQUAL statement - EQUAL containing multiple public keys`() {
+        SelfCleaningDir().use { file ->
+            val aliasA = "Ironman"
+            val aliasB = "Captain America"
+            val aliasC = "Blackwidow"
+            val aliasD = "Thor"
+            val password = "avengers, assemble!"
+            file.path.generateKey(aliasA, password)
+            file.path.generateKey(aliasB, password)
+            file.path.generateKey(aliasC, password)
+            file.path.generateKey(aliasD, password)
+
+            val jarSignedByA = makeTestContractJar(file.path, "foo.bar.DummyContract")
+            val keyA = file.path.signJar(jarSignedByA.toAbsolutePath().toString(), aliasA, password)
+
+            val jarSignedByAB = makeTestContractJar(file.path, "foo.bar.DifferentContract")
+            file.path.signJar(jarSignedByAB.toAbsolutePath().toString(), aliasA, password)
+            val keyB = file.path.signJar(jarSignedByAB.toAbsolutePath().toString(), aliasB, password)
+
+            val jarSignedByBC = makeTestContractJar(file.path, "foo.bar.ExpensiveContract")
+            file.path.signJar(jarSignedByBC.toAbsolutePath().toString(), aliasB, password)
+            val keyC = file.path.signJar(jarSignedByBC.toAbsolutePath().toString(), aliasC, password)
+
+            val jarSignedByCD = makeTestContractJar(file.path, "foo.bar.DidNotReadThisContract")
+            file.path.signJar(jarSignedByCD.toAbsolutePath().toString(), aliasC, password)
+            val keyD = file.path.signJar(jarSignedByCD.toAbsolutePath().toString(), aliasD, password)
+
+            val attachmentA = jarSignedByA.read { storage.privilegedImportAttachment(it, "app", "A.jar") }
+            val attachmentB = jarSignedByAB.read { storage.privilegedImportAttachment(it, "app", "B.jar") }
+            val attachmentC = jarSignedByBC.read { storage.privilegedImportAttachment(it, "app", "C.jar") }
+            val attachmentD = jarSignedByCD.read { storage.privilegedImportAttachment(it, "app", "D.jar") }
+
+            storage.queryAttachments(
+                AttachmentsQueryCriteria(
+                    signersCondition = Builder.equal(listOf(keyA, keyC))
+                )
+            ).let { result ->
+                assertEquals(4, result.size)
+                assertEquals(
+                    listOf(attachmentA, attachmentB, attachmentC, attachmentD),
+                    result
+                )
+            }
+
+            storage.queryAttachments(
+                AttachmentsQueryCriteria(
+                    signersCondition = Builder.equal(listOf(keyA, keyB))
+                )
+            ).let { result ->
+                // made a [Set] due to [NodeAttachmentService.queryAttachments] not returning distinct results
+                assertEquals(3, result.toSet().size)
+                assertEquals(setOf(attachmentA, attachmentB, attachmentC), result.toSet())
+            }
+
+            storage.queryAttachments(
+                AttachmentsQueryCriteria(
+                    signersCondition = Builder.equal(listOf(keyB, keyC, keyD))
+                )
+            ).let { result ->
+                // made a [Set] due to [NodeAttachmentService.queryAttachments] not returning distinct results
+                assertEquals(3, result.toSet().size)
+                assertEquals(setOf(attachmentB, attachmentC, attachmentD), result.toSet())
+            }
         }
     }
 


### PR DESCRIPTION
Related jira - https://r3-cev.atlassian.net/browse/CORDA-3018

This change covers the relaxing the signer restrictions. The blacklisting of public keys will be handled in a separate PR.

-------------

The requirement of containing the same contract classes has been removed. Therefore the contents of the existing trusted attachment no longer matters.

Allow a subset/intersection of signers to satisfy the signer requirements of `isAttachmentTrusted`. This allows an "untrusted" attachment that is signed by one or more keys to be "trusted" as long as another trusted attachment already exists that is signed by at least one of the "untrusted" attachments signers.

A cache of trusted and untrusted public keys is now held (replacing the previous cache of `List<PublicKey>`.

Tests have been added to `NodeAttachmentServiceTest` to confirm that an attachment query using an `EQUAL` statement will actually return attachments that are signed by any of the keys passed into the query.

Confirming this allowed an `EQUAL` query to satisfy the search that had to be done as part of this change.

`MockAttachmentStorage`'s query criteria was updated to better match the real `NodeAttachmentService` implementation.