### PR TITLE
TM-35 Update docs

### DIFF
--- a/docs/source/cordapp-custom-serializers.rst
+++ b/docs/source/cordapp-custom-serializers.rst
@@ -218,9 +218,12 @@ the serialization framework can reason about.
 .. important:: When composing a proxy object for a class be aware that everything within that structure will be written
     into the serialized byte stream.
 
-Whitelisting
-------------
-By writing a custom serializer for a class it has the effect of adding that class to the whitelist, meaning such
+Registration and Whitelisting
+-----------------------------
+Classes inheriting from ``net.corda.core.serialization.SerializationCustomSerializer`` are automatically detected and
+registered via classpath scanning during CorDapp loading.
+
+When a custom serializer is found for a class, this has the effect of adding that class to the whitelist, meaning that such
 classes don't need explicitly adding to the CorDapp's whitelist.
 
 


### PR DESCRIPTION
It is not entirely obvious from the documentation as it stands that custom serializers defined within a CorDapp's jar file are automatically detected and registered when the jar is loaded (based on their implementation of the `net.corda.core.serialization.SerializationCustomSerializer` interface). This PR addresses that.