### PR TITLE
[CORDA-3373][CORDA-3374] Update Cordform docs to discuss setting Jolokia version, update version number

### DIFF
--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -247,6 +247,13 @@ To copy the same file to all nodes `ext.drivers` can be defined in the top level
         }
     }
 
+The Cordform task will automatically copy a Jolokia agent JAR into each generated node's `drivers` subdirectory. The version of this JAR
+defaults to `1.6.0`. This can be changed by setting the `jolokia_version` property anywhere in your `build.gradle` file:
+
+.. sourcecode:: groovy
+
+    ext.jolokia_version = "1.6.1"
+
 .. _node_package_namespace_ownership:
 
 Package namespace ownership

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -116,7 +116,7 @@ In order to ensure that a Jolokia agent is instrumented with the JVM run-time, y
 
 * Specify the Node configuration parameter ``jmxMonitoringHttpPort`` which will attempt to load the jolokia driver from the ``drivers`` folder.
   The format of the driver name needs to be ``jolokia-jvm-{VERSION}-agent.jar`` where VERSION is the version required by Corda, currently |jolokia_version|.
-* Start the node with ``java -Dcapsule.jvm.args="-javaagent:drivers/jolokia-jvm-1.6.0-agent.jar=port=7777,host=localhost" -jar corda.jar``.
+* Start the node with ``java -Dcapsule.jvm.args="-javaagent:drivers/jolokia-jvm-1.6.1-agent.jar=port=7777,host=localhost" -jar corda.jar``.
 
 
 The following JMX statistics are exported:


### PR DESCRIPTION
The `Cordform` gradle plugin task automatically copies a Jolokia agent JAR to the drivers directory on every node. Cordform attempts to read a `jolokia_version` property from gradle to decide what version of the JAR to copy, and if it can't find one defaults to 1.6.0. This PR documents that behaviour.

Note that the default should really be 1.6.1, as that is what Corda itself uses. Updating this should be done in a separate JIRA for 4.4.

See [the original JIRA ticket](https://r3-cev.atlassian.net/browse/CORDA-3374) for a discussion of why different samples end up deploying different versions of Jolokia.