### PR TITLE
CORDA-3175 Remove dependency on 3rd party javax.xml.bind library for simple hex parsing/printing.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt
@@ -10,7 +10,6 @@ import net.corda.core.internal.hash
 import java.nio.charset.Charset
 import java.security.PublicKey
 import java.util.*
-import javax.xml.bind.DatatypeConverter
 
 // This file includes useful encoding methods and extension functions for the most common encoding/decoding operations.
 
@@ -31,7 +30,7 @@ fun ByteArray.toBase58(): String = Base58.encode(this)
 fun ByteArray.toBase64(): String = Base64.getEncoder().encodeToString(this)
 
 /** Convert a byte array to a hex (Base16) capitalized encoded [String]. */
-fun ByteArray.toHex(): String = DatatypeConverter.printHexBinary(this)
+fun ByteArray.toHex(): String = toHexString()
 
 // [String] encoders and decoders
 
@@ -49,7 +48,7 @@ fun String.base58ToByteArray(): ByteArray = Base58.decode(this)
 fun String.base64ToByteArray(): ByteArray = Base64.getDecoder().decode(this)
 
 /** Hex-String to [ByteArray]. Accept any hex form (capitalized, lowercase, mixed). */
-fun String.hexToByteArray(): ByteArray = DatatypeConverter.parseHexBinary(this)
+fun String.hexToByteArray(): ByteArray = parseAsHex()
 
 // Encoding changers
 

--- a/core/src/test/kotlin/net/corda/core/utilities/ByteArraysTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/ByteArraysTest.kt
@@ -1,7 +1,10 @@
 package net.corda.core.utilities
 
+import net.corda.core.contracts.StateRef
+import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.declaredField
 import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.Assert
 import org.junit.Assert.assertSame
 import org.junit.Test
 import java.nio.ByteBuffer
@@ -41,5 +44,18 @@ class ByteArraysTest {
         check(byteArrayOf(2), seq.slice(2, 3))
         check(byteArrayOf(), seq.slice(2, 2))
         check(byteArrayOf(), seq.slice(2, 1))
+    }
+
+    @Test
+    fun `test hex parsing strictly uppercase`() {
+        val HEX_REGEX = "^[0-9A-F]+\$".toRegex()
+
+        val privacySalt = net.corda.core.contracts.PrivacySalt()
+        val privacySaltAsHexString = privacySalt.bytes.toHexString()
+        Assert.assertTrue(privacySaltAsHexString.matches(HEX_REGEX))
+
+        val stateRef = StateRef(SecureHash.randomSHA256(), 0)
+        val txhashAsHexString = stateRef.txhash.bytes.toHexString()
+        Assert.assertTrue(txhashAsHexString.matches(HEX_REGEX))
     }
 }


### PR DESCRIPTION
See https://r3-cev.atlassian.net/browse/CORDA-3175

**Note**: without this refactoring, when moving to JDK11 it becomes necessary to add the following 3rd party compile time dependency to several Corda modules:

```
// JDK 11 (https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist)
compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
```