### PR TITLE
OS PR for ENT-4326: Internal shell uses hard coded credentials which can be used remotely for SSH access

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
@@ -1,5 +1,6 @@
 package net.corda.nodeapi.internal
 
+import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.Party
 import net.corda.core.messaging.MessageRecipientGroup
@@ -25,7 +26,9 @@ class ArtemisMessagingComponent {
         const val NODE_RPC_USER = "SystemUsers/NodeRPC"
         const val PEER_USER = "SystemUsers/Peer"
         // User used only in devMode when nodes have a shell attached by default.
+
         const val INTERNAL_SHELL_USER = "internalShell"
+        val internalShellPassword: String by lazy { SecureHash.randomSHA256().toString() }
 
         const val INTERNAL_PREFIX = "internal."
         const val PEERS_PREFIX = "${INTERNAL_PREFIX}peers." //TODO Come up with better name for common peers/services queue

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -54,6 +54,7 @@ import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.node.utilities.*
 import net.corda.nodeapi.internal.ArtemisMessagingClient
+import net.corda.nodeapi.internal.ArtemisMessagingComponent
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.INTERNAL_SHELL_USER
 import net.corda.nodeapi.internal.ShutdownHook
 import net.corda.nodeapi.internal.addShutdownHook
@@ -253,7 +254,8 @@ open class Node(configuration: NodeConfiguration,
                 ?: SecurityConfiguration.AuthService.fromUsers(configuration.rpcUsers)
 
         val securityManager = with(RPCSecurityManagerImpl(securityManagerConfig, cacheFactory)) {
-            if (configuration.shouldStartLocalShell()) RPCSecurityManagerWithAdditionalUser(this, User(INTERNAL_SHELL_USER, INTERNAL_SHELL_USER, setOf(Permissions.all()))) else this
+            if (configuration.shouldStartLocalShell()) RPCSecurityManagerWithAdditionalUser(this,
+                User(INTERNAL_SHELL_USER, ArtemisMessagingComponent.internalShellPassword, setOf(Permissions.all()))) else this
         }
 
         val messageBroker = if (!configuration.messagingServerExternal) {

--- a/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.config.shell
 import net.corda.core.internal.div
 import net.corda.node.internal.clientSslOptionsCompatibleWith
 import net.corda.node.services.config.NodeConfiguration
+import net.corda.nodeapi.internal.ArtemisMessagingComponent
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.INTERNAL_SHELL_USER
 import net.corda.tools.shell.ShellConfiguration
 import net.corda.tools.shell.ShellConfiguration.Companion.COMMANDS_DIR
@@ -14,7 +15,7 @@ fun NodeConfiguration.toShellConfig() = ShellConfiguration(
         commandsDirectory = this.baseDirectory / COMMANDS_DIR,
         cordappsDirectory = this.baseDirectory.toString() / CORDAPPS_DIR,
         user = INTERNAL_SHELL_USER,
-        password = INTERNAL_SHELL_USER,
+        password = ArtemisMessagingComponent.internalShellPassword,
         hostAndPort = this.rpcOptions.address,
         ssl = clientSslOptionsCompatibleWith(this.rpcOptions),
         sshdPort = this.sshd?.port,


### PR DESCRIPTION
The Corda Node Internal Shell uses a hard coded username and password. There are added to the security manager using a class that accepts an additional user. This allows the internal shell to issue commands as that user.

A side affect of the above is that if the Internal shell is on, the user internalShell can be used to connect from SSH which effectively opens a security hole giving the remote user full access to the node.

This relates to Jira: https://r3-cev.atlassian.net/browse/ENT-4326

This has been tested with both shells turned on.