### PR TITLE
[CORDA-3274] - Enhance backwards compatibility logic to include Inter…

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -17,6 +17,7 @@ import net.corda.core.context.Trace
 import net.corda.core.context.Trace.InvocationId
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.*
+import net.corda.core.internal.messaging.InternalCordaRPCOps
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.RPCOps
 import net.corda.core.serialization.SerializationContext
@@ -286,8 +287,12 @@ class RPCClientProxyHandler(
     }
 
     private fun produceMethodFullyQualifiedName(method: Method) : String {
-        // For CordaRPCOps send method only - for backwards compatibility
-        return if (CordaRPCOps::class.java == rpcOpsClass) {
+        /*
+         * Until version 4.3, rpc calls did not include class names.
+         * Up to this version, only CordaRPCOps and InternalCordaRPCOps were supported.
+         * So, for these classes only methods are sent across the wire to preserve backwards compatibility.
+         */
+        return if (CordaRPCOps::class.java == rpcOpsClass || InternalCordaRPCOps::class.java == rpcOpsClass) {
             method.name
         } else {
             rpcOpsClass.name + CLASS_METHOD_DIVIDER + method.name

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
@@ -14,6 +14,7 @@ import net.corda.core.context.Trace.InvocationId
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.LifeCycle
 import net.corda.core.internal.NamedCacheFactory
+import net.corda.core.internal.messaging.InternalCordaRPCOps
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.RPCOps
 import net.corda.core.serialization.SerializationContext
@@ -158,7 +159,12 @@ class RPCServer(
         opsList.forEach { ops ->
             listOfApplicableInterfacesRec(ops.javaClass).toSet().forEach { interfaceClass ->
                 val groupedMethods = with(interfaceClass) {
-                    if(interfaceClass == CordaRPCOps::class.java) {
+                    /*
+                     * Until version 4.3, rpc calls did not include class names.
+                     * Up to this version, only CordaRPCOps and InternalCordaRPCOps were supported.
+                     * So, for these classes methods are registered without their class name as well to preserve backwards compatibility.
+                     */
+                    if(interfaceClass == CordaRPCOps::class.java || interfaceClass == InternalCordaRPCOps::class.java) {
                         methods.groupBy { it.name }
                     } else {
                         methods.groupBy { interfaceClass.name + CLASS_METHOD_DIVIDER + it.name }


### PR DESCRIPTION
## Changes
Enhancing the logic for backwards compatibility to also include `InternalCordaRPCOps`. This interface arguably needs to be removed, but this can be done in a separate task, since it requires more extensive effort and consideration around implications (i.e. it has been backported and potentially used by customers).

## Testing
Used the `spring-webserver` sample to connect a 4.3 rpc client to a <4.3 node successfully.