### PR TITLE
CORDA-2744 - Prevent ClassCastException if error during initial registration

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -84,7 +84,8 @@ class InitialRegistration(val baseDirectory: Path, private val networkRootTrustS
     }
 
     private fun initialRegistration(config: NodeConfiguration) {
-        // Null checks for [compatibilityZoneURL], [rootTruststorePath] and [rootTruststorePassword] has been done in [CmdLineOptions.loadConfig]
+        // Null checks for [compatibilityZoneURL], [rootTruststorePath] and
+        // [rootTruststorePassword] have been done in [CmdLineOptions.loadConfig]
         val result = attempt { registerWithNetwork(config) }.doOnFailure(Consumer(this::handleRegistrationError))
         
         if (result.isSuccess) {

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -85,9 +85,12 @@ class InitialRegistration(val baseDirectory: Path, private val networkRootTrustS
 
     private fun initialRegistration(config: NodeConfiguration) {
         // Null checks for [compatibilityZoneURL], [rootTruststorePath] and [rootTruststorePassword] has been done in [CmdLineOptions.loadConfig]
-        attempt { registerWithNetwork(config) }.doOnFailure(Consumer(this::handleRegistrationError)) as Try.Success
-        // At this point the node registration was successful. We can delete the marker file.
-        deleteNodeRegistrationMarker(baseDirectory)
+        val result = attempt { registerWithNetwork(config) }.doOnFailure(Consumer(this::handleRegistrationError))
+        
+        if (result.isSuccess) {
+            // At this point the node registration was successful. We can delete the marker file.
+            deleteNodeRegistrationMarker(baseDirectory)
+        }
     }
 
     private fun deleteNodeRegistrationMarker(baseDir: Path) {


### PR DESCRIPTION
# Issue
Currently during initial registration of the node, the registration output is cast to a `Try.Success` regardless of the actual result. See offending line [here](https://github.com/corda/corda/blob/987415dd831e698394a8d7a2d50410e3a7f9895e/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt#L88). This results in a class cast exception whenever something goes wrong during registration (for example if the Identity Manager cannot be reached). This does not affect any actual logic, but does add some confusing noise to the output displayed to the user. The actual error is also displayed but is followed by the red herring class cast exception:

<img width="944" alt="Screenshot 2019-11-14 at 10 31 06" src="https://user-images.githubusercontent.com/12070000/68849437-fceff980-06c9-11ea-8cb4-4e6af3de481a.png">


Looking through the history it seems like this line used to use a safe `as?` cast but was changed to a non-safe cast for some reason. This class cast does in an indirect way serve a purpose (whether intentional or not) - the initial registration marker is only deleted if the registration is actually successful.

# Fix
As we don't actually do anything with this result we can just check the registration success directly instead, and delete the registration marker only if registration was completed. In the case of an error this means that only the relevant error is displayed:

<img width="912" alt="Screenshot 2019-11-14 at 10 27 03" src="https://user-images.githubusercontent.com/12070000/68849067-54da3080-06c9-11ea-9da4-2ce8d9b7eb5c.png">
