### PR TITLE
CORDA-3327: Fix API scanning for Java 11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
         ext.quasar_classifier = constants.getProperty("quasarClassifier")
         ext.jdkClassifier = constants.getProperty("jdkClassifier")
     }
+    ext.cordaScanApiClassifier = jdkClassifier
     ext.quasar_exclusions = [
             'co.paralleluniverse**',
             'groovy**',
@@ -186,9 +187,6 @@ plugins {
     id 'com.bmuschko.docker-remote-api'
 }
 
-ext {
-}
-
 apply plugin: 'project-report'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'net.corda.plugins.publish-utils'
@@ -201,16 +199,17 @@ apply plugin: 'com.jfrog.artifactory'
 // the resulting import. This fixes it.
 apply plugin: 'java'
 
-println "Java version: " + JavaVersion.current()
+logger.lifecycle("Java version: {}", JavaVersion.current())
 sourceCompatibility = VERSION_1_8
-if (JavaVersion.current() == JavaVersion.VERSION_1_8)
+if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
     targetCompatibility = VERSION_1_8
-else
+} else {
     targetCompatibility = VERSION_11
-println "Java source compatibility: " + sourceCompatibility
-println "Java target compatibility: " + targetCompatibility
-println "Quasar version: " + quasar_version
-println "Quasar classifier: " + quasar_classifier
+}
+logger.lifecycle("Java source compatibility: {}", sourceCompatibility)
+logger.lifecycle("Java target compatibility: {}", targetCompatibility)
+logger.lifecycle("Quasar version: {}", quasar_version)
+logger.lifecycle("Quasar classifier: {}", quasar_classifier.toString())
 
 allprojects {
     apply plugin: 'kotlin'
@@ -241,10 +240,11 @@ allprojects {
         }
     }
     sourceCompatibility = VERSION_1_8
-    if (JavaVersion.current() == JavaVersion.VERSION_1_8)
+    if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
         targetCompatibility = VERSION_1_8
-    else
+    } else {
         targetCompatibility = VERSION_11
+    }
 
     jacoco {
         // JDK11 official support (https://github.com/jacoco/jacoco/releases/tag/v0.8.3)
@@ -319,10 +319,11 @@ allprojects {
         }
     }
 
-    jar {
-        // JDK11 built and published artifacts to include classifier
-        if (jdkClassifier != null)
+    if (jdkClassifier) {
+        jar {
+            // JDK11 built and published artifacts to include classifier
             archiveClassifier = jdkClassifier
+        }
     }
 
     group 'net.corda'

--- a/constants.properties
+++ b/constants.properties
@@ -3,7 +3,7 @@
 # their own projects. So don't get fancy with syntax!
 
 cordaVersion=4.4-SNAPSHOT
-gradlePluginsVersion=5.0.4
+gradlePluginsVersion=5.0.5
 kotlinVersion=1.2.71
 java8MinUpdateVersion=171
 # ***************************************************************#

--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-jpa'
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.publish-utils'
-apply plugin: 'net.corda.plugins.api-scanner'
 
 description 'Corda core tests'
 


### PR DESCRIPTION
Upgrade to Corda Gradle plugins 5.0.5 so that the API scanner plugin can generate `api-corda.txt` when artifacts have been assigned the `jdk11` classifier.