### PR TITLE
Test runners don't need to compile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                             "-Ddocker.push.password=\"\${DOCKER_PUSH_PWD}\" " +
                             "-Ddocker.work.dir=\"/tmp/\${EXECUTOR_NUMBER}\" " +
                             "-Ddocker.provided.tag=\"\${DOCKER_TAG_TO_USE}\"" +
-                            " clean pushBuildImage"
+                            " clean compileAll pushBuildImage"
                 }
                 sh "kubectl auth can-i get pods"
             }


### PR DESCRIPTION
Put compiled classes in docker image so that test runners don't need to compile them.