### PR TITLE
TM-137 Daily email report for release branch regression tests

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -53,6 +53,40 @@ pipeline {
             archiveArtifacts artifacts: '**/pod-logs/**/*.log', fingerprint: false
             junit '**/build/test-results-xml/**/*.xml'
             allure includeProperties: false, jdk: '', results: [[path: '**/build/test-results-xml/**']]
+
+            script
+            {
+                // We want to send a summary email, but want to limit to once per day.
+                // Comparing the dates of the previous and current builds achieves this,
+                // i.e. we will only send an email for the first build on a given day.
+                def prevBuildDate = new Date(
+                        currentBuild?.previousBuild.timeInMillis ?: 0).clearTime()
+                def currentBuildDate = new Date(
+                        currentBuild.timeInMillis).clearTime()
+
+                if (prevBuildDate != currentBuildDate) {
+                    def statusSymbol = '\u2753'
+                    switch(currentBuild.result) {
+                        case 'SUCCESS':
+                            statusSymbol = '\u2705'
+                            break;
+                        case 'UNSTABLE':
+                        case 'FAILURE':
+                            statusSymbol = '\u274c'
+                            break;
+                        default:
+                            break;
+                    }
+
+                    echo('First build for this date, sending summary email')
+                    emailext to: '$DEFAULT_RECIPIENTS',
+                        subject: "$statusSymbol" + '$BRANCH_NAME regression tests - $BUILD_STATUS',
+                        mimeType: 'text/html',
+                        body: '${SCRIPT, template="groovy-html.template"}'
+                } else {
+                    echo('Already sent summary email today, suppressing')
+                }
+            }
         }
         cleanup {
             deleteDir() /* clean up our workspace */

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -52,7 +52,6 @@ pipeline {
         always {
             archiveArtifacts artifacts: '**/pod-logs/**/*.log', fingerprint: false
             junit '**/build/test-results-xml/**/*.xml'
-<<<<<<< HEAD
             allure includeProperties: false, jdk: '', results: [[path: '**/build/test-results-xml/**']]
 
             script
@@ -86,7 +85,6 @@ pipeline {
                         body: '${SCRIPT, template="groovy-html.template"}'
                 } else {
                     echo('Already sent summary email today, suppressing')
-=======
 
             script {
                 try {
@@ -116,7 +114,6 @@ pipeline {
                     if (currentBuild.resultIsBetterOrEqualTo('SUCCESS')) {
                         currentBuild.result = 'UNSTABLE'
                     }
->>>>>>> 38fb51b74b068d9e05aff0f524a8e166ed60f387
                 }
             }
         }


### PR DESCRIPTION
Basic daily email reports for regression test builds, using default Jenkins HTML mail template.

*NOTE* This has been tested successfully, but with the allure report generation (not part of the diff of this PR) commented out due to issues with this plugin at present.