### PR TITLE
CORDA-3335 Corda Shell flow kill - better warning for misformatted flow ID

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -81,6 +81,7 @@ object InteractiveShell {
     private var classLoader: ClassLoader? = null
     private lateinit var shellConfiguration: ShellConfiguration
     private var onExit: () -> Unit = {}
+    private const val uuidStringSize = 36
 
     @JvmStatic
     fun getCordappsClassloader() = classLoader
@@ -375,12 +376,12 @@ object InteractiveShell {
                 return
             }
             //auxiliary validation - workaround for JDK8 bug https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8159339
-            val uuidStringSize = 36
             if (id.length < uuidStringSize) {
-                val msg = "Flow ID of '$id' seems to be malformed - a UUID should have $uuidStringSize characters. " +
+                val msg = "Can not kill the flow. Flow ID of '$id' seems to be malformed - a UUID should have $uuidStringSize characters. " +
                         "Expand the terminal window to see the full UUID value."
-                output.println(msg, Color.yellow)
+                output.println(msg, Color.red)
                 log.warn(msg)
+                return
             }
             if (rpcOps.killFlow(runId)) {
                 output.println("Killed flow $runId", Color.yellow)

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -374,7 +374,14 @@ object InteractiveShell {
                 log.error("Failed to parse flow ID", e)
                 return
             }
-
+            //auxiliary validation - workaround for JDK8 bug https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8159339
+            val uuidStringSize = 36
+            if (id.length < uuidStringSize) {
+                val msg = "Flow ID of '$id' seems to be malformed - a UUID should have $uuidStringSize characters. " +
+                        "Expand the terminal window to see the full UUID value."
+                output.println(msg, Color.yellow)
+                log.warn(msg)
+            }
             if (rpcOps.killFlow(runId)) {
                 output.println("Killed flow $runId", Color.yellow)
             } else {


### PR DESCRIPTION
Corda shell ``flow watch`` command renders a table, if the screen size is small then the table is squeezed and e.g. flow id is trimmed (not all characters are dispalyed). 
If a flow ID is copied to use in ``flow kill`` command, then it would be silenty fail as there was no message that wrong ID was used.
Beacuse of Crash shell implementation there is no way to make a single column size constant is a nice way, the only fix is to guard better ``flow kill`` command: 
Fix:
Warn that flow ID passed to flow kill is malformed as due to JDK8 doesn't fully validate it - JDK8 bug https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8159339

Test procedure:
``./gradlew samples:trader-demo:deploynodes``

``cd ./samples/trader-demo/build/nodes``

edit "Bank A"/node.conf , add ``sshd { port = 2222 }``

``./runnodes``

in "Bank A" shell: 
 ``flow start CashIssueFlow amount: $100, issuerBankPartyRef: 123, notary: "Notary Service" ``

kill BankOfCorda node

in "Bank A"  shell:
``flow watch``
expand the screen to see the full flow ID value.

on the terminal (not any node's shell):  ``ssh demo@localhost -p 2222``
and : ``flow start CashPaymentFlow amount: $1, recipient: BankOfCorda``

on Bank A shell you should see e.g:
``f1fc0302-e4f3-4e75-bb64-2db181777eaf       Cash Payment     demo      In progress
Waiting for completion or Ctrl-C ...``

Copy flow ID
Ctrl+C

``flow kill <flow-id>`` but remove two last characters to give wrong ID e.g.:
````>>> flow kill 30b716b0-c6c3-4cfa-8272-a9e79d1e695 
Can not kill the flow. Flow ID of '30b716b0-c6c3-4cfa-8272-a9e79d1e695' seems to be malformed - a UUID should have 36 characters. Expand the terminal window to see the full UUID value.````

then to check if the flow can be killed while providing the full ID:
``flow kill <flow-id>``
e.g:
``>>> flow kill 30b716b0-c6c3-4cfa-8272-a9e79d1e6950
Killed flow [30b716b0-c6c3-4cfa-8272-a9e79d1e6950]

[ERROR] 10:40:34+0100 [Node thread-1] corda.flow. - Flow interrupted while waiting for events, aborting immediately {actor_id=demo, actor_owning_identity=O=Bank A, L=London, C=GB, actor_store_id=NODE_CONFIG, fiber-id=100Tue Oc0t0003, flow 22- id=10:40:34 BST 2019>>> 30b716b0-c6c3-4cfa-8272-a9e79d1e6950, invocation_id=746ee0b1-007c-4b16-842d-4a0f23606ce6, invocation_timestamp=2019-10-22T09:40:10.040Z, origin=demo, session_id=fb9e1b94-551f-4075-8c66-dd560ebfcb22, session_timestamp=2019-10-22T09:35:15.382Z, thread-id=170}``

