### PR TITLE
CORDA-3181 Correct JDK install instructions + streamlining

### DIFF
--- a/docs/source/cordapp-build-systems.rst
+++ b/docs/source/cordapp-build-systems.rst
@@ -10,6 +10,9 @@ Building and installing a CorDapp
 .. contents::
 
 CorDapps run on the Corda platform and integrate with it and each other. This article explains how to build CorDapps.
+
+Applications on Corda (CorDapps) can be written in any language targeting the JVM. However, Corda itself and most of the samples are written in Kotlin. Kotlin is an `official Android language <https://developer.android.com/kotlin/index.html>`_, and you can read more about why Kotlin is a strong successor to Java `here <https://medium.com/@octskyward/why-kotlin-is-my-next-programming-language-c25c001e26e3>`_. If you're unfamiliar with Kotlin, there is an official `getting started guide <https://kotlinlang.org/docs/tutorials/>`_, and a series of `Kotlin Koans <https://kotlinlang.org/docs/tutorials/koans.html>`_
+
 To learn what a CorDapp is, please read :doc:`cordapp-overview`.
 
 CorDapp format
@@ -26,12 +29,12 @@ JAR will contain:
 Build tools
 -----------
 In the instructions that follow, we assume you are using Gradle and the ``cordapp`` plugin to build your
-CorDapp. You can find examples of building a CorDapp using these tools in the 
-`Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin>`_ and the 
+CorDapp. You can find examples of building a CorDapp using these tools in the
+`Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin>`_ and the
 `Java CorDapp Template <https://github.com/corda/cordapp-template-java>`_.
 
 To ensure you are using the correct version of Gradle, you should use the provided Gradle Wrapper by copying across
-the following folder and files from the `Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin>`_ or the 
+the following folder and files from the `Kotlin CorDapp Template <https://github.com/corda/cordapp-template-kotlin>`_ or the
 `Java CorDapp Template <https://github.com/corda/cordapp-template-java>`_ to the root of your project:
 
 * ``gradle/``
@@ -333,7 +336,7 @@ Once your dependencies are set correctly, you can build your CorDapp JAR(s) usin
 
 * Windows: ``gradlew.bat jar``
 
-Each of the project's modules will be compiled into its own CorDapp JAR. You can find these CorDapp JARs in the ``build/libs`` 
+Each of the project's modules will be compiled into its own CorDapp JAR. You can find these CorDapp JARs in the ``build/libs``
 folders of each of the project's modules.
 
 .. warning:: The hash of the generated CorDapp JAR is not deterministic, as it depends on variables such as the
@@ -354,8 +357,8 @@ Installing the CorDapp JAR
 .. note:: Before installing a CorDapp, you must create one or more nodes to install it on. For instructions, please see
    :doc:`generating-a-node`.
 
-At start-up, nodes will load any CorDapps present in their ``cordapps`` folder. In order to install a CorDapp on a node, the 
-CorDapp JAR must be added to the ``<node_dir>/cordapps/`` folder (where ``node_dir`` is the folder in which the node's JAR 
+At start-up, nodes will load any CorDapps present in their ``cordapps`` folder. In order to install a CorDapp on a node, the
+CorDapp JAR must be added to the ``<node_dir>/cordapps/`` folder (where ``node_dir`` is the folder in which the node's JAR
 and configuration files are stored) and the node restarted.
 
 .. _cordapp_configuration_files_ref:
@@ -558,6 +561,3 @@ and subsequently retry the failed flow (currently this requires a node re-start)
 
 .. note:: this behaviour is to protect the node from executing contract code that was not vetted. It is a temporary precaution until the
    Deterministic JVM is integrated into Corda whereby execution takes place in a sandboxed environment which protects the node from malicious code.
-
-
-

--- a/docs/source/getting-set-up.rst
+++ b/docs/source/getting-set-up.rst
@@ -1,187 +1,38 @@
 Getting set up for CorDapp development
 ======================================
 
-Software requirements
----------------------
+There are four pieces of required software for CorDapp development: the Java 8 JDK, IntelliJ IDEA, Git, and Gradle 4.10.
 
-Corda uses industry-standard tools:
+1. Install the Java 8 JDK, version |java_version|. We have tested using the following Java builds:
 
-* **Java 8 JVM** - we require at least version |java_version|, but do not currently support Java 9 or higher.
+  - `Oracle JDK <https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_
+  - `Amazon Corretto <https://aws.amazon.com/corretto/>`_
+  - `Red Hat's OpenJDK <https://developers.redhat.com/products/openjdk/overview/>`_
+  - `Zulu's OpenJDK <https://www.azul.com/>`_
 
-  We have tested with the following builds:
+  Please note: OpenJDK builds often exclude JavaFX, which is required by the Corda GUI tools. Corda supports only Java 8.
 
-  * `Oracle JDK <https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_
+  If you are using Windows: Add Java to the PATH environment variable by following the instructions in the `Oracle documentation <https://docs.oracle.com/javase/7/docs/webnotes/install/windows/jdk-installation-windows.html#path>`_.
 
-  * `Amazon Corretto <https://aws.amazon.com/corretto/>`_
+2. Install `IntelliJ IDEA Community Edition <https://www.jetbrains.com/idea/>`_. Corda supports IntelliJ IDEA versions **2017.x**, **2018.x**, and **2019.x**; and Kotlin plugin version |kotlin_version|.
 
-  * `Red Hat's OpenJDK <https://developers.redhat.com/products/openjdk/overview/>`_
+  To install IntelliJ IDEA in a Ubuntu environment, navigate to the `Jetbrains IntelliJ snap package <https://snapcraft.io/intellij-idea-community>`_.
 
-  * `Zulu's OpenJDK <https://www.azul.com/>`_
+3. Install `git <https://git-scm.com/>`_.
 
-  Please note that OpenJDK builds usually exclude JavaFX, which our GUI tools require.
+4. Install `Gradle version 4.10 <https://gradle.org/install/>`_. If you are using a supported Corda sample, the included ``gradlew`` script should install Gradle automatically.
 
-* **IntelliJ IDEA** - supported versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version |kotlin_version|)
-
-* **Gradle** - we use 4.10 and the ``gradlew`` script in the project / samples directories will download it for you.
-
-Please note:
-
-* Applications on Corda (CorDapps) can be written in any language targeting the JVM. However, Corda itself and most of
-  the samples are written in Kotlin. Kotlin is an
-  `official Android language <https://developer.android.com/kotlin/index.html>`_, and you can read more about why
-  Kotlin is a strong successor to Java
-  `here <https://medium.com/@octskyward/why-kotlin-is-my-next-programming-language-c25c001e26e3>`_. If you're
-  unfamiliar with Kotlin, there is an official
-  `getting started guide <https://kotlinlang.org/docs/tutorials/>`_, and a series of
-  `Kotlin Koans <https://kotlinlang.org/docs/tutorials/koans.html>`_
-
-* IntelliJ IDEA is recommended due to the strength of its Kotlin integration.
-
-Following these software recommendations will minimize the number of errors you encounter, and make it easier for
-others to provide support. However, if you do use other tools, we'd be interested to hear about any issues that arise.
-
-Set-up instructions
--------------------
-The instructions below will allow you to set up your development environment for running Corda and writing CorDapps. If
-you have any issues, please reach out on `Stack Overflow <https://stackoverflow.com/questions/tagged/corda>`_ or via
-`our Slack channels <http://slack.corda.net/>`_.
-
-The set-up instructions are available for the following platforms:
-
-* :ref:`windows-label` (or `in video form <https://vimeo.com/217462250>`__)
-
-* :ref:`mac-label` (or `in video form <https://vimeo.com/217462230>`__)
-
-* :ref:`deb-ubuntu-label`
-
-* :ref:`fedora-label`
-
-.. _windows-label:
-
-.. note:: These setup instructions will guide you on how to install the Oracle JDK. Each JDK can be found on their respective sites:
-
-          * `Oracle <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_
-
-          * `Amazon Corretto <https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html>`_
-
-          * `Red Hat OpenJDK <https://developers.redhat.com/products/openjdk/download/>`_
-
-          * `Zulu OpenJDK <https://www.azul.com/downloads/zulu/>`_
-
-Windows
--------
-
-.. warning:: If you are using a Mac, Debian/Ubuntu or Fedora machine, please follow the :ref:`mac-label`, :ref:`deb-ubuntu-label` or :ref:`fedora-label` instructions instead.
-
-Java
-^^^^
-1. Visit http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
-2. Click the download link for jdk-8uXXX-windows-x64.exe (where "XXX" is the latest minor version number)
-3. Download and run the executable to install Java (use the default settings)
-4. Add Java to the PATH environment variable by following the instructions in the `Oracle documentation <https://docs.oracle.com/javase/7/docs/webnotes/install/windows/jdk-installation-windows.html#path>`_
-5. Open a new command prompt and run ``java -version`` to test that Java is installed correctly
-
-Git
-^^^
-1. Visit https://git-scm.com/download/win
-2. Click the "64-bit Git for Windows Setup" download link.
-3. Download and run the executable to install Git (use the default settings)
-4. Open a new command prompt and type ``git --version`` to test that git is installed correctly
-
-IntelliJ
-^^^^^^^^
-1. Visit https://www.jetbrains.com/idea/download/download-thanks.html?code=IIC
-2. Download and run the executable to install IntelliJ Community Edition (use the default settings)
-3. Ensure the Kotlin plugin in Intellij is updated to version |kotlin_version| (new installs will contains this version)
-
-.. _mac-label:
-
-Mac
----
-
-.. warning:: If you are using a Windows, Debian/Ubuntu or Fedora machine, please follow the :ref:`windows-label`, :ref:`deb-ubuntu-label` or :ref:`fedora-label` instructions instead.
-
-Java
-^^^^
-1. Visit http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
-2. Click the download link for jdk-8uXXX-macosx-x64.dmg (where "XXX" is the latest minor version number)
-3. Download and run the executable to install Java (use the default settings)
-4. Open a new terminal window and run ``java -version`` to test that Java is installed correctly
-
-IntelliJ
-^^^^^^^^
-1. Visit https://www.jetbrains.com/idea/download/download-thanks.html?platform=mac&code=IIC
-2. Download and run the executable to install IntelliJ Community Edition (use the default settings)
-3. Ensure the Kotlin plugin in Intellij is updated to version |kotlin_version| (new installs will contains this version)
-
-.. _deb-ubuntu-label:
-
-Debian/Ubuntu
--------------
-
-.. warning:: If you are using a Mac, Windows or Fedora machine, please follow the :ref:`mac-label`, :ref:`windows-label` or :ref:`fedora-label` instructions instead.
-
-These instructions were tested on Ubuntu Desktop 18.04 LTS.
-
-Java
-^^^^
-1. Open a new terminal and add the Oracle PPA to your repositories by typing ``sudo add-apt-repository ppa:webupd8team/java``. Press ENTER when prompted.
-2. Update your packages list with the command ``sudo apt update``
-3. Install the Oracle JDK 8 by typing ``sudo apt install oracle-java8-installer``. Press Y when prompted and agree to the licence terms.
-4. Verify that the JDK was installed correctly by running ``java -version``
-
-Git
-^^^^
-1. From the terminal, Git can be installed using apt with the command ``sudo apt install git``
-2. Verify that git was installed correctly by typing ``git --version``
-
-IntelliJ
-^^^^^^^^
-Jetbrains offers a pre-built snap package that allows for easy, one-step installation of IntelliJ onto Ubuntu.
-
-1. To download the snap, navigate to https://snapcraft.io/intellij-idea-community
-2. Click ``Install``, then ``View in Desktop Store``. Choose ``Ubuntu Software`` in the Launch Application window.
-3. Ensure the Kotlin plugin in Intellij is updated to version |kotlin_version| (new installs will contains this version)
-
-.. _fedora-label:
-
-Fedora
-------
-
-.. warning:: If you are using a Mac, Windows or Debian/Ubuntu machine, please follow the :ref:`mac-label`, :ref:`windows-label` or :ref:`deb-ubuntu-label` instructions instead.
-
-These instructions were tested on Fedora 28.
-
-Java
-^^^^
-1. Download the RPM installation file of Oracle JDK from https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html.
-2. Install the package with ``rpm -ivh jdk-<version>-linux-<architecture>.rpm`` or use the default software manager.
-3. Choose java version by using the following command ``alternatives --config java``
-4. Verify that the JDK was installed correctly by running ``java -version``
-
-Git
-^^^^
-1. From the terminal, Git can be installed using dnf with the command ``sudo dnf install git``
-2. Verify that git was installed correctly by typing ``git --version``
-
-IntelliJ
-^^^^^^^^
-1. Visit https://www.jetbrains.com/idea/download/download-thanks.html?platform=linux&code=IIC
-2. Unpack the ``tar.gz`` file using the following command ``tar xfz ideaIC-<version>.tar.gz -C /opt``
-3. Run IntelliJ with ``/opt/ideaIC-<version>/bin/idea.sh``
-4. Ensure the Kotlin plugin in IntelliJ is updated to version |kotlin_version| (new installs will contains this version)
-
+  Please note: Corda requires Gradle version 4.10, and does not support any other version of Gradle.
 
 Next steps
 ----------
+
 First, run the :doc:`example CorDapp <tutorial-cordapp>`.
 
 Next, read through the :doc:`Corda Key Concepts <key-concepts>` to understand how Corda works.
 
-By then, you'll be ready to start writing your own CorDapps. Learn how to do this in the
-:doc:`Hello, World tutorial <hello-world-introduction>`. You may want to refer to the
+By then, you'll be ready to start writing your own CorDapps. You may want to refer to the
 :doc:`API documentation <corda-api>`, the :doc:`flow cookbook <flow-cookbook>` and the
 `samples <https://www.corda.net/samples/>`_ along the way.
 
-If you encounter any issues, please ask on `Stack Overflow <https://stackoverflow.com/questions/tagged/corda>`_ or via
-`our Slack channels <http://slack.corda.net/>`_.
+If you encounter any issues, please ask on `Stack Overflow <https://stackoverflow.com/questions/tagged/corda>`_ or via `our Slack channels <http://slack.corda.net/>`_.


### PR DESCRIPTION
1. Removing needless duplication from getting set up doc.
2. Adding kotlin information to one of the cordapp docs rather than getting set up doc.

Tagging @wawrzek as the JIRA reporter.

After merging, I'll need to port this forward.