### PR TITLE
CORDA-2876: Add explicit Kotlin dependencies to DJVM serialization modules.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -10,7 +10,7 @@ java8MinUpdateVersion=171
 # When incrementing platformVersion make sure to update          #
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #
 # ***************************************************************#
-platformVersion=5
+platformVersion=6
 guavaVersion=28.0-jre
 # Quasar version to use with Java 8:
 quasarVersion=0.7.12_r3

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -30,13 +30,13 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     api "javax.persistence:javax.persistence-api:2.2"
     api "com.google.code.findbugs:jsr305:$jsr305_version"
+    api "org.slf4j:slf4j-api:$slf4j_version"
 
     // These dependencies will become "runtime" scoped in our published POM.
     // See publish.dependenciesFrom.defaultScope.
     deterministicLibraries "org.bouncycastle:bcprov-jdk15on:$bouncycastle_version"
     deterministicLibraries "org.bouncycastle:bcpkix-jdk15on:$bouncycastle_version"
     deterministicLibraries "net.i2p.crypto:eddsa:$eddsa_version"
-    deterministicLibraries "org.slf4j:slf4j-api:$slf4j_version"
 }
 
 jar {

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -25,7 +25,7 @@ import java.util.jar.JarInputStream
 
 // *Internal* Corda-specific utilities.
 
-const val PLATFORM_VERSION = 5
+const val PLATFORM_VERSION = 6
 
 fun ServicesForResolution.ensureMinimumPlatformVersion(requiredMinPlatformVersion: Int, feature: String) {
     checkMinimumPlatformVersion(networkParameters.minimumPlatformVersion, requiredMinPlatformVersion, feature)

--- a/serialization-djvm/build.gradle
+++ b/serialization-djvm/build.gradle
@@ -20,6 +20,8 @@ dependencies {
     api project(':core')
     api project(':serialization')
     api "net.corda.djvm:corda-djvm:$djvm_version"
+    api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation(project(':serialization-djvm:deserializers')) {
         transitive = false
     }

--- a/serialization-djvm/deserializers/build.gradle
+++ b/serialization-djvm/deserializers/build.gradle
@@ -12,6 +12,7 @@ description 'Deserializers for the DJVM'
 dependencies {
     api project(path: ':core-deterministic', configuration: 'deterministicArtifacts')
     api project(path: ':serialization-deterministic', configuration: 'deterministicArtifacts')
+    api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {


### PR DESCRIPTION
Kotlin is _required_ here, so make these dependencies explicit.

Also ensure that `slf4j-api` is published at `compile` scope for `corda-core-deterministic` because there will only ever be _one_ version of this API in the system and it _must_ be on the compilation classpath.

And increase the Corda platform number to **6**, for DJVM support.