### PR TITLE
Renamed BasicHSMKeyManagementService to PersistentKeyManagementService

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -54,7 +54,7 @@ import net.corda.node.services.config.shouldInitCrashShell
 import net.corda.node.services.events.NodeSchedulerService
 import net.corda.node.services.events.ScheduledActivityObserver
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.node.services.keys.KeyManagementServiceInternal
 import net.corda.node.services.messaging.DeduplicationHandler
 import net.corda.node.services.messaging.MessagingService
@@ -819,7 +819,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         // Place the long term identity key in the KMS. Eventually, this is likely going to be separated again because
         // the KMS is meant for derived temporary keys used in transactions, and we're not supposed to sign things with
         // the identity key. But the infrastructure to make that easy isn't here yet.
-        return BasicHSMKeyManagementService(cacheFactory, identityService, database, cryptoService, pkToIdCache)
+        return PersistentKeyManagementService(cacheFactory, identityService, database, cryptoService, pkToIdCache)
     }
 
     open fun stop() {

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -11,7 +11,7 @@ import net.corda.core.serialization.internal.*
 import net.corda.core.utilities.contextLogger
 import net.corda.node.internal.DBNetworkParametersStorage
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.node.services.vault.NodeVaultService
@@ -128,7 +128,7 @@ object VaultMigrationSchemaV1 : MappedSchema(schemaFamily = VaultMigrationSchema
                 DBTransactionStorage.DBTransaction::class.java,
                 PersistentIdentityService.PersistentIdentity::class.java,
                 PersistentIdentityService.PersistentIdentityNames::class.java,
-                BasicHSMKeyManagementService.PersistentKey::class.java,
+                PersistentKeyManagementService.PersistentKey::class.java,
                 NodeAttachmentService.DBAttachment::class.java,
                 DBNetworkParametersStorage.PersistentNetworkParameters::class.java
         )

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -30,11 +30,11 @@ import kotlin.collections.LinkedHashSet
  *
  * This class needs database transactions to be in-flight during method calls and init.
  */
-class BasicHSMKeyManagementService(cacheFactory: NamedCacheFactory,
-                                   override val identityService: PersistentIdentityService,
-                                   private val database: CordaPersistence,
-                                   private val cryptoService: SignOnlyCryptoService,
-                                   private val pkToIdCache: WritablePublicKeyToOwningIdentityCache) : SingletonSerializeAsToken(), KeyManagementServiceInternal {
+class PersistentKeyManagementService(cacheFactory: NamedCacheFactory,
+                                     override val identityService: PersistentIdentityService,
+                                     private val database: CordaPersistence,
+                                     private val cryptoService: SignOnlyCryptoService,
+                                     private val pkToIdCache: WritablePublicKeyToOwningIdentityCache) : SingletonSerializeAsToken(), KeyManagementServiceInternal {
     @Entity
     @Table(name = "${NODE_DATABASE_PREFIX}our_key_pairs")
     class PersistentKey(

--- a/node/src/main/kotlin/net/corda/node/services/persistence/PublicKeyToOwningIdentityCacheImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/PublicKeyToOwningIdentityCacheImpl.kt
@@ -7,7 +7,7 @@ import net.corda.core.internal.hash
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.nodeapi.internal.KeyOwningIdentity
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import java.security.PublicKey
@@ -50,10 +50,10 @@ class PublicKeyToOwningIdentityCacheImpl(private val database: CordaPersistence,
         return database.transaction {
             val criteriaBuilder = session.criteriaBuilder
             val criteriaQuery = criteriaBuilder.createQuery(Long::class.java)
-            val queryRoot = criteriaQuery.from(BasicHSMKeyManagementService.PersistentKey::class.java)
+            val queryRoot = criteriaQuery.from(PersistentKeyManagementService.PersistentKey::class.java)
             criteriaQuery.select(criteriaBuilder.count(queryRoot))
             criteriaQuery.where(
-                    criteriaBuilder.equal(queryRoot.get<String>(BasicHSMKeyManagementService.PersistentKey::publicKeyHash.name), key.toStringShort())
+                    criteriaBuilder.equal(queryRoot.get<String>(PersistentKeyManagementService.PersistentKey::publicKeyHash.name), key.toStringShort())
             )
             val query = session.createQuery(criteriaQuery)
             query.uniqueResult() > 0

--- a/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
@@ -13,7 +13,7 @@ import net.corda.node.services.api.SchemaService
 import net.corda.node.services.api.SchemaService.SchemaOptions
 import net.corda.node.services.events.NodeSchedulerService
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.node.services.messaging.P2PMessageDeduplicator
 import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.node.services.persistence.DBTransactionStorage
@@ -36,7 +36,7 @@ class NodeSchemaService(private val extraSchemas: Set<MappedSchema> = emptySet()
     object NodeCoreV1 : MappedSchema(schemaFamily = NodeCore.javaClass, version = 1,
             mappedTypes = listOf(DBCheckpointStorage.DBCheckpoint::class.java,
                     DBTransactionStorage.DBTransaction::class.java,
-                    BasicHSMKeyManagementService.PersistentKey::class.java,
+                    PersistentKeyManagementService.PersistentKey::class.java,
                     NodeSchedulerService.PersistentScheduledState::class.java,
                     NodeAttachmentService.DBAttachment::class.java,
                     P2PMessageDeduplicator.ProcessedMessage::class.java,

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -31,7 +31,7 @@ import net.corda.finance.contracts.asset.OnLedgerAsset
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.node.internal.DBNetworkParametersStorage
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.vault.VaultSchemaV1
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -189,7 +189,7 @@ class VaultStateMigrationTest {
     private fun saveOurKeys(keys: List<KeyPair>) {
         cordaDB.transaction {
             keys.forEach {
-                val persistentKey = BasicHSMKeyManagementService.PersistentKey(it.public, it.private)
+                val persistentKey = PersistentKeyManagementService.PersistentKey(it.public, it.private)
                 session.save(persistentKey)
             }
         }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateColumnConverterTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateColumnConverterTests.kt
@@ -1,42 +1,25 @@
 package net.corda.node.services.persistence
 
-import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.Amount
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
-import net.corda.core.node.services.KeyManagementService
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
-import net.corda.core.utilities.getOrThrow
 import net.corda.finance.DOLLARS
 import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
-import net.corda.finance.flows.AbstractCashFlow
 import net.corda.finance.issuedBy
-import net.corda.node.migration.VaultStateMigrationTest.Companion.bankOfCorda
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
 import net.corda.node.services.keys.E2ETestKeyManagementService
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.core.BOC_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.internal.TestingNamedCacheFactory
-import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
-import net.corda.testing.node.MockNetwork
-import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.MockServices
-import net.corda.testing.node.StartedMockNode
-import net.corda.testing.node.internal.FINANCE_CORDAPPS
-import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.TestStartedNode
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.*
 import kotlin.test.assertEquals
 
 class HibernateColumnConverterTests {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -27,7 +27,7 @@ import net.corda.node.internal.cordapp.JarScanningCordappLoader
 import net.corda.node.services.api.*
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.node.services.persistence.PublicKeyToOwningIdentityCacheImpl
 import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.services.transactions.InMemoryTransactionVerifierService
@@ -183,7 +183,7 @@ open class MockServices private constructor(
             val identityAlias = "${initialIdentity.name} private key"
             aliasKeyMap[identityAlias] = initialIdentity.keyPair
             val aliasedIdentityKey = KeyPair(initialIdentity.publicKey, AliasPrivateKey(identityAlias))
-            val keyManagementService = BasicHSMKeyManagementService(
+            val keyManagementService = PersistentKeyManagementService(
                     TestingNamedCacheFactory(),
                     identityService,
                     persistence,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -34,7 +34,7 @@ import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.config.*
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.node.services.keys.KeyManagementServiceInternal
 import net.corda.node.services.messaging.Message
 import net.corda.node.services.messaging.MessagingService
@@ -373,7 +373,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
         }
 
         override fun makeKeyManagementService(identityService: PersistentIdentityService): KeyManagementServiceInternal {
-            return BasicHSMKeyManagementService(cacheFactory, identityService, database, cryptoService, pkToIdCache)
+            return PersistentKeyManagementService(cacheFactory, identityService, database, cryptoService, pkToIdCache)
         }
 
         override fun startShell() {


### PR DESCRIPTION
"Basic HSM" does not describe what it does.

Note: PersistentKeyManagementService used to be name of the old deprecated key management service, but it was removed in 101d9780.

