### PR TITLE
Fix for CORDA-3315 

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -80,9 +80,7 @@ interface IdentityService {
      * @param key The owning [PublicKey] of the [Party].
      * @return Returns a [Party] with a matching owningKey if known, else returns null.
      */
-    fun partyFromKey(key: PublicKey): Party? =
-            @Suppress("DEPRECATION")
-            certificateFromKey(key)?.party
+    fun partyFromKey(key: PublicKey): Party?
 
     /**
      * Resolves a party name to the well known identity [Party] instance for this name. Where possible well known identity

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -6,13 +6,10 @@ import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.identity.x500Matches
 import net.corda.core.internal.CertRole
-import net.corda.core.internal.hash
-import net.corda.core.node.services.IdentityService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.trace
 import net.corda.node.services.api.IdentityServiceInternal
-import net.corda.node.services.persistence.WritablePublicKeyToOwningIdentityCache
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.crypto.x509Certificates
 import java.security.InvalidAlgorithmParameterException
@@ -99,6 +96,10 @@ class InMemoryIdentityService(
         nameToKey.computeIfAbsent(identity.name) {identity.owningKey}
         keyToName.putIfAbsent(identity.owningKey.toStringShort(), identity.name)
         return keyToPartyAndCerts[identityCertChain[1].publicKey]
+    }
+
+    override fun partyFromKey(key: PublicKey): Party? {
+        return certificateFromKey(key)?.party ?: keyToName[key.toStringShort()]?.let { wellKnownPartyFromX500Name(it) }
     }
 
     override fun certificateFromKey(owningKey: PublicKey): PartyAndCertificate? = keyToPartyAndCerts[owningKey]

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -296,6 +296,10 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
         keyToPartyAndCert[owningKey.toStringShort()]
     }
 
+    override fun partyFromKey(key: PublicKey): Party? {
+        return certificateFromKey(key)?.party ?: keyToName[key.toStringShort()]?.let { wellKnownPartyFromX500Name(it) }
+    }
+
     private fun certificateFromCordaX500Name(name: CordaX500Name): PartyAndCertificate? {
         return database.transaction {
             val partyId = nameToKey[name]

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -297,7 +297,9 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     override fun partyFromKey(key: PublicKey): Party? {
-        return certificateFromKey(key)?.party ?: keyToName[key.toStringShort()]?.let { wellKnownPartyFromX500Name(it) }
+        return certificateFromKey(key)?.party ?: database.transaction {
+            keyToName[key.toStringShort()]
+        }?.let { wellKnownPartyFromX500Name(it) }
     }
 
     private fun certificateFromCordaX500Name(name: CordaX500Name): PartyAndCertificate? {

--- a/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
@@ -262,6 +262,17 @@ class PersistentIdentityServiceTests {
     }
 
     @Test
+    fun `resolve key to party for key without certificate`() {
+        // Register Alice's PartyAndCert as if it was done so via the network map cache.
+        identityService.verifyAndRegisterIdentity(alice.identity)
+        // Use a key which is not tied to a cert.
+        val publicKey = Crypto.generateKeyPair().public
+        // Register the PublicKey to Alice's CordaX500Name.
+        identityService.registerKey(publicKey, alice.party)
+        assertEquals(alice.party, identityService.partyFromKey(publicKey))
+    }
+
+    @Test
     fun `register incorrect party to public key `(){
         database.transaction { identityService.verifyAndRegisterIdentity(ALICE_IDENTITY) }
         val (alice, anonymousAlice) = createConfidentialIdentity(ALICE.name)


### PR DESCRIPTION
Fix for CORDA-3315 by pointing `partyFromKey` to perform a look-up on the new `PublicKey` to `Party` mappings table rather than the old table which didn't contain the "new" variety of `PublicKey` to `Party` mappings.