### PR TITLE
[NOTICK]: Change Corda version

### DIFF
--- a/common/logging/src/main/kotlin/net/corda/common/logging/Constants.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/Constants.kt
@@ -8,4 +8,4 @@ package net.corda.common.logging
  * the generated file does not need to be committed to source control (originally added to source control for ease of use)
  */
 
-internal const val CURRENT_MAJOR_RELEASE = "5.0-SNAPSHOT"
+internal const val CURRENT_MAJOR_RELEASE = "4.3-SNAPSHOT"

--- a/constants.properties
+++ b/constants.properties
@@ -2,7 +2,7 @@
 # because some versions here need to be matched by app authors in
 # their own projects. So don't get fancy with syntax!
 
-cordaVersion=5.0-SNAPSHOT
+cordaVersion=4.3-SNAPSHOT
 gradlePluginsVersion=5.0.2
 kotlinVersion=1.2.71
 java8MinUpdateVersion=171

--- a/docker/src/bash/example-mini-network.sh
+++ b/docker/src/bash/example-mini-network.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 NODE_LIST=("dockerNode1" "dockerNode2" "dockerNode3")
 NETWORK_NAME=mininet
-CORDAPP_VERSION="5.0-SNAPSHOT"
-DOCKER_IMAGE_VERSION="corda-zulu-5.0-snapshot"
+CORDAPP_VERSION="4.3-SNAPSHOT"
+DOCKER_IMAGE_VERSION="corda-zulu-4.3-snapshot"
 
 mkdir cordapps
 rm -f cordapps/*

--- a/docs/source/docker-image.rst
+++ b/docs/source/docker-image.rst
@@ -21,7 +21,7 @@ In this example, the certificates are stored at ``/home/user/cordaBase/certifica
             -v /path/to/cordapps:/opt/corda/cordapps \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-5.0-snapshot:latest
+            corda/corda-zulu-4.3-snapshot:latest
 
 As the node runs within a container, several mount points are required:
 
@@ -59,7 +59,7 @@ In this example, we have previously generated a network-parameters file using th
             -v /home/user/sharedFolder/network-parameters:/opt/corda/network-parameters \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-5.0-snapshot:latest
+            corda/corda-zulu-4.3-snapshot:latest
 
 There is a new mount ``/home/user/sharedFolder/node-infos:/opt/corda/additional-node-infos`` which is used to hold the ``nodeInfo`` of all the nodes within the network.
 As the node within the container starts up, it will place it's own nodeInfo into this directory. This will allow other nodes also using this folder to see this new node.
@@ -83,7 +83,7 @@ Joining TestNet
             -e LOCALITY="London" -e COUNTRY="GB" \
             -v /home/user/docker/config:/etc/corda \
             -v /home/user/docker/certificates:/opt/corda/certificates \
-            corda/corda-zulu-5.0-snapshot:latest config-generator --testnet
+            corda/corda-zulu-4.3-snapshot:latest config-generator --testnet
 
 ``$MY_PUBLIC_ADDRESS`` will be the public address that this node will be advertised on.
 ``$ONE_TIME_DOWNLOAD_KEY`` is the one-time code provided for joining TestNet.
@@ -108,7 +108,7 @@ It is now possible to start the node using the generated config and certificates
             -v /home/user/corda/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps:/opt/corda/cordapps \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-5.0-snapshot:latest
+            corda/corda-zulu-4.3-snapshot:latest
 
 
 Joining an existing Compatibility Zone
@@ -132,7 +132,7 @@ It is possible to configure the name of the Trust Root file by setting the ``TRU
             -e MY_EMAIL_ADDRESS="cordauser@r3.com"      \
             -v /home/user/docker/config:/etc/corda          \
             -v /home/user/docker/certificates:/opt/corda/certificates \
-            corda/corda-zulu-5.0-snapshot:latest config-generator --generic
+            corda/corda-zulu-4.3-snapshot:latest config-generator --generic
 
 
 Several environment variables must also be passed to the container to allow it to register:
@@ -163,5 +163,5 @@ Once the container has finished performing the initial registration, the node ca
             -v /home/user/corda/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps:/opt/corda/cordapps \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-5.0-snapshot:latest
+            corda/corda-zulu-4.3-snapshot:latest
 

--- a/node/src/integration-test/kotlin/net/corda/node/NodeRPCTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeRPCTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class NodeRPCTests {
-    private val CORDA_VERSION_REGEX = "\\d+(\\.\\d+)?(-\\w+)?".toRegex() // e.g. "4.3-SNAPSHOT"
+    private val CORDA_VERSION_REGEX = "\\d+(\\.\\d+)?(-\\w+)?".toRegex()
     private val CORDA_VENDOR = "Corda Open Source"
     private val CORDAPPS = listOf(FINANCE_CONTRACTS_CORDAPP, FINANCE_WORKFLOWS_CORDAPP)
     private val CORDAPP_TYPES = setOf("Contract CorDapp", "Workflow CorDapp")

--- a/node/src/integration-test/kotlin/net/corda/node/NodeRPCTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeRPCTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class NodeRPCTests {
-    private val CORDA_VERSION_REGEX = "\\d+(\\.\\d+)?(-\\w+)?".toRegex() // e.g. "5.0-SNAPSHOT"
+    private val CORDA_VERSION_REGEX = "\\d+(\\.\\d+)?(-\\w+)?".toRegex() // e.g. "4.3-SNAPSHOT"
     private val CORDA_VENDOR = "Corda Open Source"
     private val CORDAPPS = listOf(FINANCE_CONTRACTS_CORDAPP, FINANCE_WORKFLOWS_CORDAPP)
     private val CORDAPP_TYPES = setOf("Contract CorDapp", "Workflow CorDapp")


### PR DESCRIPTION
Change Corda version from 5.0-SNAPSHOT to 4.3-SNAPSHOT to reflect the next version of Corda to be released.