### PR TITLE
Update node.conf template to remove single quotes

### DIFF
--- a/docs/source/deploying-a-node.rst
+++ b/docs/source/deploying-a-node.rst
@@ -58,7 +58,7 @@ handling, and ensures the Corda service is run at boot.
               ]
           }
       ]
-      custom { jvmArgs = [ '-Xmx2048m', '-XX:+UseG1GC' ] }
+      custom { jvmArgs = [ "-Xmx2048m", "-XX:+UseG1GC" ] }
 
 7. Make the following changes to ``/opt/corda/node.conf``:
 


### PR DESCRIPTION
The single quotes surrounding the jvm arguments in the node.conf template cause an error when trying to start the node.
```
[ERROR] 18:40:51+0000 [main] node.SharedNodeCmdLineOptions.logRawConfigurationErrors - There were error(s) while attempting to load the node configuration:
[ERROR] 18:40:51+0000 [main] node.SharedNodeCmdLineOptions.logRawConfigurationErrors - /opt/corda/node.conf: 21: List should have ended with ] or had a comma, instead had token: ':' (if you want ':' to be part of a string value, then double-quote it)
```
Updated docsite to include double quotes instead.