### PR TITLE
CORDA-3388: Restore mapping of 'java.lang.Void -> void'

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -27,7 +27,8 @@ object SerializerFactoryBuilder {
         Float::class,
         Int::class,
         Long::class,
-        Short::class
+        Short::class,
+        Void::class
     ).associate {
         klazz -> klazz.javaObjectType to klazz.javaPrimitiveType
     }) as Map<Class<*>, Class<*>>


### PR DESCRIPTION
While `java.lang.Void` is probably not commonly used, it still has a primitive Java type of `void`. The mapping of `java.lang.Void` to `void` was accidentally missed from [CORDA-3218](https://r3-cev.atlassian.net/browse/CORDA-3218) and should be restored to the Evolution serializer.

Note that Kotlin's `Nothing` return type uses `java.lang.Void`.