### PR TITLE
CORDA-3406: Modify DemoBench to make using the DJVM obvious and optional.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,6 +254,7 @@ allprojects {
 
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-Xlint:-options" << "-parameters"
+        options.compilerArgs << '-XDenableSunApiLintControl'
         if (warnings_as_errors) {
             // We cannot fail the build on compiler warnings because we have java warnings that you cannot disable:
             // Signal is internal proprietary API and may be removed in a future release

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -36,16 +36,13 @@ data class NodeConfig(
         /** Pass-through for generating node.conf with external DB */
         val dataSourceProperties: Properties? = null,
         val database: Properties? = null,
+        val systemProperties: Map<String, Any?>,
         private val devMode: Boolean = true,
         private val detectPublicIp: Boolean = false,
         private val useTestClock: Boolean = true
 ) {
     companion object {
         val renderOptions: ConfigRenderOptions = ConfigRenderOptions.defaults().setOriginComments(false)
-        val systemProperties: Map<String, Any> = mapOf(
-                "net.corda.djvm" to true,
-                "co.paralleluniverse.fibers.verifyInstrumentation" to false
-        )
         val defaultUser = user("guest")
         const val CORDAPP_DIR_NAME = "cordapps"
     }
@@ -143,6 +140,7 @@ fun String.toKey() = filter { !it.isWhitespace() }.toLowerCase()
 
 fun <T> valueFor(any: T): ConfigValue = ConfigValueFactory.fromAnyRef(any)
 
+@Suppress("unused")
 private fun Config.withOptionalValue(path: String, obj: ConfigObject): Config {
-    return if (obj.isEmpty()) this else this.withValue(path, obj)
+    return if (obj.isEmpty()) this else withValue(path, obj)
 }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeData.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeData.kt
@@ -28,7 +28,7 @@ object SuggestedDetails {
     private var cursor = 0
 
     fun nextBank(exists: (String) -> Boolean): Pair<String, String> {
-        for (i in 0 until banks.size) {
+        for (i in banks.indices) {
             val bank = banks[cursor]
             if (!exists(bank.first)) {
                 return bank

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -150,6 +150,11 @@ class NodeTabView : Fragment() {
                             val toggle = radiobutton(notaryType.toString(), notaryTypeToggleGroup, notaryType)
                             toggle.isSelected = index == 0
                         }
+
+                        separator()
+                        checkbox("Deterministic Contract Verification", nodeController.djvmEnabled).apply {
+                            styleClass += "djvm"
+                        }
                     }
                 }
             }

--- a/tools/demobench/src/main/resources/net/corda/demobench/style.css
+++ b/tools/demobench/src/main/resources/net/corda/demobench/style.css
@@ -52,6 +52,10 @@
     -fx-spacing: 5px;
 }
 
+.services-panel .separator {
+    -fx-padding: 15px;
+}
+
 .cordapps-panel {
     -fx-pref-width: 600px;
     -fx-spacing: 5px;

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -41,12 +41,9 @@ class NodeConfigTest {
                 .withFallback(ConfigFactory.parseMap(mapOf("devMode" to true)))
                 .resolve()
         val fullConfig = nodeConfig.parseAsNodeConfiguration().value()
-        val systemProperties = nodeConfig.getConfig("systemProperties").toProperties()
 
         // No custom configuration is created by default.
         assertFailsWith<ConfigException.Missing> { nodeConfig.getConfig("custom") }
-        assertEquals(true.toString(), systemProperties.getProperty("net.corda.djvm"))
-        assertEquals(false.toString(), systemProperties.getProperty("co.paralleluniverse.fibers.verifyInstrumentation"))
 
         assertEquals(myLegalName, fullConfig.myLegalName)
         assertEquals(localPort(40002), fullConfig.rpcOptions.address)
@@ -133,6 +130,7 @@ class NodeConfigTest {
         assertEquals("cordacadevpass", webConfig.keyStorePassword)
     }
 
+    @Suppress("LongParameterList")
     private fun createConfig(
             legalName: CordaX500Name = CordaX500Name(organisation = "Unknown", locality = "Nowhere", country = "GB"),
             p2pPort: Int = -1,
@@ -142,7 +140,8 @@ class NodeConfigTest {
             h2port: Int = -1,
             notary: NotaryService?,
             users: List<User> = listOf(user("guest")),
-            issuableCurrencies: List<String> = emptyList()
+            issuableCurrencies: List<String> = emptyList(),
+            systemProperties: Map<String, Any?> = emptyMap()
     ): NodeConfig {
         return NodeConfig(
                 myLegalName = legalName,
@@ -155,7 +154,8 @@ class NodeConfigTest {
                 h2port = h2port,
                 notary = notary,
                 rpcUsers = users,
-                issuableCurrencies = issuableCurrencies
+                issuableCurrencies = issuableCurrencies,
+                systemProperties = systemProperties
         )
     }
 


### PR DESCRIPTION
Add a checkbox to DemoBench's Notary configuration panel which controls whether or not _all_ nodes should activate the DJVM for deterministic contract verification.

There is also a command-line option `--djvm` which determines the checkbox's initial setting.

And I've tidied up a few compiler warnings too.