### PR TITLE
CORDA-2050 Prevent node startup failure upon cross-platform execution.

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -4224,7 +4224,7 @@
     <ID>TooGenericExceptionCaught:InternalUtils.kt$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:InternalUtils.kt$th: Throwable</ID>
     <ID>TooGenericExceptionCaught:IssueCash.kt$IssueCash$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:JVMAgentUtil.kt$JVMAgentUtil$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:JVMAgentUtil.kt$JVMAgentUtil$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:JacksonSupport.kt$JacksonSupport.PartyDeserializer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:JacksonSupport.kt$JacksonSupport.PublicKeyDeserializer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:JacksonSupport.kt$JacksonSupport.SecureHashDeserializer$e: Exception</ID>

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     compile "com.palominolabs.metrics:metrics-new-relic:${metrics_new_relic_version}"
     
     // Required by JVMAgentUtil (x-compatible java 8 & 11 agent lookup mechanism)
-    compileOnly files("${System.properties['java.home']}/../lib/tools.jar")
+    compile files("${System.properties['java.home']}/../lib/tools.jar")
     
     testCompile(project(':test-cli'))
     testCompile(project(':test-utils'))

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     compile "com.palominolabs.metrics:metrics-new-relic:${metrics_new_relic_version}"
     
     // Required by JVMAgentUtil (x-compatible java 8 & 11 agent lookup mechanism)
-    compile files("${System.properties['java.home']}/../lib/tools.jar")
+    compileOnly files("${System.properties['java.home']}/../lib/tools.jar")
     
     testCompile(project(':test-cli'))
     testCompile(project(':test-utils'))

--- a/node/src/main/kotlin/net/corda/node/utilities/JVMAgentUtil.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JVMAgentUtil.kt
@@ -17,7 +17,7 @@ object JVMAgentUtil {
             val vm = VirtualMachine.attach(jvmPid)
             return vm.agentProperties
         } catch (e: Throwable) {
-            log.warn("Unable to determine whether checkpoint agent is running: ${e.message}.\n" +
+            log.warn("Unable to determine whether agent is running: ${e.message}.\n" +
                      "You may need to pass in -Djdk.attach.allowAttachSelf=true if running on a Java 9 or later VM")
             Properties()
         }

--- a/node/src/main/kotlin/net/corda/node/utilities/JVMAgentUtil.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JVMAgentUtil.kt
@@ -16,7 +16,7 @@ object JVMAgentUtil {
         return try {
             val vm = VirtualMachine.attach(jvmPid)
             return vm.agentProperties
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             log.warn("Unable to determine whether checkpoint agent is running: ${e.message}.\n" +
                      "You may need to pass in -Djdk.attach.allowAttachSelf=true if running on a Java 9 or later VM")
             Properties()


### PR DESCRIPTION
The new `JVMAgentUtil` introduced to provide cross-Java 8 / 11 compatibility uses a JDK class - `com.sun.tools.attach.VirtualMachine` - which is included in the JDK "`lib/tools.jar`" for Java 8.
Unfortunately, this lib/tools.jar is *not* included in the JRE/lib run-time (and thus needs packaging).
This in itself leads to platform dependency tie-in.
Need to identify a better mechanism for breaking this hard platform dependency.

This fix will display a warning upon Node startup and continue (with no side-effects).