### PR TITLE
CORDA-3346: Remove the JitPack repository from Corda.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,6 @@ allprojects {
         mavenCentral()
         jcenter()
         maven { url "$artifactory_contextUrl/corda-dependencies" }
-        maven { url 'https://jitpack.io' }
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
     }
 

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -57,7 +57,6 @@ repositories {
     maven {
         url 'https://dl.bintray.com/palantir/releases' // docker-compose-rule is published on bintray
     }
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {


### PR DESCRIPTION
We shouldn't be using JitPack artifacts in Corda, so remove the repository.