### PR TITLE
CORDA-3158: Update docs with info about CAPSULE_CACHE_DIR 

### DIFF
--- a/docs/source/deploying-a-node.rst
+++ b/docs/source/deploying-a-node.rst
@@ -7,6 +7,12 @@ Deploying a node to a server
    whether they have developed and tested a CorDapp following the instructions in :doc:`generating-a-node`
    or are deploying a third-party CorDapp.
 
+.. note:: When deploying multiple nodes in parallel the package tool (Capsule) that Corda uses can encounter
+   issues retrieving dependencies. This is due to each node trying to download the dependencies in a common
+   location.  In these cases it is recommended to set the environment variable ``CAPSULE_CACHE_DIR`` which
+   will allow the Capsule to maintain a separate cache for each node.  This is used in the example descriptions
+   below. See the `Capsule documentation <http://www.capsule.io>`_ for more details.
+
 Linux: Installing and running Corda as a system service
 -------------------------------------------------------
 We recommend creating system services to run a node and the optional test webserver. This provides logging and service
@@ -90,6 +96,7 @@ handling, and ensures the Corda service is run at boot.
        WorkingDirectory=/opt/corda
        ExecStart=/usr/bin/java -jar /opt/corda/corda.jar
        Restart=on-failure
+       Environment="CAPSULE_CACHE_DIR=.capsule"
 
        [Install]
        WantedBy=multi-user.target
@@ -248,6 +255,7 @@ at boot, and means the Corda service stays running with no users connected to th
       nssm set cordanode1 AppDirectory C:\Corda
       nssm set cordanode1 AppStdout C:\Corda\service.log
       nssm set cordanode1 AppStderr C:\Corda\service.log
+      nssm set cordanode1 AppEnvironmentExtra CAPSULE_CACHE_DIR=.capsule
       nssm set cordanode1 Description Corda Node - Bank of Breakfast Tea
       nssm set cordanode1 Start SERVICE_AUTO_START
       sc start cordanode1

--- a/docs/source/deploying-a-node.rst
+++ b/docs/source/deploying-a-node.rst
@@ -96,7 +96,7 @@ handling, and ensures the Corda service is run at boot.
        WorkingDirectory=/opt/corda
        ExecStart=/usr/bin/java -jar /opt/corda/corda.jar
        Restart=on-failure
-       Environment="CAPSULE_CACHE_DIR=.capsule"
+       Environment="CAPSULE_CACHE_DIR=./capsule"
 
        [Install]
        WantedBy=multi-user.target
@@ -251,18 +251,20 @@ at boot, and means the Corda service stays running with no users connected to th
 
    .. code-block:: batch
 
-      nssm install cordanode1 C:\ProgramData\Oracle\Java\javapath\java.exe
+      nssm install cordanode1 java.exe
+      nssm set cordanode1 AppParameters "-jar corda.jar"
       nssm set cordanode1 AppDirectory C:\Corda
       nssm set cordanode1 AppStdout C:\Corda\service.log
       nssm set cordanode1 AppStderr C:\Corda\service.log
-      nssm set cordanode1 AppEnvironmentExtra CAPSULE_CACHE_DIR=.capsule
+      nssm set cordanode1 AppEnvironmentExtra CAPSULE_CACHE_DIR=./capsule
       nssm set cordanode1 Description Corda Node - Bank of Breakfast Tea
       nssm set cordanode1 Start SERVICE_AUTO_START
       sc start cordanode1
 
 9. Modify the batch file:
 
-    * If you are installing multiple nodes, use a different service name (``cordanode1``) for each node
+    * If you are installing multiple nodes, use a different service name (``cordanode1``), and modify
+      `AppDirectory`, `AppStdout` and `AppStderr` for each node accordingly
     * Set an informative description
 
 10. Provision the required certificates to your node. Contact the network permissioning service or see


### PR DESCRIPTION
The `CAPSULE_CACHE_DIR` is needed for capsule to avoid overwriting/interfering with itself when running multiple nodes in parallel for the first time (or whenever Capsule downloads the dependencies)
