### PR TITLE
ENT-3973 missing logging on shutdown

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="info" packages="net.corda.common.logging">
+<Configuration status="info" packages="net.corda.common.logging" shutdownHook="disable">
 
     <Properties>
         <Property name="log-path">${sys:log-path:-logs}</Property>


### PR DESCRIPTION
Added a disable shutdownHook in the log4j2.xml to prevent double call to shutdown from our code and from the library, otherwise the async appenders never finish out flushing events.

https://r3-cev.atlassian.net/browse/CORDA-3246