### PR TITLE
CORDA-3220: Updating FinalityFlow with functionality to specify StatesToRecord

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -40,7 +40,8 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
                                        private val oldParticipants: Collection<Party>,
                                        override val progressTracker: ProgressTracker,
                                        private val sessions: Collection<FlowSession>,
-                                       private val newApi: Boolean) : FlowLogic<SignedTransaction>() {
+                                       private val newApi: Boolean,
+                                       private val statesToRecord: StatesToRecord = ONLY_RELEVANT) : FlowLogic<SignedTransaction>() {
     @Deprecated(DEPRECATION_MSG)
     constructor(transaction: SignedTransaction, extraRecipients: Set<Party>, progressTracker: ProgressTracker) : this(
             transaction, extraRecipients, progressTracker, emptyList(), false
@@ -73,8 +74,9 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     constructor(
             transaction: SignedTransaction,
             sessions: Collection<FlowSession>,
-            progressTracker: ProgressTracker = tracker()
-    ) : this(transaction, emptyList(), progressTracker, sessions, true)
+            progressTracker: ProgressTracker = tracker(),
+            statesToRecord: StatesToRecord = ONLY_RELEVANT
+    ) : this(transaction, emptyList(), progressTracker, sessions, true, statesToRecord)
 
     /**
      * Notarise the given transaction and broadcast it to all the participants.
@@ -202,7 +204,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
             transaction
         }
         logger.info("Recording transaction locally.")
-        serviceHub.recordTransactions(notarised)
+        serviceHub.recordTransactions(statesToRecord, listOf(notarised))
         logger.info("Recorded transaction locally successfully.")
         return notarised
     }


### PR DESCRIPTION
Updating FinalityFlow with functionality to indicate the appropriate StatesToRecord. 

This allows the initiating party to record states from transactions which they are proposing but are not necessarily participants to. An example would be the issuance of a token where the only participant is the holder NOT the issuer.

JIRA Tickets - Corda-3220

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

# PR Checklist:

- [ ✅ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ✅ ] If you added public APIs, did you write the JavaDocs?
- [ ✅ ] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [ ✅ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
