### PR TITLE
[ENT-4024] Use string for the status column in the transaction table

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -70,16 +70,16 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
             for (downloaded in downloadedTxs) {
                 suspended = false
                 val dependencies = downloaded.dependencies
-                val downloadedTxs = this.txsInCheckpoint
-                if (downloadedTxs != null) {
-                    if (downloadedTxs.size < MAX_CHECKPOINT_RESOLUTION) {
-                        downloadedTxs[downloaded.id] = downloaded
+                val checkpointedTxs = this.txsInCheckpoint
+                if (checkpointedTxs != null) {
+                    if (checkpointedTxs.size < MAX_CHECKPOINT_RESOLUTION) {
+                        checkpointedTxs[downloaded.id] = downloaded
                     } else {
                         logger.debug {
                             "Resolving transaction dependencies has reached a checkpoint limit of $MAX_CHECKPOINT_RESOLUTION " +
                                     "transactions. Switching to the node database for storing the unverified transactions."
                         }
-                        downloadedTxs.values.forEach(transactionStorage::addUnverifiedTransaction)
+                        checkpointedTxs.values.forEach(transactionStorage::addUnverifiedTransaction)
                         // This acts as both a flag that we've switched over to storing the backchain into the db, and to remove what's been
                         // built up in the checkpoint
                         this.txsInCheckpoint = null
@@ -92,8 +92,9 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
                 // The write locks are only released over a suspend, so need to keep track of whether the flow has been suspended to ensure
                 // that locks are not held beyond each while loop iteration (as doing this would result in a deadlock due to claiming locks
                 // in the wrong order)
-                suspended = suspended || flow.fetchMissingAttachments(downloaded)
-                suspended = suspended || flow.fetchMissingNetworkParameters(downloaded)
+                val suspendedViaAttachments = flow.fetchMissingAttachments(downloaded)
+                val suspendedViaParams = flow.fetchMissingNetworkParameters(downloaded)
+                suspended = suspended || suspendedViaAttachments || suspendedViaParams
 
                 // Add all input states and reference input states to the work queue.
                 nextRequests.addAll(dependencies)

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -44,7 +44,7 @@ class DBTransactionStorage(private val database: CordaPersistence, cacheFactory:
             @Column(name = "transaction_value", nullable = false)
             val transaction: ByteArray,
 
-            @Column(name = "status", nullable = false)
+            @Column(name = "status", nullable = false, length = 1)
             @Convert(converter = TransactionStatusConverter::class)
             val status: TransactionStatus
     )

--- a/node/src/main/resources/migration/node-core.changelog-v13.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v13.xml
@@ -4,9 +4,9 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
                    logicalFilePath="migration/node-services.changelog-init.xml">
 
-    <changeSet author="R3.Corda" id="add_is_verified_column">
+    <changeSet author="R3.Corda" id="add_status_column">
         <addColumn tableName="node_transactions">
-            <column name="status" type="NCHAR(255)" defaultValue="V">
+            <column name="status" type="NVARCHAR(255)" defaultValue="V">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/node/src/main/resources/migration/node-core.changelog-v13.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v13.xml
@@ -6,7 +6,7 @@
 
     <changeSet author="R3.Corda" id="add_status_column">
         <addColumn tableName="node_transactions">
-            <column name="status" type="NVARCHAR(255)" defaultValue="V">
+            <column name="status" type="NVARCHAR(1)" defaultValue="V">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -212,7 +212,7 @@ class VaultStateMigrationTest {
                     txId = tx.id.toString(),
                     stateMachineRunId = null,
                     transaction = tx.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes,
-                    status = 'V'
+                    status = "V"
             )
             session.save(persistentTx)
         }

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -212,7 +212,7 @@ class VaultStateMigrationTest {
                     txId = tx.id.toString(),
                     stateMachineRunId = null,
                     transaction = tx.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes,
-                    status = "V"
+                    status = DBTransactionStorage.TransactionStatus.VERIFIED
             )
             session.save(persistentTx)
         }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -284,7 +284,7 @@ class RetryFlowMockTest {
         }
 
         private fun doInsert() {
-            val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES, "V")
+            val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES, DBTransactionStorage.TransactionStatus.VERIFIED)
             contextTransaction.session.save(tx)
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -284,7 +284,7 @@ class RetryFlowMockTest {
         }
 
         private fun doInsert() {
-            val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES, 'V')
+            val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES, "V")
             contextTransaction.session.save(tx)
         }
     }


### PR DESCRIPTION
The new database transaction resolver can sometimes cause issues when some database providers are used, due to the character type used by the transaction status column. Moving this to be a string type fixes the problem.

Additionally, a small number of other issues have been corrected.
