### PR TITLE
TM-23 compileAll task to compile all code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,9 +262,9 @@ allprojects {
         }
     }
 
-    task('compileAll') {}
-    compileAll.dependsOn tasks.withType(JavaCompile)
-    compileAll.dependsOn tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
+    tasks.register('compileAll') { task ->
+        task.dependsOn tasks.withType(AbstractCompile)
+    }
 
     tasks.withType(Jar) { task ->
         // Includes War and Ear

--- a/build.gradle
+++ b/build.gradle
@@ -239,7 +239,7 @@ allprojects {
         // JDK11 official support (https://github.com/jacoco/jacoco/releases/tag/v0.8.3)
         toolVersion = "0.8.3"    
     }
-    
+
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-Xlint:-options" << "-parameters"
         if (warnings_as_errors) {
@@ -261,6 +261,10 @@ allprojects {
             allWarningsAsErrors = warnings_as_errors
         }
     }
+
+    task('compileAll') {}
+    compileAll.dependsOn tasks.withType(JavaCompile)
+    compileAll.dependsOn tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
 
     tasks.withType(Jar) { task ->
         // Includes War and Ear


### PR DESCRIPTION
Current warning check is difficult to invoke. In order to compile all code in all source sets (production and tests) the command currently needs to list a gradle task per source set (`classes`, `testClasses` and `integrationTestClasses`, etc). When new source sets are introduced, we need to add them to the command. This is error prone.

I have added a single `compileAll` task that compiles all code, so none will be missed by the warning checks.