### PR TITLE
CORDA-3396 fixed blob inspector npe

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -252,7 +252,7 @@ object JacksonSupport {
                 writeObjectField("issuerUniqueID", value.issuerUniqueID)
                 writeObjectField("subjectUniqueID", value.subjectUniqueID)
                 writeObjectField("keyUsage", value.keyUsage?.asList()?.mapIndexedNotNull { i, flag -> if (flag) keyUsages[i] else null })
-                writeObjectField("extendedKeyUsage", value.extendedKeyUsage.map { keyPurposeIds[it] ?: it })
+                writeObjectField("extendedKeyUsage", value.extendedKeyUsage?.map { keyPurposeIds[it] ?: it })
                 jsonObject("basicConstraints") {
                     val isCa = value.basicConstraints != -1
                     writeBooleanField("isCA", isCa)

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -8,10 +8,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.convertValue
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.*
 import net.corda.client.jackson.internal.childrenAs
 import net.corda.client.jackson.internal.valueAs
 import net.corda.core.contracts.*
@@ -636,6 +633,14 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         assertThat(json["notAfter"].valueAs<Date>(mapper)).isEqualTo(cert.notAfter)
         assertThat(json["notBefore"].valueAs<Date>(mapper)).isEqualTo(cert.notBefore)
         assertThat(json["encoded"].binaryValue()).isEqualTo(cert.encoded)
+    }
+
+    @Test
+    fun `X509Certificate serialization when extendedKeyUsage is null`() {
+        val cert: X509Certificate = spy(MINI_CORP.identity.certificate)
+        whenever(cert.extendedKeyUsage).thenReturn(null)
+        // should work even if extendedKeyUsage is null
+        mapper.valueToTree<ObjectNode>(cert)
     }
 
     @Test

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -8,7 +8,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.convertValue
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
 import net.corda.client.jackson.internal.childrenAs
 import net.corda.client.jackson.internal.valueAs
 import net.corda.core.contracts.*

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -12,6 +12,7 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.spy
 import net.corda.client.jackson.internal.childrenAs
 import net.corda.client.jackson.internal.valueAs
 import net.corda.core.contracts.*

--- a/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/BlobInspector.kt
+++ b/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/BlobInspector.kt
@@ -79,6 +79,11 @@ class BlobInspector : CordaCliWrapper("blob-inspector", "Convert AMQP serialised
             mapper.writeValue(out, deserialized)
             ExitCodes.SUCCESS
         } catch (e: Exception) {
+            print("Unexpected exception: ${e.message}")
+            if (verbose) {
+                println()
+                e.printStackTrace(System.out)
+            }
             ExitCodes.FAILURE
         } finally {
             _contextSerializationEnv.set(null)


### PR DESCRIPTION
1. Fixed NPE due to extendedKeyUsage being null
2. BlobInspector now prints message if error happens with optional stacktrace