### PR TITLE
ENT-4090: move startFlow into try block so exception is caught and managed

### DIFF
--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt
@@ -20,7 +20,6 @@ import net.corda.core.contracts.withoutIssuer
 import net.corda.core.flows.FlowException
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.startFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.OpaqueBytes
@@ -94,15 +93,14 @@ class NewTransaction : Fragment() {
                 initOwner(window)
                 show()
             }
-            val handle: FlowHandle<AbstractCashFlow.Result> = when (request) {
-                is IssueAndPaymentRequest -> rpcProxy.value!!.startFlow(::CashIssueAndPaymentFlow, request)
-                is PaymentRequest -> rpcProxy.value!!.startFlow(::CashPaymentFlow, request)
-                is ExitRequest -> rpcProxy.value!!.startFlow(::CashExitFlow, request)
-                else -> throw IllegalArgumentException("Unexpected request type: $request")
-            }
             runAsync {
                 try {
-                    handle.returnValue.getOrThrow()
+                    when (request) {
+                        is IssueAndPaymentRequest -> rpcProxy.value!!.startFlow(::CashIssueAndPaymentFlow, request)
+                        is PaymentRequest -> rpcProxy.value!!.startFlow(::CashPaymentFlow, request)
+                        is ExitRequest -> rpcProxy.value!!.startFlow(::CashExitFlow, request)
+                        else -> throw IllegalArgumentException("Unexpected request type: $request")
+                    }.returnValue.getOrThrow()
                 } finally {
                     dialog.dialogPane.isDisable = false
                 }


### PR DESCRIPTION
`startFlow` can throw an exception (and does when the RPC connection is down).  By moving it into the try block we can catch the exception instead of the default uncaught handler.