### PR TITLE
CORDA-3279 Fix documentation for setting up custom jvmArgs in node.conf

### DIFF
--- a/docs/source/running-a-node.rst
+++ b/docs/source/running-a-node.rst
@@ -51,7 +51,7 @@ anything set earlier.
    .. code-block:: none
 
       custom = {
-         jvmArgs: [ '-Xmx1G', '-XX:+UseG1GC' ]
+         jvmArgs: [ "-Xmx1G", "-XX:+UseG1GC" ]
       }
 
    Note that this will completely replace any defaults set by capsule above, not just the flags that are set here, so if you use this
@@ -85,7 +85,7 @@ anything set earlier.
    .. code-block:: none
 
       custom = {
-         jvmArgs: [ '-Xmx1G', '-XX:+UseG1GC', '-XX:-HeapDumpOnOutOfMemoryError' ]
+         jvmArgs: [ "-Xmx1G", "-XX:+UseG1GC", "-XX:-HeapDumpOnOutOfMemoryError" ]
       }
 
 


### PR DESCRIPTION
CORDA-3279 Change single quotes to double quotes fixes node's shutdown

This change has been made because a ConfigException$Parse exception was thrown at CordaCaplet#parseConfigFile.

Args parsing done by com.typesafe.config.ConfigFactory needs ':' to be included in a double quoted and not in a single quoted string.