### PR TITLE
CORDA-3060: Improve Notary logging from an operator/admins point of view

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -61,7 +61,7 @@ class NotaryFlow {
             logger.info("Sending transaction to notary: ${notaryParty.name}.")
             progressTracker.currentStep = REQUESTING
             val response = notarise(notaryParty)
-            logger.info("Notary responded.")
+            logger.info("Notary responded (${notaryParty.name}).")
             progressTracker.currentStep = VALIDATING
             return validateResponse(response, notaryParty)
         }

--- a/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
@@ -81,6 +81,7 @@ abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service:
         try {
             val transaction = extractParts(requestPayload)
             transactionId = transaction.id
+            logger.info("Received a notarisation request for Tx [$transactionId] from [${otherSideSession.counterparty.name}]")
             checkNotary(transaction.notary)
             checkParameterHash(transaction.networkParametersHash)
             checkInputs(transaction.inputs + transaction.references)
@@ -125,6 +126,7 @@ abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service:
     @Suspendable
     private fun signTransactionAndSendResponse(txId: SecureHash) {
         val signature = service.signTransaction(txId)
+        logger.info("Transaction [$txId] successfully notarised, sending signature back to [${otherSideSession.counterparty.name}]")
         otherSideSession.send(NotarisationResponse(listOf(signature)))
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -181,6 +181,7 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
         val future = openFuture<UniquenessProvider.Result>()
         val request = CommitRequest(states, txId, callerIdentity, requestSignature, timeWindow, references, future)
         requestQueue.put(request)
+        log.debug { "Request added to queue. txId: $txId" }
         return future
     }
 
@@ -246,18 +247,18 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
     private fun handleReferenceConflicts(txId: SecureHash, conflictingStates: LinkedHashMap<StateRef, StateConsumptionDetails>) {
         if (!previouslyCommitted(txId)) {
             val conflictError = NotaryError.Conflict(txId, conflictingStates)
-            log.debug { "Failure, input states already committed: ${conflictingStates.keys}" }
+            log.info("Failure, input states already committed: ${conflictingStates.keys}. txId: $txId")
             throw NotaryInternalException(conflictError)
         }
-        log.debug { "Transaction $txId already notarised" }
+        log.info("Transaction $txId already notarised. txId: $txId")
     }
 
     private fun handleConflicts(txId: SecureHash, conflictingStates: LinkedHashMap<StateRef, StateConsumptionDetails>) {
         if (isConsumedByTheSameTx(txId.sha256(), conflictingStates)) {
-            log.debug { "Transaction $txId already notarised" }
+            log.info("Transaction $txId already notarised. txId: $txId")
             return
         } else {
-            log.debug { "Failure, input states already committed: ${conflictingStates.keys}" }
+            log.info("Failure, input states already committed: ${conflictingStates.keys}. txId: $txId")
             val conflictError = NotaryError.Conflict(txId, conflictingStates)
             throw NotaryInternalException(conflictError)
         }
@@ -276,7 +277,7 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
             }
             val session = currentDBSession()
             session.persist(CommittedTransaction(txId.toString()))
-            log.debug { "Successfully committed all input states: $states" }
+            log.info("Successfully committed all input states: $states. txId: $txId")
         } else {
             throw NotaryInternalException(outsideTimeWindowError)
         }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -181,7 +181,7 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
         val future = openFuture<UniquenessProvider.Result>()
         val request = CommitRequest(states, txId, callerIdentity, requestSignature, timeWindow, references, future)
         requestQueue.put(request)
-        log.debug { "Request added to queue. txId: $txId" }
+        log.debug { "Request added to queue. TxId: $txId" }
         return future
     }
 
@@ -247,18 +247,18 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
     private fun handleReferenceConflicts(txId: SecureHash, conflictingStates: LinkedHashMap<StateRef, StateConsumptionDetails>) {
         if (!previouslyCommitted(txId)) {
             val conflictError = NotaryError.Conflict(txId, conflictingStates)
-            log.info("Failure, input states already committed: ${conflictingStates.keys}. txId: $txId")
+            log.info("Failure, input states already committed: ${conflictingStates.keys}. TxId: $txId")
             throw NotaryInternalException(conflictError)
         }
-        log.info("Transaction $txId already notarised. txId: $txId")
+        log.info("Transaction $txId already notarised. TxId: $txId")
     }
 
     private fun handleConflicts(txId: SecureHash, conflictingStates: LinkedHashMap<StateRef, StateConsumptionDetails>) {
         if (isConsumedByTheSameTx(txId.sha256(), conflictingStates)) {
-            log.info("Transaction $txId already notarised. txId: $txId")
+            log.info("Transaction $txId already notarised. TxId: $txId")
             return
         } else {
-            log.info("Failure, input states already committed: ${conflictingStates.keys}. txId: $txId")
+            log.info("Failure, input states already committed: ${conflictingStates.keys}. TxId: $txId")
             val conflictError = NotaryError.Conflict(txId, conflictingStates)
             throw NotaryInternalException(conflictError)
         }
@@ -277,7 +277,7 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
             }
             val session = currentDBSession()
             session.persist(CommittedTransaction(txId.toString()))
-            log.info("Successfully committed all input states: $states. txId: $txId")
+            log.info("Successfully committed all input states: $states. TxId: $txId")
         } else {
             throw NotaryInternalException(outsideTimeWindowError)
         }

--- a/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
@@ -211,7 +211,7 @@ class RaftUniquenessProvider(
             timeWindow: TimeWindow?,
             references: List<StateRef>
     ): CordaFuture<UniquenessProvider.Result> {
-        log.debug { "Attempting to commit input states: ${states.joinToString()}" }
+        log.debug { "Attempting to commit input states: ${states.joinToString()} for txId: $txId" }
         val commitCommand = CommitTransaction(
                 states,
                 txId,
@@ -223,9 +223,10 @@ class RaftUniquenessProvider(
         val future = openFuture<UniquenessProvider.Result>()
         client.submit(commitCommand).thenAccept { commitError ->
             val result = if (commitError != null) {
+                log.info("Error occurred while notarising $txId: $commitError")
                 UniquenessProvider.Result.Failure(commitError)
             } else {
-                log.debug { "All input states of transaction $txId have been committed" }
+                log.info("All input states of transaction $txId have been committed")
                 UniquenessProvider.Result.Success
             }
             future.set(result)


### PR DESCRIPTION
Added logging during the processing steps of the PersistentUniqunessProvider and the RaftUniquenessProvider
Bumped up logging level of existing logging statements that occur while processing from debug to info
Added mention of txId to logging statements to enable a request to be traced through from the time it is added to the queue to the time that it is committed.