### PR TITLE
ENT-4382: Core module changes to support multi-RPC work

### DIFF
--- a/core/src/main/kotlin/net/corda/core/CordaInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/CordaInternal.kt
@@ -8,7 +8,7 @@ import kotlin.annotation.AnnotationTarget.*
  *
  * These are only meant to be used by Corda internally, and are not intended to be part of the public API.
  */
-@Target(PROPERTY_GETTER, PROPERTY_SETTER, FUNCTION, ANNOTATION_CLASS)
+@Target(PROPERTY_GETTER, PROPERTY_SETTER, PROPERTY, FUNCTION, ANNOTATION_CLASS, CLASS)
 @Retention(BINARY)
 @MustBeDocumented
 annotation class CordaInternal

--- a/core/src/main/kotlin/net/corda/core/internal/AttachmentTrustCalculator.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AttachmentTrustCalculator.kt
@@ -1,5 +1,6 @@
 package net.corda.core.internal
 
+import net.corda.core.CordaInternal
 import net.corda.core.contracts.Attachment
 import net.corda.core.node.services.AttachmentId
 import net.corda.core.serialization.CordaSerializable
@@ -7,6 +8,7 @@ import net.corda.core.serialization.CordaSerializable
 /**
  * Calculates the trust of attachments stored in the node.
  */
+@CordaInternal
 interface AttachmentTrustCalculator {
 
     /**

--- a/core/src/main/kotlin/net/corda/core/internal/utilities/InvocationHandlerTemplate.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/utilities/InvocationHandlerTemplate.kt
@@ -1,4 +1,4 @@
-package net.corda.node.internal
+package net.corda.core.internal.utilities
 
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.InvocationTargetException
@@ -7,7 +7,7 @@ import java.lang.reflect.Method
 /**
  * Helps writing correct [InvocationHandler]s.
  */
-internal interface InvocationHandlerTemplate : InvocationHandler {
+interface InvocationHandlerTemplate : InvocationHandler {
     val delegate: Any
 
     override fun invoke(proxy: Any, method: Method, arguments: Array<out Any?>?): Any? {

--- a/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt
@@ -4,7 +4,7 @@ import net.corda.client.rpc.PermissionException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.internal.messaging.InternalCordaRPCOps
 import net.corda.core.messaging.CordaRPCOps
-import net.corda.node.internal.InvocationHandlerTemplate
+import net.corda.core.internal.utilities.InvocationHandlerTemplate
 import net.corda.node.services.rpc.RpcAuthContext
 import net.corda.node.services.rpc.rpcContext
 import java.lang.reflect.Method

--- a/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ThreadContextAdjustingRpcOpsProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ThreadContextAdjustingRpcOpsProxy.kt
@@ -3,7 +3,7 @@ package net.corda.node.internal.rpc.proxies
 import net.corda.core.internal.executeWithThreadContextClassLoader
 import net.corda.core.internal.messaging.InternalCordaRPCOps
 import net.corda.core.messaging.CordaRPCOps
-import net.corda.node.internal.InvocationHandlerTemplate
+import net.corda.core.internal.utilities.InvocationHandlerTemplate
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 


### PR DESCRIPTION
Since `core` module now only available in OS, these changes need to be made in OS and then propagated to ENT.

IMO they are sensible and fairly minor changes to make to `core/internal` classes