### PR TITLE
CORDA-3209 Vault query not parsing participants in common query case.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -314,6 +314,29 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             val expression = CriteriaExpression.ColumnPredicateExpression(timeColumn, timeCondition.predicate)
             predicateSet.add(parseExpression(vaultStates, expression) as Predicate)
         }
+
+        // Participants.
+        criteria.participants?.let {
+            val participants = criteria.participants!!
+
+            // Get the persistent party entity.
+            val persistentPartyEntity = VaultSchemaV1.PersistentParty::class.java
+            val entityRoot = rootEntities.getOrElse(persistentPartyEntity) {
+                val entityRoot = criteriaQuery.from(persistentPartyEntity)
+                rootEntities[persistentPartyEntity] = entityRoot
+                entityRoot
+            }
+
+            // Add the join and participants predicates.
+            val statePartyJoin = criteriaBuilder.equal(vaultStates.get<VaultSchemaV1.VaultStates>("stateRef"), entityRoot.get<VaultSchemaV1.PersistentParty>("compositeKey").get<PersistentStateRef>("stateRef"))
+            println("ENTITYPRINT " + entityRoot.get<VaultSchemaV1.PersistentParty>("x500Name"))
+
+            val participantsPredicate = criteriaBuilder.and(entityRoot.get<VaultSchemaV1.PersistentParty>("x500Name").`in`(participants))
+            predicateSet.add(statePartyJoin)
+            predicateSet.add(participantsPredicate)
+            println(participantsPredicate.toString())
+        }
+
         return predicateSet
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -315,28 +315,6 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             predicateSet.add(parseExpression(vaultStates, expression) as Predicate)
         }
 
-        // Participants.
-        criteria.participants?.let {
-            val participants = criteria.participants!!
-
-            // Get the persistent party entity.
-            val persistentPartyEntity = VaultSchemaV1.PersistentParty::class.java
-            val entityRoot = rootEntities.getOrElse(persistentPartyEntity) {
-                val entityRoot = criteriaQuery.from(persistentPartyEntity)
-                rootEntities[persistentPartyEntity] = entityRoot
-                entityRoot
-            }
-
-            // Add the join and participants predicates.
-            val statePartyJoin = criteriaBuilder.equal(vaultStates.get<VaultSchemaV1.VaultStates>("stateRef"), entityRoot.get<VaultSchemaV1.PersistentParty>("compositeKey").get<PersistentStateRef>("stateRef"))
-            println("ENTITYPRINT " + entityRoot.get<VaultSchemaV1.PersistentParty>("x500Name"))
-
-            val participantsPredicate = criteriaBuilder.and(entityRoot.get<VaultSchemaV1.PersistentParty>("x500Name").`in`(participants))
-            predicateSet.add(statePartyJoin)
-            predicateSet.add(participantsPredicate)
-            println(participantsPredicate.toString())
-        }
-
         return predicateSet
     }
 
@@ -699,6 +677,25 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             val externalIdPredicate = criteriaBuilder.and(entityRoot.get<VaultSchemaV1.StateToExternalId>("externalId").`in`(ids))
             constraintPredicates.add(externalIdJoin)
             constraintPredicates.add(externalIdPredicate)
+        }
+
+        // Participants.
+        criteria.participants?.let {
+            val participants = criteria.participants!!
+
+            // Get the persistent party entity.
+            val persistentPartyEntity = VaultSchemaV1.PersistentParty::class.java
+            val entityRoot = rootEntities.getOrElse(persistentPartyEntity) {
+                val entityRoot = criteriaQuery.from(persistentPartyEntity)
+                rootEntities[persistentPartyEntity] = entityRoot
+                entityRoot
+            }
+
+            // Add the join and participants predicates.
+            val statePartyJoin = criteriaBuilder.equal(vaultStates.get<VaultSchemaV1.VaultStates>("stateRef"), entityRoot.get<VaultSchemaV1.PersistentParty>("compositeKey").get<PersistentStateRef>("stateRef"))
+            val participantsPredicate = criteriaBuilder.and(entityRoot.get<VaultSchemaV1.PersistentParty>("x500Name").`in`(participants))
+            constraintPredicates.add(statePartyJoin)
+            constraintPredicates.add(participantsPredicate)
         }
 
         return emptySet()

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -229,6 +229,38 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
      * Query API tests
      */
 
+    /**
+     * VaultQueryCriteria tests for base ContractState
+     * */
+
+    @Test
+    fun `unconsumed base contract states for single participant`() {
+        database.transaction {
+            identitySvc.verifyAndRegisterIdentity(BIG_CORP_IDENTITY)
+            vaultFiller.fillWithDummyState(participants = listOf(MEGA_CORP, MINI_CORP))
+            vaultFiller.fillWithDummyState(participants = listOf(MEGA_CORP, BIG_CORP)) // true
+            vaultFiller.fillWithDummyState(participants = listOf(BIG_CORP))
+            val criteria = VaultQueryCriteria(participants = listOf(MINI_CORP))
+            val results = vaultService.queryBy<ContractState>(criteria)
+            assertThat(results.states).hasSize(3)
+
+        }
+    }
+
+    @Test
+    fun `unconsumed base contract states for two participants`() {
+        database.transaction {
+            identitySvc.verifyAndRegisterIdentity(BIG_CORP_IDENTITY)
+            vaultFiller.fillWithDummyState(participants = listOf(MEGA_CORP, MINI_CORP)) // true
+            vaultFiller.fillWithDummyState(participants = listOf(MEGA_CORP, BIG_CORP)) // true
+            vaultFiller.fillWithDummyState(participants = listOf(MEGA_CORP))
+            val criteria = VaultQueryCriteria(participants = listOf(BIG_CORP, MINI_CORP))
+            val results = vaultService.queryBy<ContractState>(criteria)
+            assertThat(results.states).hasSize(2)
+        }
+    }
+
+
     /** Generic Query tests
     (combining both FungibleState and LinearState contract types) */
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -240,9 +240,9 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             vaultFiller.fillWithDummyState(participants = listOf(MEGA_CORP, MINI_CORP))
             vaultFiller.fillWithDummyState(participants = listOf(MEGA_CORP, BIG_CORP)) // true
             vaultFiller.fillWithDummyState(participants = listOf(BIG_CORP))
-            val criteria = VaultQueryCriteria(participants = listOf(MINI_CORP))
+            val criteria = VaultQueryCriteria(participants = listOf(BIG_CORP))
             val results = vaultService.queryBy<ContractState>(criteria)
-            assertThat(results.states).hasSize(3)
+            assertThat(results.states).hasSize(2)
 
         }
     }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
@@ -224,15 +224,16 @@ class VaultFiller @JvmOverloads constructor(
     /**
      * Records a dummy state in the Vault (useful for creating random states when testing vault queries)
      */
-    fun fillWithDummyState() : Vault<DummyState> {
+    fun fillWithDummyState(participants: List<AbstractParty> = listOf(services.myInfo.singleIdentity())) : Vault<DummyState> {
         val outputState = TransactionState(
-                data = DummyState(Random().nextInt(), participants = listOf(services.myInfo.singleIdentity())),
+                data = DummyState(Random().nextInt(), participants = participants),
                 contract = DummyContract.PROGRAM_ID,
                 notary = defaultNotary.party
         )
+        val participantKeys : List<PublicKey> = participants.map { it.owningKey }
         val builder = TransactionBuilder()
                 .addOutputState(outputState)
-                .addCommand(DummyCommandData, defaultNotary.party.owningKey)
+                .addCommand(DummyCommandData, participantKeys)
         val stxn = services.signInitialTransaction(builder)
         services.recordTransactions(stxn)
         return Vault(setOf(stxn.tx.outRef(0)))


### PR DESCRIPTION
**JIRA 3209**

In HibernateQueryCriteriaParser.kt move the join logic from the parseCriteria methods for LinearStateQueryCriteria or a FungibleStateQueryCriteria to the parseCriteria method on for line **680** for CommonQueryCriteria.

Test for single and participant and two participant created.
'unconsumed base contract states for single participant' **FAILS - should be 2, returns 1**
'unconsumed base contract states for two participants' **PASS**

VaultFiller.kt edited to take participant arg for DummyState

