### PR TITLE
CORDA-3443: Do not log warning when appending duplicated network parameters

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
@@ -90,7 +90,7 @@ class DBNetworkParametersStorage(
         val hash = signedNetworkParameters.raw.hash
         log.trace { "Parameters to save $networkParameters with hash $hash" }
         database.transaction {
-            hashToParameters.addWithDuplicatesAllowed(hash, signedNetworkParameters)
+            hashToParameters.addWithDuplicatesAllowed(hash, signedNetworkParameters, false)
         }
     }
 


### PR DESCRIPTION
Since we always update network parameters on ``AbstractNode`` start (``networkParametersStorage.setCurrentParameters(signedNetParams, trustRoot)``), it doesn't make sense to log warning on duplicated append in DB.