### PR TITLE
CORDA-2979: Remove quasar from RPC client

### DIFF
--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'kotlin'
+apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'net.corda.plugins.api-scanner'
 apply plugin: 'com.jfrog.artifactory'

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'kotlin'
-apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'net.corda.plugins.api-scanner'
 apply plugin: 'com.jfrog.artifactory'


### PR DESCRIPTION
By removing the usage of the class we avoid loading it and, therefore, the check for a java agent running.  This was raising QUASAR error which would be unpleasant for end users.