### PR TITLE
Create an emptyMap when MDC.getCopyOfContextMap() is null

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
@@ -83,7 +83,7 @@ class AMQPBridgeManager(config: MutualSslConfiguration,
         }
 
         private fun withMDC(block: () -> Unit) {
-            val oldMDC = MDC.getCopyOfContextMap()
+            val oldMDC = MDC.getCopyOfContextMap() ?: emptyMap<String, String>()
             try {
                 MDC.put("queueName", queueName)
                 MDC.put("targets", targets.joinToString(separator = ";") { it.toString() })

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
@@ -46,7 +46,7 @@ internal class ConnectionStateMachine(private val serverMode: Boolean,
     }
 
     private fun withMDC(block: () -> Unit) {
-        val oldMDC = MDC.getCopyOfContextMap()
+        val oldMDC = MDC.getCopyOfContextMap() ?: emptyMap<String, String>()
         try {
             MDC.put("serverMode", serverMode.toString())
             MDC.put("localLegalName", localLegalName)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt
@@ -41,7 +41,7 @@ internal class EventProcessor(channel: Channel,
     }
 
     private fun withMDC(block: () -> Unit) {
-        val oldMDC = MDC.getCopyOfContextMap()
+        val oldMDC = MDC.getCopyOfContextMap() ?: emptyMap<String, String>()
         try {
             MDC.put("serverMode", serverMode.toString())
             MDC.put("localLegalName", localLegalName)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
@@ -49,7 +49,7 @@ internal class AMQPChannelHandler(private val serverMode: Boolean,
     private var badCert: Boolean = false
 
     private fun withMDC(block: () -> Unit) {
-        val oldMDC = MDC.getCopyOfContextMap()
+        val oldMDC = MDC.getCopyOfContextMap() ?: emptyMap<String, String>()
         try {
             MDC.put("serverMode", serverMode.toString())
             MDC.put("remoteAddress", remoteAddress.toString())


### PR DESCRIPTION
To address #5544 

Since according to the SLF4J javadocs, MDC.getCopyOfContextMap() can be null, create an empty map so NullPointerExceptions don't occur further down.
