### PR TITLE
[NOTICK] Expose type in CryptoService

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
@@ -59,6 +59,11 @@ interface CryptoService : SignOnlyCryptoService {
      * Returns the [PublicKey] of the generated [KeyPair].
      */
     fun generateKeyPair(alias: String, scheme: SignatureScheme): PublicKey
+
+    /**
+     * Returns the type of the service.
+     */
+    fun getType(): SupportedCryptoServices
 }
 
 open class CryptoServiceException(message: String?, cause: Throwable? = null) : Exception(message, cause)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/SupportedCryptoServices.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/SupportedCryptoServices.kt
@@ -1,9 +1,6 @@
 package net.corda.nodeapi.internal.cryptoservice
 
-enum class SupportedCryptoServices {
+enum class SupportedCryptoServices(val userFriendlyName: String) {
     /** Identifier for [BCCryptoService]. */
-    BC_SIMPLE
-    // UTIMACO, // Utimaco HSM.
-    // GEMALTO_LUNA, // Gemalto Luna HSM.
-    // AZURE_KV // Azure key Vault.
+    BC_SIMPLE("file-based keystore")
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoService.kt
@@ -11,6 +11,7 @@ import net.corda.nodeapi.internal.crypto.ContentSignerBuilder
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.cryptoservice.CryptoService
 import net.corda.nodeapi.internal.cryptoservice.CryptoServiceException
+import net.corda.nodeapi.internal.cryptoservice.SupportedCryptoServices
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
 import java.security.KeyStore
@@ -24,6 +25,8 @@ import javax.security.auth.x500.X500Principal
  * This service reuses the [NodeConfiguration.signingCertificateStore] to store keys.
  */
 class BCCryptoService(private val legalName: X500Principal, private val certificateStoreSupplier: CertificateStoreSupplier) : CryptoService {
+
+    override fun getType(): SupportedCryptoServices = SupportedCryptoServices.BC_SIMPLE
 
     // TODO check if keyStore exists.
     // TODO make it private when E2ETestKeyManagementService does not require direct access to the private key.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockCryptoService.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockCryptoService.kt
@@ -8,12 +8,15 @@ import net.corda.core.crypto.sha256
 import net.corda.nodeapi.internal.crypto.ContentSignerBuilder
 import net.corda.nodeapi.internal.cryptoservice.CryptoService
 import net.corda.nodeapi.internal.cryptoservice.CryptoServiceException
+import net.corda.nodeapi.internal.cryptoservice.SupportedCryptoServices
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
 import java.security.PublicKey
 import java.security.Signature
 
 class MockCryptoService(initialKeyPairs: Map<String, KeyPair>) : CryptoService {
+
+    override fun getType(): SupportedCryptoServices = SupportedCryptoServices.BC_SIMPLE
 
     private val aliasToKey: MutableMap<String, KeyPair> = mutableMapOf()
 


### PR DESCRIPTION
Exposing the type of a `CryptoService` through a method in the interface.
For context on what are the benefits/uses of this, see: https://github.com/corda/enterprise/pull/2483

Note: removed the commented-out types, since they were not up-to-date and they are essentially noise here.