### PR TITLE
TM-40 Persistent storage for k8s workers

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,6 +3,14 @@
     <option name="LINE_SEPARATOR" value="&#10;" />
     <option name="RIGHT_MARGIN" value="140" />
     <option name="SOFT_MARGINS" value="140" />
+    <GroovyCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    </GroovyCodeStyleSettings>
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
@@ -11,6 +19,8 @@
           <package name="tornadofx" withSubpackages="false" static="false" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="100" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="100" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="true" />
       <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="true" />
       <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="true" />

--- a/buildSrc/src/main/groovy/net/corda/testing/KubesTest.groovy
+++ b/buildSrc/src/main/groovy/net/corda/testing/KubesTest.groovy
@@ -78,7 +78,7 @@ class KubesTest extends DefaultTask {
         }
 
         List<CompletableFuture<KubePodResult>> futures = IntStream.range(0, numberOfPods).mapToObj({ i ->
-            String podName = (taskToExecuteName + "-" + stableRunId + suffix + i).toLowerCase()
+            String podName = "$taskToExecuteName-$stableRunId-$suffix-$i".toLowerCase()
             runBuild(client, namespace, numberOfPods, i, podName, printOutput, 3)
         }).collect(Collectors.toList())
         this.testOutput = Collections.synchronizedList(futures.collect { it -> it.get().binaryResults }.flatten())

--- a/buildSrc/src/main/groovy/net/corda/testing/KubesTest.groovy
+++ b/buildSrc/src/main/groovy/net/corda/testing/KubesTest.groovy
@@ -252,7 +252,7 @@ class KubesTest extends DefaultTask {
 
                 .addNewVolume()
                 .withName("poddata")
-                .withNewHostPath().withPath(podData.path).withType("Directory").endHostPath()
+                .withNewHostPath().withType("Directory").withPath(podData.path).endHostPath()
                 .endVolume()
 
                 .addNewContainer()
@@ -271,7 +271,7 @@ class KubesTest extends DefaultTask {
                 .addToRequests("memory", new Quantity("${memoryGbPerFork}Gi"))
                 .endResources()
                 .addNewVolumeMount().withName("gradlecache").withMountPath("/tmp/gradle").endVolumeMount()
-                .addNewVolumeMount().withName("poddata").withMountPath("/poddata").endVolumeMount()
+                .addNewVolumeMount().withName("poddata").withMountPath("/shared-data").endVolumeMount()
                 .endContainer()
 
                 .withImagePullSecrets(new LocalObjectReference("regcred"))

--- a/buildSrc/src/main/java/net/corda/testing/KubePodResult.java
+++ b/buildSrc/src/main/java/net/corda/testing/KubePodResult.java
@@ -5,19 +5,16 @@ import io.fabric8.kubernetes.api.model.Pod;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
 
 public class KubePodResult {
 
     private final Pod createdPod;
-    private final CompletableFuture<Void> waiter;
     private volatile Integer resultCode = 255;
     private final File output;
     private volatile Collection<File> binaryResults = Collections.emptyList();
 
-    KubePodResult(Pod createdPod, CompletableFuture<Void> waiter, File output) {
+    KubePodResult(Pod createdPod, File output) {
         this.createdPod = createdPod;
-        this.waiter = waiter;
         this.output = output;
     }
 


### PR DESCRIPTION
Test runner workers receive a new volume mounted at `/shared-data` which is persistent between multiple runs of the same pod (on the same PR check). This is in preparation for the ability to rerun tests when the worker node dies and continue where the previous execution left off.