### PR TITLE
Prevent on-demand tests re-triggering from branch indexing

### DIFF
--- a/.ci/dev/smoke/Jenkinsfile
+++ b/.ci/dev/smoke/Jenkinsfile
@@ -5,7 +5,8 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 
 pipeline {
     agent { label 'k8s' }
-    options { timestamps() }
+    options { timestamps() 
+              overrideIndexTriggers(false) }
 
     triggers {
         issueCommentTrigger('.*smoke tests.*')


### PR DESCRIPTION
On-demand tests appeared to be re-triggering despite no meaningful changes. It is suspected this is due to branch merging that subsequently rebases changes for open PR's.

This change prevents this behaviour by disabling organisation level triggers, ensuring branch indexing only triggers the first build.