### PR TITLE
Fix empty IN statements in vault queries for MS SQL Server

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -1065,6 +1065,20 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     }
 
     @Test
+    fun `logical operator IN with empty parameters`() {
+        database.transaction {
+            listOf(USD, GBP, CHF).forEach {
+                vaultFiller.fillWithSomeTestCash(AMOUNT(100, it), notaryServices, 1, DUMMY_CASH_ISSUER)
+            }
+            val currencies = emptyList<String>()
+            val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.`in`(currencies) }
+            val criteria = VaultCustomQueryCriteria(logicalExpression)
+            val results = vaultService.queryBy<Cash.State>(criteria)
+            assertThat(results.states).hasSize(0)
+        }
+    }
+
+    @Test
     fun `logical operator NOT IN`() {
         database.transaction {
             listOf(USD, GBP, CHF).forEach {


### PR DESCRIPTION
From Insurwave fork of the Open Source 4.1

Courtesy of @marko-mets-gt (bug fix) and me (test)