### PR TITLE
Fix for CORDA-3178. 

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
@@ -95,7 +95,7 @@ class BasicHSMKeyManagementService(cacheFactory: NamedCacheFactory,
     }
 
     override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> = database.transaction {
-        identityService.stripNotOurKeys(candidateKeys)
+        candidateKeys.filter(::containsPublicKey)
     }
 
     override fun freshKeyInternal(externalId: UUID?): PublicKey {

--- a/node/src/test/kotlin/net/corda/node/services/keys/FilterMyKeysTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/keys/FilterMyKeysTests.kt
@@ -1,0 +1,27 @@
+package net.corda.node.services.keys
+
+import net.corda.core.crypto.Crypto
+import net.corda.core.identity.CordaX500Name
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.node.MockServices
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class FilterMyKeysTests {
+    @Test
+    fun test() {
+        val name = CordaX500Name("Roger", "Office", "GB")
+        val (_, services) = MockServices.makeTestDatabaseAndPersistentServices(
+                cordappPackages = emptyList(),
+                initialIdentity = TestIdentity(name),
+                networkParameters = testNetworkParameters(),
+                moreKeys = emptySet(),
+                moreIdentities = emptySet()
+        )
+        val ourKey = services.keyManagementService.freshKey()
+        val notOurKey = Crypto.generateKeyPair().public
+        val result = services.keyManagementService.filterMyKeys(listOf(ourKey, notOurKey))
+        assertEquals(listOf(ourKey), result)
+    }
+}


### PR DESCRIPTION
FilterMyKeys now uses the key store as opposed to the cert store. See JIRA for more details: https://r3-cev.atlassian.net/browse/CORDA-3178

Added a test which proves the check now works as expected.