### PR TITLE
BACKPORT: Fix links to GitHub master branches

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -23,3 +23,5 @@ snakeYamlVersion=1.19
 caffeineVersion=2.6.2
 metricsVersion=3.2.5
 metricsNewRelicVersion=1.1.1
+openSourceBranch=https://github.com/corda/corda/blob/release/4
+openSourceSamplesBranch=https://github.com/corda/samples/blob/release-V4

--- a/docs/source/api-testing.rst
+++ b/docs/source/api-testing.rst
@@ -161,8 +161,8 @@ Further examples
 * See the flow testing tutorial :doc:`here <flow-testing>`
 * See the oracle tutorial :doc:`here <oracles>` for information on testing ``@CordaService`` classes
 * Further examples are available in the Example CorDapp in
-  `Java <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-java/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
-  `Kotlin <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
+  `Java <|os_samples_branch|/cordapp-example/workflows-java/src/test/java/com/example/test/flow/IOUFlowTests.java>`_ and
+  `Kotlin <|os_samples_branch|/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/test/flow/IOUFlowTests.kt>`_
 
 Contract testing
 ----------------
@@ -380,5 +380,5 @@ Further examples
 
 * See the flow testing tutorial :doc:`here <tutorial-test-dsl>`
 * Further examples are available in the Example CorDapp in
-  `Java <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-java/src/test/java/com/example/flow/IOUFlowTests.java>`_ and
-  `Kotlin <https://github.com/corda/samples/blob/release-V|platform_version|/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/flow/IOUFlowTests.kt>`_
+  `Java <|os_samples_branch|/cordapp-example/workflows-java/src/test/java/com/example/test/flow/IOUFlowTests.java>`_ and
+  `Kotlin <|os_samples_branch|/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/test/flow/IOUFlowTests.kt>`_

--- a/docs/source/azure-vm.rst
+++ b/docs/source/azure-vm.rst
@@ -101,7 +101,7 @@ The nodes you will use to send and receive Yo messages require the Yo! CorDapp j
 
 Connect to one of your Corda nodes (make sure this is not the Notary node) using an SSH client of your choice (e.g. Putty) and log into the virtual machine using the public IP address and your SSH key or username / password combination you defined in Step 1 of the Azure build process. Type the following command:
 
-Build the yo cordapp sample which you can find here: https://github.com/corda/samples/tree/release-V|platform_version|/yo-cordapp and install it in the cordapp directory.
+Build the yo cordapp sample which you can find here: |os_samples_branch|/yo-cordapp and install it in the cordapp directory.
 
 Now restart Corda and the Corda webserver using the following commands or restart your Corda VM from the Azure portal:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,9 @@ corda_substitutions = {
     "|kotlin_version|" : constants_properties_dict["kotlinVersion"],
     "|gradle_plugins_version|" : constants_properties_dict["gradlePluginsVersion"],
     "|quasar_version|" : constants_properties_dict["quasarVersion"],
-    "|platform_version|" : constants_properties_dict["platformVersion"]
+    "|platform_version|" : constants_properties_dict["platformVersion"],
+    "|os_branch|" : constants_properties_dict["openSourceBranch"],
+    "|os_samples_branch|" : constants_properties_dict["openSourceSamplesBranch"]
 }
 
 def setup(app):

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -251,7 +251,7 @@ following line to each node's ``node.conf`` file:
 
 Where ``2222`` is the port you want to open to SSH into the shell.
 
-Below you can find the example task from the `IRS Demo <https://github.com/corda/corda/blob/release/|platform_version|/samples/irs-demo/cordapp/build.gradle#L111>`_ included in the samples directory of main Corda GitHub repository:
+Below you can find the example task from the `IRS Demo <|os_branch|/samples/irs-demo/cordapp/build.gradle#L111>`_ included in the samples directory of main Corda GitHub repository:
 
 .. sourcecode:: groovy
 

--- a/docs/source/running-a-notary.rst
+++ b/docs/source/running-a-notary.rst
@@ -35,14 +35,14 @@ Crash fault-tolerant (experimental)
 ===================================
 
 Corda provides a prototype `Raft-based <http://atomix.io/>`_ highly available notary implementation. You can try it out on our
-`notary demo <https://github.com/corda/corda/tree/release/|platform_version|/samples/notary-demo>`_ page. Note that it has known limitations
+`notary demo <|os_branch|/samples/notary-demo>`_ page. Note that it has known limitations
 and is not recommended for production use.
 
 Byzantine fault-tolerant (experimental)
 =======================================
 
 A prototype BFT notary implementation based on `BFT-Smart <https://github.com/bft-smart/library>`_ is available. You can
-try it out on our `notary demo <https://github.com/corda/corda/tree/release/|platform_version|/samples/notary-demo>`_ page. Note that it
+try it out on our `notary demo <|os_branch|/samples/notary-demo>`_ page. Note that it
 is still experimental and there is active work ongoing for a production ready solution. Additionally, BFT-Smart requires Java
 serialization which is disabled by default in Corda due to security risks, and it will only work in dev mode where this can
 be customised.


### PR DESCRIPTION
Add constants for the open source and samples repos branch names

* Add constants for the open source and samples repos branch names

Open source branch name - `openSourceBranchName`
Sample repos branch name - `openSourceSamplesBranchName`

* Add base path constants to the open source and samples repos

Fully replace base path to open source codebase - `openSourceBranch`
Fully replace base path to open source samples - `openSourceSamplesBranch`

These can be accessed in the docs using `os_branch` and `os_samples_branch`

Correct usages in the docs to use these constants.

* Correct links

Cherry picked from - commit 91667559

Docs only change
No related jira