### PR TITLE
CORDA-2876: Upgrade to deterministic-rt 1.0-RC01.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ buildscript {
     ext.metrics_version = constants.getProperty("metricsVersion")
     ext.metrics_new_relic_version = constants.getProperty("metricsNewRelicVersion")
     ext.djvm_version = constants.getProperty("djvmVersion")
+    ext.deterministic_rt_version = constants.getProperty('deterministicRtVersion')
     ext.okhttp_version = '3.14.2'
     ext.netty_version = '4.1.22.Final'
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")

--- a/constants.properties
+++ b/constants.properties
@@ -30,6 +30,7 @@ caffeineVersion=2.7.0
 metricsVersion=4.1.0
 metricsNewRelicVersion=1.1.1
 djvmVersion=1.0-RC03
+deterministicRtVersion=1.0-RC01
 openSourceBranch=https://github.com/corda/corda/blob/release/os/4.4
 openSourceSamplesBranch=https://github.com/corda/samples/blob/release-V4
 jolokiaAgentVersion=1.6.1

--- a/jdk8u-deterministic/build.gradle
+++ b/jdk8u-deterministic/build.gradle
@@ -1,9 +1,6 @@
 repositories {
     maven {
-        url "$artifactory_contextUrl/corda-releases"
-    }
-    maven {
-        url "$artifactory_contextUrl/corda-dev"
+        url "$artifactory_contextUrl/corda-dependencies"
     }
 }
 
@@ -13,14 +10,11 @@ ext {
 }
 
 configurations {
-    jdk.resolutionStrategy {
-        cacheChangingModulesFor 0, 'seconds'
-    }
+    jdk
 }
 
 dependencies {
-    // Ensure everyone uses the latest SNAPSHOT.
-    jdk "net.corda:deterministic-rt:latest.integration:api"
+    jdk "net.corda:deterministic-rt:$deterministic_rt_version:api"
 }
 
 task copyJdk(type: Copy) {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -31,13 +31,6 @@ apply plugin: 'com.jfrog.artifactory'
 
 description 'Corda node modules'
 
-repositories {
-    // Extra repository for the deterministic-rt JAR.
-    maven {
-        url "$artifactory_contextUrl/corda-dev"
-    }
-}
-
 //noinspection GroovyAssignabilityCheck
 configurations {
     integrationTestCompile.extendsFrom testCompile
@@ -46,9 +39,7 @@ configurations {
     slowIntegrationTestCompile.extendsFrom testCompile
     slowIntegrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 
-    jdkRt.resolutionStrategy {
-        cacheChangingModulesFor 0, 'seconds'
-    }
+    jdkRt
     deterministic
 }
 
@@ -174,7 +165,7 @@ dependencies {
     compile(project(':node:djvm')) {
         transitive = false
     }
-    jdkRt "net.corda:deterministic-rt:latest.integration"
+    jdkRt "net.corda:deterministic-rt:$deterministic_rt_version"
     deterministic project(path: ':core-deterministic', configuration: 'deterministicArtifacts')
     deterministic project(path: ':serialization-deterministic', configuration: 'deterministicArtifacts')
     deterministic project(':serialization-djvm:deserializers')


### PR DESCRIPTION
Upgrade deterministic-rt artifacts from 1.0-SNAPSHOT to 1.0-RC01 in the corda-dependencies repository.