### PR TITLE
ENT-4595: Don't change existing archive classifiers for test artifacts.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -149,9 +149,7 @@ quasar {
 
 artifacts {
     testArtifacts testJar
-    publish testJar {
-        archiveClassifier = "test"
-    }
+    publish testJar
 }
 
 scanApi {

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -59,9 +59,7 @@ task testJar(type: Jar) {
 
 artifacts {
     testArtifacts testJar
-    publish testJar {
-        archiveClassifier = "test"
-    }
+    publish testJar
 }
 
 jar {


### PR DESCRIPTION
The test artifacts have already been assigned a classifier of `tests` (the same as [Maven's `test-jar`](https://maven.apache.org/plugins/maven-jar-plugin/test-jar-mojo.html)). There's no need to change it, and even if there were the `artifacts` block is still the wrong place to do it.