### PR TITLE
Mark integration test tasks with "big" node taint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -606,6 +606,7 @@ task allParallelIntegrationTest(type: ParallelTestGroup) {
     coresPerFork 5
     memoryInGbPerFork 12
     distribute DistributeTestsBy.METHOD
+    nodeTaints "big"
 }
 task allParallelUnitTest(type: ParallelTestGroup) {
     podLogLevel PodLogLevel.INFO
@@ -624,6 +625,7 @@ task allParallelUnitAndIntegrationTest(type: ParallelTestGroup) {
     coresPerFork 6
     memoryInGbPerFork 10
     distribute DistributeTestsBy.METHOD
+    nodeTaints "big"
 }
 task parallelRegressionTest(type: ParallelTestGroup) {
     testGroups "test", "integrationTest", "slowIntegrationTest", "smokeTest"
@@ -632,6 +634,7 @@ task parallelRegressionTest(type: ParallelTestGroup) {
     coresPerFork 6
     memoryInGbPerFork 10
     distribute DistributeTestsBy.METHOD
+    nodeTaints "big"
 }
 task allParallelSmokeTest(type: ParallelTestGroup) {
     testGroups "slowIntegrationTest", "smokeTest"
@@ -640,6 +643,7 @@ task allParallelSmokeTest(type: ParallelTestGroup) {
     coresPerFork 6
     memoryInGbPerFork 10
     distribute DistributeTestsBy.CLASS
+    nodeTaints "big"
 }
 apply plugin: 'com.r3.testing.distributed-testing'
 apply plugin: 'com.r3.testing.image-building'


### PR DESCRIPTION
Unit tests have already been marked with "small" node taint to ensure unit tests run on boxes with fewer resources, which is more economical whilst having a minimal impact on run-time.

Conversely, we want to mark integration tests with "big" so that we can force these to run on faster boxes.
