### PR TITLE
CORDA-3197 Fix flow has been waiting message

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -145,7 +145,7 @@
     <ID>ComplexMethod:DriverDSLImpl.kt$DriverDSLImpl$override fun start()</ID>
     <ID>ComplexMethod:Expect.kt$ fun &lt;S, E : Any&gt; S.genericExpectEvents( isStrict: Boolean = true, stream: S.((E) -&gt; Unit) -&gt; Unit, expectCompose: () -&gt; ExpectCompose&lt;E&gt; )</ID>
     <ID>ComplexMethod:FinalityFlow.kt$FinalityFlow$@Suspendable @Throws(NotaryException::class) override fun call(): SignedTransaction</ID>
-    <ID>ComplexMethod:FlowMonitor.kt$FlowMonitor$private fun warningMessageForFlowWaitingOnIo(request: FlowIORequest&lt;*&gt;, flow: FlowStateMachineImpl&lt;*&gt;, now: Instant): String</ID>
+    <ID>ComplexMethod:FlowMonitor.kt$FlowMonitor$private fun warningMessageForFlowWaitingOnIo(request: FlowIORequest&lt;*&gt;, flow: FlowStateMachineImpl&lt;*&gt;, suspensionDuration: Duration): String</ID>
     <ID>ComplexMethod:FlowStateMachineImpl.kt$FlowStateMachineImpl$ @Suspendable private fun processEventsUntilFlowIsResumed(isDbTransactionOpenOnEntry: Boolean, isDbTransactionOpenOnExit: Boolean): Any?</ID>
     <ID>ComplexMethod:GenerateRpcSslCertsCli.kt$GenerateRpcSslCerts$private fun generateRpcSslCertificates(conf: NodeConfiguration)</ID>
     <ID>ComplexMethod:GenericsTests.kt$GenericsTests$@Test fun nestedSerializationInMultipleContextsDoesntColideGenericTypes()</ID>

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -6,11 +6,6 @@
     <ID>ClassNaming:AbstractCashFlow.kt$AbstractCashFlow.Companion$GENERATING_ID : Step</ID>
     <ID>ClassNaming:AbstractCashFlow.kt$AbstractCashFlow.Companion$GENERATING_TX : Step</ID>
     <ID>ClassNaming:AbstractCashFlow.kt$AbstractCashFlow.Companion$SIGNING_TX : Step</ID>
-    <ID>ClassNaming:BlobWriter.kt$_Li_</ID>
-    <ID>ClassNaming:BlobWriter.kt$_Mis_</ID>
-    <ID>ClassNaming:BlobWriter.kt$_i_</ID>
-    <ID>ClassNaming:BlobWriter.kt$_i_is__</ID>
-    <ID>ClassNaming:BlobWriter.kt$_is_</ID>
     <ID>ClassNaming:BuyerFlow.kt$BuyerFlow$STARTING_BUY : Step</ID>
     <ID>ClassNaming:CompositeMemberCompositeSchemaToClassCarpenterTests.kt$I_</ID>
     <ID>ClassNaming:CordaServiceTest.kt$CordaServiceTest.DummyServiceFlow.Companion$TEST_STEP : Step</ID>
@@ -187,6 +182,7 @@
     <ID>ComplexMethod:RPCClientProxyHandler.kt$RPCClientProxyHandler$// This is the general function that transforms a client side RPC to internal Artemis messages. override fun invoke(proxy: Any, method: Method, arguments: Array&lt;out Any?&gt;?): Any?</ID>
     <ID>ComplexMethod:RPCClientProxyHandler.kt$RPCClientProxyHandler$private fun attemptReconnect()</ID>
     <ID>ComplexMethod:RPCServer.kt$RPCServer$private fun clientArtemisMessageHandler(artemisMessage: ClientMessage)</ID>
+    <ID>ComplexMethod:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ private tailrec fun establishConnectionWithRetry( retryInterval: Duration = 1.seconds, roundRobinIndex: Int = 0, retries: Int = -1 ): CordaRPCConnection</ID>
     <ID>ComplexMethod:RemoteTypeCarpenter.kt$SchemaBuildingRemoteTypeCarpenter$override fun carpent(typeInformation: RemoteTypeInformation): Type</ID>
     <ID>ComplexMethod:RpcReconnectTests.kt$RpcReconnectTests$ @Test fun `test that the RPC client is able to reconnect and proceed after node failure, restart, or connection reset`()</ID>
     <ID>ComplexMethod:SchemaMigration.kt$SchemaMigration$ private fun migrateOlderDatabaseToUseLiquibase(existingCheckpoints: Boolean): Boolean</ID>
@@ -684,7 +680,6 @@
     <ID>LongParameterList:Driver.kt$DriverParameters$( isDebug: Boolean, driverDirectory: Path, portAllocation: PortAllocation, debugPortAllocation: PortAllocation, systemProperties: Map&lt;String, String&gt;, useTestClock: Boolean, startNodesInProcess: Boolean, waitForAllNodesToFinish: Boolean, notarySpecs: List&lt;NotarySpec&gt;, extraCordappPackagesToScan: List&lt;String&gt;, jmxPolicy: JmxPolicy, networkParameters: NetworkParameters, cordappsForAllNodes: Set&lt;TestCordapp&gt;? )</ID>
     <ID>LongParameterList:DriverDSL.kt$DriverDSL$( defaultParameters: NodeParameters = NodeParameters(), providedName: CordaX500Name? = defaultParameters.providedName, rpcUsers: List&lt;User&gt; = defaultParameters.rpcUsers, verifierType: VerifierType = defaultParameters.verifierType, customOverrides: Map&lt;String, Any?&gt; = defaultParameters.customOverrides, startInSameProcess: Boolean? = defaultParameters.startInSameProcess, maximumHeapSize: String = defaultParameters.maximumHeapSize )</ID>
     <ID>LongParameterList:DriverDSL.kt$DriverDSL$( defaultParameters: NodeParameters = NodeParameters(), providedName: CordaX500Name? = defaultParameters.providedName, rpcUsers: List&lt;User&gt; = defaultParameters.rpcUsers, verifierType: VerifierType = defaultParameters.verifierType, customOverrides: Map&lt;String, Any?&gt; = defaultParameters.customOverrides, startInSameProcess: Boolean? = defaultParameters.startInSameProcess, maximumHeapSize: String = defaultParameters.maximumHeapSize, logLevelOverride: String? = defaultParameters.logLevelOverride )</ID>
-    <ID>LongParameterList:DriverDSLImpl.kt$DriverDSLImpl.Companion$( config: NodeConfig, quasarJarPath: String, debugPort: Int?, bytemanJarPath: String?, bytemanPort: Int?, overriddenSystemProperties: Map&lt;String, String&gt;, maximumHeapSize: String, logLevelOverride: String?, vararg extraCmdLineFlag: String )</ID>
     <ID>LongParameterList:DummyFungibleContract.kt$DummyFungibleContract$(inputs: List&lt;State&gt;, outputs: List&lt;State&gt;, tx: LedgerTransaction, issueCommand: CommandWithParties&lt;Commands.Issue&gt;, currency: Currency, issuer: PartyAndReference)</ID>
     <ID>LongParameterList:IRS.kt$FloatingRatePaymentEvent$(date: LocalDate = this.date, accrualStartDate: LocalDate = this.accrualStartDate, accrualEndDate: LocalDate = this.accrualEndDate, dayCountBasisDay: DayCountBasisDay = this.dayCountBasisDay, dayCountBasisYear: DayCountBasisYear = this.dayCountBasisYear, fixingDate: LocalDate = this.fixingDate, notional: Amount&lt;Currency&gt; = this.notional, rate: Rate = this.rate)</ID>
     <ID>LongParameterList:IRS.kt$InterestRateSwap$(floatingLeg: FloatingLeg, fixedLeg: FixedLeg, calculation: Calculation, common: Common, oracle: Party, notary: Party)</ID>
@@ -716,8 +711,6 @@
     <ID>LongParameterList:ParametersUtilities.kt$( notaries: List&lt;NotaryInfo&gt; = emptyList(), minimumPlatformVersion: Int = 1, modifiedTime: Instant = Instant.now(), maxMessageSize: Int = 10485760, // TODO: Make this configurable and consistence across driver, bootstrapper, demobench and NetworkMapServer maxTransactionSize: Int = maxMessageSize * 50, whitelistedContractImplementations: Map&lt;String, List&lt;AttachmentId&gt;&gt; = emptyMap(), epoch: Int = 1, eventHorizon: Duration = 30.days, packageOwnership: Map&lt;String, PublicKey&gt; = emptyMap() )</ID>
     <ID>LongParameterList:PersistentUniquenessProvider.kt$PersistentUniquenessProvider$( states: List&lt;StateRef&gt;, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature, timeWindow: TimeWindow?, references: List&lt;StateRef&gt; )</ID>
     <ID>LongParameterList:PhysicalLocationStructures.kt$WorldCoordinate$(screenWidth: Double, screenHeight: Double, topLatitude: Double, bottomLatitude: Double, leftLongitude: Double, rightLongitude: Double)</ID>
-    <ID>LongParameterList:ProcessUtilities.kt$ProcessUtilities$( arguments: List&lt;String&gt;, classPath: List&lt;String&gt; = defaultClassPath, workingDirectory: Path? = null, jdwpPort: Int? = null, extraJvmArguments: List&lt;String&gt; = emptyList(), maximumHeapSize: String? = null )</ID>
-    <ID>LongParameterList:ProcessUtilities.kt$ProcessUtilities$( className: String, arguments: List&lt;String&gt;, classPath: List&lt;String&gt; = defaultClassPath, workingDirectory: Path? = null, jdwpPort: Int? = null, extraJvmArguments: List&lt;String&gt; = emptyList(), maximumHeapSize: String? = null )</ID>
     <ID>LongParameterList:QueryCriteria.kt$QueryCriteria.FungibleAssetQueryCriteria$( participants: List&lt;AbstractParty&gt;? = this.participants, owner: List&lt;AbstractParty&gt;? = this.owner, quantity: ColumnPredicate&lt;Long&gt;? = this.quantity, issuer: List&lt;AbstractParty&gt;? = this.issuer, issuerRef: List&lt;OpaqueBytes&gt;? = this.issuerRef, status: Vault.StateStatus = this.status, contractStateTypes: Set&lt;Class&lt;out ContractState&gt;&gt;? = this.contractStateTypes )</ID>
     <ID>LongParameterList:QueryCriteria.kt$QueryCriteria.FungibleAssetQueryCriteria$( participants: List&lt;AbstractParty&gt;? = this.participants, owner: List&lt;AbstractParty&gt;? = this.owner, quantity: ColumnPredicate&lt;Long&gt;? = this.quantity, issuer: List&lt;AbstractParty&gt;? = this.issuer, issuerRef: List&lt;OpaqueBytes&gt;? = this.issuerRef, status: Vault.StateStatus = this.status, contractStateTypes: Set&lt;Class&lt;out ContractState&gt;&gt;? = this.contractStateTypes, relevancyStatus: Vault.RelevancyStatus = this.relevancyStatus )</ID>
     <ID>LongParameterList:QueryCriteria.kt$QueryCriteria.LinearStateQueryCriteria$( participants: List&lt;AbstractParty&gt;? = this.participants, uuid: List&lt;UUID&gt;? = this.uuid, externalId: List&lt;String&gt;? = this.externalId, status: Vault.StateStatus = this.status, contractStateTypes: Set&lt;Class&lt;out ContractState&gt;&gt;? = this.contractStateTypes, relevancyStatus: Vault.RelevancyStatus = this.relevancyStatus )</ID>
@@ -1234,7 +1227,6 @@
     <ID>MatchingDeclarationName:IRSDemo.kt$net.corda.irs.web.demo.IRSDemo.kt</ID>
     <ID>MatchingDeclarationName:InterestSwapRestAPI.kt$net.corda.irs.web.api.InterestSwapRestAPI.kt</ID>
     <ID>MatchingDeclarationName:InternalAccessTestHelpers.kt$net.corda.serialization.internal.InternalAccessTestHelpers.kt</ID>
-    <ID>MatchingDeclarationName:InternalTestUtils.kt$net.corda.testing.node.internal.InternalTestUtils.kt</ID>
     <ID>MatchingDeclarationName:IrsDemoClientApi.kt$net.corda.irs.web.demo.IrsDemoClientApi.kt</ID>
     <ID>MatchingDeclarationName:KeyStoreConfigHelpers.kt$net.corda.nodeapi.internal.KeyStoreConfigHelpers.kt</ID>
     <ID>MatchingDeclarationName:Main.kt$net.corda.bootstrapper.Main.kt</ID>
@@ -2294,7 +2286,6 @@
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration : RunAfterNodeInitialisationNodeStartupLogging</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration$println("Node was started before with `--initial-registration`, but the registration was not completed.\nResuming registration.")</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration$println("Successfully registered Corda node with compatibility zone, node identity keys and certificates are stored in '${conf.certificatesDirectory}', it is advised to backup the private keys and certificates.")</ID>
-    <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration${ // Null checks for [compatibilityZoneURL], [rootTruststorePath] and [rootTruststorePassword] has been done in [CmdLineOptions.loadConfig] attempt { registerWithNetwork(config) }.doOnFailure(Consumer(this::handleRegistrationError)) as Try.Success // At this point the node registration was successful. We can delete the marker file. deleteNodeRegistrationMarker(baseDirectory) }</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistrationCli : CliWrapperBase</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistrationCli$@Option(names = ["-p", "--network-root-truststore-password"], description = ["Network root trust store password obtained from network operator."], required = true)</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistrationCli$return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, startup))</ID>
@@ -2723,7 +2714,6 @@
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$error is java.nio.file.AccessDeniedException -&gt; error.logAsExpected("Exception during node startup. Corda started with insufficient privileges to access ${error.file}")</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$error is java.nio.file.NoSuchFileException -&gt; error.logAsExpected("Exception during node startup. Corda cannot find file ${error.file}")</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$error.isOpenJdkKnownIssue() -&gt; error.logAsExpected("Exception during node startup - ${error.message}. This is a known OpenJDK issue on some Linux distributions, please use OpenJDK from zulu.org or Oracle JDK.")</ID>
-    <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$fun Throwable.logAsUnexpected(message: String? = this.message, error: Throwable = this, print: (String?, Throwable) -&gt; Unit = logger::error)</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging.Companion$val startupErrors = setOf(MultipleCordappsForFlowException::class, CheckpointIncompatibleException::class, AddressBindingException::class, NetworkParametersReader::class, DatabaseIncompatibleException::class)</ID>
     <ID>MaxLineLength:NodeStatePersistenceTests.kt$NodeStatePersistenceTests$val nodeHandle = startNode(providedName = nodeName, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to "false")).getOrThrow()</ID>
     <ID>MaxLineLength:NodeTabView.kt$NodeTabView$CityDatabase.cityMap.values.map { it.countryCode }.toSet().map { it to Image(resources["/net/corda/demobench/flags/$it.png"]) }.toMap()</ID>
@@ -3807,7 +3797,6 @@
     <ID>SpreadOperator:DemoBench.kt$DemoBench.Companion$(DemoBench::class.java, *args)</ID>
     <ID>SpreadOperator:DevCertificatesTest.kt$DevCertificatesTest$(*oldX509Certificates)</ID>
     <ID>SpreadOperator:DockerInstantiator.kt$DockerInstantiator$(*it.toTypedArray())</ID>
-    <ID>SpreadOperator:DriverDSLImpl.kt$DriverDSLImpl$( config, quasarJarPath, debugPort, bytemanJarPath, null, systemProperties, "512m", null, *extraCmdLineFlag )</ID>
     <ID>SpreadOperator:DummyContract.kt$DummyContract.Companion$( /* INPUTS */ *priors.toTypedArray(), /* COMMAND */ Command(cmd, priorState.owner.owningKey), /* OUTPUT */ StateAndContract(state, PROGRAM_ID) )</ID>
     <ID>SpreadOperator:DummyContract.kt$DummyContract.Companion$(*items)</ID>
     <ID>SpreadOperator:DummyContractV2.kt$DummyContractV2.Companion$( /* INPUTS */ *priors.toTypedArray(), /* COMMAND */ Command(cmd, priorState.owners.map { it.owningKey }), /* OUTPUT */ StateAndContract(state, DummyContractV2.PROGRAM_ID) )</ID>
@@ -4561,8 +4550,6 @@
     <ID>WildcardImport:DoRemainingWorkTransition.kt$import net.corda.node.services.statemachine.*</ID>
     <ID>WildcardImport:DockerInstantiator.kt$import com.github.dockerjava.api.model.*</ID>
     <ID>WildcardImport:DriverDSLImpl.kt$import net.corda.testing.driver.*</ID>
-    <ID>WildcardImport:DriverTests.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:DriverTests.kt$import org.assertj.core.api.Assertions.*</ID>
     <ID>WildcardImport:DummyContract.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:DummyContractV2.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:DummyContractV3.kt$import net.corda.core.contracts.*</ID>

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -187,7 +187,6 @@
     <ID>ComplexMethod:RPCClientProxyHandler.kt$RPCClientProxyHandler$// This is the general function that transforms a client side RPC to internal Artemis messages. override fun invoke(proxy: Any, method: Method, arguments: Array&lt;out Any?&gt;?): Any?</ID>
     <ID>ComplexMethod:RPCClientProxyHandler.kt$RPCClientProxyHandler$private fun attemptReconnect()</ID>
     <ID>ComplexMethod:RPCServer.kt$RPCServer$private fun clientArtemisMessageHandler(artemisMessage: ClientMessage)</ID>
-    <ID>ComplexMethod:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ private tailrec fun establishConnectionWithRetry( retryInterval: Duration = 1.seconds, roundRobinIndex: Int = 0, retries: Int = -1 ): CordaRPCConnection</ID>
     <ID>ComplexMethod:RemoteTypeCarpenter.kt$SchemaBuildingRemoteTypeCarpenter$override fun carpent(typeInformation: RemoteTypeInformation): Type</ID>
     <ID>ComplexMethod:RpcReconnectTests.kt$RpcReconnectTests$ @Test fun `test that the RPC client is able to reconnect and proceed after node failure, restart, or connection reset`()</ID>
     <ID>ComplexMethod:SchemaMigration.kt$SchemaMigration$ private fun migrateOlderDatabaseToUseLiquibase(existingCheckpoints: Boolean): Boolean</ID>
@@ -685,6 +684,7 @@
     <ID>LongParameterList:Driver.kt$DriverParameters$( isDebug: Boolean, driverDirectory: Path, portAllocation: PortAllocation, debugPortAllocation: PortAllocation, systemProperties: Map&lt;String, String&gt;, useTestClock: Boolean, startNodesInProcess: Boolean, waitForAllNodesToFinish: Boolean, notarySpecs: List&lt;NotarySpec&gt;, extraCordappPackagesToScan: List&lt;String&gt;, jmxPolicy: JmxPolicy, networkParameters: NetworkParameters, cordappsForAllNodes: Set&lt;TestCordapp&gt;? )</ID>
     <ID>LongParameterList:DriverDSL.kt$DriverDSL$( defaultParameters: NodeParameters = NodeParameters(), providedName: CordaX500Name? = defaultParameters.providedName, rpcUsers: List&lt;User&gt; = defaultParameters.rpcUsers, verifierType: VerifierType = defaultParameters.verifierType, customOverrides: Map&lt;String, Any?&gt; = defaultParameters.customOverrides, startInSameProcess: Boolean? = defaultParameters.startInSameProcess, maximumHeapSize: String = defaultParameters.maximumHeapSize )</ID>
     <ID>LongParameterList:DriverDSL.kt$DriverDSL$( defaultParameters: NodeParameters = NodeParameters(), providedName: CordaX500Name? = defaultParameters.providedName, rpcUsers: List&lt;User&gt; = defaultParameters.rpcUsers, verifierType: VerifierType = defaultParameters.verifierType, customOverrides: Map&lt;String, Any?&gt; = defaultParameters.customOverrides, startInSameProcess: Boolean? = defaultParameters.startInSameProcess, maximumHeapSize: String = defaultParameters.maximumHeapSize, logLevelOverride: String? = defaultParameters.logLevelOverride )</ID>
+    <ID>LongParameterList:DriverDSLImpl.kt$DriverDSLImpl.Companion$( config: NodeConfig, quasarJarPath: String, debugPort: Int?, bytemanJarPath: String?, bytemanPort: Int?, overriddenSystemProperties: Map&lt;String, String&gt;, maximumHeapSize: String, logLevelOverride: String?, vararg extraCmdLineFlag: String )</ID>
     <ID>LongParameterList:DummyFungibleContract.kt$DummyFungibleContract$(inputs: List&lt;State&gt;, outputs: List&lt;State&gt;, tx: LedgerTransaction, issueCommand: CommandWithParties&lt;Commands.Issue&gt;, currency: Currency, issuer: PartyAndReference)</ID>
     <ID>LongParameterList:IRS.kt$FloatingRatePaymentEvent$(date: LocalDate = this.date, accrualStartDate: LocalDate = this.accrualStartDate, accrualEndDate: LocalDate = this.accrualEndDate, dayCountBasisDay: DayCountBasisDay = this.dayCountBasisDay, dayCountBasisYear: DayCountBasisYear = this.dayCountBasisYear, fixingDate: LocalDate = this.fixingDate, notional: Amount&lt;Currency&gt; = this.notional, rate: Rate = this.rate)</ID>
     <ID>LongParameterList:IRS.kt$InterestRateSwap$(floatingLeg: FloatingLeg, fixedLeg: FixedLeg, calculation: Calculation, common: Common, oracle: Party, notary: Party)</ID>
@@ -717,6 +717,7 @@
     <ID>LongParameterList:PersistentUniquenessProvider.kt$PersistentUniquenessProvider$( states: List&lt;StateRef&gt;, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature, timeWindow: TimeWindow?, references: List&lt;StateRef&gt; )</ID>
     <ID>LongParameterList:PhysicalLocationStructures.kt$WorldCoordinate$(screenWidth: Double, screenHeight: Double, topLatitude: Double, bottomLatitude: Double, leftLongitude: Double, rightLongitude: Double)</ID>
     <ID>LongParameterList:ProcessUtilities.kt$ProcessUtilities$( arguments: List&lt;String&gt;, classPath: List&lt;String&gt; = defaultClassPath, workingDirectory: Path? = null, jdwpPort: Int? = null, extraJvmArguments: List&lt;String&gt; = emptyList(), maximumHeapSize: String? = null )</ID>
+    <ID>LongParameterList:ProcessUtilities.kt$ProcessUtilities$( className: String, arguments: List&lt;String&gt;, classPath: List&lt;String&gt; = defaultClassPath, workingDirectory: Path? = null, jdwpPort: Int? = null, extraJvmArguments: List&lt;String&gt; = emptyList(), maximumHeapSize: String? = null )</ID>
     <ID>LongParameterList:QueryCriteria.kt$QueryCriteria.FungibleAssetQueryCriteria$( participants: List&lt;AbstractParty&gt;? = this.participants, owner: List&lt;AbstractParty&gt;? = this.owner, quantity: ColumnPredicate&lt;Long&gt;? = this.quantity, issuer: List&lt;AbstractParty&gt;? = this.issuer, issuerRef: List&lt;OpaqueBytes&gt;? = this.issuerRef, status: Vault.StateStatus = this.status, contractStateTypes: Set&lt;Class&lt;out ContractState&gt;&gt;? = this.contractStateTypes )</ID>
     <ID>LongParameterList:QueryCriteria.kt$QueryCriteria.FungibleAssetQueryCriteria$( participants: List&lt;AbstractParty&gt;? = this.participants, owner: List&lt;AbstractParty&gt;? = this.owner, quantity: ColumnPredicate&lt;Long&gt;? = this.quantity, issuer: List&lt;AbstractParty&gt;? = this.issuer, issuerRef: List&lt;OpaqueBytes&gt;? = this.issuerRef, status: Vault.StateStatus = this.status, contractStateTypes: Set&lt;Class&lt;out ContractState&gt;&gt;? = this.contractStateTypes, relevancyStatus: Vault.RelevancyStatus = this.relevancyStatus )</ID>
     <ID>LongParameterList:QueryCriteria.kt$QueryCriteria.LinearStateQueryCriteria$( participants: List&lt;AbstractParty&gt;? = this.participants, uuid: List&lt;UUID&gt;? = this.uuid, externalId: List&lt;String&gt;? = this.externalId, status: Vault.StateStatus = this.status, contractStateTypes: Set&lt;Class&lt;out ContractState&gt;&gt;? = this.contractStateTypes, relevancyStatus: Vault.RelevancyStatus = this.relevancyStatus )</ID>
@@ -1233,6 +1234,7 @@
     <ID>MatchingDeclarationName:IRSDemo.kt$net.corda.irs.web.demo.IRSDemo.kt</ID>
     <ID>MatchingDeclarationName:InterestSwapRestAPI.kt$net.corda.irs.web.api.InterestSwapRestAPI.kt</ID>
     <ID>MatchingDeclarationName:InternalAccessTestHelpers.kt$net.corda.serialization.internal.InternalAccessTestHelpers.kt</ID>
+    <ID>MatchingDeclarationName:InternalTestUtils.kt$net.corda.testing.node.internal.InternalTestUtils.kt</ID>
     <ID>MatchingDeclarationName:IrsDemoClientApi.kt$net.corda.irs.web.demo.IrsDemoClientApi.kt</ID>
     <ID>MatchingDeclarationName:KeyStoreConfigHelpers.kt$net.corda.nodeapi.internal.KeyStoreConfigHelpers.kt</ID>
     <ID>MatchingDeclarationName:Main.kt$net.corda.bootstrapper.Main.kt</ID>
@@ -2114,11 +2116,8 @@
     <ID>MaxLineLength:FlowMessaging.kt$FlowMessagingImpl$val mightDeadlockDrainingTarget = FlowStateMachineImpl.currentStateMachine()?.context?.origin.let { it is InvocationOrigin.Peer &amp;&amp; it.party == target.name }</ID>
     <ID>MaxLineLength:FlowMessaging.kt$FlowMessagingImpl$val networkMessage = serviceHub.networkService.createMessage(sessionTopic, serializeSessionMessage(message).bytes, deduplicationId, message.additionalHeaders(party))</ID>
     <ID>MaxLineLength:FlowMessaging.kt$FlowMessagingImpl${ // Handling Kryo and AMQP serialization problems. Unfortunately the two exception types do not share much of a common exception interface. if ((exception is KryoException || exception is NotSerializableException) &amp;&amp; message is ExistingSessionMessage &amp;&amp; message.payload is ErrorSessionMessage) { val error = message.payload.flowException val rewrappedError = FlowException(error?.message) message.copy(payload = message.payload.copy(flowException = rewrappedError)).serialize() } else { throw exception } }</ID>
-    <ID>MaxLineLength:FlowMonitor.kt$FlowMonitor$is FlowIORequest.ExecuteAsyncOperation -&gt; "for asynchronous operation of type ${request.operation::javaClass} to complete"</ID>
     <ID>MaxLineLength:FlowMonitor.kt$FlowMonitor$is FlowIORequest.SendAndReceive -&gt; "to send and receive messages from parties ${request.sessionToMessage.keys.partiesInvolved()}"</ID>
     <ID>MaxLineLength:FlowMonitor.kt$FlowMonitor$is FlowIORequest.Sleep -&gt; "to wake up from sleep ending at ${LocalDateTime.ofInstant(request.wakeUpAfter, ZoneId.systemDefault())}"</ID>
-    <ID>MaxLineLength:FlowMonitor.kt$FlowMonitor$scheduler!!.scheduleAtFixedRate({ logFlowsWaitingForParty(suspensionLoggingThreshold) }, 0, monitoringPeriod.toMillis(), TimeUnit.MILLISECONDS)</ID>
-    <ID>MaxLineLength:FlowMonitor.kt$FlowMonitor$val message = StringBuilder("Flow with id ${flow.id.uuid} has been waiting for ${flow.ongoingDuration(now).toMillis() / 1000} seconds ")</ID>
     <ID>MaxLineLength:FlowRetryTest.kt$FlowRetryTest$it.proxy.startFlow(::InitiatorFlow, numSessions, numIterations, nodeBHandle.nodeInfo.singleIdentity()).returnValue.getOrThrow()</ID>
     <ID>MaxLineLength:FlowSessionImpl.kt$FlowSessionImpl$@Suspendable override</ID>
     <ID>MaxLineLength:FlowStackSnapshot.kt$FlowStackSnapshotFactoryImpl$private</ID>
@@ -2295,6 +2294,7 @@
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration : RunAfterNodeInitialisationNodeStartupLogging</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration$println("Node was started before with `--initial-registration`, but the registration was not completed.\nResuming registration.")</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration$println("Successfully registered Corda node with compatibility zone, node identity keys and certificates are stored in '${conf.certificatesDirectory}', it is advised to backup the private keys and certificates.")</ID>
+    <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistration${ // Null checks for [compatibilityZoneURL], [rootTruststorePath] and [rootTruststorePassword] has been done in [CmdLineOptions.loadConfig] attempt { registerWithNetwork(config) }.doOnFailure(Consumer(this::handleRegistrationError)) as Try.Success // At this point the node registration was successful. We can delete the marker file. deleteNodeRegistrationMarker(baseDirectory) }</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistrationCli : CliWrapperBase</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistrationCli$@Option(names = ["-p", "--network-root-truststore-password"], description = ["Network root trust store password obtained from network operator."], required = true)</ID>
     <ID>MaxLineLength:InitialRegistrationCli.kt$InitialRegistrationCli$return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, startup))</ID>
@@ -2723,6 +2723,7 @@
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$error is java.nio.file.AccessDeniedException -&gt; error.logAsExpected("Exception during node startup. Corda started with insufficient privileges to access ${error.file}")</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$error is java.nio.file.NoSuchFileException -&gt; error.logAsExpected("Exception during node startup. Corda cannot find file ${error.file}")</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$error.isOpenJdkKnownIssue() -&gt; error.logAsExpected("Exception during node startup - ${error.message}. This is a known OpenJDK issue on some Linux distributions, please use OpenJDK from zulu.org or Oracle JDK.")</ID>
+    <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging$fun Throwable.logAsUnexpected(message: String? = this.message, error: Throwable = this, print: (String?, Throwable) -&gt; Unit = logger::error)</ID>
     <ID>MaxLineLength:NodeStartup.kt$NodeStartupLogging.Companion$val startupErrors = setOf(MultipleCordappsForFlowException::class, CheckpointIncompatibleException::class, AddressBindingException::class, NetworkParametersReader::class, DatabaseIncompatibleException::class)</ID>
     <ID>MaxLineLength:NodeStatePersistenceTests.kt$NodeStatePersistenceTests$val nodeHandle = startNode(providedName = nodeName, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to "false")).getOrThrow()</ID>
     <ID>MaxLineLength:NodeTabView.kt$NodeTabView$CityDatabase.cityMap.values.map { it.countryCode }.toSet().map { it to Image(resources["/net/corda/demobench/flags/$it.png"]) }.toMap()</ID>
@@ -3806,6 +3807,7 @@
     <ID>SpreadOperator:DemoBench.kt$DemoBench.Companion$(DemoBench::class.java, *args)</ID>
     <ID>SpreadOperator:DevCertificatesTest.kt$DevCertificatesTest$(*oldX509Certificates)</ID>
     <ID>SpreadOperator:DockerInstantiator.kt$DockerInstantiator$(*it.toTypedArray())</ID>
+    <ID>SpreadOperator:DriverDSLImpl.kt$DriverDSLImpl$( config, quasarJarPath, debugPort, bytemanJarPath, null, systemProperties, "512m", null, *extraCmdLineFlag )</ID>
     <ID>SpreadOperator:DummyContract.kt$DummyContract.Companion$( /* INPUTS */ *priors.toTypedArray(), /* COMMAND */ Command(cmd, priorState.owner.owningKey), /* OUTPUT */ StateAndContract(state, PROGRAM_ID) )</ID>
     <ID>SpreadOperator:DummyContract.kt$DummyContract.Companion$(*items)</ID>
     <ID>SpreadOperator:DummyContractV2.kt$DummyContractV2.Companion$( /* INPUTS */ *priors.toTypedArray(), /* COMMAND */ Command(cmd, priorState.owners.map { it.owningKey }), /* OUTPUT */ StateAndContract(state, DummyContractV2.PROGRAM_ID) )</ID>
@@ -4559,6 +4561,8 @@
     <ID>WildcardImport:DoRemainingWorkTransition.kt$import net.corda.node.services.statemachine.*</ID>
     <ID>WildcardImport:DockerInstantiator.kt$import com.github.dockerjava.api.model.*</ID>
     <ID>WildcardImport:DriverDSLImpl.kt$import net.corda.testing.driver.*</ID>
+    <ID>WildcardImport:DriverTests.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:DriverTests.kt$import org.assertj.core.api.Assertions.*</ID>
     <ID>WildcardImport:DummyContract.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:DummyContractV2.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:DummyContractV3.kt$import net.corda.core.contracts.*</ID>

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -500,21 +500,16 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             smm.start(frozenTokenizableServices)
             // Shut down the SMM so no Fibers are scheduled.
             runOnStop += { smm.stop(acceptableLiveFiberCountOnStop()) }
-            (smm as? StateMachineManagerInternal)?.let {
-                val flowMonitor = FlowMonitor({
-                    smm.snapshot().filter { flow -> flow !in smm.flowHospital }.toSet()
-                }, configuration.flowMonitorPeriodMillis, configuration.flowMonitorSuspensionLoggingThresholdMillis)
-                runOnStop += flowMonitor::stop
-                flowMonitor.start()
-            }
-
+            val flowMonitor = FlowMonitor(smm,
+                    configuration.flowMonitorPeriodMillis,
+                    configuration.flowMonitorSuspensionLoggingThresholdMillis)
+            runOnStop += flowMonitor::stop
+            flowMonitor.start()
             schedulerService.start()
 
             createStartedNode(nodeInfo, rpcOps, notaryService).also { _started = it }
         }
     }
-
-    private operator fun StaffedFlowHospital.contains(flow: FlowStateMachine<*>) = contains(flow.id)
 
     /** Subclasses must override this to create a "started" node of the desired type, using the provided machinery. */
     abstract fun createStartedNode(nodeInfo: NodeInfo, rpcOps: CordaRPCOps, notaryService: NotaryService?): S

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -500,9 +500,11 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             smm.start(frozenTokenizableServices)
             // Shut down the SMM so no Fibers are scheduled.
             runOnStop += { smm.stop(acceptableLiveFiberCountOnStop()) }
-            val flowMonitor = FlowMonitor(smm,
-                    configuration.flowMonitorPeriodMillis,
-                    configuration.flowMonitorSuspensionLoggingThresholdMillis)
+            val flowMonitor = FlowMonitor(
+                smm,
+                configuration.flowMonitorPeriodMillis,
+                configuration.flowMonitorSuspensionLoggingThresholdMillis
+            )
             runOnStop += flowMonitor::stop
             flowMonitor.start()
             schedulerService.start()

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
@@ -184,7 +184,7 @@ class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private
                 flowCallStackSummary = flowCallStack.toSummary(),
                 flowCallStack = flowCallStack,
                 suspendedOn = (flowState as? FlowState.Started)?.flowIORequest?.toSuspendedOn(
-                        suspendedTimestamp(),
+                        timestamp,
                         now
                 ),
                 origin = invocationContext.origin.toOrigin(),
@@ -193,8 +193,6 @@ class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private
                 errored = errorState as? ErrorState.Errored
         )
     }
-
-    private fun Checkpoint.suspendedTimestamp(): Instant = invocationContext.trace.invocationId.timestamp
 
     private fun checkpointDeserializationErrorMessage(
             checkpointId: StateMachineRunId,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -791,7 +791,10 @@ class SingleThreadedStateMachineManager(
             is FlowState.Started -> {
                 val fiber = tryCheckpointDeserialize(flowState.frozenFiber, id) ?: return null
                 val state = StateMachineState(
-                        checkpoint = checkpoint,
+                        // Do a trivial checkpoint copy below, to update the Checkpoint#timestamp value. This is for FlowMonitor.
+                        // We need to refresh the suspension starting time of a to be re-executed from checkpoint flow.
+                        // This applies in case of an e.g. Node startUp after a long period, and for 'Started' flows only (Please check FlowMonitor's flow logging criteria).
+                        checkpoint = checkpoint.copy(),
                         pendingDeduplicationHandlers = initialDeduplicationHandler?.let { listOf(it) } ?: emptyList(),
                         isFlowResumed = false,
                         isTransactionTracked = false,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -10,6 +10,7 @@ import net.corda.core.internal.FlowIORequest
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.utilities.Try
 import net.corda.node.services.messaging.DeduplicationHandler
+import java.time.Instant
 
 /**
  * The state of the state machine, capturing the state of a flow. It consists of two parts, an *immutable* part that is
@@ -62,6 +63,9 @@ data class Checkpoint(
         val errorState: ErrorState,
         val numberOfSuspends: Int
 ) {
+
+    val timestamp: Instant = Instant.now()
+
     companion object {
 
         fun create(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -64,7 +64,7 @@ data class Checkpoint(
         val numberOfSuspends: Int
 ) {
 
-    val timestamp: Instant = Instant.now()
+    val timestamp: Instant = Instant.now() // This will get updated every time a Checkpoint object is created/ created by copy.
 
     companion object {
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -46,11 +46,14 @@ import org.junit.Before
 import org.junit.Test
 import rx.Notification
 import rx.Observable
+import java.time.Duration
 import java.time.Instant
 import java.util.*
 import java.util.function.Predicate
 import kotlin.reflect.KClass
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class FlowFrameworkTests {
     companion object {
@@ -156,6 +159,54 @@ class FlowFrameworkTests {
         assertThatExceptionOfType(UnexpectedFlowEndException::class.java).isThrownBy {
             resultFuture.getOrThrow()
         }
+    }
+
+    @Test
+    fun `FlowMonitor flow suspends on a FlowIORequest`() { // alice flow only, suspends on a FlowIORequest
+        monitorFlows { aliceFlowMonitor, bobFlowMonitor ->
+            val terminationSignal = Semaphore(0)
+            // bob's flow need to wait otherwise it could end the session prematurely
+            bobNode.registerCordappFlowFactory(ReceiveFlow::class) { NoOpFlow( terminateUponSignal = terminationSignal) }
+            aliceNode.services.startFlow(ReceiveFlow(bob))
+            mockNet.runNetwork()
+            assertEquals(1, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            assertEquals(0, bobFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            // continue bob's NoOpFlow, it will send an EndSessionMessage to alice
+            terminationSignal.release()
+            mockNet.runNetwork()
+            // alice's ReceiveFlow is not finished because bob sent an EndSessionMessage, check that flow is no longer waiting
+            assertEquals(0, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+        }
+    }
+
+    @Test
+    fun `FlowMonitor flows suspend on a FlowIORequest`() { // alice and bob's flows, both suspend on a FlowIORequest
+        monitorFlows { aliceFlowMonitor, bobFlowMonitor ->
+            bobNode.registerCordappFlowFactory(ReceiveFlow::class) { InitiatedReceiveFlow(it) }
+            aliceNode.services.startFlow(ReceiveFlow(bob)) // infinite recursion, needs to be stopped at some point
+            mockNet.runNetwork()
+            // both flows are suspened on a receive from the counter party
+            assertEquals(1, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            assertEquals(1, bobFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+        }
+    }
+
+    @Test
+    fun `FlowMonitor flow is running`() { // flow is running a "take a long time" task
+        monitorFlows { aliceFlowMonitor, _ ->
+            val terminationSignal = Semaphore(0)
+            // "take a long time" task, implemented by a NoOpFlow stuck in call method
+            aliceNode.services.startFlow(NoOpFlow( terminateUponSignal = terminationSignal))
+            mockNet.waitQuiescent() // current thread needs to wait fiber running on a different thread, has reached the blocking point
+            assertEquals(0, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            // "take a long time" flow continues ...
+            terminationSignal.release()
+            assertEquals(0, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+        }
+    }
+
+    private fun monitorFlows(script: (FlowMonitor, FlowMonitor) -> Unit) {
+        script(FlowMonitor(aliceNode.smm, Duration.ZERO, Duration.ZERO), FlowMonitor(bobNode.smm, Duration.ZERO, Duration.ZERO))
     }
 
     @Test
@@ -709,7 +760,10 @@ internal open class SendFlow(private val payload: Any, private vararg val otherP
     }
 }
 
-internal class NoOpFlow(val nonTerminating: Boolean = false) : FlowLogic<Unit>() {
+internal class NoOpFlow(
+        val nonTerminating: Boolean = false,
+        @Transient val terminateUponSignal: Semaphore? = null
+) : FlowLogic<Unit>() {
     @Transient
     var flowStarted = false
 
@@ -719,6 +773,8 @@ internal class NoOpFlow(val nonTerminating: Boolean = false) : FlowLogic<Unit>()
         if (nonTerminating) {
             Fiber.park()
         }
+
+        terminateUponSignal?.acquire() // block at Semaphore and resume upon external signaling
     }
 }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -53,7 +53,6 @@ import java.util.function.Predicate
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 
 class FlowFrameworkTests {
     companion object {
@@ -169,13 +168,13 @@ class FlowFrameworkTests {
             bobNode.registerCordappFlowFactory(ReceiveFlow::class) { NoOpFlow( terminateUponSignal = terminationSignal) }
             aliceNode.services.startFlow(ReceiveFlow(bob))
             mockNet.runNetwork()
-            assertEquals(1, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
-            assertEquals(0, bobFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            assertEquals(1, aliceFlowMonitor.waitingFlowDurations(Duration.ZERO).toSet().size)
+            assertEquals(0, bobFlowMonitor.waitingFlowDurations(Duration.ZERO).toSet().size)
             // continue bob's NoOpFlow, it will send an EndSessionMessage to alice
             terminationSignal.release()
             mockNet.runNetwork()
             // alice's ReceiveFlow is not finished because bob sent an EndSessionMessage, check that flow is no longer waiting
-            assertEquals(0, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            assertEquals(0, aliceFlowMonitor.waitingFlowDurations(Duration.ZERO).toSet().size)
         }
     }
 
@@ -186,8 +185,8 @@ class FlowFrameworkTests {
             aliceNode.services.startFlow(ReceiveFlow(bob))
             mockNet.runNetwork()
             // both flows are suspened on a receive from the counter party
-            assertEquals(1, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
-            assertEquals(1, bobFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            assertEquals(1, aliceFlowMonitor.waitingFlowDurations(Duration.ZERO).toSet().size)
+            assertEquals(1, bobFlowMonitor.waitingFlowDurations(Duration.ZERO).toSet().size)
         }
     }
 
@@ -198,10 +197,10 @@ class FlowFrameworkTests {
             // "take a long time" task, implemented by a NoOpFlow stuck in call method
             aliceNode.services.startFlow(NoOpFlow( terminateUponSignal = terminationSignal))
             mockNet.waitQuiescent() // current thread needs to wait fiber running on a different thread, has reached the blocking point
-            assertEquals(0, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            assertEquals(0, aliceFlowMonitor.waitingFlowDurations(Duration.ZERO).toSet().size)
             // "take a long time" flow continues ...
             terminationSignal.release()
-            assertEquals(0, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)
+            assertEquals(0, aliceFlowMonitor.waitingFlowDurations(Duration.ZERO).toSet().size)
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -183,7 +183,7 @@ class FlowFrameworkTests {
     fun `FlowMonitor flows suspend on a FlowIORequest`() { // alice and bob's flows, both suspend on a FlowIORequest
         monitorFlows { aliceFlowMonitor, bobFlowMonitor ->
             bobNode.registerCordappFlowFactory(ReceiveFlow::class) { InitiatedReceiveFlow(it) }
-            aliceNode.services.startFlow(ReceiveFlow(bob)) // infinite recursion, needs to be stopped at some point
+            aliceNode.services.startFlow(ReceiveFlow(bob))
             mockNet.runNetwork()
             // both flows are suspened on a receive from the counter party
             assertEquals(1, aliceFlowMonitor.waitingFlowsToDurations(Duration.ZERO).size)


### PR DESCRIPTION
FlowMonitor would consider as starting time of a "waiting" flow  (suspended flow), the time of its initial creation. That way, it would for e.g. log as "waiting" a flow that could be actually running at that moment and its execution time exceeded the FlowMonitor#suspensionLoggingThreshold.

What we would want instead is the flow to somehow update its current execution time, and therefore FlowMonitor to actually start counting always from that updated time. 

To achieve this, we added a timestamp property to Checkpoint getting a new Instant.now() value at every Checkpoint instantiation/ instantiation by copy. FlowMonitor is now using this new property (Checkpoint#timestamp) as the starting point of a potential suspension. 

That alone though would not be enough, because we could for e.g. have a checkpoint before some long taking task and that could be mistakenly considered by FlowMonitor a suspension period while its not, the flow is still running. 

To overcome the above, FlowMonitor additionally, uses StateMachineState#isFlowResumed to determine if a flow is actually suspended, e.g. waiting for counter parties messages. It leaves out flows that are actually running.