### PR TITLE
NOTICK: Change build number to snapshot

### DIFF
--- a/common/logging/src/main/kotlin/net/corda/common/logging/Constants.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/Constants.kt
@@ -8,4 +8,4 @@ package net.corda.common.logging
  * the generated file does not need to be committed to source control (originally added to source control for ease of use)
  */
 
-internal const val CURRENT_MAJOR_RELEASE = "4.3-RC01"
+internal const val CURRENT_MAJOR_RELEASE = "4.3-SNAPSHOT"

--- a/constants.properties
+++ b/constants.properties
@@ -2,7 +2,7 @@
 # because some versions here need to be matched by app authors in
 # their own projects. So don't get fancy with syntax!
 
-cordaVersion=4.3-RC01
+cordaVersion=4.3-SNAPSHOT
 gradlePluginsVersion=5.0.2
 kotlinVersion=1.2.71
 java8MinUpdateVersion=171

--- a/docker/src/bash/example-mini-network.sh
+++ b/docker/src/bash/example-mini-network.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 NODE_LIST=("dockerNode1" "dockerNode2" "dockerNode3")
 NETWORK_NAME=mininet
-CORDAPP_VERSION="4.3-RC01"
-DOCKER_IMAGE_VERSION="corda-zulu-4.3-RC01"
+CORDAPP_VERSION="4.3-SNAPSHOT"
+DOCKER_IMAGE_VERSION="corda-zulu-4.3-SNAPSHOT"
 
 mkdir cordapps
 rm -f cordapps/*


### PR DESCRIPTION
Change build number back to snapshot to fix the nightly build. In future, release candidates will be cut using orphaned commits rather than changes to the underlying branch.