### PR TITLE
[NOTICK] - Constrain the cordapps loaded from driver tests to the minimum required

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt
@@ -10,6 +10,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
+import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
 
@@ -29,7 +30,7 @@ class BlacklistKotlinClosureTest {
 
     @Test
     fun `closure sent via RPC`() {
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
             val rpc = startNode(providedName = ALICE_NAME).getOrThrow().rpc
             val packet = Packet { EVIL }
             assertThatExceptionOfType(RPCException::class.java)

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -414,7 +414,6 @@
     <ID>ForbiddenComment:NodeInfoWatcher.kt$NodeInfoWatcher$// TODO: Use NIO watch service instead?</ID>
     <ID>ForbiddenComment:NodeInterestRates.kt$NodeInterestRates.FixContainer$// TODO: the calendar data needs to be specified for every fix type in the input string</ID>
     <ID>ForbiddenComment:NodeInterestRates.kt$NodeInterestRates.UnknownFix$// TODO: can we split into two? Fix not available (retryable/transient) and unknown (permanent)</ID>
-    <ID>ForbiddenComment:NodeSchemaServiceTest.kt$NodeSchemaServiceTest$// TODO: driver limitation: cannot restrict CorDapps that get automatically created by default,</ID>
     <ID>ForbiddenComment:NodeTerminalView.kt$NodeTerminalView$// TODO: Remove this special case once Rick's serialisation work means we can deserialise states that weren't on our own classpath.</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: Optimise this.</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: Perhaps these can be stored in a batch?</ID>
@@ -429,7 +428,6 @@
     <ID>ForbiddenComment:NotaryChangeTests.kt$NotaryChangeTests$// TODO: Re-enable the test when parameter currentness checks are in place, ENT-2666.</ID>
     <ID>ForbiddenComment:NotaryError.kt$StateConsumptionDetails$// TODO: include notary timestamp?</ID>
     <ID>ForbiddenComment:NotaryFlow.kt$NotaryFlow.Client$// TODO: This is not required any more once our AMQP serialization supports turning off object referencing.</ID>
-    <ID>ForbiddenComment:NotaryFlow.kt$NotaryFlow.Client$// TODO: [CORDA-2274] Perform full transaction verification once verification caching is enabled.</ID>
     <ID>ForbiddenComment:NotaryServiceFlow.kt$NotaryServiceFlow.Companion$// TODO: Determine an appropriate limit and also enforce in the network parameters and the transaction builder.</ID>
     <ID>ForbiddenComment:NotaryUtils.kt$// TODO: if requestSignature was generated over an old version of NotarisationRequest, we need to be able to</ID>
     <ID>ForbiddenComment:OGUtils.kt$// TODO: Do this correctly</ID>
@@ -770,15 +768,6 @@
     <ID>LongParameterList:internalAccessTestHelpers.kt$( inputs: List&lt;StateAndRef&lt;ContractState&gt;&gt;, outputs: List&lt;TransactionState&lt;ContractState&gt;&gt;, commands: List&lt;CommandWithParties&lt;CommandData&gt;&gt;, attachments: List&lt;Attachment&gt;, id: SecureHash, notary: Party?, timeWindow: TimeWindow?, privacySalt: PrivacySalt, networkParameters: NetworkParameters, references: List&lt;StateAndRef&lt;ContractState&gt;&gt;, componentGroups: List&lt;ComponentGroup&gt;? = null, serializedInputs: List&lt;SerializedStateAndRef&gt;? = null, serializedReferences: List&lt;SerializedStateAndRef&gt;? = null, isAttachmentTrusted: (Attachment) -&gt; Boolean )</ID>
     <ID>MagicNumber:AMQPClientSerializationScheme.kt$AMQPClientSerializationScheme$128</ID>
     <ID>MagicNumber:AMQPClientSerializationScheme.kt$AMQPClientSerializationScheme.Companion$128</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.CHOICE$7</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.COMPOSITE_TYPE$5</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.FIELD$4</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.OBJECT_DESCRIPTOR$3</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.REFERENCED_OBJECT$8</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.RESTRICTED_TYPE$6</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.TRANSFORM_ELEMENT$10</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.TRANSFORM_ELEMENT_KEY$11</ID>
-    <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.TRANSFORM_SCHEMA$9</ID>
     <ID>MagicNumber:AMQPSerializationScheme.kt$AbstractAMQPSerializationScheme$128</ID>
     <ID>MagicNumber:AMQPServer.kt$AMQPServer$100</ID>
     <ID>MagicNumber:AMQPServerSerializationScheme.kt$AMQPServerSerializationScheme$128</ID>
@@ -894,13 +883,6 @@
     <ID>MagicNumber:ExchangeRateModel.kt$1.01</ID>
     <ID>MagicNumber:ExchangeRateModel.kt$1.18</ID>
     <ID>MagicNumber:ExchangeRateModel.kt$1.31</ID>
-    <ID>MagicNumber:FinanceTypes.kt$Frequency.BiWeekly$26</ID>
-    <ID>MagicNumber:FinanceTypes.kt$Frequency.Daily$365</ID>
-    <ID>MagicNumber:FinanceTypes.kt$Frequency.Monthly$12</ID>
-    <ID>MagicNumber:FinanceTypes.kt$Frequency.Quarterly$3</ID>
-    <ID>MagicNumber:FinanceTypes.kt$Frequency.Quarterly$4</ID>
-    <ID>MagicNumber:FinanceTypes.kt$Frequency.SemiAnnual$6</ID>
-    <ID>MagicNumber:FinanceTypes.kt$Frequency.Weekly$52</ID>
     <ID>MagicNumber:FixingFlow.kt$FixingFlow.Fixer.&lt;no name provided&gt;$30</ID>
     <ID>MagicNumber:FlowCookbook.kt$InitiatorFlow$30</ID>
     <ID>MagicNumber:FlowCookbook.kt$InitiatorFlow$45</ID>
@@ -1326,7 +1308,6 @@
     <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingParameterList$data</ID>
     <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingRawType$data</ID>
     <ID>MaxLineLength:AMQPTypeIdentifierParserTests.kt$AMQPTypeIdentifierParserTests$verify(" java.util.Map &lt; java.util.Map&lt; java.lang.String, java.lang.Integer &gt;, java.util.Map &lt; java.lang.Long , java.lang.String &gt; &gt;")</ID>
-    <ID>MaxLineLength:ANSIProgressRenderer.kt$ANSIProgressRenderer$ansi.a("${IntStream.range(indent, indent).mapToObj { "\t" }.toList().joinToString(separator = "") { s -&gt; s }} $errorIcon ${error.message}")</ID>
     <ID>MaxLineLength:ANSIProgressRenderer.kt$StdoutANSIProgressRenderer$val consoleAppender = manager.configuration.appenders.values.filterIsInstance&lt;ConsoleAppender&gt;().singleOrNull { it.name == "Console-Selector" }</ID>
     <ID>MaxLineLength:ANSIProgressRendererTest.kt$ANSIProgressRendererTest$checkTrackingState(captor, 5, listOf(stepSuccess(STEP_1_LABEL), stepSuccess(STEP_3_LABEL), stepSuccess(STEP_2_LABEL), stepActive(STEP_3_LABEL)))</ID>
     <ID>MaxLineLength:ANSIProgressRendererTest.kt$ANSIProgressRendererTest$checkTrackingState(captor, 6, listOf(stepSuccess(STEP_1_LABEL), stepSuccess(STEP_3_LABEL), stepSuccess(STEP_2_LABEL), stepActive(STEP_3_LABEL), stepNotRun(STEP_4_LABEL)))</ID>
@@ -1533,6 +1514,7 @@
     <ID>MaxLineLength:BasicHSMKeyManagementService.kt$BasicHSMKeyManagementService$require(it.private is AliasPrivateKey) { "${this.javaClass.name} supports AliasPrivateKeys only, but ${it.private.algorithm} key was found" }</ID>
     <ID>MaxLineLength:BlobInspector.kt$BlobInspector$@Option(names = ["--input-format"], paramLabel = "type", description = ["Input format. If the file can't be decoded with the given value it's auto-detected, so you should never normally need to specify this. Possible values: [BINARY, HEX, BASE64]"])</ID>
     <ID>MaxLineLength:BootTests.kt$BootTests$val logFile = logFolder.list { it.filter { a -&gt; a.isRegularFile() &amp;&amp; a.fileName.toString().startsWith("node") }.findFirst().get() }</ID>
+    <ID>MaxLineLength:BootTests.kt$BootTests.ObjectInputStreamFlow$val data = ByteArrayOutputStream().apply { ObjectOutputStream(this).use { it.writeObject(object : Serializable {}) } }.toByteArray()</ID>
     <ID>MaxLineLength:BootstrapperView.kt$BootstrapperView$return Pair(mapOf(Constants.REGION_ARG_NAME to ChoiceDialog&lt;Region&gt;(Region.EUROPE_WEST, Region.values().toList().sortedBy { it.name() }).showAndWait().get().name()), networkName1)</ID>
     <ID>MaxLineLength:BridgeControlListener.kt$BridgeControlListener$bridgeManager.deployBridge(controlMessage.bridgeInfo.queueName, controlMessage.bridgeInfo.targets, controlMessage.bridgeInfo.legalNames.toSet())</ID>
     <ID>MaxLineLength:BridgeControlListener.kt$BridgeControlListener$val startupMessage = BridgeControl.BridgeToNodeSnapshotRequest(bridgeId).serialize(context = SerializationDefaults.P2P_CONTEXT).bytes</ID>
@@ -2646,7 +2628,6 @@
     <ID>MaxLineLength:Node.kt$Node$ArtemisRpcBroker.withSsl(configuration.p2pSslOptions, this.address, adminAddress, sslConfig!!, securityManager, MAX_RPC_MESSAGE_SIZE, jmxMonitoringHttpPort != null, rpcBrokerDirectory, shouldStartLocalShell())</ID>
     <ID>MaxLineLength:Node.kt$Node$ArtemisRpcBroker.withoutSsl(configuration.p2pSslOptions, this.address, adminAddress, securityManager, MAX_RPC_MESSAGE_SIZE, jmxMonitoringHttpPort != null, rpcBrokerDirectory, shouldStartLocalShell())</ID>
     <ID>MaxLineLength:Node.kt$Node$System.setProperty("h2.allowedClasses", "org.h2.mvstore.db.MVTableEngine,org.locationtech.jts.geom.Geometry,org.h2.server.TcpServer")</ID>
-    <ID>MaxLineLength:Node.kt$Node$if (configuration.shouldStartLocalShell()) RPCSecurityManagerWithAdditionalUser(this, User(INTERNAL_SHELL_USER, INTERNAL_SHELL_USER, setOf(Permissions.all()))) else this</ID>
     <ID>MaxLineLength:Node.kt$Node$internalRpcMessagingClient = InternalRPCMessagingClient(configuration.p2pSslOptions, it.admin, MAX_RPC_MESSAGE_SIZE, CordaX500Name.build(configuration.p2pSslOptions.keyStore.get()[X509Utilities.CORDA_CLIENT_TLS].subjectX500Principal), rpcServerConfiguration)</ID>
     <ID>MaxLineLength:Node.kt$Node$log.info("Detected public IP: ${foundPublicIP.hostAddress}. This will be used instead of the provided \"$host\" as the advertised address.")</ID>
     <ID>MaxLineLength:Node.kt$Node$log.info("Retrieved public IP from Network Map Service: $this. This will be used instead of the provided \"$host\" as the advertised address.")</ID>
@@ -2739,8 +2720,8 @@
     <ID>MaxLineLength:NodeSchemaService.kt$NodeSchemaService$fun internalSchemas()</ID>
     <ID>MaxLineLength:NodeSchemaService.kt$NodeSchemaService$override val schemaOptions: Map&lt;MappedSchema, SchemaService.SchemaOptions&gt; = requiredSchemas + extraSchemas.associateBy({ it }, { SchemaOptions() })</ID>
     <ID>MaxLineLength:NodeSchemaService.kt$NodeSchemaService$return VaultSchemaV1.VaultFungibleStates(state.owner, state.amount.quantity, state.amount.token.issuer.party, state.amount.token.issuer.reference)</ID>
-    <ID>MaxLineLength:NodeSchemaServiceTest.kt$TestSchema.Child$@JoinColumns(JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id"), JoinColumn(name = "output_index", referencedColumnName = "output_index"))</ID>
-    <ID>MaxLineLength:NodeSchemaServiceTest.kt$TestSchema.Parent$@JoinColumns(JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id"), JoinColumn(name = "output_index", referencedColumnName = "output_index"))</ID>
+    <ID>MaxLineLength:NodeSchemaServiceTest.kt$NodeSchemaServiceTest.TestSchema.Child$@JoinColumns(JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id"), JoinColumn(name = "output_index", referencedColumnName = "output_index"))</ID>
+    <ID>MaxLineLength:NodeSchemaServiceTest.kt$NodeSchemaServiceTest.TestSchema.Parent$@JoinColumns(JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id"), JoinColumn(name = "output_index", referencedColumnName = "output_index"))</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeCliCommand$abstract</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartup$"""\____/ /_/ \__,_/\__,_/"""</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartup$"Your computer took over a second to resolve localhost due an incorrect configuration. Corda will work but start very slowly until this is fixed. "</ID>
@@ -3550,6 +3531,7 @@
     <ID>MaxLineLength:TransactionViewer.kt$TransactionViewer.ContractStatesView$label</ID>
     <ID>MaxLineLength:TransactionViewer.kt$outputs.mapNotNull { it as? Cash.State } .filter { it.amount.token.issuer.party.owningKey.toKnownParty().value == myIdentity &amp;&amp; it.owner.owningKey.toKnownParty().value != myIdentity }</ID>
     <ID>MaxLineLength:TransactionWithSignatures.kt$TransactionWithSignatures${ val sigKeys = sigs.map { it.by }.toSet() // TODO Problem is that we can get single PublicKey wrapped as CompositeKey in allowedToBeMissing/mustSign // equals on CompositeKey won't catch this case (do we want to single PublicKey be equal to the same key wrapped in CompositeKey with threshold 1?) return requiredSigningKeys.filter { !it.isFulfilledBy(sigKeys) }.toSet() }</ID>
+    <ID>MaxLineLength:TutorialFlowAsyncOperationTest.kt$TutorialFlowAsyncOperationTest$driver</ID>
     <ID>MaxLineLength:TwoPartyDealFlow.kt$TwoPartyDealFlow</ID>
     <ID>MaxLineLength:TwoPartyDealFlow.kt$TwoPartyDealFlow.Acceptor$override</ID>
     <ID>MaxLineLength:TwoPartyDealFlow.kt$TwoPartyDealFlow.Acceptor$return Triple(ptx, arrayListOf(deal.participants.single { it is Party &amp;&amp; serviceHub.myInfo.isLegalIdentity(it) }.owningKey), emptyList())</ID>
@@ -4194,7 +4176,7 @@
     <ID>TooGenericExceptionThrown:NodeConnection.kt$NodeConnection.ShellCommandOutput$throw Exception(diagnostic)</ID>
     <ID>TooGenericExceptionThrown:PhysicalLocationStructures.kt$CityDatabase$throw Exception("Could not parse line: $line")</ID>
     <ID>TooGenericExceptionThrown:RPCDriver.kt$RandomRpcUser.Companion$throw Exception("No generator for ${it.type}")</ID>
-    <ID>TooGenericExceptionThrown:RpcExceptionHandlingTest.kt$ClientRelevantErrorFlow$throw Exception(message, SQLException("Oops!"))</ID>
+    <ID>TooGenericExceptionThrown:RpcExceptionHandlingTest.kt$RpcExceptionHandlingTest.ClientRelevantErrorFlow$throw Exception(message, SQLException("Oops!"))</ID>
     <ID>TooGenericExceptionThrown:RpcServerObservableSerializerTests.kt$RpcServerObservableSerializerTests$throw Error("Observable serializer must be registerable with factory, unexpected exception - ${e.message}")</ID>
     <ID>TooGenericExceptionThrown:RpcServerObservableSerializerTests.kt$RpcServerObservableSerializerTests$throw Error("Serialization of observable should not throw - ${e.message}")</ID>
     <ID>TooGenericExceptionThrown:SelfIssueTest.kt$throw Exception( "Simulated state diverged from actual state" + "\nSimulated state:\n${previousState.vaultsSelfIssued}" + "\nActual state:\n$selfIssueVaults" + "\nDiff:\n$diffString" )</ID>
@@ -4887,7 +4869,6 @@
     <ID>WildcardImport:NotaryChangeTests.kt$import net.corda.testing.node.*</ID>
     <ID>WildcardImport:NotaryChangeTransactions.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:NotaryChangeTransactions.kt$import net.corda.core.transactions.NotaryChangeWireTransaction.Component.*</ID>
-    <ID>WildcardImport:NotaryFlow.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NotaryFlow.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:NotaryServiceFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:NotaryServiceTests.kt$import net.corda.core.crypto.*</ID>

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/TutorialFlowAsyncOperationTest.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/TutorialFlowAsyncOperationTest.kt
@@ -9,6 +9,8 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.cordappWithPackages
+import net.corda.testing.node.internal.findCordapp
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -16,7 +18,7 @@ class TutorialFlowAsyncOperationTest {
     // DOCSTART summingWorks
     @Test
     fun summingWorks() {
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = listOf(cordappWithPackages("net.corda.docs.kotlin.tutorial.flowstatemachines")))) {
             val aliceUser = User("aliceUser", "testPassword1", permissions = setOf(Permissions.all()))
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(aliceUser)).getOrThrow()
             val aliceClient = CordaRPCClient(alice.rpcAddress)

--- a/finance/workflows/src/integration-test/kotlin/net/corda/finance/workflows/CashExceptionSerialisationTest.kt
+++ b/finance/workflows/src/integration-test/kotlin/net/corda/finance/workflows/CashExceptionSerialisationTest.kt
@@ -9,6 +9,7 @@ import net.corda.node.services.Permissions.Companion.all
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -16,7 +17,7 @@ import org.junit.Test
 class CashExceptionSerialisationTest {
     @Test
     fun `cash exception with a cause can be serialised with AMQP`() {
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
             val node = startNode(rpcUsers = listOf(User("mark", "dadada", setOf(all())))).getOrThrow()
             val action = { node.rpc.startFlow(CashExceptionSerialisationTest::CashExceptionThrowingFlow).returnValue.getOrThrow() }
             assertThatThrownBy(action).isInstanceOfSatisfying(CashException::class.java) { thrown ->

--- a/node/src/integration-test-slow/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
@@ -19,7 +19,12 @@ class FlowsExecutionModeRpcTest {
         Assume.assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win"))
 
         val user = User("mark", "dadada", setOf(Permissions.invokeRpc("setFlowsDrainingModeEnabled"), Permissions.invokeRpc("isFlowsDrainingModeEnabled")))
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = true,
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name

--- a/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
@@ -17,7 +17,7 @@ import javax.security.auth.x500.X500Principal
 class NodeKeystoreCheckTest {
     @Test
     fun `starting node in non-dev mode with no key store`() {
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = emptyList())) {
             assertThatThrownBy {
                 startNode(customOverrides = mapOf("devMode" to false)).getOrThrow()
             }.hasMessageContaining("One or more keyStores (identity or TLS) or trustStore not found.")
@@ -26,7 +26,7 @@ class NodeKeystoreCheckTest {
 
     @Test
     fun `node should throw exception if cert path does not chain to the trust root`() {
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = emptyList())) {
             // Create keystores.
             val keystorePassword = "password"
             val certificatesDirectory = baseDirectory(ALICE_NAME) / "certificates"

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/DbSchemaInitialisationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/DbSchemaInitialisationTest.kt
@@ -14,7 +14,7 @@ class DbSchemaInitialisationTest {
 
     @Test
     fun `database is initialised`() {
-        driver(DriverParameters(startNodesInProcess = isQuasarAgentSpecified())) {
+        driver(DriverParameters(startNodesInProcess = isQuasarAgentSpecified(), cordappsForAllNodes = emptyList())) {
             val nodeHandle = {
                 startNode(NodeParameters(customOverrides = mapOf("database.initialiseSchema" to "true"))).getOrThrow()
             }()
@@ -24,7 +24,7 @@ class DbSchemaInitialisationTest {
 
     @Test
     fun `database is not initialised`() {
-        driver(DriverParameters(startNodesInProcess = isQuasarAgentSpecified())) {
+        driver(DriverParameters(startNodesInProcess = isQuasarAgentSpecified(), cordappsForAllNodes = emptyList())) {
             assertFailsWith(DatabaseIncompatibleException::class) {
                 startNode(NodeParameters(customOverrides = mapOf("database.initialiseSchema" to "false"))).getOrThrow()
             }

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -13,6 +13,7 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.enclosedCordapp
 import org.h2.jdbc.JdbcSQLNonTransientException
 import org.junit.Test
 import java.net.InetAddress
@@ -31,7 +32,12 @@ class H2SecurityTests {
 
     @Test
     fun `h2 server starts when h2Settings are set`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             val port = getFreePort()
             startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
             DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
@@ -42,7 +48,12 @@ class H2SecurityTests {
 
     @Test
     fun `h2 server on the host name requires non-default database password`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
                 startNode(customOverrides = mapOf(h2AddressKey to "${InetAddress.getLocalHost().hostName}:${getFreePort()}")).getOrThrow()
             }
@@ -51,7 +62,12 @@ class H2SecurityTests {
 
     @Test
     fun `h2 server on the external host IP requires non-default database password`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
                 startNode(customOverrides = mapOf(h2AddressKey to "${InetAddress.getLocalHost().hostAddress}:${getFreePort()}")).getOrThrow()
             }
@@ -60,7 +76,12 @@ class H2SecurityTests {
 
     @Test
     fun `h2 server on host name requires non-blank database password`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
                 startNode(customOverrides = mapOf(h2AddressKey to "${InetAddress.getLocalHost().hostName}:${getFreePort()}",
                         dbPasswordKey to " ")).getOrThrow()
@@ -70,7 +91,12 @@ class H2SecurityTests {
 
     @Test
     fun `h2 server on external host IP requires non-blank database password`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
                 startNode(customOverrides = mapOf(h2AddressKey to "${InetAddress.getLocalHost().hostAddress}:${getFreePort()}",
                         dbPasswordKey to " ")).getOrThrow()
@@ -80,21 +106,36 @@ class H2SecurityTests {
 
     @Test
     fun `h2 server on localhost runs with the default database password`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = false, notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = false,
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             startNode(customOverrides = mapOf(h2AddressKey to "localhost:${getFreePort()}")).getOrThrow()
         }
     }
 
     @Test
     fun `h2 server to loopback IP runs with the default database password`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:${getFreePort()}")).getOrThrow()
         }
     }
 
     @Test
     fun `remote code execution via h2 server is disabled`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = false, notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = false,
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = emptyList()
+        )) {
             val port = getFreePort()
             startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port", dbPasswordKey to "x")).getOrThrow()
             DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "x").use {
@@ -110,7 +151,12 @@ class H2SecurityTests {
     @Test
     fun `malicious flow tries to enable remote code execution via h2 server`() {
         val user = User("mark", "dadada", setOf(Permissions.startFlow<MaliciousFlow>()))
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = false, notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = false,
+                notarySpecs = emptyList(),
+                cordappsForAllNodes = listOf(enclosedCordapp())
+        )) {
             val port = getFreePort()
             val nodeHandle = startNode(rpcUsers = listOf(user), customOverrides = mapOf(h2AddressKey to "localhost:$port",
                     dbPasswordKey to "x")).getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceFlowTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceFlowTests.kt
@@ -11,13 +11,14 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
+import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class CordaServiceFlowTests {
     @Test
     fun `corda service can start a flow and wait for it`() {
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = listOf(enclosedCordapp()))) {
             val node = startNode().getOrThrow()
             val text = "191ejodaimadc8i"
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/NodeHandleTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/NodeHandleTests.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class NodeHandleTests {
     @Test
     fun object_defined_functions_are_static_for_node_rpc_ops() {
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = emptyList())) {
             val rpcClient = startNode().getOrThrow().rpc
 
             assertThatCode { rpcClient.hashCode() }.doesNotThrowAnyException()

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
@@ -12,6 +12,7 @@ import net.corda.node.services.Permissions
 import net.corda.testing.core.*
 import net.corda.testing.driver.*
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startNode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
@@ -33,7 +34,7 @@ class RpcExceptionHandlingTest {
             rpc.startFlow(::ClientRelevantErrorFlow, clientRelevantMessage).returnValue.getOrThrow()
         }
 
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
             val devModeNode = startNode(params, BOB_NAME).getOrThrow()
             assertThatThrownBy { devModeNode.throwExceptionFromFlow() }.isInstanceOfSatisfying(CordaRuntimeException::class.java) { exception ->
                 assertEquals((exception.cause as CordaRuntimeException).originalExceptionClassName, SQLException::class.qualifiedName)
@@ -57,7 +58,7 @@ class RpcExceptionHandlingTest {
             }
         }
 
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
             val devModeNode = startNode(params, BOB_NAME).getOrThrow()
             val node = startNode(ALICE_NAME, devMode = false, parameters = params).getOrThrow()
 
@@ -76,7 +77,7 @@ class RpcExceptionHandlingTest {
             rpc.startFlow(::FlowExceptionFlow, expectedMessage, expectedErrorId).returnValue.getOrThrow()
         }
 
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
             val devModeNode = startNode(params, BOB_NAME).getOrThrow()
             val node = startNode(ALICE_NAME, devMode = false, parameters = params).getOrThrow()
 
@@ -108,7 +109,7 @@ class RpcExceptionHandlingTest {
             nodeA.rpc.startFlow(::InitFlow, nodeB.nodeInfo.singleIdentity()).returnValue.getOrThrow()
         }
 
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
 
             assertThatThrownBy { scenario(ALICE_NAME, BOB_NAME,true) }.isInstanceOfSatisfying(CordaRuntimeException::class.java) { exception ->
 
@@ -123,39 +124,41 @@ class RpcExceptionHandlingTest {
             }.isInstanceOf(UnexpectedFlowEndException::class.java)
         }
     }
-}
 
-@StartableByRPC
-@InitiatingFlow
-class InitFlow(private val party: Party) : FlowLogic<String>() {
-    @Suspendable
-    override fun call(): String {
-        val session = initiateFlow(party)
-        return session.sendAndReceive<String>("hey").unwrap { it }
+    @StartableByRPC
+    @InitiatingFlow
+    class InitFlow(private val party: Party) : FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String {
+            val session = initiateFlow(party)
+            return session.sendAndReceive<String>("hey").unwrap { it }
+        }
     }
-}
 
-@InitiatedBy(InitFlow::class)
-class InitiatedFlow(private val initiatingSession: FlowSession) : FlowLogic<Unit>() {
-    @Suspendable
-    override fun call() {
-        initiatingSession.receive<String>().unwrap { it }
-        throw GenericJDBCException("Something went wrong!", SQLException("Oops!"))
+    @InitiatedBy(InitFlow::class)
+    class InitiatedFlow(private val initiatingSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            initiatingSession.receive<String>().unwrap { it }
+            throw GenericJDBCException("Something went wrong!", SQLException("Oops!"))
+        }
     }
-}
 
-@StartableByRPC
-class ClientRelevantErrorFlow(private val message: String) : FlowLogic<String>() {
-    @Suspendable
-    override fun call(): String = throw Exception(message, SQLException("Oops!"))
-}
-
-@StartableByRPC
-class FlowExceptionFlow(private val message: String, private val errorId: Long? = null) : FlowLogic<String>() {
-    @Suspendable
-    override fun call(): String {
-        val exception = FlowException(message)
-        errorId?.let { exception.originalErrorId = it }
-        throw exception
+    @StartableByRPC
+    class ClientRelevantErrorFlow(private val message: String) : FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String = throw Exception(message, SQLException("Oops!"))
     }
+
+    @StartableByRPC
+    class FlowExceptionFlow(private val message: String, private val errorId: Long? = null) : FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String {
+            val exception = FlowException(message)
+            errorId?.let { exception.originalErrorId = it }
+            throw exception
+        }
+    }
+
+
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -23,8 +23,11 @@ import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyContract.SingleOwnerState
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.CHARLIE_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.enclosedCordapp
+import net.corda.testing.node.internal.findCordapp
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -38,7 +41,7 @@ class FlowHospitalTest {
 
     @Test
     fun `when double spend occurs, the flow is successfully deleted on the counterparty`() {
-        driver {
+        driver(DriverParameters(cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
             val charlie = startNode(providedName = CHARLIE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/HardRestartTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/HardRestartTest.kt
@@ -21,6 +21,7 @@ import net.corda.testing.driver.OutOfProcess
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.Test
 import java.util.*
 import java.util.concurrent.CountDownLatch
@@ -67,7 +68,8 @@ class HardRestartTest {
                 startNodesInProcess = false,
                 inMemoryDB = false,
                 notarySpecs = emptyList(),
-                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())
+                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()),
+                cordappsForAllNodes = listOf(enclosedCordapp())
         )) {
             val (a, b) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
@@ -105,7 +107,8 @@ class HardRestartTest {
                 startNodesInProcess = false,
                 inMemoryDB = false,
                 notarySpecs = emptyList(),
-                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())
+                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()),
+                cordappsForAllNodes = listOf(enclosedCordapp())
         )) {
             val (a, b) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
@@ -143,7 +146,8 @@ class HardRestartTest {
                 startNodesInProcess = false,
                 inMemoryDB = false,
                 notarySpecs = emptyList(),
-                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())
+                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()),
+                cordappsForAllNodes = listOf(enclosedCordapp())
         )) {
             val (a, b) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
@@ -225,7 +229,8 @@ class HardRestartTest {
                 startNodesInProcess = false,
                 inMemoryDB = false,
                 notarySpecs = emptyList(),
-                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())
+                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()),
+                cordappsForAllNodes = listOf(enclosedCordapp())
         )) {
             val (a, b) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),

--- a/node/src/test/kotlin/net/corda/node/services/schema/PersistentStateServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/schema/PersistentStateServiceTests.kt
@@ -8,6 +8,7 @@ import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.QueryableState
 import net.corda.node.services.api.SchemaService
+import net.corda.node.services.schema.NodeSchemaServiceTest.TestSchema
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.nodeapi.internal.persistence.currentDBSession
 import net.corda.testing.contracts.DummyContract


### PR DESCRIPTION
Adjusting driver tests to make use of `cordappsForAllNodes`, so that only the minimum required set of cordapps is generated & loaded.