### PR TITLE
CORDA-3236 fix observables not being tagged with notUsed()

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -161,6 +161,7 @@ class RPCClientProxyHandler(
         val onObservableRemove = RemovalListener<InvocationId, UnicastSubject<Notification<*>>> { key, _, cause ->
             val observableId = key!!
             val rpcCallSite: CallSite? = callSiteMap?.remove(observableId)
+
             if (cause == RemovalCause.COLLECTED) {
                 log.warn(listOf(
                         "A hot observable returned from an RPC was never subscribed to.",
@@ -174,7 +175,13 @@ class RPCClientProxyHandler(
             }
             observablesToReap.locked { observables.add(observableId) }
         }
-        return cacheFactory.buildNamed(Caffeine.newBuilder().weakValues().removalListener(onObservableRemove).executor(SameThreadExecutor.getExecutor()), "RpcClientProxyHandler_rpcObservable")
+        return cacheFactory.buildNamed(
+                Caffeine.newBuilder()
+                        .weakValues()
+                        .removalListener(onObservableRemove)
+                        .executor(SameThreadExecutor.getExecutor()),
+                "RpcClientProxyHandler_rpcObservable"
+        )
     }
 
     private var sessionFactory: ClientSessionFactory? = null

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -150,6 +150,7 @@ internal class CordaRPCOpsImpl(
     override fun killFlow(id: StateMachineRunId): Boolean = if (smm.killFlow(id)) true else smm.flowHospital.dropSessionInit(id.uuid)
 
     override fun stateMachinesFeed(): DataFeed<List<StateMachineInfo>, StateMachineUpdate> {
+
         val (allStateMachines, changes) = smm.track()
         return DataFeed(
                 allStateMachines.map { stateMachineInfoFromFlowLogic(it) },

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -640,7 +640,7 @@ object InteractiveShell {
 
     private class PrintingSubscriber(private val printerFun: (Any?) -> String, private val toStream: PrintWriter) : Subscriber<Any>() {
         private var count = 0
-        var future = openFuture<Unit>()
+        val future = openFuture<Unit>()
 
         init {
             // The future is public and can be completed by something else to indicate we don't wish to follow
@@ -690,8 +690,6 @@ object InteractiveShell {
 
                 val unsubscribeAndPrint: (Any?) -> String = { resp ->
                     if (resp is StateMachineUpdate.Added) {
-                        //this prevents leaking observables to the deserialization collector.
-                        //should be investigated if it should be implemented instead.
                         resp.stateMachineInfo.progressTrackerStepAndUpdates?.updates?.notUsed()
                     }
                     printerFun(resp)


### PR DESCRIPTION
Running stateMachineFeed rpc command triggers a dataFeed that sends us StateMachineUpdated.Added classes which contain progressTrack observables which are never used and blow up on reaping from the general collector. This should prevent resource accumulation on the node.
Opened ENT-4263 for investigation of why have we omitted implementing the observables from status update step. 

 ~~Needs a fix for stateMachinesFeed accumulation as they never unsubscribe.~~