### PR TITLE
[CORDA-2890] - Close security manager after broker is shut down

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -116,8 +116,6 @@ class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance"), notaries =
                 } catch (e: RPCException) {
                     log.info("... node is not running.")
                     nodeIsShut.onCompleted()
-                } catch (e: ActiveMQSecurityException) {
-                    // nothing here - this happens if trying to connect before the node is started
                 } catch (e: Exception) {
                     nodeIsShut.onError(e)
                 }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -128,7 +128,7 @@ class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance"), notaries =
                 val nodeTerminated = try {
                     poll(scheduler, pollName = "node's started state", check = { if (node.node.started == null) true else null })
                             .get(10, TimeUnit.SECONDS)
-                } catch (e: TimeoutException) {
+                } catch (e: Exception) {
                     false
                 }
                 successful = nodeTerminated

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -27,6 +27,7 @@ import net.corda.testing.core.*
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.NodeBasedTest
 import net.corda.testing.node.internal.ProcessUtilities
+import net.corda.testing.node.internal.poll
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -37,10 +38,7 @@ import rx.subjects.PublishSubject
 import java.net.URLClassLoader
 import java.nio.file.Paths
 import java.util.*
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -101,7 +99,7 @@ class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance"), notaries =
         var successful = false
         val maxCount = 120
         var count = 0
-        CloseableExecutor(Executors.newSingleThreadScheduledExecutor()).use { scheduler ->
+        CloseableExecutor(Executors.newScheduledThreadPool(2)).use { scheduler ->
 
             val task = scheduler.scheduleAtFixedRate({
                 try {
@@ -124,13 +122,19 @@ class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance"), notaries =
             nodeIsShut.doOnError { error ->
                 log.error("FAILED TO SHUT DOWN NODE DUE TO", error)
                 successful = false
-                task.cancel(true)
+                task.cancel(false)
                 latch.countDown()
             }.doOnCompleted {
-                        successful = (node.node.started == null)
-                        task.cancel(true)
-                        latch.countDown()
-                    }.subscribe()
+                val nodeTerminated = try {
+                    poll(scheduler, pollName = "node's started state", check = { if (node.node.started == null) true else null })
+                            .get(10, TimeUnit.SECONDS)
+                } catch (e: TimeoutException) {
+                    false
+                }
+                successful = nodeTerminated
+                task.cancel(false)
+                latch.countDown()
+            }.subscribe()
 
             client.start(rpcUser.username, rpcUser.password).use { rpc -> rpc.proxy.shutdown() }
 

--- a/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt
@@ -15,6 +15,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager
 import java.io.IOException
+import java.lang.RuntimeException
 import java.nio.file.Path
 import java.security.KeyStoreException
 import javax.security.auth.login.AppConfigurationEntry
@@ -60,6 +61,7 @@ class ArtemisRpcBroker internal constructor(
     override fun stop() {
         logger.debug("Artemis RPC broker is stopping.")
         server.stop(true)
+        securityManager.close()
         logger.debug("Artemis RPC broker is stopped.")
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
@@ -243,7 +243,6 @@ class RPCServer(
         reaperScheduledFuture?.cancel(false)
         rpcExecutor?.shutdownNow()
         reaperExecutor?.shutdownNow()
-        securityManager.close()
         sessionFactory?.close()
         observableMap.invalidateAll()
         reapSubscriptions()


### PR DESCRIPTION
`SecurityManager` was closed from the `RpcServer` component, instead of `RpcBroker` component. As a result, during node shut down, clients attempting to perform RPC calls could be erroneously receiving `ActiveMQSecurityException` indicating authentication failed.

This moves the tear down of `SecurityManager` into `RpcBroker`. It also contains some cleanups on tests that were ignoring `ActiveMQSecurityException`s, since it can mask other genuine issues.