### PR TITLE
CORDA-3218: Make set of serializer types considered suitable for object reference to be configurable.

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
@@ -188,7 +188,7 @@ class DeserializationInput constructor(
                 // Store the reference in case we need it later on.
                 // Skip for primitive types as they are too small and overhead of referencing them will be much higher
                 // than their content
-                if (serializerFactory.isSuitebleForObjectReference(objectRead.javaClass)) {
+                if (serializerFactory.isSuitableForObjectReference(objectRead.javaClass)) {
                     objectHistory.add(objectRead)
                 }
                 objectRead

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
@@ -188,7 +188,7 @@ class DeserializationInput constructor(
                 // Store the reference in case we need it later on.
                 // Skip for primitive types as they are too small and overhead of referencing them will be much higher
                 // than their content
-                if (suitableForObjectReference(objectRead.javaClass)) {
+                if (serializerFactory.isSuitebleForObjectReference(objectRead.javaClass)) {
                     objectHistory.add(objectRead)
                 }
                 objectRead

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -83,7 +83,7 @@ interface LocalSerializerFactory {
      * Determines whether instances of this type should be added to the object history
      * when serialising and deserialising.
      */
-    fun isSuitebleForObjectReference(type: Type): Boolean
+    fun isSuitableForObjectReference(type: Type): Boolean
 }
 
 /**
@@ -136,7 +136,7 @@ class DefaultLocalSerializerFactory(
             get(typeInformation.observedType, typeInformation)
 
     // ByteArrays, primitives and boxed primitives are not stored in the object history
-    override fun isSuitebleForObjectReference(type: Type): Boolean {
+    override fun isSuitableForObjectReference(type: Type): Boolean {
         val clazz = type.asClass()
         return type != ByteArray::class.java && !isPrimitiveType.test(clazz)
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt
@@ -1,6 +1,5 @@
 package net.corda.serialization.internal.amqp
 
-import com.google.common.primitives.Primitives
 import com.google.common.reflect.TypeToken
 import net.corda.core.serialization.*
 import net.corda.serialization.internal.model.TypeIdentifier
@@ -107,12 +106,6 @@ internal fun Type.asParameterizedType(): ParameterizedType {
 
 internal fun Type.isSubClassOf(type: Type): Boolean {
     return TypeToken.of(this).isSubtypeOf(TypeToken.of(type).rawType)
-}
-
-// ByteArrays, primitives and boxed primitives are not stored in the object history
-internal fun suitableForObjectReference(type: Type): Boolean {
-    val clazz = type.asClass()
-    return type != ByteArray::class.java && (!clazz.isPrimitive && !Primitives.unwrap(clazz).isPrimitive)
 }
 
 /**

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt
@@ -137,7 +137,7 @@ open class SerializationOutput constructor(
             // Important to do it after serialization such that dependent object will have preceding reference numbers
             // assigned to them first as they will be first read from the stream on receiving end.
             // Skip for primitive types as they are too small and overhead of referencing them will be much higher than their content
-            if (serializerFactory.isSuitebleForObjectReference(obj.javaClass)) {
+            if (serializerFactory.isSuitableForObjectReference(obj.javaClass)) {
                 objectHistory[obj] = objectHistory.size
             }
         } else {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt
@@ -137,7 +137,7 @@ open class SerializationOutput constructor(
             // Important to do it after serialization such that dependent object will have preceding reference numbers
             // assigned to them first as they will be first read from the stream on receiving end.
             // Skip for primitive types as they are too small and overhead of referencing them will be much higher than their content
-            if (suitableForObjectReference(obj.javaClass)) {
+            if (serializerFactory.isSuitebleForObjectReference(obj.javaClass)) {
                 objectHistory[obj] = objectHistory.size
             }
         } else {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -1,5 +1,6 @@
 package net.corda.serialization.internal.amqp
 
+import com.google.common.primitives.Primitives
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.serialization.ClassWhitelist
@@ -9,6 +10,7 @@ import net.corda.serialization.internal.model.*
 import java.io.NotSerializableException
 import java.util.Collections.unmodifiableMap
 import java.util.function.Function
+import java.util.function.Predicate
 
 @KeepForDJVM
 object SerializerFactoryBuilder {
@@ -109,6 +111,7 @@ object SerializerFactoryBuilder {
                 classCarpenter.classloader,
                 descriptorBasedSerializerRegistry,
                 Function { clazz -> AMQPPrimitiveSerializer(clazz) },
+                Predicate { clazz -> clazz.isPrimitive || Primitives.unwrap(clazz).isPrimitive },
                 customSerializerRegistry,
                 onlyCustomSerializers)
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
@@ -236,7 +236,9 @@ private class FingerPrintingState(
         // Any Custom Serializer cached for a ParameterizedType can only be
         // found by searching for that exact same type. Searching for its raw
         // class will not work!
-        val observedGenericType = if (observedType !is ParameterizedType && type.typeIdentifier is Parameterised) {
+        val observedGenericType = if (observedType !is ParameterizedType
+                && type.typeIdentifier is Parameterised
+                && observedClass != Class::class.java) {
             type.typeIdentifier.getLocalType(classLoaderFor(observedClass))
         } else {
             observedType


### PR DESCRIPTION
The DJVM needs to instruct Corda's serializer to consider boxed types such as `sandbox.java.lang.String` to be "primitive" so that the deserializer's object history matches the serializer's one.

Also fix an edge case where `Class<?>` is and yet is _not_ a parameterised type.