### PR TITLE
TM-10 - Parallelise DB Integration Tests (Postgres)

### DIFF
--- a/buildSrc/src/main/groovy/net/corda/testing/DistributedTesting.groovy
+++ b/buildSrc/src/main/groovy/net/corda/testing/DistributedTesting.groovy
@@ -117,6 +117,8 @@ class DistributedTesting implements Plugin<Project> {
                     podLogLevel = testGrouping.getLogLevel()
                     doFirst {
                         dockerTag = tagToUseForRunningTests ? (ImageBuilding.registryName + ":" + tagToUseForRunningTests) : (imagePushTask.imageName.get() + ":" + imagePushTask.tag.get())
+                        sidecarImage = testGrouping.sidecarImage
+                        additionalArgs = testGrouping.additionalArgs
                     }
                 }
                 def reportOnAllTask = project.rootProject.tasks.create("userDefinedReports${testGrouping.getName().capitalize()}", KubesReporting) {

--- a/buildSrc/src/main/groovy/net/corda/testing/KubesTest.java
+++ b/buildSrc/src/main/groovy/net/corda/testing/KubesTest.java
@@ -68,7 +68,9 @@ public class KubesTest extends DefaultTask {
     String dockerTag;
     String fullTaskToExecutePath;
     String taskToExecuteName;
+    String sidecarImage;
     Boolean printOutput = false;
+    List<String> additionalArgs;
 
     Integer numberOfCoresPerFork = 4;
     Integer memoryGbPerFork = 6;
@@ -226,7 +228,7 @@ public class KubesTest extends DefaultTask {
                         }
                     }
                     getProject().getLogger().lifecycle("creating pod: " + podName);
-                    createdPod = client.pods().inNamespace(namespace).create(buildPodRequest(podName, pvc));
+                    createdPod = client.pods().inNamespace(namespace).create(buildPodRequest(podName, pvc, sidecarImage != null));
                     getProject().getLogger().lifecycle("scheduled pod: " + podName);
                 }
 
@@ -282,20 +284,27 @@ public class KubesTest extends DefaultTask {
         String[] buildCommand = getBuildCommand(numberOfPods, podIdx);
         getProject().getLogger().quiet("About to execute " + Arrays.stream(buildCommand).reduce("", (s, s2) -> s + " " + s2) + " on pod " + podName);
         client.pods().inNamespace(namespace).withName(podName)
+                .inContainer(podName)
                 .writingOutput(stdOutOs)
                 .writingErrorChannel(errChannelStream)
                 .usingListener(execListener)
-                .exec(getBuildCommand(numberOfPods, podIdx));
+                .exec(buildCommand);
 
         return startLogPumping(stdOutIs, podIdx, podLogsDirectory, printOutput);
     }
 
-    private Pod buildPodRequest(String podName, PersistentVolumeClaim pvc) {
+    private Pod buildPodRequest(String podName, PersistentVolumeClaim pvc, boolean withDb) {
+        if (withDb) {
+            return buildPodRequestWithWorkerNodeAndDbContainer(podName, pvc);
+        } else {
+            return buildPodRequestWithOnlyWorkerNode(podName, pvc);
+        }
+    }
+
+    private Pod buildPodRequestWithOnlyWorkerNode(String podName, PersistentVolumeClaim pvc) {
         return new PodBuilder()
                 .withNewMetadata().withName(podName).endMetadata()
-
                 .withNewSpec()
-
                 .addNewVolume()
                 .withName("gradlecache")
                 .withNewHostPath()
@@ -322,18 +331,76 @@ public class KubesTest extends DefaultTask {
                 .withName(podName)
                 .withNewResources()
                 .addToRequests("cpu", new Quantity(numberOfCoresPerFork.toString()))
-                .addToRequests("memory", new Quantity(memoryGbPerFork.toString() + "Gi"))
+                .addToRequests("memory", new Quantity(memoryGbPerFork.toString()))
+                .endResources()
+                .addNewVolumeMount().withName("gradlecache").withMountPath("/tmp/gradle").endVolumeMount()
+                .addNewVolumeMount().withName("testruns").withMountPath(TEST_RUN_DIR).endVolumeMount()
+                .endContainer()
+                .addNewImagePullSecret(REGISTRY_CREDENTIALS_SECRET_NAME)
+                .withRestartPolicy("Never")
+                .endSpec()
+                .build();
+    }
+
+    private Pod buildPodRequestWithWorkerNodeAndDbContainer(String podName, PersistentVolumeClaim pvc) {
+        return new PodBuilder()
+                .withNewMetadata().withName(podName).endMetadata()
+                .withNewSpec()
+
+                .addNewVolume()
+                .withName("gradlecache")
+                .withNewHostPath()
+                .withType("DirectoryOrCreate")
+                .withPath("/tmp/gradle")
+                .endHostPath()
+                .endVolume()
+                .addNewVolume()
+                .withName("testruns")
+                .withNewPersistentVolumeClaim()
+                .withClaimName(pvc.getMetadata().getName())
+                .endPersistentVolumeClaim()
+                .endVolume()
+
+                .addNewContainer()
+                .withImage(dockerTag)
+                .withCommand("bash")
+                .withArgs("-c", "sleep 3600")
+                .addNewEnv()
+                .withName("DRIVER_NODE_MEMORY")
+                .withValue("1024m")
+                .withName("DRIVER_WEB_MEMORY")
+                .withValue("1024m")
+                .endEnv()
+                .withName(podName)
+                .withNewResources()
+                .addToRequests("cpu", new Quantity(Integer.valueOf(numberOfCoresPerFork - 1).toString()))
+                .addToRequests("memory", new Quantity(Integer.valueOf(memoryGbPerFork - 1).toString() + "Gi"))
                 .endResources()
                 .addNewVolumeMount().withName("gradlecache").withMountPath("/tmp/gradle").endVolumeMount()
                 .addNewVolumeMount().withName("testruns").withMountPath(TEST_RUN_DIR).endVolumeMount()
                 .endContainer()
 
+                .addNewContainer()
+                .withImage(sidecarImage)
+                .addNewEnv()
+                .withName("DRIVER_NODE_MEMORY")
+                .withValue("1024m")
+                .withName("DRIVER_WEB_MEMORY")
+                .withValue("1024m")
+                .endEnv()
+                .withName(podName + "-pg")
+                .withNewResources()
+                .addToRequests("cpu", new Quantity("1"))
+                .addToRequests("memory", new Quantity("1Gi"))
+                .endResources()
+                .endContainer()
+
                 .addNewImagePullSecret(REGISTRY_CREDENTIALS_SECRET_NAME)
                 .withRestartPolicy("Never")
-
                 .endSpec()
                 .build();
     }
+
 
     private File startLogPumping(InputStream stdOutIs, int podIdx, File podLogsDirectory, boolean printOutput) throws IOException {
         File outputFile = new File(podLogsDirectory, "container-" + podIdx + ".log");
@@ -400,6 +467,7 @@ public class KubesTest extends DefaultTask {
             client.pods()
                     .inNamespace(namespace)
                     .withName(podName)
+                    .inContainer(podName)
                     .dir(resultsInContainerPath)
                     .copy(tempDir);
         }
@@ -411,6 +479,7 @@ public class KubesTest extends DefaultTask {
         final String gitTargetBranch = " -Dgit.target.branch=" + Properties.getTargetGitBranch();
         final String artifactoryUsername = " -Dartifactory.username=" + Properties.getUsername() + " ";
         final String artifactoryPassword = " -Dartifactory.password=" + Properties.getPassword() + " ";
+        final String additionalArgs = this.additionalArgs.isEmpty() ? "" : String.join(" ", this.additionalArgs);
 
         String shellScript = "(let x=1 ; while [ ${x} -ne 0 ] ; do echo \"Waiting for DNS\" ; curl services.gradle.org > /dev/null 2>&1 ; x=$? ; sleep 1 ; done ) && "
                 + " cd /tmp/source && " +
@@ -420,7 +489,7 @@ public class KubesTest extends DefaultTask {
                 gitTargetBranch +
                 artifactoryUsername +
                 artifactoryPassword +
-                "-Dkubenetize -PdockerFork=" + podIdx + " -PdockerForks=" + numberOfPods + " " + fullTaskToExecutePath + " " + getLoggingLevel() + " 2>&1) ; " +
+                "-Dkubenetize -PdockerFork=" + podIdx + " -PdockerForks=" + numberOfPods + " " + fullTaskToExecutePath + " " + additionalArgs + " " + getLoggingLevel() + " 2>&1) ; " +
                 "let rs=$? ; sleep 10 ; exit ${rs}";
         return new String[]{"bash", "-c", shellScript};
     }

--- a/buildSrc/src/main/groovy/net/corda/testing/ParallelTestGroup.java
+++ b/buildSrc/src/main/groovy/net/corda/testing/ParallelTestGroup.java
@@ -15,6 +15,8 @@ public class ParallelTestGroup extends DefaultTask {
     private int gbOfMemory = 4;
     private boolean printToStdOut = true;
     private PodLogLevel logLevel = PodLogLevel.INFO;
+    private String sidecarImage;
+    private List<String> additionalArgs = new ArrayList<>();
 
     public DistributeTestsBy getDistribution() {
         return distribution;
@@ -43,6 +45,10 @@ public class ParallelTestGroup extends DefaultTask {
     public PodLogLevel getLogLevel() {
         return logLevel;
     }
+
+    public String getSidecarImage() { return sidecarImage; }
+
+    public List<String> getAdditionalArgs() { return additionalArgs; }
 
     public void numberOfShards(int shards) {
         this.shardCount = shards;
@@ -75,6 +81,18 @@ public class ParallelTestGroup extends DefaultTask {
 
     private void testGroups(List<String> group) {
         groups.addAll(group);
+    }
+
+    public void sidecarImage(String sidecarImage) {
+        this.sidecarImage = sidecarImage;
+    }
+
+    public void additionalArgs(String... additionalArgs) {
+        additionalArgs(Arrays.asList(additionalArgs));
+    }
+
+    private void additionalArgs(List<String> additionalArgs) {
+        this.additionalArgs.addAll(additionalArgs);
     }
 
 }


### PR DESCRIPTION
## Changes
- Adds Gradle task to parallelise database integration tests for postgres
- Modifies `KubesTest` so that test pods are created with two containers (worker node, postgres) when postgres db integration tests are run
- Modifies `ParallelTestGroup` task, adding `sidecarImage` and `additionalArgs` properties
- `sidecarImage` in this case is the docker tag for the db flavour - the same "infrastructure" can be used for e.g. HSM integration tests by loading HSM simulator sidecar image
- `additionalArgs` in this case are the command line args required for the worker container to connect with the db container
- Modifies `DistributedTesting` to pass `sidecarImage` and `additionalArgs` to `KubesTest`

https://r3-cev.atlassian.net/browse/TM-10

***Note:*** Updated `build.gradle` with `allPostgres11ParallelDatabaseIntegrationTest` etc not included, as OS does not have db integration tests. See: https://github.com/corda/enterprise/pull/2779#issuecomment-553342946
