### PR TITLE
CORDA-3220: Updating FinalityFlow with functionality to specify StatesToRecord

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -75,6 +75,20 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     constructor(
             transaction: SignedTransaction,
             sessions: Collection<FlowSession>,
+            progressTracker: ProgressTracker = tracker()
+    ) : this(transaction, emptyList(), progressTracker, sessions, true)
+
+    /**
+     * Notarise the given transaction and broadcast it to all the participants.
+     *
+     * @param transaction What to commit.
+     * @param sessions A collection of [FlowSession]s for each non-local participant of the transaction. Sessions to non-participants can
+     * also be provided.
+     * @param statesToRecord Which transactions to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
+     */
+    constructor(
+            transaction: SignedTransaction,
+            sessions: Collection<FlowSession>,
             progressTracker: ProgressTracker = tracker(),
             statesToRecord: StatesToRecord = ONLY_RELEVANT
     ) : this(transaction, emptyList(), progressTracker, sessions, true, statesToRecord)

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -69,7 +69,6 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
      * @param transaction What to commit.
      * @param sessions A collection of [FlowSession]s for each non-local participant of the transaction. Sessions to non-participants can
      * also be provided.
-     * @param statesToRecord Which transactions to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
      */
     @JvmOverloads
     constructor(
@@ -86,11 +85,12 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
      * also be provided.
      * @param statesToRecord Which transactions to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
      */
+    @JvmOverloads
     constructor(
             transaction: SignedTransaction,
             sessions: Collection<FlowSession>,
-            progressTracker: ProgressTracker = tracker(),
-            statesToRecord: StatesToRecord
+            statesToRecord: StatesToRecord,
+            progressTracker: ProgressTracker = tracker()
     ) : this(transaction, emptyList(), progressTracker, sessions, true, statesToRecord)
 
     /**

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -87,7 +87,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
      * @param transaction What to commit.
      * @param sessions A collection of [FlowSession]s for each non-local participant of the transaction. Sessions to non-participants can
      * also be provided.
-     * @param statesToRecord Which transactions to commit to the vault.
+     * @param statesToRecord Which states to commit to the vault.
      */
     @JvmOverloads
     constructor(
@@ -267,7 +267,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
  * @param otherSideSession The session which is providing the transaction to record.
  * @param expectedTxId Expected ID of the transaction that's about to be received. This is typically retrieved from
  * [SignTransactionFlow]. Setting it to null disables the expected transaction ID check.
- * @param statesToRecord Which transactions to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
+ * @param statesToRecord Which states to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
  */
 class ReceiveFinalityFlow @JvmOverloads constructor(private val otherSideSession: FlowSession,
                                                     private val expectedTxId: SecureHash? = null,

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -69,6 +69,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
      * @param transaction What to commit.
      * @param sessions A collection of [FlowSession]s for each non-local participant of the transaction. Sessions to non-participants can
      * also be provided.
+     * @param statesToRecord Which transactions to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
      */
     @JvmOverloads
     constructor(

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -90,7 +90,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
             transaction: SignedTransaction,
             sessions: Collection<FlowSession>,
             progressTracker: ProgressTracker = tracker(),
-            statesToRecord: StatesToRecord = ONLY_RELEVANT
+            statesToRecord: StatesToRecord
     ) : this(transaction, emptyList(), progressTracker, sessions, true, statesToRecord)
 
     /**

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -20,6 +20,10 @@ import net.corda.core.utilities.debug
  * is acceptable then it is from that point onwards committed to the ledger, and will be written through to the
  * vault. Additionally it will be distributed to the parties reflected in the participants list of the states.
  *
+ * By default, the initiating flow will commit states that are relevant to the initiating party as indicated by
+ * [StatesToRecord.ALL_VISIBLE]. Relevance is determined by the union of all participants to states which have been
+ * included in the transaction. This default behaviour may be modified by passing in an alternate value for [StatesToRecord].
+ *
  * The transaction is expected to have already been resolved: if its dependencies are not available in local
  * storage, verification will fail. It must have signatures from all necessary parties other than the notary.
  *
@@ -83,7 +87,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
      * @param transaction What to commit.
      * @param sessions A collection of [FlowSession]s for each non-local participant of the transaction. Sessions to non-participants can
      * also be provided.
-     * @param statesToRecord Which transactions to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
+     * @param statesToRecord Which transactions to commit to the vault.
      */
     @JvmOverloads
     constructor(

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -21,7 +21,7 @@ import net.corda.core.utilities.debug
  * vault. Additionally it will be distributed to the parties reflected in the participants list of the states.
  *
  * By default, the initiating flow will commit states that are relevant to the initiating party as indicated by
- * [StatesToRecord.ALL_VISIBLE]. Relevance is determined by the union of all participants to states which have been
+ * [StatesToRecord.ONLY_RELEVANT]. Relevance is determined by the union of all participants to states which have been
  * included in the transaction. This default behaviour may be modified by passing in an alternate value for [StatesToRecord].
  *
  * The transaction is expected to have already been resolved: if its dependencies are not available in local

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -40,7 +40,8 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
                                        private val oldParticipants: Collection<Party>,
                                        override val progressTracker: ProgressTracker,
                                        private val sessions: Collection<FlowSession>,
-                                       private val newApi: Boolean) : FlowLogic<SignedTransaction>() {
+                                       private val newApi: Boolean,
+                                       private val statesToRecord: StatesToRecord = ONLY_RELEVANT) : FlowLogic<SignedTransaction>() {
     @Deprecated(DEPRECATION_MSG)
     constructor(transaction: SignedTransaction, extraRecipients: Set<Party>, progressTracker: ProgressTracker) : this(
             transaction, extraRecipients, progressTracker, emptyList(), false
@@ -73,8 +74,9 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     constructor(
             transaction: SignedTransaction,
             sessions: Collection<FlowSession>,
-            progressTracker: ProgressTracker = tracker()
-    ) : this(transaction, emptyList(), progressTracker, sessions, true)
+            progressTracker: ProgressTracker = tracker(),
+            statesToRecord: StatesToRecord = ONLY_RELEVANT
+    ) : this(transaction, emptyList(), progressTracker, sessions, true, statesToRecord)
 
     /**
      * Notarise the given transaction and broadcast it to all the participants.
@@ -202,7 +204,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
             transaction
         }
         logger.info("Recording transaction locally.")
-        serviceHub.recordTransactions(notarised)
+        serviceHub.recordTransactions(statesToRecord, listOf(notarised))
         logger.info("Recorded transaction locally successfully.")
         return notarised
     }

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,9 @@ release, see :doc:`app-upgrade-notes`.
 Unreleased
 ----------
 
+* Updating FinalityFlow with functionality to indicate the appropriate StatesToRecord. This allows the initiating party to record states
+  from transactions which they are proposing, but are not necessarily participants of.
+
 * Removed the RPC exception privacy feature. Previously, in production mode, the exceptions thrown on the node were stripped of all content
   when rethrown on the RPC client.
 


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

Updating FinalityFlow with functionality to allow the initiator to indicate the appropriate StatesToRecord. This allows the initiating party to record states in transactions which they are proposing, but are not necessarily participants of. 

An example would be the issuance of a token where the only participant is the holder NOT the issuer.

JIRA Tickets - Corda-3220

# PR Checklist:

- [✅ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [✅ ] If you added public APIs, did you write the JavaDocs?
- [✅ ] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [✅ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
