### PR TITLE
ISSUE-246 deployNodes doesn't use right version of Java

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -33,6 +33,7 @@ import java.io.File
 import java.net.URL
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.security.PublicKey
 import java.time.Duration
@@ -68,7 +69,7 @@ internal constructor(private val initSerEnv: Boolean,
     companion object {
         // TODO This will probably need to change once we start using a bundled JVM
         private val nodeInfoGenCmd = listOf(
-                "java",
+                Paths.get(System.getProperty("java.home"), "bin", "java").toString(),
                 "-jar",
                 "corda.jar",
                 "generate-node-info"

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/notaries/NotaryCopier.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/notaries/NotaryCopier.kt
@@ -6,6 +6,7 @@ import net.corda.networkbuilder.nodes.FoundNode
 import net.corda.networkbuilder.nodes.NodeCopier
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.nio.file.Paths
 
 class NotaryCopier(private val cacheDir: File) : NodeCopier(cacheDir) {
 
@@ -28,7 +29,9 @@ class NotaryCopier(private val cacheDir: File) : NodeCopier(cacheDir) {
 
     fun generateNodeInfo(dirToGenerateFrom: File): File {
         val nodeInfoGeneratorProcess = ProcessBuilder()
-                .command(listOf("java", "-jar", "corda.jar", "generate-node-info"))
+                .command(listOf(
+                        Paths.get(System.getProperty("java.home"), "bin", "java").toString(),
+                        "-jar", "corda.jar", "generate-node-info"))
                 .directory(dirToGenerateFrom)
                 .inheritIO()
                 .start()


### PR DESCRIPTION
https://github.com/corda/corda-gradle-plugins/issues/246

This issue has also recently surfaced upon running `deployNodes` within the TC environment for JDK11 builds (eg. the default environment is configured to use Java 8), leading to:

```
[02:40:30][Step 7/10] #### Error while generating node info file /data/BuildAgent/work/9da52194858f0d5a/docs/source/example-code/build/nodes/Alice Corp/logs ####
[02:40:30][Step 7/10] CAPSULE EXCEPTION: CordaCaplet has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0 (for stack trace, run with -Dcapsule.log=verbose)
```
This PR explicitly sets the full path of the java binary. 
