### PR TITLE
ENT-3965 Improved welcome message for Standalone Shell

### DIFF
--- a/docs/source/shell.rst
+++ b/docs/source/shell.rst
@@ -205,8 +205,8 @@ Shutting down the node
 
 You can shut the node down via shell:
 
-* ``gracefulShutdown`` will put node into draining mode, and shut down when there are no flows running
-* ``shutdown`` will shut the node down immediately
+* ``run gracefulShutdown`` will put node into draining mode, and shut down when there are no flows running
+* ``run shutdown`` will shut the node down immediately
 
 Output Formats
 **********************

--- a/tools/shell-cli/src/main/resources/net/corda/tools/shell/base/login.groovy
+++ b/tools/shell-cli/src/main/resources/net/corda/tools/shell/base/login.groovy
@@ -1,0 +1,16 @@
+package net.corda.tools.shell.base
+
+// Note that this file MUST be in a sub-directory called "base" relative to the path
+// given in the configuration code in InteractiveShell.
+
+// Copy of the login.groovy file from 'shell' module with the welcome tailored for the standalone shell
+welcome = """
+
+Welcome to the Corda interactive shell.
+Useful commands include 'help' to see what is available, and 'bye' to exit the shell.
+
+"""
+
+prompt = { ->
+    return "${new Date()}>>> "
+}


### PR DESCRIPTION
Improved welcome message for Standalone Shell - bye command to exit shell only - not the node.
Docs clarifications gracefulShutdown/shutdown commands needs 'run' as other commands.