### PR TITLE
[CORDA-3151] Fix observable leak in stateMachinesFeed RPC

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -472,6 +472,7 @@ object InteractiveShell {
             try {
                 result = result.get()
             } catch (e: InterruptedException) {
+                subscriber.unsubscribe()
                 Thread.currentThread().interrupt()
             } catch (e: ExecutionException) {
                 throw e.rootCause


### PR DESCRIPTION
When hitting ctrl+ c while in the stateMachinesFeed, observables leaked. That fixes the issue. To test: deployNodes, add sshd on the node start flow, run stateMachinesFeed on the ssh session, interrupt flow, start it again and then interrupt stateMachinesFeed. The error should not be present in the logs and is present on "master" branch.