### PR TITLE
[NOTICK] Quick and dirty change to stop "Unable to start notaries." error message

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -441,6 +441,7 @@ interface NodeStartupLogging {
     companion object {
         val logger by lazy { contextLogger() }
         val startupErrors = setOf(MultipleCordappsForFlowException::class, CheckpointIncompatibleException::class, AddressBindingException::class, NetworkParametersReader::class, DatabaseIncompatibleException::class)
+        @Suppress("TooGenericExceptionCaught")
         val PRINT_ERRORS_TO_STD_ERR = try {
             System.getProperty("net.corda.node.printErrorsToStdErr") == "true"
         } catch (e: NullPointerException) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -557,6 +557,7 @@ class DriverDSLImpl(
      * Start the node with the given flag which is expected to start the node for some function, which once complete will
      * terminate the node.
      */
+    @Suppress("SpreadOperator")
     private fun startOutOfProcessMiniNode(config: NodeConfig, vararg extraCmdLineFlag: String): CordaFuture<Unit> {
         val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
         val process = startOutOfProcessNode(
@@ -774,7 +775,7 @@ class DriverDSLImpl(
             }
         }
 
-        @Suppress("ComplexMethod", "MaxLineLength")
+        @Suppress("ComplexMethod", "MaxLineLength", "LongParameterList")
         private fun startOutOfProcessNode(
             config: NodeConfig,
             quasarJarPath: String,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -58,12 +58,12 @@ import rx.schedulers.Schedulers
 import java.io.File
 import java.net.ConnectException
 import java.net.URL
-import java.net.URLClassLoader
 import java.nio.file.Path
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.Executors
@@ -377,6 +377,13 @@ class DriverDSLImpl(
         }
         try {
             _notaries.map { notary -> notary.map { handle -> handle.nodeHandles } }.getOrThrow(notaryHandleTimeout).forEach { future -> future.getOrThrow(notaryHandleTimeout) }
+        } catch(e: NodeListenProcessDeathException) {
+            val message = if (e.causeFromStdError.isNotBlank()) {
+                "Unable to start notaries. Failed with the following error: ${e.causeFromStdError}"
+            } else {
+                "Unable to start notaries. A required port might be bound already."
+            }
+            throw IllegalStateException(message)
         } catch (e: ListenProcessDeathException) {
             throw IllegalStateException("Unable to start notaries. A required port might be bound already.", e)
         } catch (e: TimeoutException) {
@@ -553,15 +560,16 @@ class DriverDSLImpl(
     private fun startOutOfProcessMiniNode(config: NodeConfig, vararg extraCmdLineFlag: String): CordaFuture<Unit> {
         val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
         val process = startOutOfProcessNode(
-                config,
-                quasarJarPath,
-                debugPort,
-                bytemanJarPath,
-                null,
-                systemProperties,
-                "512m",
-                null,
-                *extraCmdLineFlag
+            config,
+            quasarJarPath,
+            debugPort,
+            bytemanJarPath,
+            null,
+            systemProperties,
+            "512m",
+            null,
+            ZonedDateTime.now().format(DateTimeFormatter.ofPattern("HHmmss.SSS")),
+            *extraCmdLineFlag
         )
 
         return poll(executorService, "$extraCmdLineFlag (${config.corda.myLegalName})") {
@@ -577,6 +585,7 @@ class DriverDSLImpl(
                                   bytemanPort: Int?): CordaFuture<NodeHandle> {
         val visibilityHandle = networkVisibilityController.register(config.corda.myLegalName)
         val baseDirectory = config.corda.baseDirectory.createDirectories()
+        val identifier = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("HHmmss.SSS"))
         localNetworkMap?.networkParametersCopier?.install(baseDirectory)
         localNetworkMap?.nodeInfosCopier?.addConfig(baseDirectory)
 
@@ -621,14 +630,15 @@ class DriverDSLImpl(
         } else {
             val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
             val process = startOutOfProcessNode(
-                    config,
-                    quasarJarPath,
-                    debugPort,
-                    bytemanJarPath,
-                    bytemanPort,
-                    systemProperties,
-                    parameters.maximumHeapSize,
-                    parameters.logLevelOverride
+                config,
+                quasarJarPath,
+                debugPort,
+                bytemanJarPath,
+                bytemanPort,
+                systemProperties,
+                parameters.maximumHeapSize,
+                parameters.logLevelOverride,
+                identifier
             )
 
             // Destroy the child process when the parent exits.This is needed even when `waitForAllNodesToFinish` is
@@ -646,7 +656,18 @@ class DriverDSLImpl(
                 }
             }
             val effectiveP2PAddress = config.corda.messagingServerAddress ?: config.corda.p2pAddress
-            val p2pReadyFuture = addressMustBeBoundFuture(executorService, effectiveP2PAddress, process)
+            val p2pReadyFuture = nodeMustBeStartedFuture(
+                executorService,
+                effectiveP2PAddress,
+                process
+            ) {
+                NodeListenProcessDeathException(
+                    effectiveP2PAddress,
+                    process,
+                    (config.corda.baseDirectory / "net.corda.node.Corda.$identifier.stderr.log").readText()
+                )
+            }
+
             p2pReadyFuture.flatMap {
                 val processDeathFuture = poll(executorService, "process death while waiting for RPC (${config.corda.myLegalName})") {
                     if (process.isAlive) null else process
@@ -755,15 +776,16 @@ class DriverDSLImpl(
 
         @Suppress("ComplexMethod", "MaxLineLength")
         private fun startOutOfProcessNode(
-                config: NodeConfig,
-                quasarJarPath: String,
-                debugPort: Int?,
-                bytemanJarPath: String?,
-                bytemanPort: Int?,
-                overriddenSystemProperties: Map<String, String>,
-                maximumHeapSize: String,
-                logLevelOverride: String?,
-                vararg extraCmdLineFlag: String
+            config: NodeConfig,
+            quasarJarPath: String,
+            debugPort: Int?,
+            bytemanJarPath: String?,
+            bytemanPort: Int?,
+            overriddenSystemProperties: Map<String, String>,
+            maximumHeapSize: String,
+            logLevelOverride: String?,
+            identifier: String,
+            vararg extraCmdLineFlag: String
         ): Process {
             log.info("Starting out-of-process Node ${config.corda.myLegalName.organisation}, " +
                     "debug port is " + (debugPort ?: "not enabled") + ", " +
@@ -832,13 +854,14 @@ class DriverDSLImpl(
             }
 
             return ProcessUtilities.startJavaProcess(
-                    className = "net.corda.node.Corda", // cannot directly get class for this, so just use string
-                    arguments = arguments,
-                    jdwpPort = debugPort,
-                    extraJvmArguments = extraJvmArguments + bytemanJvmArgs,
-                    workingDirectory = config.corda.baseDirectory,
-                    maximumHeapSize = maximumHeapSize,
-                    classPath = cp
+                className = "net.corda.node.Corda", // cannot directly get class for this, so just use string
+                arguments = arguments,
+                jdwpPort = debugPort,
+                extraJvmArguments = extraJvmArguments + bytemanJvmArgs + "-Dnet.corda.node.printErrorsToStdErr=true",
+                workingDirectory = config.corda.baseDirectory,
+                maximumHeapSize = maximumHeapSize,
+                classPath = cp,
+                identifier = identifier
             )
         }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
@@ -3,8 +3,6 @@ package net.corda.testing.node.internal
 import net.corda.core.internal.div
 import java.io.File
 import java.nio.file.Path
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
 object ProcessUtilities {
     inline fun <reified C : Any> startJavaProcess(
@@ -25,7 +23,8 @@ object ProcessUtilities {
             workingDirectory: Path? = null,
             jdwpPort: Int? = null,
             extraJvmArguments: List<String> = emptyList(),
-            maximumHeapSize: String? = null
+            maximumHeapSize: String? = null,
+            identifier: String = ""
     ): Process {
         val command = mutableListOf<String>().apply {
             add(javaPath)
@@ -40,11 +39,10 @@ object ProcessUtilities {
             inheritIO()
             environment()["CLASSPATH"] = classPath.joinToString(File.pathSeparator)
             if (workingDirectory != null) {
-                // Timestamp may be handy if the same process started, killed and then re-started. Without timestamp
-                // StdOut and StdErr will be overwritten.
-                val timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("HHmmss.SSS"))
-                redirectError((workingDirectory / "$className.$timestamp.stderr.log").toFile())
-                redirectOutput((workingDirectory / "$className.$timestamp.stdout.log").toFile())
+                // An identifier may be handy if the same process started, killed and then re-started. Without the identifier
+                // StdOut and StdErr will be overwritten. By default the identifier is a timestamp passed down to here.
+                redirectError((workingDirectory / "$className.$identifier.stderr.log").toFile())
+                redirectOutput((workingDirectory / "$className.$identifier.stdout.log").toFile())
                 directory(workingDirectory.toFile())
             }
         }.start()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
@@ -16,6 +16,7 @@ object ProcessUtilities {
         return startJavaProcess(C::class.java.name, arguments, classPath, workingDirectory, jdwpPort, extraJvmArguments, maximumHeapSize)
     }
 
+    @Suppress("LongParameterList")
     fun startJavaProcess(
             className: String,
             arguments: List<String>,


### PR DESCRIPTION
"Unable to start notaries. A required port might be bound already" is
returned whenever a startup error occurs while starting the notary nodes
in driver tests. This hides the real error.

This change prints the actual error to std_err and read from file
at a later point. This means the real error is not lost and will be
shown in failed builds.