### PR TITLE
[ENT-4119] Make welcome message more accurate

### DIFF
--- a/tools/shell/src/main/resources/net/corda/tools/shell/base/login.groovy
+++ b/tools/shell/src/main/resources/net/corda/tools/shell/base/login.groovy
@@ -3,12 +3,23 @@ package net.corda.tools.shell.base
 // Note that this file MUST be in a sub-directory called "base" relative to the path
 // given in the configuration code in InteractiveShell.
 
-welcome = """
-
-Welcome to the Corda interactive shell.
-Useful commands include 'help' to see what is available, and 'bye' to shut down the node.
-
-"""
+welcome = { ->
+    if (crash.context.attributes["crash.localShell"] == true) {
+        """
+        
+        Welcome to the Corda interactive shell.
+        Useful commands include 'help' to see what is available, and 'bye' to exit the shell.
+        
+        """.stripIndent()
+    } else {
+        """
+        
+        Welcome to the Corda interactive shell.
+        Useful commands include 'help' to see what is available, and 'bye' to shut down the node.
+        
+        """.stripIndent()
+    }
+}
 
 prompt = { ->
     return "${new Date()}>>> "


### PR DESCRIPTION
### Changes
Adjusting slightly the welcome message for the shell, since `bye` does different things depending on whether it's a local or remote shell.

### Testing
Using the nodes generated from bank-of-corda demo, I verified that running the node with `devMode=true` shows:
```
Useful commands include 'help' to see what is available, and 'bye' to shut down the node.
```
while running the node with `devMode=false`, `sshd.port = ...` and connecting via SSH, it shows:
```
Useful commands include 'help' to see what is available, and 'bye' to exit the shell.
```