### PR TITLE
CORDA-3202 Add a specific exception for flows to hospitalise themselves

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -55,6 +55,6 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
 /**
  * Thrown when the user needs to pause a flow. It will send the current flow directly to the hospital.
  */
-class HospitalizeFlowException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause) {
+open class HospitalizeFlowException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause) {
     constructor(message: String) : this(message, null)
 }

--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -55,6 +55,6 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
 /**
  * Thrown when the user needs to pause a flow. It will send the current flow directly to the hospital.
  */
-class PauseFlowException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause) {
+class HospitalizeFlowException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause) {
     constructor(message: String) : this(message, null)
 }

--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -55,6 +55,8 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
 /**
  * Thrown when the user needs to pause a flow. It will send the current flow directly to the hospital.
  */
-open class HospitalizeFlowException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause) {
-    constructor(message: String) : this(message, null)
+open class HospitalizeFlowException(message: String?, cause: Throwable?) : CordaRuntimeException(message, cause) {
+    constructor(message: String?) : this(message, null)
+    constructor(cause: Throwable?) : this(cause?.toString(), cause)
+    constructor() : this(null, null)
 }

--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -51,12 +51,3 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
 
     override fun getErrorId(): Long? = originalErrorId
 }
-
-/**
- * Thrown when the user needs to pause a flow. It will send the current flow directly to the hospital.
- */
-open class HospitalizeFlowException(message: String?, cause: Throwable?) : CordaRuntimeException(message, cause) {
-    constructor(message: String?) : this(message, null)
-    constructor(cause: Throwable?) : this(cause?.toString(), cause)
-    constructor() : this(null, null)
-}

--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -51,3 +51,10 @@ class UnexpectedFlowEndException(message: String, cause: Throwable?, val origina
 
     override fun getErrorId(): Long? = originalErrorId
 }
+
+/**
+ * Thrown when the user needs to pause a flow. It will send the current flow directly to the hospital.
+ */
+class PauseFlowException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause) {
+    constructor(message: String) : this(message, null)
+}

--- a/core/src/main/kotlin/net/corda/core/flows/HospitalizeFlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/HospitalizeFlowException.kt
@@ -1,0 +1,12 @@
+package net.corda.core.flows
+
+import net.corda.core.CordaRuntimeException
+
+/**
+ * Thrown when the user needs to pause a flow. It will send the flow throwing it directly to the hospital.
+ */
+open class HospitalizeFlowException(message: String?, cause: Throwable?) : CordaRuntimeException(message, cause) {
+    constructor(message: String?) : this(message, null)
+    constructor(cause: Throwable?) : this(cause?.toString(), cause)
+    constructor() : this(null, null)
+}

--- a/core/src/main/kotlin/net/corda/core/flows/HospitalizeFlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/HospitalizeFlowException.kt
@@ -3,7 +3,10 @@ package net.corda.core.flows
 import net.corda.core.CordaRuntimeException
 
 /**
- * Thrown when the user needs to pause a flow. It will send the flow throwing it directly to the hospital.
+ * This exception allows a flow to pass itself to the flow hospital. Once the flow reaches
+ * the hospital it will determine how to progress depending on what [cause]s the exception wraps.
+ * Assuming there are no important wrapped exceptions, throwing a [HospitalizeFlowException]
+ * will place the flow in overnight observation, where it will be replayed at a later time.
  */
 open class HospitalizeFlowException(message: String?, cause: Throwable?) : CordaRuntimeException(message, cause) {
     constructor(message: String?) : this(message, null)

--- a/core/src/main/kotlin/net/corda/core/flows/HospitalizeFlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/HospitalizeFlowException.kt
@@ -2,6 +2,7 @@ package net.corda.core.flows
 
 import net.corda.core.CordaRuntimeException
 
+// DOCSTART 1
 /**
  * This exception allows a flow to pass itself to the flow hospital. Once the flow reaches
  * the hospital it will determine how to progress depending on what [cause]s the exception wraps.
@@ -13,3 +14,4 @@ open class HospitalizeFlowException(message: String?, cause: Throwable?) : Corda
     constructor(cause: Throwable?) : this(cause?.toString(), cause)
     constructor() : this(null, null)
 }
+// DOCEND 1

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -775,11 +775,10 @@ There are many scenarios in which throwing a ``FlowException`` would be appropri
 
 HospitalizeFlowException
 ------------------------
-When writing flows it could be the case that you would want to stop the execution of a flow at some point
-under certain circumstances. Or, prevent a flow's erroneous termination that would lead to all the
-flow's records being removed. In both such cases the flow would then be re-executed at a later point in time.
+Some operations can fail intermittently and will succeed if they are tried again at a later time. Flows have the ability to halt their
+execution in such situations. By throwing a ``HospitalizeFlowException`` a flow will stop and retry at a later time (on the next node restart).
 
-The way to do this is by throwing a ``HospitalizeFlowException``:
+A ``HospitalizeFlowException`` can be defined in various ways:
 
 .. container:: codeset
 
@@ -788,18 +787,12 @@ The way to do this is by throwing a ``HospitalizeFlowException``:
         :start-after: DOCSTART 1
         :end-before: DOCEND 1
 
-The flow framework will hospitalise a flow throwing a ``HospitalizeFlowException``.
+.. note:: If a ``HospitalizeFlowException`` is wrapping or extending an exception already being handled by the :doc:`node-flow-hospital`, the outcome of a flow may change. For example, the flow
+  could instantly retry or terminate if a critical error occurred.
 
-This exception could be thrown arbitrarily or it could wrap an exception being thrown in the flow execution.
+.. note:: ``HospitalizeFlowException`` can be extended for customized exceptions. These exceptions will be treated in the same way when thrown.
 
-Normally, within a flow's execution, if an exception is being thrown and if this exception is not one of the exception types
-already being handled by the flow framework described in :ref:`flow hospital runtime behaviour <flow-hospital-runtime>`,
-it will lead to the flow's erroneous termination. All of the flow's records will then be removed. To avoid this;
-keep the flow and have it retrying its execution at a later point in time, we could wrap this thrown exception with a
-``HospitalizeFlowException`` and throw it instead. In that case, the flow will be held by the :doc:`node-flow-hospital`
-and will be retried from its last checkpoint upon node restart.
-
-Here is an example of a flow that we might have wanted to be retried again in the future instead of terminating erroneously:
+Below is an example of a flow that should retry again in the future if an error occurs:
 
 .. container:: codeset
 
@@ -815,8 +808,6 @@ Here is an example of a flow that we might have wanted to be retried again in th
             }
         }
     }
-
-.. note:: Custom exceptions extending HospitalizeFlowException will be treated the same way, as described above, whenever thrown.
 
 ProgressTracker
 ---------------

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -811,7 +811,6 @@ Here is an example of a flow that we might have wanted to be retried again in th
                 val code = serviceHub.cordaService(HTTPService::class.java).get() // throws UnknownHostException.
             } catch (e: UnknownHostException) {
                 // Accessing the service failed! It might be offline. Let's hospitalize this flow, and have it retry again on next node startup.
-                // We can achieve this by wrapping the thrown exception with a HospitalizeFlowException and throw it instead.
                 throw HospitalizeFlowException("Service might be offline!", e)
             }
         }

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -819,7 +819,7 @@ Here is an example of a flow that we might have wanted to be retried again in th
         }
     }
 
-.. note:: Custom exceptions extending HospitalizeFlowException will be treated the same way when thrown.
+.. note:: Custom exceptions extending HospitalizeFlowException will be treated the same way, as described above, whenever thrown.
 
 ProgressTracker
 ---------------

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -813,7 +813,7 @@ Here is an example of a flow that we might have wanted to be retried again in th
                     throw HospitalizeFlowException("The resource requested could not be found!") // throw a HospitalizeFlowException arbitrarily.
             } catch (e: UnknownHostException) {
                 // Accessing the service failed! It might be offline. Let's hospitalize this flow, and have it retry again on next node startup.
-                // We can achieve this by wrapping the thrown exception with a HospitalizeFlowException and throw this instead.
+                // We can achieve this by wrapping the thrown exception with a HospitalizeFlowException and throw it instead.
                 throw HospitalizeFlowException("Service might be offline!", e)
             }
         }

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -831,16 +831,16 @@ Below is an example of a flow that should retry again in the future if an error 
 
    .. sourcecode:: kotlin
 
-    class TryAccessServiceFlow(): FlowLogic<Unit>() {
-        override fun call() {
-            try {
-                val code = serviceHub.cordaService(HTTPService::class.java).get() // throws UnknownHostException.
-            } catch (e: UnknownHostException) {
-                // Accessing the service failed! It might be offline. Let's hospitalize this flow, and have it retry again on next node startup.
-                throw HospitalizeFlowException("Service might be offline!", e)
+        class TryAccessServiceFlow(): FlowLogic<Unit>() {
+            override fun call() {
+                try {
+                    val code = serviceHub.cordaService(HTTPService::class.java).get() // throws UnknownHostException.
+                } catch (e: UnknownHostException) {
+                    // Accessing the service failed! It might be offline. Let's hospitalize this flow, and have it retry again on next node startup.
+                    throw HospitalizeFlowException("Service might be offline!", e)
+                }
             }
         }
-    }
 
 ProgressTracker
 ---------------

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -809,8 +809,6 @@ Here is an example of a flow that we might have wanted to be retried again in th
         override fun call() {
             try {
                 val code = serviceHub.cordaService(HTTPService::class.java).get() // throws UnknownHostException.
-                if (code == 404)
-                    throw HospitalizeFlowException("The resource requested could not be found!") // throw a HospitalizeFlowException arbitrarily.
             } catch (e: UnknownHostException) {
                 // Accessing the service failed! It might be offline. Let's hospitalize this flow, and have it retry again on next node startup.
                 // We can achieve this by wrapping the thrown exception with a HospitalizeFlowException and throw it instead.

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -773,7 +773,7 @@ There are many scenarios in which throwing a ``FlowException`` would be appropri
 * The transaction does not match the parameters of the deal as discussed
 * You are reneging on a deal
 
-Below is an example of a flow couple making use of ``FlowException``:
+Below is an example using ``FlowException``:
 
 .. container:: codeset
 

--- a/docs/source/node-flow-hospital.rst
+++ b/docs/source/node-flow-hospital.rst
@@ -71,11 +71,8 @@ Specifically, there are two main ways a flow is hospitalized:
      This can occur an infinite number of times.  i.e. we never give up notarising.  No intervention required.
 
    * ``HospitalizeFlowException``:
-     This kind of exception should be thrown whenever we would need a flow to get hospitalised. This flow will not be retried and be kept for observation.
-     However, please **note** that if a ``HospitalizeFlowException`` extends or wraps one of the other exception types handled by the flow hospital, then in that case,
-     if the extended or wrapped exception is of higher priority, the hospital will treat the extended/ wrapped exception instead, and not the ``HospitalizeFlowException``.
-     So if for example, a HospitalizeFlowException exception is wrapping an ``SQLException`` mentioning a **deadlock** , then this ``HospitalizeFlowException``
-     will be treated as an ``SQLException`` mentioning a **deadlock**.
+     The aim of this exception is to provide user code a way to retry a flow from its last checkpoint if a known intermittent failure occurred.
+     Any ``HospitalizeFlowException`` that is thrown and not handled by any of the scenarios detailed above, will be kept in for observation.
 
    * **Internal Corda errors**:
      Flows that experience errors from inside the Corda statemachine, that are not handled by any of the scenarios details above, will be retried a number of times

--- a/docs/source/node-flow-hospital.rst
+++ b/docs/source/node-flow-hospital.rst
@@ -70,15 +70,15 @@ Specifically, there are two main ways a flow is hospitalized:
      The time is hard to document as the notary members, if actually alive, will inform the requester of the ETA of a response.
      This can occur an infinite number of times.  i.e. we never give up notarising.  No intervention required.
 
-   * **Internal Corda errors**:
-     Flows that experience errors from inside the Corda statemachine, that are not handled by any of the scenarios details above, will be retried a number of times
-     and then kept in for observation if the error continues.
-
    * ``HospitalizeFlowException``:
      This kind of exception should be thrown whenever we would need a flow to get hospitalised. This flow will not be retried and be kept for observation.
      However, please **note** that if a ``HospitalizeFlowException`` extends or wraps one of the other exception types handled by the flow hospital, then in that case,
      if the extended or wrapped exception is of higher priority, the hospital will treat the extended/ wrapped exception instead, and not the ``HospitalizeFlowException``.
      So if for example, a HospitalizeFlowException exception is wrapping an ``SQLException`` mentioning a **deadlock** , then this ``HospitalizeFlowException``
      will be treated as an ``SQLException`` mentioning a **deadlock**.
+
+   * **Internal Corda errors**:
+     Flows that experience errors from inside the Corda statemachine, that are not handled by any of the scenarios details above, will be retried a number of times
+     and then kept in for observation if the error continues.
 
 .. note:: Flows that are kept in for observation are retried upon node restart.

--- a/docs/source/node-flow-hospital.rst
+++ b/docs/source/node-flow-hospital.rst
@@ -74,4 +74,11 @@ Specifically, there are two main ways a flow is hospitalized:
      Flows that experience errors from inside the Corda statemachine, that are not handled by any of the scenarios details above, will be retried a number of times
      and then kept in for observation if the error continues.
 
+   * ``HospitalizeFlowException``:
+     This kind of exception should be thrown whenever we would need a flow to get hospitalised. This flow will not be retried and be kept for observation.
+     However, please **note** that if a ``HospitalizeFlowException`` extends or wraps one of the other exception types handled by the flow hospital, then in that case,
+     if the extended or wrapped exception is of higher priority, the hospital will treat the extended/ wrapped exception instead, and not the ``HospitalizeFlowException``.
+     So if for example, a HospitalizeFlowException exception is wrapping an ``SQLException`` mentioning a **deadlock** , then this ``HospitalizeFlowException``
+     will be treated as an ``SQLException`` mentioning a **deadlock**.
+
 .. note:: Flows that are kept in for observation are retried upon node restart.

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -1,9 +1,6 @@
 package net.corda.node.services.statemachine
 
-import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import co.paralleluniverse.strands.Strand
-import co.paralleluniverse.strands.concurrent.Semaphore
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.StateAndRef
@@ -37,7 +34,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import java.sql.SQLException
-import java.util.Random
+import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -154,7 +151,7 @@ class FlowHospitalTest {
     }
 
     @Test
-    fun `HospitalizeFlowException cloaking an important exception`() {
+    fun `HospitalizeFlowException cloaking an important exception thrown`() {
         var dischargedCounter = 0
         var observationCounter: Int = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ ->

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -1,6 +1,9 @@
 package net.corda.node.services.statemachine
 
+import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
+import co.paralleluniverse.strands.Strand
+import co.paralleluniverse.strands.concurrent.Semaphore
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.StateAndRef
@@ -8,6 +11,7 @@ import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
+import net.corda.core.flows.HospitalizeFlowException
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.NotaryException
@@ -18,6 +22,7 @@ import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
 import net.corda.node.services.Permissions
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyContract.SingleOwnerState
@@ -31,9 +36,14 @@ import net.corda.testing.node.internal.findCordapp
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import java.sql.SQLException
 import java.util.Random
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class FlowHospitalTest {
 
@@ -85,6 +95,84 @@ class FlowHospitalTest {
             assertThat(secondLatch.await(5, TimeUnit.SECONDS)).isTrue()
             secondSubscription.unsubscribe()
             assertThat(aliceClient.stateMachinesSnapshot()).isEmpty()
+        }
+    }
+
+    @Test
+    fun `HospitalizeFlowException thrown`() {
+        var observationCounter: Int = 0
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
+            ++observationCounter
+        }
+        driver(DriverParameters(startNodesInProcess = true,
+                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
+            val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
+            assertFailsWith<TimeoutException> {
+                aliceClient.startFlow(::ThrowingHospitalisedExceptionFlow, HospitalizeFlowException::class.java)
+                    .returnValue.getOrThrow(5.seconds)
+            }
+            assertEquals(1, observationCounter)
+        }
+    }
+
+    @Test
+    fun `Custom exception wrapping HospitalizeFlowException thrown`() {
+        var observationCounter: Int = 0
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
+            ++observationCounter
+        }
+        driver(DriverParameters(startNodesInProcess = true,
+                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
+            val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
+            assertFailsWith<TimeoutException> {
+                aliceClient.startFlow(::ThrowingHospitalisedExceptionFlow, WrappingHospitalizeFlowException::class.java)
+                    .returnValue.getOrThrow(5.seconds)
+            }
+            assertEquals(1, observationCounter)
+        }
+    }
+
+    @Test
+    fun `Custom exception extending HospitalizeFlowException thrown`() {
+        var observationCounter: Int = 0
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
+            ++observationCounter
+        }
+        driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+            // one node will be enough for this testing
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
+            val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
+            assertFailsWith<TimeoutException> {
+                aliceClient.startFlow(::ThrowingHospitalisedExceptionFlow, ExtendingHospitalizeFlowException::class.java)
+                    .returnValue.getOrThrow(5.seconds)
+            }
+            assertEquals(1, observationCounter)
+        }
+    }
+
+    @Test
+    fun `HospitalizeFlowException cloaking an important exception`() {
+        var dischargedCounter = 0
+        var observationCounter: Int = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ ->
+            ++dischargedCounter
+        }
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
+            ++observationCounter
+        }
+        driver(DriverParameters(startNodesInProcess = true,
+                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
+            val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
+            assertFailsWith<TimeoutException> {
+                aliceClient.startFlow(::ThrowingHospitalisedExceptionFlow, CloakingHospitalizeFlowException::class.java)
+                    .returnValue.getOrThrow(5.seconds)
+            }
+            assertEquals(0, observationCounter)
+            // Since the flow will keep getting discharged from hospital dischargedCounter will be > 1.
+            assertTrue(dischargedCounter > 0)
         }
     }
 
@@ -164,5 +252,33 @@ class FlowHospitalTest {
     }
 
     class DoubleSpendException(message: String, cause: Throwable): FlowException(message, cause)
+
+    @StartableByRPC
+    class ThrowingHospitalisedExceptionFlow(
+        // Starting this Flow from an RPC client: if we pass in an encapsulated exception within another exception then the wrapping
+        // exception, when deserialized, will get grounded into a CordaRuntimeException (this happens in ThrowableSerializer#fromProxy).
+        private val hospitalizeFlowExceptionClass: Class<*>): FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            // Create an instance out of the Class reference and TODO check if it is or has a HospitalizeFlowException.
+            val throwable = hospitalizeFlowExceptionClass.newInstance()
+            (throwable as Throwable)?.let {
+                throw it
+            }
+        }
+    }
+
+    class WrappingHospitalizeFlowException(cause: HospitalizeFlowException =  HospitalizeFlowException()) : Exception(cause)
+
+    class ExtendingHospitalizeFlowException : HospitalizeFlowException()
+
+    class CloakingHospitalizeFlowException : HospitalizeFlowException() { // HospitalizeFlowException wrapping important exception
+        init {
+            // Wrapping an SQLException with "deadlock" as a message should lead the flow being handled by StaffedFlowHospital#DeadlockNurse as well
+            // and therefore having the flow discharged and not getting it for overnight observation.
+            setCause(SQLException("deadlock"))
+        }
+    }
 
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -101,8 +101,12 @@ class FlowHospitalTest {
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
             ++observationCounter
         }
-        driver(DriverParameters(startNodesInProcess = true,
-                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+        driver(
+            DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts"))
+            )
+        ) {
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
             val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
             assertFailsWith<TimeoutException> {
@@ -119,8 +123,12 @@ class FlowHospitalTest {
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
             ++observationCounter
         }
-        driver(DriverParameters(startNodesInProcess = true,
-                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+        driver(
+            DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts"))
+            )
+        ) {
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
             val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
             assertFailsWith<TimeoutException> {
@@ -137,8 +145,12 @@ class FlowHospitalTest {
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
             ++observationCounter
         }
-        driver(DriverParameters(startNodesInProcess = true,
-                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+        driver(
+            DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts"))
+            )
+        ) {
             // one node will be enough for this testing
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
             val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
@@ -160,8 +172,12 @@ class FlowHospitalTest {
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
             ++observationCounter
         }
-        driver(DriverParameters(startNodesInProcess = true,
-                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+        driver(
+            DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts"))
+            )
+        ) {
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
             val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
             assertFailsWith<TimeoutException> {

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -275,7 +275,6 @@ class FlowHospitalTest {
 
         @Suspendable
         override fun call() {
-            // Create an instance out of the Class reference and TODO check if it is or has a HospitalizeFlowException.
             val throwable = hospitalizeFlowExceptionClass.newInstance()
             (throwable as? Throwable)?.let {
                 throw it

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -261,7 +261,7 @@ class FlowHospitalTest {
         override fun call() {
             // Create an instance out of the Class reference and TODO check if it is or has a HospitalizeFlowException.
             val throwable = hospitalizeFlowExceptionClass.newInstance()
-            (throwable as Throwable)?.let {
+            (throwable as? Throwable)?.let {
                 throw it
             }
         }

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -140,7 +140,8 @@ class FlowHospitalTest {
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
             ++observationCounter
         }
-        driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
+        driver(DriverParameters(startNodesInProcess = true,
+                                cordappsForAllNodes = listOf(enclosedCordapp(), findCordapp("net.corda.testing.contracts")))) {
             // one node will be enough for this testing
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(rpcUser)).getOrThrow()
             val aliceClient = CordaRPCClient(alice.rpcAddress).start(rpcUser.username, rpcUser.password).proxy
@@ -275,8 +276,9 @@ class FlowHospitalTest {
 
     class CloakingHospitalizeFlowException : HospitalizeFlowException() { // HospitalizeFlowException wrapping important exception
         init {
-            // Wrapping an SQLException with "deadlock" as a message should lead the flow being handled by StaffedFlowHospital#DeadlockNurse as well
-            // and therefore having the flow discharged and not getting it for overnight observation.
+            // Wrapping an SQLException with "deadlock" as a message should lead the flow being handled
+            // by StaffedFlowHospital#DeadlockNurse as well and therefore having the flow discharged
+            // and not getting it for overnight observation.
             setCause(SQLException("deadlock"))
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -567,7 +567,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
             newError: Throwable,
             history: FlowMedicalHistory
         ): Diagnosis {
-            return if (newError is HospitalizeFlowException) {
+            return if (newError.mentionsThrowable(HospitalizeFlowException::class.java)) {
                 Diagnosis.OVERNIGHT_OBSERVATION
             } else {
                 Diagnosis.NOT_MY_SPECIALTY

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -558,7 +558,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
     }
 
     /**
-     * Pauses a flow, hospitalizing it immediately, upon throwing a [HospitalizeFlowException].
+     * Keeps the flow in for overnight observation if [HospitalizeFlowException] is received.
      */
     object SedationNurse : Staff {
         override fun consult(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -2,7 +2,7 @@ package net.corda.node.services.statemachine
 
 import net.corda.core.crypto.newSecureRandom
 import net.corda.core.flows.FlowException
-import net.corda.core.flows.PauseFlowException
+import net.corda.core.flows.HospitalizeFlowException
 import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.flows.ReceiveTransactionFlow
 import net.corda.core.flows.StateMachineRunId
@@ -558,7 +558,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
     }
 
     /**
-     * Pauses a flow, hospitalizing it immediately, upon throwing a [PauseFlowException].
+     * Pauses a flow, hospitalizing it immediately, upon throwing a [HospitalizeFlowException].
      */
     object SedationNurse : Staff {
         override fun consult(
@@ -567,7 +567,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
             newError: Throwable,
             history: FlowMedicalHistory
         ): Diagnosis {
-            return if (newError is PauseFlowException) {
+            return if (newError is HospitalizeFlowException) {
                 Diagnosis.OVERNIGHT_OBSERVATION
             } else {
                 Diagnosis.NOT_MY_SPECIALTY

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.statemachine
 
 import net.corda.core.crypto.newSecureRandom
 import net.corda.core.flows.FlowException
+import net.corda.core.flows.PauseFlowException
 import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.flows.ReceiveTransactionFlow
 import net.corda.core.flows.StateMachineRunId
@@ -46,7 +47,8 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
             FinalityDoctor,
             TransientConnectionCardiologist,
             DatabaseEndocrinologist,
-            TransitionErrorGeneralPractitioner
+            TransitionErrorGeneralPractitioner,
+            SedationNurse
         )
 
         @VisibleForTesting
@@ -551,6 +553,24 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
                         ${(newError as? StateTransitionException)?.transitionEvent?.let { "- Event: $it" }}
                         """.trimIndent()
                 }
+            }
+        }
+    }
+
+    /**
+     * Pauses a flow, hospitalizing it immediately, upon throwing a [PauseFlowException].
+     */
+    object SedationNurse : Staff {
+        override fun consult(
+            flowFiber: FlowFiber,
+            currentState: StateMachineState,
+            newError: Throwable,
+            history: FlowMedicalHistory
+        ): Diagnosis {
+            return if (newError is PauseFlowException) {
+                Diagnosis.OVERNIGHT_OBSERVATION
+            } else {
+                Diagnosis.NOT_MY_SPECIALTY
             }
         }
     }


### PR DESCRIPTION
Introducing a new type of exception, which, whenever thrown by a flow, leads to the flow being sent to the hospital immediately for overnight observation.

This new exception is being handled by a newly introduced staff of the StaffedFlowHospital.