### PR TITLE
TM-45 Make detektBaseline pass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -439,7 +439,7 @@ task detektBaseline(type: JavaExec) {
     main = "io.gitlab.arturbosch.detekt.cli.Main"
     classpath = configurations.detekt
     def input = "$projectDir"
-    def config = "$projectDir/detekt-config.yml"
+    def config = "$projectDir/detekt-config.yml, $projectDir/detekt-baseline-config.yml"
     def baseline = "$projectDir/detekt-baseline.xml"
     def params = ['-i', input, '-c', config, '-b', baseline, '--create-baseline']
     args(params)

--- a/detekt-baseline-config.yml
+++ b/detekt-baseline-config.yml
@@ -1,2 +1,6 @@
+#Detekt 1.0.1
+#Gradle task detektBaseline would always fail due to the fact that the existing baseline would not be taken into
+#account so existing issues flare up. We set the max issues allowed to a high number to force detekt to pass when
+#generating a baseline.
 build:
   maxIssues: 9999999

--- a/detekt-baseline-config.yml
+++ b/detekt-baseline-config.yml
@@ -1,0 +1,2 @@
+build:
+  maxIssues: 9999999


### PR DESCRIPTION
The task detektBaseline would always fail because when generating the baseline, the existing one will not be taken into account so existing violations will flare up and fail the build. Fixed by introducing a second config with a high threshold number to force detekt to stay quiet and return a successful build since returning a failure can be misleading. Tried to find a less hackier solution but no luck. Unless we fork detekt and build it ourselves, so this will have to do