### PR TITLE
CORDA-3157: Modify Corda's custom serialiser support for the DJVM.

### DIFF
--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -22,12 +22,12 @@ dependencies {
     // Configure these by hand. It should be a minimal subset of dependencies,
     // and without any obviously non-deterministic ones such as Hibernate.
 
-    // This dependency will become "compile" scoped in our published POM.
+    // These dependencies will become "compile" scoped in our published POM.
     // See publish.dependenciesFrom.defaultScope.
     deterministicLibraries project(path: ':core-deterministic', configuration: 'deterministicArtifacts')
+    deterministicLibraries "org.apache.qpid:proton-j:$protonj_version"
 
     // These "implementation" dependencies will become "runtime" scoped in our published POM.
-    implementation "org.apache.qpid:proton-j:$protonj_version"
     implementation "org.iq80.snappy:snappy:$snappy_version"
     implementation "com.google.guava:guava:$guava_version"
 }

--- a/serialization-deterministic/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializerFactories.kt
+++ b/serialization-deterministic/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializerFactories.kt
@@ -13,11 +13,16 @@ import net.corda.serialization.internal.carpenter.Schema
 @Suppress("UNUSED")
 fun createSerializerFactoryFactory(): SerializerFactoryFactory = DeterministicSerializerFactoryFactory()
 
+/**
+ * Creates a [ClassCarpenter] suitable for the DJVM, i.e. one that doesn't work.
+ */
+fun createClassCarpenter(context: SerializationContext): ClassCarpenter = DummyClassCarpenter(context.whitelist, context.deserializationClassLoader)
+
 private class DeterministicSerializerFactoryFactory : SerializerFactoryFactory {
     override fun make(context: SerializationContext) =
             SerializerFactoryBuilder.build(
             whitelist = context.whitelist,
-            classCarpenter = DummyClassCarpenter(context.whitelist, context.deserializationClassLoader))
+            classCarpenter = createClassCarpenter(context))
 }
 
 private class DummyClassCarpenter(

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializerFactories.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializerFactories.kt
@@ -3,14 +3,21 @@
 package net.corda.serialization.internal.amqp
 
 import net.corda.core.serialization.SerializationContext
+import net.corda.serialization.internal.carpenter.ClassCarpenter
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 
 fun createSerializerFactoryFactory(): SerializerFactoryFactory = SerializerFactoryFactoryImpl()
 
+fun createClassCarpenter(context: SerializationContext): ClassCarpenter = ClassCarpenterImpl(
+    whitelist = context.whitelist,
+    cl = context.deserializationClassLoader,
+    lenient = context.lenientCarpenterEnabled
+)
+
 open class SerializerFactoryFactoryImpl : SerializerFactoryFactory {
     override fun make(context: SerializationContext): SerializerFactory {
         return SerializerFactoryBuilder.build(context.whitelist,
-                ClassCarpenterImpl(context.whitelist, context.deserializationClassLoader, context.lenientCarpenterEnabled),
+                createClassCarpenter(context),
                 mustPreserveDataWhenEvolving = context.preventDataLoss
         )
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifiers.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifiers.kt
@@ -29,7 +29,7 @@ object AMQPTypeIdentifiers {
             Float::class to "float",
             Double::class to "double",
             Decimal32::class to "decimal32",
-            Decimal64::class to "decimal62",
+            Decimal64::class to "decimal64",
             Decimal128::class to "decimal128",
             Date::class to "timestamp",
             UUID::class to "uuid",

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt
@@ -88,7 +88,9 @@ open class ArraySerializer(override val type: Type, factory: LocalSerializerFact
                             context: SerializationContext
     ): Any {
         if (obj is List<*>) {
-            return obj.map { input.readObjectOrNull(it, schemas, elementType, context) }.toArrayOfType(elementType)
+            return obj.map {
+                input.readObjectOrNull(redescribe(it, elementType), schemas, elementType, context)
+            }.toArrayOfType(elementType)
         } else throw AMQPNotSerializableException(type, "Expected a List but found $obj")
     }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ComposableTypePropertySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ComposableTypePropertySerializer.kt
@@ -1,6 +1,7 @@
 package net.corda.serialization.internal.amqp
 
 import net.corda.core.serialization.SerializationContext
+import net.corda.serialization.internal.amqp.AMQPTypeIdentifiers.isPrimitive
 import net.corda.serialization.internal.model.*
 import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.codec.Data
@@ -18,7 +19,7 @@ interface PropertyReadStrategy {
          * Select the correct strategy for reading properties, based on the property type.
          */
         fun make(name: String, typeIdentifier: TypeIdentifier, type: Type): PropertyReadStrategy =
-                if (AMQPTypeIdentifiers.isPrimitive(typeIdentifier)) {
+                if (isPrimitive(typeIdentifier)) {
                     when (typeIdentifier) {
                         in characterTypes -> AMQPCharPropertyReadStrategy
                         else -> AMQPPropertyReadStrategy
@@ -47,7 +48,7 @@ interface PropertyWriteStrategy {
         fun make(name: String, propertyInformation: LocalPropertyInformation, factory: LocalSerializerFactory): PropertyWriteStrategy {
             val reader = PropertyReader.make(propertyInformation)
             val type = propertyInformation.type
-            return if (AMQPTypeIdentifiers.isPrimitive(type.typeIdentifier)) {
+            return if (isPrimitive(type.typeIdentifier)) {
                 when (type.typeIdentifier) {
                     in characterTypes -> AMQPCharPropertyWriteStategy(reader)
                     else -> AMQPPropertyWriteStrategy(reader)
@@ -191,15 +192,14 @@ object EvolutionPropertyWriteStrategy : PropertyWriteStrategy {
  * Read a type that comes with its own [TypeDescriptor], by calling back into [RemoteSerializerFactory] to obtain a suitable
  * serializer for that descriptor.
  */
-class DescribedTypeReadStrategy(name: String,
-                                typeIdentifier: TypeIdentifier,
+class DescribedTypeReadStrategy(name: String, typeIdentifier: TypeIdentifier,
                                 private val type: Type): PropertyReadStrategy {
 
     private val nameForDebug = "$name(${typeIdentifier.prettyPrint(false)})"
 
     override fun readProperty(obj: Any?, schemas: SerializationSchemas, input: DeserializationInput, context: SerializationContext): Any? =
             ifThrowsAppend({ nameForDebug }) {
-                input.readObjectOrNull(obj, schemas, type, context)
+                input.readObjectOrNull(redescribe(obj, type), schemas, type, context)
             }
 }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ComposableTypePropertySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ComposableTypePropertySerializer.kt
@@ -192,7 +192,8 @@ object EvolutionPropertyWriteStrategy : PropertyWriteStrategy {
  * Read a type that comes with its own [TypeDescriptor], by calling back into [RemoteSerializerFactory] to obtain a suitable
  * serializer for that descriptor.
  */
-class DescribedTypeReadStrategy(name: String, typeIdentifier: TypeIdentifier,
+class DescribedTypeReadStrategy(name: String,
+                                typeIdentifier: TypeIdentifier,
                                 private val type: Type): PropertyReadStrategy {
 
     private val nameForDebug = "$name(${typeIdentifier.prettyPrint(false)})"

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
@@ -57,6 +57,8 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
     abstract fun writeDescribedObject(obj: T, data: Data, type: Type, output: SerializationOutput,
                                       context: SerializationContext)
 
+    open fun specialiseFor(declaredType: Type): AMQPSerializer<T>? = this
+
     /**
      * This custom serializer represents a sort of symbolic link from a subclass to a super class, where the super
      * class custom serializer is responsible for the "on the wire" format but we want to create a reference to the

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
@@ -29,6 +29,10 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
      */
     open val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
 
+    /**
+     * This custom serializer is also allowed to deserialize these classes.
+     */
+    open val deserializationAliases: Set<Class<*>> = emptySet()
 
     protected abstract val descriptor: Descriptor
     /**
@@ -110,7 +114,7 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
      */
     abstract class CustomSerializerImp<T : Any>(protected val clazz: Class<T>, protected val withInheritance: Boolean) : CustomSerializer<T>() {
         override val type: Type get() = clazz
-        override val typeDescriptor: Symbol = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${AMQPTypeIdentifiers.nameForType(clazz)}")
+        override val typeDescriptor: Symbol = typeDescriptorFor(clazz)
         override fun writeClassInfo(output: SerializationOutput) {}
         override val descriptor: Descriptor = Descriptor(typeDescriptor)
         override fun isSerializerFor(clazz: Class<*>): Boolean = if (withInheritance) this.clazz.isAssignableFrom(clazz) else this.clazz == clazz

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
@@ -123,11 +123,13 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
     /**
      * Additional base features for a custom serializer for a particular class, that excludes subclasses.
      */
+    @KeepForDJVM
     abstract class Is<T : Any>(clazz: Class<T>) : CustomSerializerImp<T>(clazz, false)
 
     /**
      * Additional base features for a custom serializer for all implementations of a particular interface or super class.
      */
+    @KeepForDJVM
     abstract class Implements<T : Any>(clazz: Class<T>) : CustomSerializerImp<T>(clazz, true)
 
     /**
@@ -137,6 +139,7 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
      * The proxy class must use only types which are either native AMQP or other types for which there are pre-registered
      * custom serializers.
      */
+    @KeepForDJVM
     abstract class Proxy<T : Any, P : Any>(clazz: Class<T>,
                                            protected val proxyClass: Class<P>,
                                            protected val factory: LocalSerializerFactory,
@@ -195,6 +198,7 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
      * @param maker A lambda for constructing an instance, that defaults to calling a constructor that expects a string.
      * @param unmaker A lambda that extracts the string value for an instance, that defaults to the [toString] method.
      */
+    @KeepForDJVM
     abstract class ToString<T : Any>(clazz: Class<T>, withInheritance: Boolean = false,
                                      private val maker: (String) -> T = clazz.getConstructor(String::class.java).let { `constructor` ->
                                          { string -> `constructor`.newInstance(string) }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
@@ -30,7 +30,8 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
     open val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
 
     /**
-     * This custom serializer is also allowed to deserialize these classes.
+     * This custom serializer is also allowed to deserialize these classes. This allows us
+     * to deserialize objects into completely different types, e.g. `A` -> `sandbox.A`.
      */
     open val deserializationAliases: Set<Class<*>> = emptySet()
 
@@ -57,6 +58,12 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
     abstract fun writeDescribedObject(obj: T, data: Data, type: Type, output: SerializationOutput,
                                       context: SerializationContext)
 
+    /**
+     * [CustomSerializerRegistry.findCustomSerializer] will invoke this method on the [CustomSerializer]
+     * that it selects to give that serializer an opportunity to customise its behaviour. The serializer
+     * can also return `null` here, in which case [CustomSerializerRegistry] will proceed as if no
+     * serializer is available for [declaredType].
+     */
     open fun specialiseFor(declaredType: Type): AMQPSerializer<T>? = this
 
     /**

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -57,8 +57,10 @@ interface CustomSerializerRegistry {
 }
 
 class CachingCustomSerializerRegistry(
-        private val descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry)
-    : CustomSerializerRegistry {
+        private val descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry,
+        private val allowedFor: Set<Class<*>>
+) : CustomSerializerRegistry {
+    constructor(descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry) : this(descriptorBasedSerializerRegistry, emptySet())
 
     companion object {
         val logger = contextLogger()
@@ -185,6 +187,7 @@ class CachingCustomSerializerRegistry(
     private val Class<*>.isCustomSerializationForbidden: Boolean get() = when {
         AMQPTypeIdentifiers.isPrimitive(this) -> true
         isSubClassOf(CordaThrowable::class.java) -> false
+        allowedFor.any { it.isAssignableFrom(this) } -> false
         isAnnotationPresent(CordaSerializable::class.java) -> true
         else -> false
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -44,7 +44,7 @@ interface CustomSerializerRegistry {
      *
      * @param clazz The actual class to look for a custom serializer for.
      * @param declaredType The declared type to look for a custom serializer for.
-     * @return The custom serializer handing the class, if found, or `null`.
+     * @return The custom serializer handling the class, if found, or `null`.
      *
      * @throws IllegalCustomSerializerException If a custom serializer identifies itself as the serializer for
      * a class annotated with [CordaSerializable], since all such classes should be serializable via standard object

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -129,7 +129,7 @@ class CachingCustomSerializerRegistry(
             customSerializer
         }
     }
-    
+
     override fun findCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? {
         val typeIdentifier = CustomSerializerIdentifier(
                 TypeIdentifier.forClass(clazz),
@@ -173,7 +173,13 @@ class CachingCustomSerializerRegistry(
             throw IllegalCustomSerializerException(declaredSerializers.first(), clazz)
         }
 
-        return declaredSerializers.first()
+        return declaredSerializers.first().let {
+            if (it is CustomSerializer<Any>) {
+                it.specialiseFor(declaredType)
+            } else {
+                it
+            }
+        }
     }
 
     private val Class<*>.isCustomSerializationForbidden: Boolean get() = when {
@@ -183,3 +189,4 @@ class CachingCustomSerializerRegistry(
         else -> false
     }
 }
+

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
@@ -142,12 +142,12 @@ class DeserializationInput constructor(
                 envelope)
     }
 
-    internal fun readObjectOrNull(obj: Any?, schema: SerializationSchemas, type: Type, context: SerializationContext
+    fun readObjectOrNull(obj: Any?, schema: SerializationSchemas, type: Type, context: SerializationContext
     ): Any? {
         return if (obj == null) null else readObject(obj, schema, type, context)
     }
 
-    internal fun readObject(obj: Any, schemas: SerializationSchemas, type: Type, context: SerializationContext): Any =
+    fun readObject(obj: Any, schemas: SerializationSchemas, type: Type, context: SerializationContext): Any =
             if (obj is DescribedType && ReferencedObject.DESCRIPTOR == obj.descriptor) {
                 // It must be a reference to an instance that has already been read, cheaply and quickly returning it by reference.
                 val objectIndex = (obj.described as UnsignedInteger).toInt()

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -12,6 +12,7 @@ import org.apache.qpid.proton.amqp.Symbol
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.util.*
+import java.util.function.Function
 import javax.annotation.concurrent.ThreadSafe
 
 /**
@@ -89,6 +90,7 @@ class DefaultLocalSerializerFactory(
         private val fingerPrinter: FingerPrinter,
         override val classloader: ClassLoader,
         private val descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry,
+        private val primitiveSerializerFactory: Function<Class<*>, AMQPSerializer<Any>>,
         private val customSerializerRegistry: CustomSerializerRegistry,
         private val onlyCustomSerializers: Boolean)
     : LocalSerializerFactory {
@@ -237,7 +239,7 @@ class DefaultLocalSerializerFactory(
                 throw AMQPNotSerializableException(
                         type,
                         "Serializer does not support synthetic classes")
-            AMQPTypeIdentifiers.isPrimitive(typeInformation.typeIdentifier) -> AMQPPrimitiveSerializer(clazz)
+            AMQPTypeIdentifiers.isPrimitive(typeInformation.typeIdentifier) -> primitiveSerializerFactory.apply(clazz)
             else -> makeNonCustomSerializer(type, typeInformation, clazz)
         }
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/RemoteSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/RemoteSerializerFactory.kt
@@ -3,7 +3,6 @@ package net.corda.serialization.internal.amqp
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.model.*
-import org.hibernate.type.descriptor.java.ByteTypeDescriptor
 import java.io.NotSerializableException
 
 /**

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
@@ -3,10 +3,10 @@ package net.corda.serialization.internal.amqp
 import net.corda.core.KeepForDJVM
 import net.corda.core.internal.uncheckedCast
 import net.corda.serialization.internal.CordaSerializationMagic
-import org.apache.qpid.proton.amqp.DescribedType
-import org.apache.qpid.proton.amqp.Symbol
-import org.apache.qpid.proton.amqp.UnsignedInteger
-import org.apache.qpid.proton.amqp.UnsignedLong
+import net.corda.serialization.internal.amqp.AMQPTypeIdentifiers.isPrimitive
+import net.corda.serialization.internal.model.TypeIdentifier.TopType
+import net.corda.serialization.internal.model.TypeIdentifier.Companion.forGenericType
+import org.apache.qpid.proton.amqp.*
 import org.apache.qpid.proton.codec.DescribedTypeConstructor
 import java.io.NotSerializableException
 import java.lang.reflect.Type
@@ -15,6 +15,26 @@ const val DESCRIPTOR_DOMAIN: String = "net.corda"
 val amqpMagic = CordaSerializationMagic("corda".toByteArray() + byteArrayOf(1, 0))
 
 fun typeDescriptorFor(type: Type): Symbol = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${AMQPTypeIdentifiers.nameForType(type)}")
+
+fun redescribe(obj: Any?, type: Type): Any? {
+    return if (obj == null || obj is DescribedType || obj is Binary || forGenericType(type).run { isPrimitive(this) || this == TopType }) {
+        obj
+    } else {
+        /**
+         * This must be a primitive [obj] that has a non-primitive [type].
+         * Rewrap it with the required descriptor for further deserialization.
+         */
+        RedescribedType(typeDescriptorFor(type), obj)
+    }
+}
+
+private class RedescribedType(
+    private val descriptor: Symbol,
+    private val described: Any?
+) : DescribedType {
+    override fun getDescriptor(): Symbol = descriptor
+    override fun getDescribed(): Any? = described
+}
 
 /**
  * This and the classes below are OO representations of the AMQP XML schema described in the specification. Their

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
@@ -9,11 +9,12 @@ import org.apache.qpid.proton.amqp.UnsignedInteger
 import org.apache.qpid.proton.amqp.UnsignedLong
 import org.apache.qpid.proton.codec.DescribedTypeConstructor
 import java.io.NotSerializableException
-import net.corda.serialization.internal.carpenter.Field as CarpenterField
-import net.corda.serialization.internal.carpenter.Schema as CarpenterSchema
+import java.lang.reflect.Type
 
 const val DESCRIPTOR_DOMAIN: String = "net.corda"
 val amqpMagic = CordaSerializationMagic("corda".toByteArray() + byteArrayOf(1, 0))
+
+fun typeDescriptorFor(type: Type): Symbol = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${AMQPTypeIdentifiers.nameForType(type)}")
 
 /**
  * This and the classes below are OO representations of the AMQP XML schema described in the specification. Their

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
@@ -4,6 +4,7 @@ import net.corda.core.KeepForDJVM
 import net.corda.core.internal.uncheckedCast
 import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.amqp.AMQPTypeIdentifiers.isPrimitive
+import net.corda.serialization.internal.model.TypeIdentifier
 import net.corda.serialization.internal.model.TypeIdentifier.TopType
 import net.corda.serialization.internal.model.TypeIdentifier.Companion.forGenericType
 import org.apache.qpid.proton.amqp.*
@@ -14,7 +15,8 @@ import java.lang.reflect.Type
 const val DESCRIPTOR_DOMAIN: String = "net.corda"
 val amqpMagic = CordaSerializationMagic("corda".toByteArray() + byteArrayOf(1, 0))
 
-fun typeDescriptorFor(type: Type): Symbol = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${AMQPTypeIdentifiers.nameForType(type)}")
+fun typeDescriptorFor(typeId: TypeIdentifier): Symbol = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${AMQPTypeIdentifiers.nameForType(typeId)}")
+fun typeDescriptorFor(type: Type): Symbol = typeDescriptorFor(forGenericType(type))
 
 fun redescribe(obj: Any?, type: Type): Any? {
     return if (obj == null || obj is DescribedType || obj is Binary || forGenericType(type).run { isPrimitive(this) || this == TopType }) {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt
@@ -18,6 +18,11 @@ val amqpMagic = CordaSerializationMagic("corda".toByteArray() + byteArrayOf(1, 0
 fun typeDescriptorFor(typeId: TypeIdentifier): Symbol = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${AMQPTypeIdentifiers.nameForType(typeId)}")
 fun typeDescriptorFor(type: Type): Symbol = typeDescriptorFor(forGenericType(type))
 
+/**
+ * Repackages a naked, non-primitive [obj] as a [DescribedType]. If [obj] is primitive, [Binary] or already
+ * an instance of [DescribedType]] then it is returned unchanged. This allows Corda to search for a serializer
+ * capable of handling instances of [type].
+ */
 fun redescribe(obj: Any?, type: Type): Any? {
     return if (obj == null || obj is DescribedType || obj is Binary || forGenericType(type).run { isPrimitive(this) || this == TopType }) {
         obj

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -92,7 +92,7 @@ object SerializerFactoryBuilder {
                 customSerializerRegistry,
                 onlyCustomSerializers)
 
-        val typeLoader = ClassCarpentingTypeLoader(
+        val typeLoader: TypeLoader = ClassCarpentingTypeLoader(
                 SchemaBuildingRemoteTypeCarpenter(classCarpenter),
                 classCarpenter.classloader)
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -7,9 +7,24 @@ import net.corda.serialization.internal.carpenter.ClassCarpenter
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import net.corda.serialization.internal.model.*
 import java.io.NotSerializableException
+import java.util.Collections.unmodifiableMap
 
 @KeepForDJVM
 object SerializerFactoryBuilder {
+    /**
+     * The standard mapping of Java object types to Java primitive types.
+     * The DJVM will need to override these, but probably not anyone else.
+     */
+    private val javaPrimitiveTypes: Map<Class<*>, Class<*>> = unmodifiableMap(mapOf<Class<out Any>?, Class<out Any>?>(
+        Boolean::class.javaObjectType to Boolean::class.javaPrimitiveType,
+        Byte::class.javaObjectType to Byte::class.javaPrimitiveType,
+        Char::class.javaObjectType to Char::class.javaPrimitiveType,
+        Double::class.javaObjectType to Double::class.javaPrimitiveType,
+        Float::class.javaObjectType to Float::class.javaPrimitiveType,
+        Int::class.javaObjectType to Int::class.javaPrimitiveType,
+        Long::class.javaObjectType to Long::class.javaPrimitiveType,
+        Short::class.javaObjectType to Short::class.javaPrimitiveType
+    )) as Map<Class<*>, Class<*>>
 
     @JvmStatic
     fun build(whitelist: ClassWhitelist, classCarpenter: ClassCarpenter): SerializerFactory {
@@ -99,7 +114,8 @@ object SerializerFactoryBuilder {
         val evolutionSerializerFactory = if (allowEvolution) DefaultEvolutionSerializerFactory(
                 localSerializerFactory,
                 classCarpenter.classloader,
-                mustPreserveDataWhenEvolving
+                mustPreserveDataWhenEvolving,
+                javaPrimitiveTypes
         ) else NoEvolutionSerializerFactory
 
         val remoteSerializerFactory = DefaultRemoteSerializerFactory(
@@ -127,4 +143,6 @@ Local:
 ${localTypeInformation.prettyPrint(false)}
         """)
     }
+
+    override val primitiveTypes: Map<Class<*>, Class<*>> = emptyMap()
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -17,16 +17,18 @@ object SerializerFactoryBuilder {
      * The DJVM will need to override these, but probably not anyone else.
      */
     @Suppress("unchecked_cast")
-    private val javaPrimitiveTypes: Map<Class<*>, Class<*>> = unmodifiableMap(mapOf<Class<out Any>?, Class<out Any>?>(
-        Boolean::class.javaObjectType to Boolean::class.javaPrimitiveType,
-        Byte::class.javaObjectType to Byte::class.javaPrimitiveType,
-        Char::class.javaObjectType to Char::class.javaPrimitiveType,
-        Double::class.javaObjectType to Double::class.javaPrimitiveType,
-        Float::class.javaObjectType to Float::class.javaPrimitiveType,
-        Int::class.javaObjectType to Int::class.javaPrimitiveType,
-        Long::class.javaObjectType to Long::class.javaPrimitiveType,
-        Short::class.javaObjectType to Short::class.javaPrimitiveType
-    )) as Map<Class<*>, Class<*>>
+    private val javaPrimitiveTypes: Map<Class<*>, Class<*>> = unmodifiableMap(listOf(
+        Boolean::class,
+        Byte::class,
+        Char::class,
+        Double::class,
+        Float::class,
+        Int::class,
+        Long::class,
+        Short::class
+    ).associate {
+        klazz -> klazz.javaObjectType to klazz.javaPrimitiveType
+    }) as Map<Class<*>, Class<*>>
 
     @JvmStatic
     fun build(whitelist: ClassWhitelist, classCarpenter: ClassCarpenter): SerializerFactory {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -8,6 +8,7 @@ import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import net.corda.serialization.internal.model.*
 import java.io.NotSerializableException
 import java.util.Collections.unmodifiableMap
+import java.util.function.Function
 
 @KeepForDJVM
 object SerializerFactoryBuilder {
@@ -15,6 +16,7 @@ object SerializerFactoryBuilder {
      * The standard mapping of Java object types to Java primitive types.
      * The DJVM will need to override these, but probably not anyone else.
      */
+    @Suppress("unchecked_cast")
     private val javaPrimitiveTypes: Map<Class<*>, Class<*>> = unmodifiableMap(mapOf<Class<out Any>?, Class<out Any>?>(
         Boolean::class.javaObjectType to Boolean::class.javaPrimitiveType,
         Byte::class.javaObjectType to Byte::class.javaPrimitiveType,
@@ -104,6 +106,7 @@ object SerializerFactoryBuilder {
                 fingerPrinter,
                 classCarpenter.classloader,
                 descriptorBasedSerializerRegistry,
+                Function { clazz -> AMQPPrimitiveSerializer(clazz) },
                 customSerializerRegistry,
                 onlyCustomSerializers)
 
@@ -132,15 +135,15 @@ object SerializerFactoryBuilder {
 }
 
 object NoEvolutionSerializerFactory : EvolutionSerializerFactory {
-    override fun getEvolutionSerializer(remoteTypeInformation: RemoteTypeInformation, localTypeInformation: LocalTypeInformation): AMQPSerializer<Any> {
+    override fun getEvolutionSerializer(remote: RemoteTypeInformation, local: LocalTypeInformation): AMQPSerializer<Any> {
         throw NotSerializableException("""
 Evolution not permitted.
 
 Remote:
-${remoteTypeInformation.prettyPrint(false)}
+${remote.prettyPrint(false)}
 
 Local:
-${localTypeInformation.prettyPrint(false)}
+${local.prettyPrint(false)}
         """)
     }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeModel.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeModel.kt
@@ -1,7 +1,5 @@
 package net.corda.serialization.internal.model
 
-import net.corda.core.serialization.ClassWhitelist
-import net.corda.serialization.internal.amqp.*
 import java.lang.reflect.*
 
 /**
@@ -54,7 +52,7 @@ class ConfigurableLocalTypeModel(private val typeModelConfiguration: LocalTypeMo
     private val typeInformationCache = DefaultCacheProvider.createCache<TypeIdentifier, LocalTypeInformation>()
 
     /**
-     * We need to provide the [TypeInformationBuilder] with a temporary local cache, so that it doesn't leak
+     * We need to provide the [LocalTypeInformationBuilder] with a temporary local cache, so that it doesn't leak
      * [LocalTypeInformation] with unpatched cycles into the global cache where other threads can access them
      * before we've patched the cycles up.
      */

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
@@ -63,6 +63,8 @@ sealed class TypeIdentifier {
         // This method has locking.  So we memo the value here.
         private val systemClassLoader: ClassLoader = ClassLoader.getSystemClassLoader()
 
+        fun classLoaderFor(clazz: Class<*>): ClassLoader = clazz.classLoader ?: systemClassLoader
+
         /**
          * Obtain the [TypeIdentifier] for an erased Java class.
          *

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
@@ -206,7 +206,10 @@ sealed class TypeIdentifier {
 
         override fun toString() = "Parameterised(${prettyPrint()})"
         override fun getLocalType(classLoader: ClassLoader): Type {
-            val rawType = Class.forName(name, false, classLoader)
+            // We need to invoke ClassLoader.loadClass() directly, because
+            // the JVM will complain if Class.forName() returns a class
+            // that has a name other than the requested one.
+            val rawType = classLoader.loadClass(name)
             if (rawType.typeParameters.size != parameters.size) {
                 throw IncompatibleTypeIdentifierException(
                         "Class $rawType expects ${rawType.typeParameters.size} type arguments, " +

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
@@ -210,7 +210,8 @@ sealed class TypeIdentifier {
         override fun getLocalType(classLoader: ClassLoader): Type {
             // We need to invoke ClassLoader.loadClass() directly, because
             // the JVM will complain if Class.forName() returns a class
-            // that has a name other than the requested one.
+            // that has a name other than the requested one. This will happen
+            // for "transformative" class loaders, i.e. `A` -> `sandbox.A`.
             val rawType = classLoader.loadClass(name)
             if (rawType.typeParameters.size != parameters.size) {
                 throw IncompatibleTypeIdentifierException(

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
@@ -36,11 +36,15 @@ class TypeModellingFingerPrinter(
     private val cache: MutableMap<TypeIdentifier, String> = DefaultCacheProvider.createCache()
 
     override fun fingerprint(typeInformation: LocalTypeInformation): String =
-            cache.computeIfAbsent(typeInformation.typeIdentifier) {
-                FingerPrintingState(
-                        customTypeDescriptorLookup,
-                        FingerprintWriter(debugEnabled)).fingerprint(typeInformation)
-            }
+        /*
+         * We cannot use ConcurrentMap.computeIfAbsent() here because it requires
+         * that the map not be re-entered during the computation function. And
+         * the Fingerprinter cannot guarantee that.
+         */
+        cache.getOrPut(typeInformation.typeIdentifier) {
+            FingerPrintingState(customTypeDescriptorLookup, FingerprintWriter(debugEnabled))
+                    .fingerprint(typeInformation)
+        }
 }
 
 /**

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
@@ -4,7 +4,9 @@ import com.google.common.hash.Hashing
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.toBase64
 import net.corda.serialization.internal.amqp.*
-import java.io.NotSerializableException
+import net.corda.serialization.internal.model.TypeIdentifier.*
+import net.corda.serialization.internal.model.TypeIdentifier.Companion.classLoaderFor
+import java.lang.reflect.ParameterizedType
 
 /**
  * A fingerprinter that fingerprints [LocalTypeInformation].
@@ -224,7 +226,22 @@ private class FingerPrintingState(
 
     // Give any custom serializers loaded into the factory the chance to supply their own type-descriptors
     private fun fingerprintWithCustomSerializerOrElse(type: LocalTypeInformation, defaultAction: () -> Unit) {
-        val customTypeDescriptor = customSerializerRegistry.findCustomSerializer(type.observedType.asClass(), type.observedType)?.typeDescriptor?.toString()
+        val observedType = type.observedType
+        val observedClass = observedType.asClass()
+
+        // Any Custom Serializer cached for a ParameterizedType can only be
+        // found by searching for that exact same type. Searching for its raw
+        // class will not work!
+        val observedGenericType = if (observedType !is ParameterizedType && type.typeIdentifier is Parameterised) {
+            type.typeIdentifier.getLocalType(classLoaderFor(observedClass))
+        } else {
+            observedType
+        }
+
+        val customTypeDescriptor = customSerializerRegistry.findCustomSerializer(
+            clazz = observedClass,
+            declaredType = observedGenericType
+        )?.typeDescriptor?.toString()
         if (customTypeDescriptor != null) writer.write(customTypeDescriptor)
         else defaultAction()
     }


### PR DESCRIPTION
- Support "factory" custom serialisers that can generate specific `AMQPSerializer` instances at runtime.
- Fix lockup when computing fingerprints for custom serialisers.
- Allow a custom serialiser to deserialise "alias" types.
- Ensure that all subclasses of `CustomSerializer` are present in `corda-serialization-deterministic`.
- Fix custom serialiser look-up to use any generic type values, where available, because a raw type is *insufficient* to find a custom serialiser created for a parameterised type.
- Fix some typos and compiler warnings.
- Make `DeserialisationInput.readObject()` methods public so that other custom serialisers can use them.