### PR TITLE
CORDA-3139: Cater for port already bound scenario during port allocation

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/SharedMemoryIncremental.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/SharedMemoryIncremental.kt
@@ -1,0 +1,74 @@
+package net.corda.testing.driver.internal
+
+import net.corda.core.utilities.contextLogger
+import net.corda.testing.driver.PortAllocation
+import net.corda.testing.internal.isLocalPortBound
+import sun.misc.Unsafe
+import sun.nio.ch.DirectBuffer
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
+
+/**
+ * It uses backing file to store information about last allocated port.
+ * Implementation note:
+ * The (small)file is read into memory and then `Unsafe` operation is used to work directly with that memory
+ * performing atomic compare and swap operations as necessary
+ * This enables the same file to be used my multiple processed running on the same machine such that they will be
+ * able to concurrently allocate ports without clashing with each other.
+ */
+internal class SharedMemoryIncremental
+private constructor(private val startPort: Int, private val endPort: Int,
+                    file: File = File(System.getProperty("user.home"), "corda-$startPort-to-$endPort-port-allocator.bin")) : PortAllocation() {
+
+    private val backingFile: RandomAccessFile = RandomAccessFile(file, "rw")
+    private val mb: MappedByteBuffer
+    private val memoryOffsetAddress: Long
+
+    init {
+        mb = backingFile.channel.map(FileChannel.MapMode.READ_WRITE, 0, 16) // TODO: Do we really need 16 bytes? Given that we care about Int it should be enough to have 4
+        memoryOffsetAddress = (mb as DirectBuffer).address()
+    }
+
+    /**
+     * An implementation of [PortAllocation] which allocates ports sequentially
+     */
+    companion object {
+
+        private val UNSAFE: Unsafe = getUnsafe()
+        private fun getUnsafe(): Unsafe {
+            val f = Unsafe::class.java.getDeclaredField("theUnsafe")
+            f.isAccessible = true
+            return f.get(null) as Unsafe
+        }
+
+        val INSTANCE = SharedMemoryIncremental(DEFAULT_START_PORT, FIRST_EPHEMERAL_PORT)
+
+        val logger = contextLogger()
+    }
+
+    override fun nextPort(): Int {
+        var newValue: Long
+
+        do {
+            val oldValue = UNSAFE.getLongVolatile(null, memoryOffsetAddress)
+            newValue = if (oldValue + 1 >= endPort || oldValue < startPort) {
+                logger.warn("Port allocation rolling over: oldValue=$oldValue, startPort=$startPort, endPort=$endPort")
+                startPort.toLong()
+            } else {
+                (oldValue + 1)
+            }
+            val compareAndSwapSuccess = UNSAFE.compareAndSwapLong(null, memoryOffsetAddress, oldValue, newValue)
+            val success = if (!compareAndSwapSuccess) false else {
+                val alreadyBound = isLocalPortBound(newValue.toInt())
+                if (alreadyBound) {
+                    logger.warn("Port $newValue appears to be bound. Allocator will skip it.")
+                }
+                !alreadyBound
+            }
+        } while (!success)
+
+        return newValue.toInt()
+    }
+}

--- a/testing/node-driver/src/test/java/net/corda/testing/node/PortAllocationRunner.java
+++ b/testing/node-driver/src/test/java/net/corda/testing/node/PortAllocationRunner.java
@@ -36,7 +36,8 @@ public class PortAllocationRunner {
          * allocate ports and print out for later consumption by the spawning test
          */
         PortAllocation pa = PortAllocation.getDefaultAllocator();
-        for (int i = 0; i < 10000; i++) {
+        int iterCount = Integer.parseInt(args[2]);
+        for (int i = 0; i < iterCount; i++) {
             System.out.println(pa.nextPort());
         }
     }

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/driver/PortAllocationTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/driver/PortAllocationTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.core.IsNot.not
 import org.hamcrest.number.OrderingComparison
 import org.junit.Assert
+import org.junit.Assume.assumeFalse
 import org.junit.Test
 import java.io.RandomAccessFile
 import java.nio.channels.FileChannel
@@ -19,7 +20,7 @@ class PortAllocationTest {
         val portAllocator = PortAllocation.defaultAllocator
 
         var previous = portAllocator.nextPort()
-        (0 until 1000000).forEach { _ ->
+        (0 until 50_000).forEach { _ ->
             val next = portAllocator.nextPort()
             Assert.assertThat(next, `is`(not(previous)))
             Assert.assertThat(next, `is`(OrderingComparison.lessThan(PortAllocation.FIRST_EPHEMERAL_PORT)))
@@ -27,7 +28,7 @@ class PortAllocationTest {
             if (next == startingPoint) {
                 Assert.assertThat(previous, `is`(PortAllocation.FIRST_EPHEMERAL_PORT - 1))
             } else {
-                Assert.assertThat(next, `is`(previous + 1))
+                Assert.assertTrue(next >= previous + 1)
             }
             previous = next
         }
@@ -35,47 +36,47 @@ class PortAllocationTest {
 
     @Test(timeout = 120_000)
     fun `should support multiprocess port allocation`() {
-        if (!System.getProperty("os.name").toLowerCase().contains("windows")) {
-            println("Starting multiprocess port allocation test")
-            val spinnerFile = Files.newTemporaryFile().also { it.deleteOnExit() }.absolutePath
-            val process1 = buildJvmProcess(spinnerFile, 1)
-            val process2 = buildJvmProcess(spinnerFile, 2)
+        assumeFalse(System.getProperty("os.name").toLowerCase().contains("windows"))
 
-            println("Started child processes")
+        println("Starting multiprocess port allocation test")
+        val spinnerFile = Files.newTemporaryFile().also { it.deleteOnExit() }.absolutePath
+        val process1 = buildJvmProcess(spinnerFile, 1)
+        val process2 = buildJvmProcess(spinnerFile, 2)
 
-            val processes = listOf(process1, process2)
+        println("Started child processes")
 
-            val spinnerBackingFile = RandomAccessFile(spinnerFile, "rw")
-            println("Mapped spinner file")
-            val spinnerBuffer = spinnerBackingFile.channel.map(FileChannel.MapMode.READ_WRITE, 0, 512)
-            println("Created spinner buffer")
+        val processes = listOf(process1, process2)
 
-            var timeWaited = 0L
+        val spinnerBackingFile = RandomAccessFile(spinnerFile, "rw")
+        println("Mapped spinner file")
+        val spinnerBuffer = spinnerBackingFile.channel.map(FileChannel.MapMode.READ_WRITE, 0, 512)
+        println("Created spinner buffer")
 
-            while (spinnerBuffer.getShort(1) != 10.toShort() && spinnerBuffer.getShort(2) != 10.toShort() && timeWaited < 60_000) {
-                println("Waiting to childProcesses to report back. waited ${timeWaited}ms")
-                Thread.sleep(1000)
-                timeWaited += 1000
-            }
+        var timeWaited = 0L
 
-            //GO!
-            println("Instructing child processes to start allocating ports")
-            spinnerBuffer.putShort(0, 8)
-            println("Waiting for child processes to terminate")
-            processes.forEach { it.waitFor(1, TimeUnit.MINUTES) }
-            println("child processes terminated")
-
-            val process1Output = process1.inputStream.reader().readLines().toSet()
-            val process2Output = process2.inputStream.reader().readLines().toSet()
-
-            println("child process out captured")
-
-            Assert.assertThat(process1Output.size, `is`(10_000))
-            Assert.assertThat(process2Output.size, `is`(10_000))
-
-            //there should be no overlap between the outputs as each process should have been allocated a unique set of ports
-            Assert.assertThat(process1Output.intersect(process2Output), `is`(emptySet()))
+        while (spinnerBuffer.getShort(1) != 10.toShort() && spinnerBuffer.getShort(2) != 10.toShort() && timeWaited < 60_000) {
+            println("Waiting to childProcesses to report back. waited ${timeWaited}ms")
+            Thread.sleep(1000)
+            timeWaited += 1000
         }
+
+        //GO!
+        println("Instructing child processes to start allocating ports")
+        spinnerBuffer.putShort(0, 8)
+        println("Waiting for child processes to terminate")
+        processes.forEach { it.waitFor(1, TimeUnit.MINUTES) }
+        println("child processes terminated")
+
+        val process1Output = process1.inputStream.reader().readLines().toSet()
+        val process2Output = process2.inputStream.reader().readLines().toSet()
+
+        println("child process out captured")
+
+        Assert.assertThat(process1Output.size, `is`(10_000))
+        Assert.assertThat(process2Output.size, `is`(10_000))
+
+        //there should be no overlap between the outputs as each process should have been allocated a unique set of ports
+        Assert.assertThat(process1Output.intersect(process2Output), `is`(emptySet()))
     }
 
     private fun buildJvmProcess(spinnerFile: String, reportingIndex: Int): Process {
@@ -92,6 +93,3 @@ class PortAllocationTest {
         return processBuilder.start()
     }
 }
-
-
-

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/driver/PortAllocationTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/driver/PortAllocationTest.kt
@@ -1,5 +1,6 @@
 package net.corda.testing.driver
 
+import net.corda.core.utilities.Try
 import net.corda.testing.node.PortAllocationRunner
 import org.assertj.core.util.Files
 import org.hamcrest.CoreMatchers.`is`
@@ -67,8 +68,13 @@ class PortAllocationTest {
         processes.forEach { it.waitFor(1, TimeUnit.MINUTES) }
         println("child processes terminated")
 
-        val process1Output = process1.inputStream.reader().readLines().toSet()
-        val process2Output = process2.inputStream.reader().readLines().toSet()
+        fun Process.setOfPorts() : Set<Int> {
+            // May include warnings when ports are busy
+            return inputStream.reader().readLines().map { Try.on { Integer.parseInt(it)} }.filter { it.isSuccess }.map { it.getOrThrow() }.toSet()
+        }
+
+        val process1Output = process1.setOfPorts()
+        val process2Output = process2.setOfPorts()
 
         println("child process out captured")
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -40,6 +40,8 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.internal.stubs.CertificateStoreStubs
 import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.net.ServerSocket
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyPair
@@ -227,5 +229,20 @@ fun <R> withTestSerializationEnvIfNotSet(block: () -> R): R {
         block()
     } else {
         createTestSerializationEnv().asTestContextEnv { block() }
+    }
+}
+
+/**
+ * Used to check if particular port is already bound i.e. not vacant
+ */
+fun isLocalPortBound(port: Int) : Boolean {
+    return try {
+        ServerSocket(port).use {
+            // Successful means that the port was vacant
+            false
+        }
+    } catch (e: IOException) {
+        // Failed to open server socket means that it is already bound by someone
+        true
     }
 }


### PR DESCRIPTION
Also moved `SharedMemoryIncremental` into a separate file as it getting bigger
and improved readability of logic and added some logging.