### PR TITLE
fix: warning when @NoConstraintPropagation used needs to use the correct classloader

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -295,7 +295,7 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
         for (contractClassName in (inputContractGroups.keys + outputContractGroups.keys)) {
 
             if (!contractClassName.contractHasAutomaticConstraintPropagation(transactionClassLoader)) {
-                contractClassName.warnContractWithoutConstraintPropagation()
+                contractClassName.warnContractWithoutConstraintPropagation(transactionClassLoader)
                 continue
             }
 


### PR DESCRIPTION
If a contract with `@NoConstraintPropagation` is detected, it will print a warning. But the warning function tries to load that contract to double-check again but .. is using the wrong classloader so it fails.

Then it confuses the function which checks if any dependencies need to be added to the transaction which ends up adding the same attachment twice and it just gets very confusing.