### PR TITLE
CORDA-3246 - Missing logs on shutdown

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="info" packages="net.corda.common.logging">
+<Configuration status="info" packages="net.corda.common.logging" shutdownHook="disable">
 
     <Properties>
         <Property name="log-path">${sys:log-path:-logs}</Property>

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -26,7 +26,8 @@ by adding ``-DLog4jContextSelector=org.apache.logging.log4j.core.selector.ClassL
 command line or to the ``jvmArgs`` section of the node configuration (see :doc:`corda-configuration-file`).
 
 .. warning:: Ensure that ``shutdownHook="disable"`` is set if you are overriding the log4j2 configuration file
-   otherwise logs will not be flushed properly on shutdown and loss may occur.
+   otherwise logs will not be flushed properly on shutdown and loss may occur. The option is set at the ``Configuration``
+   tag, for example ``<Configuration ... shutdownHook="disable">
 
 Example
 +++++++

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -26,9 +26,9 @@ by adding ``-DLog4jContextSelector=org.apache.logging.log4j.core.selector.ClassL
 command line or to the ``jvmArgs`` section of the node configuration (see :doc:`corda-configuration-file`).
 
 .. warning:: Ensure that ``shutdownHook="disable"`` is set if you are overriding the log4j2 configuration file
-   otherwise logs will not be flushed properly on shutdown and loss may occur. The option is set at the ``Configuration``
-   tag, for example ``<Configuration ... shutdownHook="disable">``. This has to be set as Corda is calling shutdown after
-   everything finishes instead of relying on the normal log4j2 shutdown logic.
+   otherwise logs will not be flushed properly on shutdown and loss may occur. The option is set in the ``Configuration``
+   tag of the log4j configuration file, for example ``<Configuration ... shutdownHook="disable">``. This is because
+   Corda overrides the default log4j2 shutdown logic in order to make sure it gets shut down correctly.
 
 Example
 +++++++

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -25,6 +25,9 @@ If you need to switch to synchronous logging (e.g. for debugging/testing purpose
 by adding ``-DLog4jContextSelector=org.apache.logging.log4j.core.selector.ClassLoaderContextSelector`` to the node's
 command line or to the ``jvmArgs`` section of the node configuration (see :doc:`corda-configuration-file`).
 
+.. warning:: Ensure that ``shutdownHook="disable"`` is set if you are overriding the log4j2 configuration file
+   otherwise logs will not be flushed properly on shutdown and loss may occur.
+
 Example
 +++++++
 

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -27,7 +27,8 @@ command line or to the ``jvmArgs`` section of the node configuration (see :doc:`
 
 .. warning:: Ensure that ``shutdownHook="disable"`` is set if you are overriding the log4j2 configuration file
    otherwise logs will not be flushed properly on shutdown and loss may occur. The option is set at the ``Configuration``
-   tag, for example ``<Configuration ... shutdownHook="disable">
+   tag, for example ``<Configuration ... shutdownHook="disable">``. This has to be set as Corda is calling shutdown after
+   everything finishes instead of relying on the normal log4j2 shutdown logic.
 
 Example
 +++++++


### PR DESCRIPTION
Moved pr to be for 4.3 os, later on cherry picked into 4.2 for the patch. 
Added doc entry that looks like that at node-administration/logging section:
<img width="1309" alt="Screenshot 2019-09-20 at 14 11 39" src="https://user-images.githubusercontent.com/46542846/65329675-e0937d00-dbb0-11e9-8fef-9316a79f4e57.png">
