### PR TITLE
CORDA-2837 Prevent node running SwapIdentitiesFlow from initiating se…

### DIFF
--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -90,10 +90,12 @@ private constructor(private val otherSideSession: FlowSession?,
 
     @Suspendable
     override fun call(): LinkedHashMap<Party, AnonymousParty> {
-        val session = otherSideSession ?: run {
+        val session = if (otherParty != null && otherParty != otherSideSession?.counterparty) {
             logger.warnOnce("The current usage of SwapIdentitiesFlow is unsafe. Please consider upgrading your CorDapp to use " +
                     "SwapIdentitiesFlow with FlowSessions. (${CordappResolver.currentCordapp?.info})")
-            initiateFlow(otherParty!!)
+            initiateFlow(otherParty)
+        } else {
+            otherSideSession!!
         }
         progressTracker.currentStep = GENERATING_IDENTITY
         val ourAnonymousIdentity = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, false)


### PR DESCRIPTION
Allow a node to create anonymous parties with itself by guarding the initiation of the counterparty session.  