### PR TITLE
CORDA-3171  Hello world tutorial docs code fixed for Corda v4

### DIFF
--- a/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUState.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUState.java
@@ -1,5 +1,7 @@
 package net.corda.docs.java.tutorial.helloworld;
 
+import com.template.TemplateContract;
+import net.corda.core.contracts.BelongsToContract;
 import net.corda.core.contracts.ContractState;
 import net.corda.core.identity.AbstractParty;
 import java.util.Arrays;

--- a/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUState.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUState.java
@@ -10,6 +10,7 @@ import java.util.List;
 import net.corda.core.identity.Party;
 
 // Replace TemplateState's definition with:
+@BelongsToContract(TemplateContract.class)
 public class IOUState implements ContractState {
     private final int value;
     private final Party lender;

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUState.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUState.kt
@@ -9,6 +9,7 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.identity.Party
 
 // Replace TemplateState's definition with:
+@BelongsToContract(TemplateContract::class)
 class IOUState(val value: Int,
                val lender: Party,
                val borrower: Party) : ContractState {

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUState.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUState.kt
@@ -2,6 +2,8 @@
 
 package net.corda.docs.kotlin.tutorial.helloworld
 
+import com.template.TemplateContract
+import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.ContractState
 
 // DOCSTART 01

--- a/docs/source/hello-world-flow.rst
+++ b/docs/source/hello-world-flow.rst
@@ -80,7 +80,7 @@ annotation out will lead to some very weird error messages!
 
 There are also a few more annotations, on the ``FlowLogic`` subclass itself:
 
-  * ``@InitiatingFlow`` means that this flow is part of a flow pair and that it triggers the other side to run the
+  * ``@InitiatingFlow`` means that this flow is part of a flow pair and that it triggers the other side to run
     the counterpart flow (which in our case is the ``IOUFlowResponder`` defined below).
   * ``@StartableByRPC`` allows the node owner to start this flow via an RPC call
 
@@ -90,7 +90,7 @@ issuing the ``IOUState`` onto a ledger.
 Choosing a notary
 ^^^^^^^^^^^^^^^^^
 Every transaction requires a notary to prevent double-spends and serve as a timestamping authority. The first thing we
-do in our flow is retrieve the a notary from the node's ``ServiceHub``. ``ServiceHub.networkMapCache`` provides
+do in our flow is retrieve a notary from the node's ``ServiceHub``. ``ServiceHub.networkMapCache`` provides
 information about the other nodes on the network and the services that they offer.
 
 .. note::

--- a/docs/source/hello-world-running.rst
+++ b/docs/source/hello-world-running.rst
@@ -40,7 +40,7 @@ service.
             p2pPort 10005
             rpcPort 10006
             webPort 10007
-            rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL]]]
+            rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
         }
         node {
             name "O=PartyB,L=New York,C=US"
@@ -153,7 +153,7 @@ The vaults of PartyA and PartyB should both display the following output:
     - ref:
         txhash: "5CED068E790A347B0DD1C6BB5B2B463406807F95E080037208627565E6A2103B"
         index: 0
-      contractStateClassName: "com.template.state.IOUState"
+      contractStateClassName: "com.template.states.IOUState"
       recordedTime: 1506415268.875000000
       consumedTime: null
       status: "UNCONSUMED"

--- a/docs/source/hello-world-state.rst
+++ b/docs/source/hello-world-state.rst
@@ -77,6 +77,7 @@ If you're following along in Java, you'll also need to rename ``TemplateState.ja
 
 To define ``IOUState``, we've made the following changes:
 
+* We've added the annotation ``@BelongsToContract`` as a contract state must be tied to a contract since Corda v4
 * We've renamed the ``TemplateState`` class to ``IOUState``
 * We've added properties for ``value``, ``lender`` and ``borrower``, along with the required getters and setters in
   Java:

--- a/docs/source/tut-two-party-contract.rst
+++ b/docs/source/tut-two-party-contract.rst
@@ -93,6 +93,9 @@ Let's write a contract that enforces these constraints. We'll do this by modifyi
 
 If you're following along in Java, you'll also need to rename ``TemplateContract.java`` to ``IOUContract.java``.
 
+If you attempt to run the code and create an IOU the contract constraints will trigger, and the IOU creation will fail
+because we have not yet updated the ``IOUFlow`` to obey the contract.  That is covered on the next page.
+
 Let's walk through this code step by step.
 
 The Create command


### PR DESCRIPTION
Added the `BelongsToContract` annotation to code in docs which is required for
`ContractState` subclasses to associate them with a Contract subclass.

Fixed various typos.
