### PR TITLE
ENT-4595: Delete SgxSupport from core-deterministic.

### DIFF
--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -64,7 +64,6 @@ task patchCore(type: Zip, dependsOn: coreJarTask) {
         exclude 'net/corda/core/serialization/*SerializationFactory*.class'
         exclude 'net/corda/core/serialization/internal/CheckpointSerializationFactory*.class'
         exclude 'net/corda/core/internal/rules/*.class'
-        exclude 'net/corda/core/utilities/SgxSupport*.class'
     }
 
     reproducibleFileOrder = true

--- a/core-deterministic/src/main/kotlin/net/corda/core/utilities/SgxSupport.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/utilities/SgxSupport.kt
@@ -1,9 +1,0 @@
-package net.corda.core.utilities
-
-import net.corda.core.KeepForDJVM
-
-@KeepForDJVM
-object SgxSupport {
-    @JvmStatic
-    val isInsideEnclave: Boolean = true
-}

--- a/core/src/main/kotlin/net/corda/core/utilities/SgxSupport.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/SgxSupport.kt
@@ -1,5 +1,8 @@
 package net.corda.core.utilities
 
+import net.corda.core.DeleteForDJVM
+
+@DeleteForDJVM
 object SgxSupport {
     @JvmStatic
     val isInsideEnclave: Boolean by lazy {


### PR DESCRIPTION
The `SgxSupport` object is unused inside `core-deterministic`.