### PR TITLE
CORDA-2963: Add calendars.properties to deterministic-rt.jar.

### DIFF
--- a/create-jdk8u/Makefile
+++ b/create-jdk8u/Makefile
@@ -12,7 +12,7 @@ jdk8u/build/%/spec.gmk: jdk8u/common/autoconf/configure
 jdk-image: jdk8u/build/linux-x86_64-normal-server-release/spec.gmk
 	$(MAKE) -C jdk8u images docs
 
-all: libs/rt.jar libs/jce.jar libs/jsse.jar libs/currency.data libs/tzdb.dat
+all: libs/rt.jar libs/jce.jar libs/jsse.jar libs/currency.data libs/tzdb.dat libs/calendars.properties
 
 clean:
 	$(MAKE) -C jdk8u clean
@@ -20,6 +20,6 @@ clean:
 libs:
 	mkdir $@
 
-libs/rt.jar libs/jce.jar libs/jsse.jar libs/currency.data libs/tzdb.dat: libs jdk-image
+libs/rt.jar libs/jce.jar libs/jsse.jar libs/currency.data libs/tzdb.dat libs/calendars.properties: libs jdk-image
 	cp -f jdk8u/build/*/images/j2re-image/lib/$(@F) $@
 

--- a/create-jdk8u/build.gradle
+++ b/create-jdk8u/build.gradle
@@ -53,6 +53,7 @@ task runtimeJar(type: Jar, dependsOn: makeJdk) {
     from(zipTree('libs/rt.jar'))
     from(zipTree('libs/jce.jar'))
     from(zipTree('libs/jsse.jar'))
+    from 'libs/calendars.properties'
     from 'libs/currency.data'
     from 'libs/tzdb.dat'
 


### PR DESCRIPTION
The `calendars.properties` file is required by built-in implementations of `java.time.chrono.Chronology`.