### PR TITLE
Update corda-testnet-intro.rst

### DIFF
--- a/docs/source/corda-testnet-intro.rst
+++ b/docs/source/corda-testnet-intro.rst
@@ -5,7 +5,11 @@ Joining Corda Testnet
 
 The Corda Testnet is an open public network of Corda nodes on the internet. It is designed to be a complement to *the* Corda Network where any entity can transact real world value with any other counterparty in the context of any application. The Corda Testnet is designed for "non-production" use in a genuine global context of Corda nodes, including but not limited to CorDapp development, multi-party testing, demonstration and showcasing of applications and services, learning, training and development of the Corda platform technology and specific applications of Corda.
 
-The Corda Testnet is based on exactly the same technology as the main Corda Network, but can be joined on a self-service basis through the automated provisioning system described below.
+The Corda Testnet is based on the same underlying technology as the main Corda Network, but can be joined on a self-service basis through the automated provisioning system described below.
+
+However, the Corda Testnet services are a demonstration version only, they are supported on a best effort basis and there are no commitments with regards to their uptime. 
+
+Users looking for long lasting supported networks should consider the Corda Network https://corda.network/ for UAT and Production Networks or https://docs.cenm.r3.com/ to evaluate or license the Software reccomended to operate a production Network on Corda.
 
 Deploying a Corda node to the Corda Testnet
 -------------------------------------------


### PR DESCRIPTION
This change is required to level set the support expectations around Testnet as well as covering the next steps for those who seek a supported network or the software to run it themselves instead.

I also clarified a sentence in the first paragraph as the version of the software run on CN vs Testnet might differ - as well as its configuration, I thus replaced "exactly same technology" to "same underlying technology" statement to soften the expectations.
