### PR TITLE
CORDA-3133 (Version 1)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -645,7 +645,6 @@ open class TransactionBuilder(
         checkNotary(stateAndRef)
         inputs.add(stateAndRef.ref)
         inputsWithTransactionState.add(stateAndRef)
-        resolveStatePointers(stateAndRef.state)
         return this
     }
 


### PR DESCRIPTION
### CORDA-3133 (Version 1)

https://r3-cev.atlassian.net/browse/CORDA-3133

This fix might be a little foolhardy. Ultimately all this fix does is relaxes the restriction by removing the `resolveStatePointers` call, but **only** for inputs. This means that you should be able to consume input states that point to stale data, but you can't create output states that point to stale data.