### PR TITLE
CORDA-3348 Improve Corda 3x to 4x migration on PostgreSQL

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -157,8 +157,12 @@ class SchemaMigration(
         val (isExistingDBWithoutLiquibase, isFinanceAppWithLiquibaseNotMigrated) = dataSource.connection.use {
 
             val existingDatabase = it.metaData.getTables(null, null, "NODE%", null).next()
+                    // Lower case names for PostgreSQL
+                    || it.metaData.getTables(null, null, "node%", null).next()
 
             val hasLiquibase = it.metaData.getTables(null, null, "DATABASECHANGELOG%", null).next()
+                    // Lower case names for PostgreSQL
+                    || it.metaData.getTables(null, null, "databasechangelog%", null).next()
 
             val isFinanceAppWithLiquibaseNotMigrated = isFinanceAppWithLiquibase // If Finance App is pre v4.0 then no need to migrate it so no need to check.
                     && existingDatabase


### PR DESCRIPTION
When upgrading Corda 3.x to 4.x running against PostgreSQL, the logic to add Liquibase change sets from DATABASECHANGELOG is not triggered on PostgreSQL and the node tries to run change sests on the existing database.
This is caused by checking if this is an exsisting database by probing occurences of "NODE%" tables. For PostgreSQL the valid check is "node%"  (due to different defult case sensitivyty policy).
The workaround is to manually create a dumy table e.g. "NODE_DEL_ME" so the 
check will find at least one Corda table.