### PR TITLE
These changes should fix the ENT database integration tests.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/migration/PersistentIdentityMigrationNewTable.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/PersistentIdentityMigrationNewTable.kt
@@ -111,7 +111,6 @@ object PersistentIdentitiesMigrationSchemaBuilder {
                             PersistentIdentityService.PersistentPartyToPublicKeyHash::class.java,
                             PersistentIdentityService.PersistentPublicKeyHashToParty::class.java,
                             PersistentIdentityService.PersistentHashToPublicKey::class.java,
-                            BasicHSMKeyManagementService.PersistentKey::class.java,
                             NodeAttachmentService.DBAttachment::class.java,
                             DBNetworkParametersStorage.PersistentNetworkParameters::class.java
                     ))

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -129,7 +129,6 @@ object VaultMigrationSchemaV1 : MappedSchema(schemaFamily = VaultMigrationSchema
                 PersistentIdentityService.PersistentPublicKeyHashToCertificate::class.java,
                 PersistentIdentityService.PersistentPartyToPublicKeyHash::class.java,
                 PersistentIdentityService.PersistentPublicKeyHashToParty::class.java,
-                PersistentIdentityService.PersistentHashToPublicKey::class.java,
                 BasicHSMKeyManagementService.PersistentKey::class.java,
                 NodeAttachmentService.DBAttachment::class.java,
                 DBNetworkParametersStorage.PersistentNetworkParameters::class.java

--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -25,9 +25,13 @@
     <include file="migration/node-core.changelog-v13.xml"/>
     <!-- This change should be done before the v14-data migration. -->
     <include file="migration/node-core.changelog-v15-table.xml"/>
-    <include file="migration/node-core.changelog-v14-data.xml"/>
     <include file="migration/node-core.changelog-v15.xml"/>
+
+    <include file="migration/node-core.changelog-v16.xml"/>
+
     <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
     <include file="migration/vault-schema.changelog-v9.xml"/>
+
+    <include file="migration/node-core.changelog-v14-data.xml"/>
 
 </databaseChangeLog>

--- a/node/src/main/resources/migration/node-core.changelog-v16.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v16.xml
@@ -1,0 +1,21 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3.Corda" id="modify public_key column type" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="bytea">
+                    SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'node_hash_to_key' AND COLUMN_NAME = 'public_key'
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <dropColumn tableName="node_hash_to_key" columnName="public_key"/>
+        <addColumn tableName="node_hash_to_key">
+            <column name="public_key" type="varbinary(64000)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Moved a couple of things around in the master changelog and removed some of the entities from the various migration schemas and that seems to fix things. Whilst this PR is for OS, I made the same changes to ENT and managed to get the node to start up with no hibernate/liquibase warnings or errors. Thanks to @willhr3 for the code for `node/src/main/resources/migration/node-core.changelog-v16.xml`