### PR TITLE
Fix report generation against regression builds

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -52,7 +52,46 @@ pipeline {
         always {
             archiveArtifacts artifacts: '**/pod-logs/**/*.log', fingerprint: false
             junit '**/build/test-results-xml/**/*.xml'
-            allure includeProperties: false, jdk: '', results: [[path: '**/build/test-results-xml/**']]
+
+            script {
+                try {
+                    /*
+                     * Copy all JUnit results files into a single top level directory.
+                     * This is necessary to stop the allure plugin from hitting out
+                     * of memory errors due to being passed many directories with
+                     * long paths.
+                     *
+                     * File names are pre-pended with the pod number when
+                     * copied to avoid collisions between files where the same test
+                     * classes have run on multiple pods.
+                     */
+                    sh label: 'Compact test results',
+                       script:
+                           '''#!/bin/bash
+                              shopt -s globstar
+                              rm -rf allure-input
+                              mkdir allure-input
+
+                              for i in **/test-results-xml/**/test-runs/test-reports/**
+                              do
+                                  [ -f $i ] &&
+                                  cp $i allure-input/$(echo $i | sed -e \\
+                                      \'s/.*test-results-xml\\/.*-\\(.*\\)\\/test-runs\\/.*\\/\\(.*\\)$/\\1\\-\\2/\')
+                              done
+
+                              echo "Finished compacting JUnit results"
+                       '''
+                    allure includeProperties: false,
+                           jdk: '',
+                           results: [[path: '**/allure-input']]
+                } catch (err) {
+                    echo("Allure report generation failed: $err")
+
+                    if (currentBuild.resultIsBetterOrEqualTo('SUCCESS')) {
+                        currentBuild.result = 'UNSTABLE'
+                    }
+                }
+            }
         }
         cleanup {
             deleteDir() /* clean up our workspace */


### PR DESCRIPTION
Allure is currently throwing a GC overhead limit exceeded error on the nightly regression builds.

Restricting to only include the core tests directories appears to resolve the issue. This has led me to believe the problem is that the glob pattern to include JUnit XML test result directories has picked up many directories, each of which has a long path and is overwhelming allure.

This change implements a workaround by copying all files into a single allure-input directory, which is provided to allure. This appears to resolve the problem. Files are pre-pended with the pod number they ran on to guard against the case of the same test class running on multiple pods (which can happen if tests are distributed by method).

Longer term this solution can probably be refined to extract into a separate bash script or library. This submission should be considered a tactical fix to get the regression test builds working again.

This change also adds protection so that failing to generate the allure report no longer marks the build as failed. Instead, it adopts a philosophy of graceful degradation, marking the build as unstable but otherwise carrying on.