### PR TITLE
CORDA-2876: Ensure that sandboxable byte-code is compiled for Java 8.

### DIFF
--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -1,3 +1,5 @@
+import static org.gradle.api.JavaVersion.VERSION_1_8
+
 /*
  * Gradle script plugin: Configure a module such that the Java and Kotlin
  * compilers use the deterministic rt.jar instead of the full JDK rt.jar.
@@ -19,11 +21,16 @@ tasks.withType(AbstractCompile) {
 
     // This is a bit ugly, but Gradle isn't recognising the KotlinCompile task
     // as it does the built-in JavaCompile task.
-    if (it.class.name.startsWith("org.jetbrains.kotlin.gradle.tasks.KotlinCompile")) {
-        kotlinOptions.jdkHome = deterministic_jdk_home
+    if (it.class.name.startsWith('org.jetbrains.kotlin.gradle.tasks.KotlinCompile')) {
+        kotlinOptions {
+            jdkHome = deterministic_jdk_home
+            jvmTarget = VERSION_1_8
+        }
     }
 }
 
 tasks.withType(JavaCompile) {
     options.compilerArgs << '-bootclasspath' << deterministic_rt_jar
+    sourceCompatibility = VERSION_1_8
+    targetCompatibility = VERSION_1_8
 }

--- a/serialization-djvm/build.gradle
+++ b/serialization-djvm/build.gradle
@@ -1,3 +1,5 @@
+import static org.gradle.api.JavaVersion.VERSION_1_8
+
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.publish-utils'
@@ -40,6 +42,18 @@ dependencies {
     sandboxTesting project(':serialization-djvm:deserializers')
     sandboxTesting project(path: ':serialization-deterministic', configuration: 'deterministicArtifacts')
     sandboxTesting "org.slf4j:slf4j-nop:$slf4j_version"
+}
+
+// The DJVM only supports Java 8 byte-code.
+compileTestJava {
+    sourceCompatibility = VERSION_1_8
+    targetCompatibility = VERSION_1_8
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = VERSION_1_8
+    }
 }
 
 jar {


### PR DESCRIPTION
Ensure that byte-code intended to run inside the DJVM's sandbox is always compiled for Java 8. This includes test code for the `serialization-djvm` module.