### PR TITLE
Tweak the docsite in various ways

### DIFF
--- a/docs/source/building-a-cordapp-index.rst
+++ b/docs/source/building-a-cordapp-index.rst
@@ -12,10 +12,6 @@ CorDapps
    cordapp-build-systems
    building-against-master
    debugging-a-cordapp
-   versioning
-   upgrading-cordapps
-   cordapp-constraint-migration
-   cordapp-upgradeability
    secure-coding-guidelines
    flow-overriding
    flow-cookbook

--- a/docs/source/corda-api.rst
+++ b/docs/source/corda-api.rst
@@ -1,27 +1,3 @@
-Corda API
-=========
-
-The following are the core APIs that are used in the development of CorDapps:
-
-.. toctree::
-   :maxdepth: 1
-
-   api-states
-   api-persistence
-   api-contracts
-   api-contract-constraints
-   api-vault-query
-   api-transactions
-   api-flows
-   api-identity
-   api-service-hub
-   api-service-classes
-   api-rpc
-   api-core-types
-   api-testing
-
-Before reading this page, you should be familiar with the :doc:`key concepts of Corda <key-concepts>`.
-
 .. _internal-apis-and-stability-guarantees:
 
 API stability guarantees

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,32 +1,52 @@
 Welcome to Corda !
 ==================
 
-`Corda <https://www.corda.net/>`_ is an open-source blockchain platform. If you’d like a quick introduction to blockchains and how Corda is different, then watch this short video:
+.. only:: html
 
-.. raw:: html
+   `Corda <https://www.corda.net/>`_ is an open-source blockchain platform. If you’d like a quick introduction to blockchains and how Corda is different, then watch this short video:
 
-    <embed>
-      <iframe src="https://player.vimeo.com/video/205410473" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-    </embed>
+   .. raw:: html
 
-Want to see Corda running? Download our demonstration application `DemoBench <https://www.corda.net/downloads/>`_ or
-follow our :doc:`quickstart guide </quickstart-index>`.
+       <embed>
+         <iframe src="https://player.vimeo.com/video/205410473" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+       </embed>
 
-If you want to start coding on Corda, then familiarise yourself with the :doc:`key concepts </key-concepts>`, then read
-our :doc:`Hello, World! tutorial </hello-world-introduction>`. For the background behind Corda, read the non-technical
+   Want to see Corda running? Download our demonstration application `DemoBench <https://www.corda.net/downloads/>`_ or
+   follow our :doc:`quickstart guide </quickstart-index>`.
+
+   If you want to start coding on Corda, then familiarise yourself with the :doc:`key concepts </key-concepts>`, then read
+our :doc:`Hello, World! tutorial </hello-world-introduction>`. For the background behind Corda, read the
+   non-technical
 `platform white paper`_ or for more detail, the `technical white paper`_.
 
-If you have questions or comments, then get in touch on `Slack <https://slack.corda.net/>`_ or ask a question on
-`Stack Overflow <https://stackoverflow.com/questions/tagged/corda>`_ .
+   If you have questions or comments, then get in touch on `Slack <https://slack.corda.net/>`_ or ask a question on
+   `Stack Overflow <https://stackoverflow.com/questions/tagged/corda>`_ .
 
-We look forward to seeing what you can do with Corda!
+   We look forward to seeing what you can do with Corda!
 
-.. note:: You can read this site offline. Either `download the PDF`_ or download the Corda source code, run ``gradle buildDocs`` and you will have
-   a copy of this site in the ``docs/build/html`` directory.
+   .. note:: You can read this site offline. Either `download the PDF`_ or download the Corda source code, run ``gradle buildDocs`` and you will have
+      a copy of this site in the ``docs/build/html`` directory.
 
-.. _`platform white paper`: _static/corda-platform-whitepaper.pdf
-.. _`technical white paper`: _static/corda-technical-whitepaper.pdf
-.. _`download the PDF`: _static/corda-developer-site.pdf
+   .. _`platform white paper`: _static/corda-platform-whitepaper.pdf
+   .. _`technical white paper`: _static/corda-technical-whitepaper.pdf
+   .. _`download the PDF`: _static/corda-developer-site.pdf
+
+.. only:: latex
+
+   Welcome to Corda, a platform for building decentralized applications. This guidebook covers everything you need to know to create
+   apps, run nodes and networks, and operate your new decentralized business network.
+
+   If you're completely new to distributed ledger technology (DLT) or Corda and would like a business-oriented overview, we recommend
+   reading the introductory white paper. If you'd like a detailed architectural description of how the Corda protocol works, why
+   it's designed how it is and what future work is planned, we recommend reading the technical white paper. Both white papers can be
+   found on `the Corda documentation website`_.
+
+   But if you'd like to dive in and start writing apps, or running nodes, this guidebook is for you. It covers the open source Corda
+   distribution. Commercial distributions (like Corda Enterprise from R3) have their own user guides that describe their enhanced features.
+
+   We look forward to seeing what you can do with Corda!
+
+   .. _`the Corda documentation website`: https://docs.corda.net
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/versioning-and-upgrades.rst
+++ b/docs/source/versioning-and-upgrades.rst
@@ -1,0 +1,24 @@
+Versioning and upgrades
+=======================
+
+| *Change is inevitable, except from a vending machine*
+| -- Abraham Lincoln
+|
+
+This section of the guide covers how CorDapps are versioned and how to manage upgrades in a decentralised network. It should be read when
+you're at a stage of your development that requires planning for post-launch iteration. You will learn:
+
+* How the ledger expresses to what extent business logic can be changed and by who.
+* How change is managed in a world where there are no privileged administrators who can force upgrades.
+
+It's worth planning for versioning and upgrades from the start, especially if you plan for your CorDapp to itself provide APIs to other
+apps. Apps extending the platform with industry-specific data models is a common case, and ensuring you can evolve your data model as
+the world changes is a key part of any professionally built software.
+
+.. toctree::
+   :maxdepth: 1
+
+   versioning
+   upgrading-cordapps
+   cordapp-constraint-migration
+   cordapp-upgradeability


### PR DESCRIPTION
* Create a new versioning and upgrades section, currently only with content from existing sections.
* Give the PDF version its own intro, to avoid odd text referring to non-existent videos etc.
* Adjust the formatting of the intro page, make the white papers have big buttons to view them.