### PR TITLE
CORDA-3200 Split migrations as per https://github.com/corda/enterpris…

### DIFF
--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -12,6 +12,9 @@
     <include file="migration/node-core.changelog-v8.xml"/>
     <include file="migration/node-core.changelog-tx-mapping.xml"/>
     <include file="migration/node-core.changelog-v9.xml"/>
+    <!-- This migration was originally written within the same script as node-core.changelog-v14-data. However, node-core.changelog-v10
+         runs a service with mapped schema which now has the new table so the table should be created before hand. The transfer of data
+         can then happen later in node-core.changelog-v14-data. -->
     <include file="migration/node-core.changelog-v14-table.xml"/>
     <include file="migration/node-core.changelog-v10.xml"/>
     <include file="migration/node-core.changelog-v11.xml"/>
@@ -20,7 +23,7 @@
          vault-schema.changelog-v9.xml), as that will use the current hibernate mappings, and those require all DB columns to be
          created. -->
     <include file="migration/node-core.changelog-v13.xml"/>
-    <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
     <include file="migration/node-core.changelog-v14-data.xml"/>
+    <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
     <include file="migration/vault-schema.changelog-v9.xml"/>
 </databaseChangeLog>

--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -12,6 +12,7 @@
     <include file="migration/node-core.changelog-v8.xml"/>
     <include file="migration/node-core.changelog-tx-mapping.xml"/>
     <include file="migration/node-core.changelog-v9.xml"/>
+    <include file="migration/node-core.changelog-v14-table.xml"/>
     <include file="migration/node-core.changelog-v10.xml"/>
     <include file="migration/node-core.changelog-v11.xml"/>
     <include file="migration/node-core.changelog-v12.xml"/>
@@ -20,6 +21,6 @@
          created. -->
     <include file="migration/node-core.changelog-v13.xml"/>
     <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
-    <include file="migration/node-core.changelog-v14.xml"/>
+    <include file="migration/node-core.changelog-v14-data.xml"/>
     <include file="migration/vault-schema.changelog-v9.xml"/>
 </databaseChangeLog>

--- a/node/src/main/resources/migration/node-core.changelog-v14-data.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v14-data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   logicalFilePath="migration/node-services.changelog-init.xml">
+
+    <changeSet author="R3.Corda" id="transfer-to-new-persistence-table">
+        <customChange class="net.corda.node.migration.PersistentIdentityMigrationNewTable">
+        </customChange>
+    </changeSet>
+
+</databaseChangeLog>

--- a/node/src/main/resources/migration/node-core.changelog-v14-table.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v14-table.xml
@@ -15,9 +15,4 @@
         </createTable>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="transfer-to-new-persistence-table">
-        <customChange class="net.corda.node.migration.PersistentIdentityMigrationNewTable">
-        </customChange>
-    </changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
Split the migrations so that the addition of the new persistence table occurs before `node-core.changelog-v10`