### PR TITLE
CORDA-2050: Remove Gradle's evaluation dependency on node:capsule.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,8 +9,6 @@ apply plugin: 'com.jfrog.artifactory'
 
 description 'Corda core'
 
-evaluationDependsOn(':node:capsule')
-
 // required by DJVM and Avian JVM (for running inside the SGX enclave) which only supports Java 8.
 targetCompatibility = VERSION_1_8
 


### PR DESCRIPTION
Remove evaluation dependency that was accidentally reintroduced when Java 11 feature branch was merged.