### PR TITLE
[CORDA-3342] - Show proper error message and adjust indentation in shell

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -175,11 +175,13 @@ abstract class ANSIProgressRenderer {
                 var indent = 0
                 while (errorToPrint != null) {
                     ansi.fgRed()
-                    ansi.a("${IntStream.range(indent, indent).mapToObj { "\t" }.toList().joinToString(separator = "") { s -> s }} $errorIcon ${error.message}")
-                    ansi.reset()
+                    ansi.a("${"\t".repeat(indent)}$errorIcon ${errorToPrint.message}")
+                    ansi.newline()
                     errorToPrint = errorToPrint.cause
                     indent++
                 }
+                ansi.reset()
+
                 ansi.eraseLine(Ansi.Erase.FORWARD)
                 ansi.newline()
                 newLinesDrawn++


### PR DESCRIPTION
### Changes
Fixing a small bug, so that errors of nested exceptions are displayed properly. I also adjusted slightly the indentation to give a hint about the semantics of the multiple messages.

### Testing
Tested manually using finance CorDapp.
Before:
```
✅   Starting
➡️   Generating transaction
🚫   Signing transaction
🚫   Finalising transaction
🚫   Done
 ☠   Exiting more cash than exists ☠   Exiting more cash than exists
```
After:
```
 ✅   Starting
➡️   Generating transaction
🚫   Signing transaction
🚫   Finalising transaction
🚫   Done
☠   Exiting more cash than exists
	☠   Insufficient balance, missing 10.00 GBP
```