### PR TITLE
CORDA-2756 - Node configuration doc change

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -51,7 +51,7 @@ JVM options
 
     java -Dcorda.rpcSettings.ssl.keyStorePassword=mypassword -jar node.jar
 
-.. note:: If you have the same field override as environment variable and system property, the system property
+.. note:: If the same field is overriden by both an environment variable and system property, the system property
    takes precedence.
 
 Configuration file fields

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -51,6 +51,9 @@ JVM options
 
     java -Dcorda.rpcSettings.ssl.keyStorePassword=mypassword -jar node.jar
 
+.. note:: If you have the same field override as environment variable and system property, the system property
+   takes precedence.
+
 Configuration file fields
 -------------------------
 

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -28,6 +28,11 @@ This prevents configuration errors when mixing keys containing ``.`` wrapped wit
 ``"dataSourceProperties.dataSourceClassName" = "val"`` in `Reference.conf`_ would be not overwritten by the property
 ``dataSourceProperties.dataSourceClassName = "val2"`` in *node.conf*.
 
+.. warning:: If a property is defined twice the last one will take precedence. The library currently used for parsing HOCON
+   currently does not provide a way to catch duplicates when parsing files and will silently override values for the same key.
+   For example having ``key=initialValue`` defined first in node.conf and later on down the
+   lines ``key=overridingValue`` will result into the value being ``overridingValue``.
+
 By default the node will fail to start in presence of unknown property keys.
 To alter this behaviour, the ``on-unknown-config-keys`` command-line argument can be set to ``IGNORE`` (default is ``FAIL``).
 


### PR DESCRIPTION
<img width="1313" alt="Screenshot 2019-10-03 at 13 18 30" src="https://user-images.githubusercontent.com/46542846/66126017-526fbb80-e5e0-11e9-89bd-f2f044a1de71.png">

Added a warning as per the ticket, as of right now the only way to catch duplicates is to write a custom parser or heavily modifying the typesafe library.