### PR TITLE
CORDA-3300 Publish checkpoint agent jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,7 +245,7 @@ allprojects {
 
     jacoco {
         // JDK11 official support (https://github.com/jacoco/jacoco/releases/tag/v0.8.3)
-        toolVersion = "0.8.3"    
+        toolVersion = "0.8.3"
     }
 
     tasks.withType(JavaCompile) {
@@ -496,7 +496,8 @@ bintrayConfig {
             'corda-common-configuration-parsing',
             'corda-common-validation',
             'corda-common-logging',
-            'corda-tools-network-builder'
+            'corda-tools-network-builder',
+            'corda-tools-checkpoint-agent'
     ]
     license {
         name = 'Apache-2.0'

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
@@ -151,8 +151,9 @@ class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private
 
     private fun checkpointAgentRunning(): Boolean {
         val agentProperties = getJvmAgentProperties(log)
+        val pattern = "(.+)?checkpoint-agent(-.+)?\\.jar.*".toRegex()
         return agentProperties.values.any { value ->
-            value is String && value.contains("checkpoint-agent.jar")
+            value is String && value.contains(pattern)
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -100,4 +100,3 @@ include 'core-deterministic:testing:verifier'
 include 'serialization-deterministic'
 
 include 'tools:checkpoint-agent'
-findProject(':tools:checkpoint-agent')?.name = 'checkpoint-agent'

--- a/tools/checkpoint-agent/build.gradle
+++ b/tools/checkpoint-agent/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 apply plugin: 'kotlin'
 apply plugin: 'idea'
+apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 description 'A javaagent to allow hooking into Kryo checkpoints'
 
@@ -49,7 +51,7 @@ dependencies {
 }
 
 jar {
-    archiveName = "${project.name}.jar"
+    archiveBaseName = "${project.name}"
     manifest {
         attributes(
                 'Premain-Class': 'net.corda.tools.CheckpointAgent',
@@ -61,4 +63,8 @@ jar {
         )
     }
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+}
+
+publish {
+    name 'corda-tools-checkpoint-agent'
 }


### PR DESCRIPTION
Also cater for checkpoint-agent.jar file inclusive of version identifiers (eg. checkpoint-agent-4.3-SNAPSHOT.jar).

Tested publication by pushing to r3-corda-dev artifactory:
https://ci-artifactory.corda.r3cev.com/artifactory/r3-corda-dev/com/r3/corda/corda-tools-checkpoint-agent/