### PR TITLE
CORDA-3273: Restore deprecated use of Class.newInstance() for sake of DJVM.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -366,7 +366,14 @@ class Verifier(val ltx: LedgerTransaction, private val transactionClassLoader: C
 
         val contractInstances: List<Contract> = contractClasses.map { (contractClassName, contractClass) ->
             try {
-                contractClass.getDeclaredConstructor().newInstance()
+                /**
+                 * This function must execute with the DJVM's sandbox, which does not
+                 * permit user code to access [java.lang.reflect.Constructor] objects.
+                 *
+                 * [Class.newInstance] is deprecated as of Java 9.
+                 */
+                @Suppress("deprecation")
+                contractClass.newInstance()
             } catch (e: Exception) {
                 throw TransactionVerificationException.ContractCreationError(ltx.id, contractClassName, e)
             }


### PR DESCRIPTION
The `Class.newInstance()` function may be deprecated as of Java 9, but the DJVM's Java 8 sandbox still needs to use it because the recommended alternative of
```java
Class.getDeclaredConstructor().newInstance()
```
triggers a DJVM `RuleViolaiionError` when it requests a `Constructor` object.