### PR TITLE
CORDA-3324: Fix corda docker image names in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ We currently support the following placeholders; they get substituted with the c
 
 ```groovy
     "|corda_version|" 
+    "|corda_version_lower|" 
     "|java_version|" 
     "|kotlin_version|" 
     "|gradle_plugins_version|" 
@@ -34,6 +35,7 @@ We currently support the following placeholders; they get substituted with the c
 ```
 
 If you put one of these in an rst file anywhere (including in a code tag), it will be substituted with the value from `constants.properties` 
-(which is in the root of the project) at build time.
+(which is in the root of the project) at build time. `corda_version_lower` returns the current Corda version in lowercase which is useful
+for case sensitive artifacts such as docker images.
 
 The code for this can be found near the top of the conf.py file in the `docs/source` directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,7 @@ def cordaSourceReadReplace(app, docname, source):
 
 corda_substitutions = {
     "|corda_version|" : constants_properties_dict["cordaVersion"],
+    "|corda_version_lower|" : constants_properties_dict["cordaVersion"].lower(),
     "|java_version|" : "8u"+constants_properties_dict["java8MinUpdateVersion"],
     "|kotlin_version|" : constants_properties_dict["kotlinVersion"],
     "|gradle_plugins_version|" : constants_properties_dict["gradlePluginsVersion"],

--- a/docs/source/docker-image.rst
+++ b/docs/source/docker-image.rst
@@ -21,7 +21,7 @@ In this example, the certificates are stored at ``/home/user/cordaBase/certifica
             -v /path/to/cordapps:/opt/corda/cordapps \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-4.3-snapshot:latest
+            corda/corda-zulu-java1.8-|corda_version_lower|:latest
 
 As the node runs within a container, several mount points are required:
 
@@ -59,7 +59,7 @@ In this example, we have previously generated a network-parameters file using th
             -v /home/user/sharedFolder/network-parameters:/opt/corda/network-parameters \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-4.3-snapshot:latest
+            corda/corda-zulu-java1.8-|corda_version_lower|:latest
 
 There is a new mount ``/home/user/sharedFolder/node-infos:/opt/corda/additional-node-infos`` which is used to hold the ``nodeInfo`` of all the nodes within the network.
 As the node within the container starts up, it will place it's own nodeInfo into this directory. This will allow other nodes also using this folder to see this new node.
@@ -83,7 +83,7 @@ Joining TestNet
             -e LOCALITY="London" -e COUNTRY="GB" \
             -v /home/user/docker/config:/etc/corda \
             -v /home/user/docker/certificates:/opt/corda/certificates \
-            corda/corda-zulu-4.3-snapshot:latest config-generator --testnet
+            corda/corda-zulu-java1.8-|corda_version_lower|:latest config-generator --testnet
 
 ``$MY_PUBLIC_ADDRESS`` will be the public address that this node will be advertised on.
 ``$ONE_TIME_DOWNLOAD_KEY`` is the one-time code provided for joining TestNet.
@@ -108,7 +108,7 @@ It is now possible to start the node using the generated config and certificates
             -v /home/user/corda/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps:/opt/corda/cordapps \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-4.3-snapshot:latest
+            corda/corda-zulu-java1.8-|corda_version_lower|:latest
 
 
 Joining an existing Compatibility Zone
@@ -132,7 +132,7 @@ It is possible to configure the name of the Trust Root file by setting the ``TRU
             -e MY_EMAIL_ADDRESS="cordauser@r3.com"      \
             -v /home/user/docker/config:/etc/corda          \
             -v /home/user/docker/certificates:/opt/corda/certificates \
-            corda/corda-zulu-4.3-snapshot:latest config-generator --generic
+            corda/corda-zulu-java1.8-|corda_version_lower|:latest config-generator --generic
 
 
 Several environment variables must also be passed to the container to allow it to register:
@@ -163,5 +163,5 @@ Once the container has finished performing the initial registration, the node ca
             -v /home/user/corda/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps:/opt/corda/cordapps \
             -p 10200:10200 \
             -p 10201:10201 \
-            corda/corda-zulu-4.3-snapshot:latest
+            corda/corda-zulu-java1.8-|corda_version_lower|:latest
 

--- a/docs/source/network-builder.rst
+++ b/docs/source/network-builder.rst
@@ -10,7 +10,7 @@ containers to abstract the complexity of managing a distributed network away fro
 
 The network you build will either be made up of local ``Docker`` nodes *or* of nodes spread across Azure
 containers.
-For each node a separate Docker image is built based on `corda/corda-zulu-|corda_version| <https://hub.docker.com/r/corda/corda-zulu-|corda_version|>`_.
+For each node a separate Docker image is built based on `corda/corda-zulu-java1.8-|corda_version| <https://hub.docker.com/r/corda/corda-zulu-java1.8-|corda_version_lower|>`_.
 Unlike the official image, a `node.conf` file and CorDapps are embedded into the image
 (they are not externally provided to the running container via volumes/mount points).
 More backends may be added in future. The tool is open source, so contributions to add more


### PR DESCRIPTION
Docker image names now include Java version in preparation for jdk 11.

-RC and -SNAPSHOT images should also have lower case names.