### PR TITLE
TM-81 Do not write out the callstack when we cannot find tests.csv

### DIFF
--- a/buildSrc/src/main/groovy/net/corda/testing/Artifactory.java
+++ b/buildSrc/src/main/groovy/net/corda/testing/Artifactory.java
@@ -82,7 +82,8 @@ public class Artifactory {
                 LOG.warn("Response body was empty");
             }
         } catch (IOException e) {
-            LOG.warn("Unable to execute GET via REST: ", e);
+            LOG.warn("Unable to execute GET via REST");
+            LOG.debug("Exception", e);
             return false;
         }
 


### PR DESCRIPTION
The first run of any new branch will not find a corresponding tests.csv
and will return 404 not found which is fine.  We do not need to display
the callstack at warning level.

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
