### PR TITLE
CORDA-2050: Do not add java.lang.Class fields and properties to local type cache.

### DIFF
--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -6,6 +6,12 @@ apply plugin: 'net.corda.plugins.quasar-utils'
 configurations {
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
+
+    compile {
+        // We already have a SLF4J implementation on our runtime classpath,
+        // and we don't need another one.
+        exclude group: "org.apache.logging.log4j"
+    }
 }
 
 sourceSets {
@@ -33,14 +39,9 @@ dependencies {
 
     compile project(':core')
     compile project(':client:jfx')
-    compile (project(':node-driver')) {
-        // We already have a SLF4J implementation on our runtime classpath,
-        // and we don't need another one.
-        exclude group: 'org.apache.logging.log4j'
-    }
-    compile (project(':webserver')) {
-        exclude group: "org.apache.logging.log4j"
-    }
+    compile project(':node-driver')
+    compile project(':webserver')
+
     testCompile project(':test-utils')
 
     compile "org.graphstream:gs-core:1.3"
@@ -49,8 +50,8 @@ dependencies {
         exclude group: "junit"
     }
 
-    compile project(path: ":node:capsule", configuration: 'runtimeArtifacts')
-    compile project(path: ":webserver:webcapsule", configuration: 'runtimeArtifacts')
+    cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')
+    cordaRuntime project(path: ":webserver:webcapsule", configuration: 'runtimeArtifacts')
 
     // CorDapps: dependent flows and services
     compile project(':finance:contracts')

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt
@@ -88,7 +88,9 @@ open class ArraySerializer(override val type: Type, factory: LocalSerializerFact
                             context: SerializationContext
     ): Any {
         if (obj is List<*>) {
-            return obj.map { input.readObjectOrNull(it, schemas, elementType, context) }.toArrayOfType(elementType)
+            return obj.map {
+                input.readObjectOrNull(redescribe(it, elementType), schemas, elementType, context)
+            }.toArrayOfType(elementType)
         } else throw AMQPNotSerializableException(type, "Expected a List but found $obj")
     }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -209,7 +209,12 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                 observedType = type,
                 typeIdentifier = typeIdentifier,
                 constructor = null,
-                properties = buildReadOnlyProperties(rawType),
+                properties = if (rawType == Class::class.java) {
+                    // Do NOT drill down into the internals of java.lang.Class.
+                    emptyMap()
+                } else {
+                    buildReadOnlyProperties(rawType)
+                },
                 superclass = superclassInformation,
                 interfaces = interfaceInformation,
                 typeParameters = typeParameterInformation,


### PR DESCRIPTION
`java.lang.Class` should be opaque, but we were scanning it for fields and properties anyway. This means that the following methods were polluting the serializer's local type cache:
- `Class<?> Class.getComponentType()`
- `T[] Class.getEnumConstants()`

By making `Class` _truly_ opaque we ensure that the local type information for `Class<*>` and `ArrayOf(*)` are correct.

This allows us to revert 32c7aa98296a3334c2c7022a37389a3251051b3f and so fix `ArraySerializer` for the DJVM.

It may also fix [CORDA-3253](https://r3-cev.atlassian.net/browse/CORDA-3253).