### PR TITLE
CORDA-3155 - Make concurrent updates to contractStateTypeMappings thread safe.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -28,6 +28,8 @@ import java.security.PublicKey
 import java.time.Clock
 import java.time.Instant
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
 import javax.persistence.Tuple
 import javax.persistence.criteria.CriteriaBuilder
 import javax.persistence.criteria.CriteriaUpdate
@@ -91,7 +93,8 @@ class NodeVaultService(
      * Maintain a list of contract state interfaces to concrete types stored in the vault
      * for usage in generic queries of type queryBy<LinearState> or queryBy<FungibleState<*>>
      */
-    private val contractStateTypeMappings = mutableMapOf<String, MutableSet<String>>().toSynchronised()
+    @VisibleForTesting
+    internal val contractStateTypeMappings = ConcurrentHashMap<String, MutableSet<String>>()
 
     override fun start() {
         bootstrapContractStateTypes()
@@ -103,7 +106,7 @@ class NodeVaultService(
                 if (!seen) {
                     val contractTypes = deriveContractTypes(concreteType)
                     contractTypes.map {
-                        val contractStateType = contractStateTypeMappings.getOrPut(it.name) { mutableSetOf() }
+                        val contractStateType = contractStateTypeMappings.getOrPut(it.name) { CopyOnWriteArraySet() }
                         contractStateType.add(concreteType.name)
                     }
                 }
@@ -202,6 +205,9 @@ class NodeVaultService(
 
     override val updates: Observable<Vault.Update<ContractState>>
         get() = mutex.locked { _updatesInDbTx }
+
+    @VisibleForTesting
+    internal val publishUpdates get() = mutex.locked { updatesPublisher }
 
     /** Groups adjacent transactions into batches to generate separate net updates per transaction type. */
     override fun notifyAll(statesToRecord: StatesToRecord, txns: Iterable<CoreTransaction>) {
@@ -716,7 +722,7 @@ class NodeVaultService(
             concreteType?.let {
                 val contractTypes = deriveContractTypes(it)
                 contractTypes.map {
-                    val contractStateType = contractStateTypeMappings.getOrPut(it.name) { mutableSetOf() }
+                    val contractStateType = contractStateTypeMappings.getOrPut(it.name) { CopyOnWriteArraySet() }
                     contractStateType.add(concreteType.name)
                 }
             }


### PR DESCRIPTION
See JIRA story: https://r3-cev.atlassian.net/browse/CORDA-3155