### PR TITLE
CORDA-2965 Make Tx verification exceptions serializable.

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/contracts/TransactionVerificationExceptionSerialisationTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/contracts/TransactionVerificationExceptionSerialisationTests.kt
@@ -16,8 +16,6 @@ import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.DeserializationInput
 import net.corda.serialization.internal.amqp.SerializationOutput
 import net.corda.serialization.internal.amqp.SerializerFactoryBuilder
-import net.corda.serialization.internal.amqp.custom.DurationSerializer
-import net.corda.serialization.internal.amqp.custom.InstantSerializer
 import net.corda.serialization.internal.amqp.custom.PublicKeySerializer
 import net.corda.serialization.internal.amqp.custom.ThrowableSerializer
 import net.corda.testing.common.internal.testNetworkParameters
@@ -35,8 +33,6 @@ class TransactionVerificationExceptionSerialisationTests {
             ClassLoader.getSystemClassLoader()
     ).apply {
         register(ThrowableSerializer(this))
-        register(DurationSerializer(this))
-        register(InstantSerializer(this))
     }
 
     private val context get() = AMQP_RPC_CLIENT_CONTEXT

--- a/core-tests/src/test/kotlin/net/corda/coretests/contracts/TransactionVerificationExceptionSerialisationTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/contracts/TransactionVerificationExceptionSerialisationTests.kt
@@ -1,6 +1,10 @@
 package net.corda.coretests.contracts
 
-import net.corda.core.contracts.*
+import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
+import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.Party
@@ -17,9 +21,12 @@ import net.corda.serialization.internal.amqp.custom.InstantSerializer
 import net.corda.serialization.internal.amqp.custom.PublicKeySerializer
 import net.corda.serialization.internal.amqp.custom.ThrowableSerializer
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.core.*
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.DUMMY_BANK_A_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.TestIdentity
 import org.junit.Test
-import java.security.PublicKey
 import kotlin.test.assertEquals
 
 class TransactionVerificationExceptionSerialisationTests {
@@ -221,7 +228,8 @@ class TransactionVerificationExceptionSerialisationTests {
 
     @Test
     fun constraintPropagationRejectionTest() {
-        val exception = TransactionVerificationException.ConstraintPropagationRejection(txid, "com.test.Contract", AlwaysAcceptAttachmentConstraint, AlwaysAcceptAttachmentConstraint)
+        val exception = TransactionVerificationException.ConstraintPropagationRejection(txid, "com.test.Contract",
+                AlwaysAcceptAttachmentConstraint, AlwaysAcceptAttachmentConstraint)
         val exception2 = DeserializationInput(factory)
                 .deserialize(
                         SerializationOutput(factory)

--- a/core-tests/src/test/kotlin/net/corda/coretests/contracts/TransactionVerificationExceptionSerialisationTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/contracts/TransactionVerificationExceptionSerialisationTests.kt
@@ -1,9 +1,9 @@
 package net.corda.coretests.contracts
 
-import net.corda.core.contracts.Contract
-import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.TransactionVerificationException
+import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.generateKeyPair
+import net.corda.core.identity.Party
 import net.corda.core.internal.createContractCreationError
 import net.corda.core.internal.createContractRejection
 import net.corda.core.transactions.LedgerTransaction
@@ -17,10 +17,9 @@ import net.corda.serialization.internal.amqp.custom.InstantSerializer
 import net.corda.serialization.internal.amqp.custom.PublicKeySerializer
 import net.corda.serialization.internal.amqp.custom.ThrowableSerializer
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.core.DUMMY_BANK_A_NAME
-import net.corda.testing.core.DUMMY_NOTARY_NAME
-import net.corda.testing.core.TestIdentity
+import net.corda.testing.core.*
 import org.junit.Test
+import java.security.PublicKey
 import kotlin.test.assertEquals
 
 class TransactionVerificationExceptionSerialisationTests {
@@ -209,6 +208,94 @@ class TransactionVerificationExceptionSerialisationTests {
     @Test
     fun missingNetworkParametersExceptionTest() {
         val exception = TransactionVerificationException.MissingNetworkParametersException(txid, SecureHash.zeroHash)
+        val exception2 = DeserializationInput(factory)
+                .deserialize(
+                        SerializationOutput(factory)
+                                .serialize(exception, context),
+                        context)
+
+        assertEquals(exception.message, exception2.message)
+        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals(exception.txId, exception2.txId)
+    }
+
+    @Test
+    fun constraintPropagationRejectionTest() {
+        val exception = TransactionVerificationException.ConstraintPropagationRejection(txid, "com.test.Contract", AlwaysAcceptAttachmentConstraint, AlwaysAcceptAttachmentConstraint)
+        val exception2 = DeserializationInput(factory)
+                .deserialize(
+                        SerializationOutput(factory)
+                                .serialize(exception, context),
+                        context)
+
+        assertEquals(exception.message, exception2.message)
+        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals(exception.txId, exception2.txId)
+        assertEquals("com.test.Contract", exception2.contractClass)
+    }
+
+    @Test
+    fun transactionDuplicateEncumbranceExceptionTest() {
+        val exception = TransactionVerificationException.TransactionDuplicateEncumbranceException(txid, 1)
+        val exception2 = DeserializationInput(factory)
+                .deserialize(
+                        SerializationOutput(factory)
+                                .serialize(exception, context),
+                        context)
+
+        assertEquals(exception.message, exception2.message)
+        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals(exception.txId, exception2.txId)
+    }
+
+    @Test
+    fun transactionNonMatchingEncumbranceExceptionTest() {
+        val exception = TransactionVerificationException.TransactionNonMatchingEncumbranceException(txid, listOf(1, 2, 3))
+        val exception2 = DeserializationInput(factory)
+                .deserialize(
+                        SerializationOutput(factory)
+                                .serialize(exception, context),
+                        context)
+
+        assertEquals(exception.message, exception2.message)
+        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals(exception.txId, exception2.txId)
+    }
+
+    @Test
+    fun transactionNotaryMismatchEncumbranceExceptionTest() {
+        val exception = TransactionVerificationException.TransactionNotaryMismatchEncumbranceException(
+                txid, 1, 2, Party(ALICE_NAME, generateKeyPair().public), Party(BOB_NAME, generateKeyPair().public))
+        val exception2 = DeserializationInput(factory)
+                .deserialize(
+                        SerializationOutput(factory)
+                                .serialize(exception, context),
+                        context)
+
+        assertEquals(exception.message, exception2.message)
+        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals(exception.txId, exception2.txId)
+    }
+
+    @Test
+    fun transactionContractConflictExceptionTest() {
+        val exception = TransactionVerificationException.TransactionContractConflictException(
+                txid, TransactionState(DummyContractState(), notary = Party(BOB_NAME, generateKeyPair().public)), "aa")
+        val exception2 = DeserializationInput(factory)
+                .deserialize(
+                        SerializationOutput(factory)
+                                .serialize(exception, context),
+                        context)
+
+        assertEquals(exception.message, exception2.message)
+        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals(exception.txId, exception2.txId)
+    }
+
+    @Test
+    fun transactionRequiredContractUnspecifiedExceptionTest() {
+        val exception = TransactionVerificationException.TransactionRequiredContractUnspecifiedException(
+                txid, TransactionState(DummyContractState(), notary = Party(BOB_NAME, generateKeyPair().public)))
         val exception2 = DeserializationInput(factory)
                 .deserialize(
                         SerializationOutput(factory)

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -71,10 +71,15 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      */
     @KeepForDJVM
     class ConstraintPropagationRejection(txId: SecureHash, message: String) : TransactionVerificationException(txId, message, null) {
-        constructor(txId: SecureHash, contractClass: String, inputConstraint: AttachmentConstraint, outputConstraint: AttachmentConstraint) :
+        constructor(txId: SecureHash,
+                    contractClass: String,
+                    inputConstraint: AttachmentConstraint,
+                    outputConstraint: AttachmentConstraint) :
                 this(txId, "Contract constraints for $contractClass are not propagated correctly. " +
                         "The outputConstraint: $outputConstraint is not a valid transition from the input constraint: $inputConstraint.")
-        val contractClass:String = message.split(" ")[3]
+
+        // This is only required for backwards compatibility. In case the message format changes, update the index.
+        val contractClass: String = message.split(" ")[3]
     }
 
     /**
@@ -228,8 +233,12 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      * If the network parameters associated with an input or reference state in a transaction are more recent than the network parameters of the new transaction itself.
      */
     @KeepForDJVM
-    class TransactionNetworkParameterOrderingException(txId: SecureHash, message: String) : TransactionVerificationException(txId, message, null) {
-        constructor(txId: SecureHash, inputStateRef: StateRef, txnNetworkParameters: NetworkParameters, inputNetworkParameters: NetworkParameters)
+    class TransactionNetworkParameterOrderingException(txId: SecureHash, message: String) :
+            TransactionVerificationException(txId, message, null) {
+        constructor(txId: SecureHash,
+                    inputStateRef: StateRef,
+                    txnNetworkParameters: NetworkParameters,
+                    inputNetworkParameters: NetworkParameters)
                 : this(txId, "The network parameters epoch (${txnNetworkParameters.epoch}) of this transaction " +
                 "is older than the epoch (${inputNetworkParameters.epoch}) of input state: $inputStateRef")
     }

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -57,7 +57,8 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      */
     @KeepForDJVM
     class ContractRejection internal constructor(txId: SecureHash, val contractClass: String, cause: Throwable?, message: String) : TransactionVerificationException(txId, "Contract verification failed: $message, contract: $contractClass", cause) {
-        internal constructor(txId: SecureHash, contract: Contract, cause: Throwable) : this(txId, contract.javaClass.name, cause, cause.message ?: "")
+        internal constructor(txId: SecureHash, contract: Contract, cause: Throwable) : this(txId, contract.javaClass.name, cause, cause.message
+                ?: "")
     }
 
     /**
@@ -122,7 +123,8 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
     @KeepForDJVM
     class ContractCreationError internal constructor(txId: SecureHash, val contractClass: String, cause: Throwable?, message: String)
         : TransactionVerificationException(txId, "Contract verification failed: $message, could not create contract class: $contractClass", cause) {
-        internal constructor(txId: SecureHash, contractClass: String, cause: Throwable) : this(txId, contractClass, cause, cause.message ?: "")
+        internal constructor(txId: SecureHash, contractClass: String, cause: Throwable) : this(txId, contractClass, cause, cause.message
+                ?: "")
     }
 
     /**
@@ -207,12 +209,11 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
             """.trimIndent(), null)
 
-
     /**
      * If the network parameters associated with an input or reference state in a transaction are more recent than the network parameters of the new transaction itself.
      */
     @KeepForDJVM
-    class TransactionNetworkParameterOrderingException(txId: SecureHash, inputStateRef: StateRef, txnNetworkParameters: NetworkParameters, inputNetworkParameters: NetworkParameters)
+    class TransactionNetworkParameterOrderingException(txId: SecureHash, val inputStateRef: StateRef, val txnNetworkParameters: NetworkParameters, val inputNetworkParameters: NetworkParameters)
         : TransactionVerificationException(txId, "The network parameters epoch (${txnNetworkParameters.epoch}) of this transaction " +
             "is older than the epoch (${inputNetworkParameters.epoch}) of input state: $inputStateRef", null)
 
@@ -224,9 +225,8 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      * @param missingNetworkParametersHash Missing hash of the network parameters associated to this transaction
      */
     @KeepForDJVM
-    class MissingNetworkParametersException(txId: SecureHash, missingNetworkParametersHash: SecureHash)
+    class MissingNetworkParametersException(txId: SecureHash, val missingNetworkParametersHash: SecureHash)
         : TransactionVerificationException(txId, "Couldn't find network parameters with hash: $missingNetworkParametersHash related to this transaction: $txId", null)
-
 
     /** Whether the inputs or outputs list contains an encumbrance issue, see [TransactionMissingEncumbranceException]. */
     @CordaSerializable

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1227,6 +1227,7 @@
     <ID>MagicNumber:TransactionBuilder.kt$TransactionBuilder$4</ID>
     <ID>MagicNumber:TransactionDSLInterpreter.kt$TransactionDSL$30</ID>
     <ID>MagicNumber:TransactionUtils.kt$4</ID>
+    <ID>MagicNumber:TransactionVerificationException.kt$TransactionVerificationException.ConstraintPropagationRejection$3</ID>
     <ID>MagicNumber:TransactionVerifierServiceInternal.kt$Verifier$4</ID>
     <ID>MagicNumber:TransactionViewer.kt$TransactionViewer$15.0</ID>
     <ID>MagicNumber:TransactionViewer.kt$TransactionViewer$20.0</ID>
@@ -3581,17 +3582,14 @@
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$ContractCreationError : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$ContractRejection : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$InvalidAttachmentException : TransactionVerificationException</ID>
-    <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$MissingNetworkParametersException : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$NotaryChangeInWrongTransactionType : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$OverlappingAttachmentsException : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$PackageOwnershipException : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$SignersMissing : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$TransactionNetworkParameterOrderingException : TransactionVerificationException</ID>
-    <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException$TransactionNotaryMismatchEncumbranceException : TransactionVerificationException</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException.ContractCreationError$internal constructor(txId: SecureHash, contractClass: String, cause: Throwable) : this(txId, contractClass, cause, cause.message ?: "")</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException.ContractRejection$internal constructor(txId: SecureHash, contract: Contract, cause: Throwable) : this(txId, contract.javaClass.name, cause, cause.message ?: "")</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException.PackageOwnershipException$"""The attachment JAR: $attachmentHash containing the class: $invalidClassName is not signed by the owner of package $packageName specified in the network parameters. Please check the source of this attachment and if it is malicious contact your zone operator to report this incident. For details see: https://docs.corda.net/network-map.html#network-parameters"""</ID>
-    <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException.TransactionNotaryMismatchEncumbranceException$"Output state with index $encumberedIndex is assigned to notary [$encumberedNotary], while its encumbrance with index $encumbranceIndex is assigned to notary [$encumbranceNotary]"</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$TransactionVerificationException.UntrustedAttachmentsException$"Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue."</ID>
     <ID>MaxLineLength:TransactionVerificationException.kt$net.corda.core.contracts.TransactionVerificationException.kt</ID>
     <ID>MaxLineLength:TransactionVerificationRequest.kt$TransactionVerificationRequest$@Suppress("MemberVisibilityCanBePrivate") //TODO the use of deprecated toLedgerTransaction need to be revisited as resolveContractAttachment requires attachments of the transactions which created input states... //TODO ...to check contract version non downgrade rule, curretly dummy Attachment if not fund is used which sets contract version to '1' @CordaSerializable</ID>

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -10,29 +10,33 @@ complexity:
   active: true
   ComplexCondition:
     active: true
+    excludes: "**/buildSrc/**"
     threshold: 4
   ComplexMethod:
     active: true
+    excludes: "**/buildSrc/**"
     threshold: 10
     ignoreSingleWhenExpression: true
   LargeClass:
     active: true
-    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt"
+    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt,**/buildSrc/**"
     threshold: 600
   LongMethod:
     active: true
-    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt"
+    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt,**/buildSrc/**"
     threshold: 120
   LongParameterList:
     active: true
+    excludes: "**/buildSrc/**"
     threshold: 6
     ignoreDefaultParameters: false
   NestedBlockDepth:
     active: true
+    excludes: "**/buildSrc/**"
     threshold: 4
   TooManyFunctions:
     active: true
-    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt"
+    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt,**/buildSrc/**"
     thresholdInFiles: 15
     thresholdInClasses: 15
     thresholdInInterfaces: 15
@@ -41,6 +45,7 @@ complexity:
 
 empty-blocks:
   active: true
+  excludes: "**/buildSrc/**"
   EmptyCatchBlock:
     active: true
     allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
@@ -71,6 +76,7 @@ empty-blocks:
 
 exceptions:
   active: true
+  excludes: "**/buildSrc/**"
   TooGenericExceptionCaught:
     active: true
     exceptionNames:
@@ -92,6 +98,7 @@ exceptions:
 
 naming:
   active: true
+  excludes: "**/buildSrc/**"
   ClassNaming:
     active: true
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
@@ -127,6 +134,7 @@ naming:
 
 performance:
   active: true
+  excludes: "**/buildSrc/**"
   ForEachOnRange:
     active: true
   SpreadOperator:
@@ -136,6 +144,7 @@ performance:
 
 potential-bugs:
   active: true
+  excludes: "**/buildSrc/**"
   DuplicateCaseInWhenExpression:
     active: true
   EqualsWithHashCodeExist:
@@ -149,10 +158,11 @@ style:
   active: true
   ForbiddenComment:
     active: true
+    excludes: "**/buildSrc/**"
     values: 'TODO:,FIXME:,STOPSHIP:'
   MagicNumber:
     active: true
-    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt"
+    excludes: "**/test/**,**/integration-test/**,**/integration-test-slow/**,**/*Test.kt,**/*Tests.kt,**/buildSrc/**"
     ignoreNumbers: '-1,0,1,2'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
@@ -163,23 +173,30 @@ style:
     ignoreEnums: false
   MaxLineLength:
     active: true
+    excludes: "**/buildSrc/**"
     maxLineLength: 140
     excludePackageStatements: true
     excludeImportStatements: true
   ModifierOrder:
     active: true
+    excludes: "**/buildSrc/**"
   OptionalAbstractKeyword:
     active: true
+    excludes: "**/buildSrc/**"
   ReturnCount:
     active: true
+    excludes: "**/buildSrc/**"
     max: 2
     excludedFunctions: "equals"
     excludeReturnFromLambda: true
   SafeCast:
     active: true
+    excludes: "**/buildSrc/**"
   ThrowsCount:
     active: true
+    excludes: "**/buildSrc/**"
     max: 2
   WildcardImport:
     active: true
+    excludes: "**/buildSrc/**"
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'


### PR DESCRIPTION
see https://r3-cev.atlassian.net/browse/CORDA-2965

Note: the changes to the detekt config are required to ignore the gradle `buildSrc` folder which is created sometimes.
