### PR TITLE
CORDA-3479: Added timestamp to the node_transactions table. (#2660)

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -846,7 +846,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     }
 
     protected open fun makeTransactionStorage(transactionCacheSizeBytes: Long): WritableTransactionStorage {
-        return DBTransactionStorage(database, cacheFactory)
+        return DBTransactionStorage(database, cacheFactory, platformClock)
     }
 
     protected open fun makeNetworkParametersStorage(): NetworkParametersStorage {

--- a/node/src/main/kotlin/net/corda/node/migration/CordaMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/CordaMigration.kt
@@ -8,6 +8,7 @@ import liquibase.exception.ValidationErrors
 import liquibase.resource.ResourceAccessor
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.schemas.MappedSchema
+import net.corda.node.SimpleClock
 import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.persistence.*
 import net.corda.nodeapi.internal.persistence.CordaPersistence
@@ -16,6 +17,7 @@ import net.corda.nodeapi.internal.persistence.SchemaMigration.Companion.NODE_X50
 import java.io.PrintWriter
 import java.sql.Connection
 import java.sql.SQLFeatureNotSupportedException
+import java.time.Clock
 import java.util.logging.Logger
 import javax.sql.DataSource
 
@@ -62,7 +64,7 @@ abstract class CordaMigration : CustomTaskChange {
 
         cordaDB.transaction {
             identityService.ourNames = setOf(ourName)
-             val dbTransactions = DBTransactionStorage(cordaDB, cacheFactory)
+             val dbTransactions = DBTransactionStorage(cordaDB, cacheFactory, SimpleClock(Clock.systemUTC()))
              val attachmentsService = NodeAttachmentService(metricRegistry, cacheFactory, cordaDB)
             _servicesForResolution = MigrationServicesForResolution(identityService, attachmentsService, dbTransactions, cordaDB, cacheFactory)
         }

--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -24,6 +24,7 @@
     <include file="migration/node-core.changelog-v13.xml"/>
     <!-- This change should be done before the v14-data migration. -->
     <include file="migration/node-core.changelog-v15.xml"/>
+    <include file="migration/node-core.changelog-v16.xml"/>
 
     <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
     <include file="migration/vault-schema.changelog-v9.xml"/>

--- a/node/src/main/resources/migration/node-core.changelog-v16.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v16.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   logicalFilePath="migration/node-services.changelog-init.xml">
+
+    <changeSet author="R3.Corda" id="add_timestamp_column_to_node_transactions">
+        <addColumn tableName="node_transactions">
+            <column name="timestamp" type="TIMESTAMP" defaultValueDate="2000-01-01 12:00:00">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -50,6 +50,7 @@ import org.mockito.Mockito
 import java.security.KeyPair
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -208,7 +209,8 @@ class VaultStateMigrationTest {
                     txId = tx.id.toString(),
                     stateMachineRunId = null,
                     transaction = tx.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes,
-                    status = DBTransactionStorage.TransactionStatus.VERIFIED
+                    status = DBTransactionStorage.TransactionStatus.VERIFIED,
+                    timestamp = Instant.now()
             )
             session.save(persistentTx)
         }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -34,6 +34,7 @@ import org.junit.Before
 import org.junit.Test
 import java.sql.SQLException
 import java.time.Duration
+import java.time.Instant
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -284,7 +285,8 @@ class RetryFlowMockTest {
         }
 
         private fun doInsert() {
-            val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES, DBTransactionStorage.TransactionStatus.VERIFIED)
+            val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES,
+                    DBTransactionStorage.TransactionStatus.VERIFIED, Instant.now())
             contextTransaction.session.save(tx)
         }
     }


### PR DESCRIPTION
Backport of ENT-4237 to Open Source