### PR TITLE
CORDA-3079 - Load drivers directory automatically.

### DIFF
--- a/node/capsule/src/main/java/CordaCaplet.java
+++ b/node/capsule/src/main/java/CordaCaplet.java
@@ -112,6 +112,9 @@ public class CordaCaplet extends Capsule {
                 // If it fails, just return the existing class path. The main Corda jar will detect the error and fail gracefully.
                 return cp;
             }
+
+            // Add additional directories of JARs to the classpath (at the end), e.g., for JDBC drivers.
+            augmentClasspath((List<Path>) cp, new File(baseDir, "drivers"));
             try {
                 List<String> jarDirs = nodeConfig.getStringList("jarDirs");
                 log(LOG_VERBOSE, "Configured JAR directories = " + jarDirs);


### PR DESCRIPTION
Found a divergence in documented behavior. A change was made to enterprise that never made it to open source, but was documented in open source. Transfered the drivers loading code, left over the other code that was introduced for ENT-1673 as it seems like an enterprise feature.