### PR TITLE
Corda 3513 rpc flow without permission

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -303,7 +303,7 @@ class ReconnectingCordaRPCOps private constructor(
          * A negative number for [maxNumberOfAttempts] means an unlimited number of retries will be performed.
          */
         private fun doInvoke(method: Method, args: Array<out Any>?, maxNumberOfAttempts: Int): Any? {
-            checkIsClosed()
+            checkIfClosed()
             var remainingAttempts = maxNumberOfAttempts
             var lastException: Throwable? = null
             while (remainingAttempts != 0) {
@@ -330,7 +330,7 @@ class ReconnectingCordaRPCOps private constructor(
                             checkIfIsStartFlow(method, e)
                         }
                         is PermissionException -> {
-                            throw RPCException("User does not have permission to perform operation ${method.name}.  Will not retry.", e)
+                            throw RPCException("User does not have permission to perform operation ${method.name}.", e)
                         }
                         else -> {
                             log.warn("Failed to perform operation ${method.name}. Unknown error. Retrying....", e)
@@ -346,7 +346,7 @@ class ReconnectingCordaRPCOps private constructor(
             throw MaxRpcRetryException(maxNumberOfAttempts, lastException)
         }
 
-        private fun checkIsClosed() {
+        private fun checkIfClosed() {
             if (reconnectingRPCConnection.isClosed()) {
                 throw RPCException("Cannot execute RPC command after client has shut down.")
             }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -303,9 +303,7 @@ class ReconnectingCordaRPCOps private constructor(
          * A negative number for [maxNumberOfAttempts] means an unlimited number of retries will be performed.
          */
         private fun doInvoke(method: Method, args: Array<out Any>?, maxNumberOfAttempts: Int): Any? {
-            if (reconnectingRPCConnection.isClosed()) {
-                throw RPCException("Cannot execute RPC command after client has shut down.")
-            }
+            checkIsClosed()
             var remainingAttempts = maxNumberOfAttempts
             var lastException: Throwable? = null
             while (remainingAttempts != 0) {
@@ -346,6 +344,12 @@ class ReconnectingCordaRPCOps private constructor(
             }
 
             throw MaxRpcRetryException(maxNumberOfAttempts, lastException)
+        }
+
+        private fun checkIsClosed() {
+            if (reconnectingRPCConnection.isClosed()) {
+                throw RPCException("Cannot execute RPC command after client has shut down.")
+            }
         }
 
         override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -331,6 +331,9 @@ class ReconnectingCordaRPCOps private constructor(
                             Thread.sleep(1000) // TODO - explain why this sleep is necessary
                             checkIfIsStartFlow(method, e)
                         }
+                        is PermissionException -> {
+                            throw RPCException("User does not have permission to perform operation ${method.name}.  Will not retry.", e)
+                        }
                         else -> {
                             log.warn("Failed to perform operation ${method.name}. Unknown error. Retrying....", e)
                             reconnectingRPCConnection.reconnectOnError(e)

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
@@ -184,6 +184,24 @@ class FlowRetryTest {
             }
         }
     }
+
+    @Test
+    fun `Permission exceptions are not retried and propagate`() {
+        val user = User("mark", "dadada", setOf())
+        driver(DriverParameters(isDebug = true, startNodesInProcess = isQuasarAgentSpecified())) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                assertThatExceptionOfType(CordaRuntimeException::class.java).isThrownBy {
+                    it.proxy.startFlow(::GeneralExternalFailureFlow, nodeBHandle.nodeInfo.singleIdentity()).returnValue.getOrThrow()
+                }.withMessageStartingWith("User not authorized to perform RPC call")
+                // This stays at -1 since the flow never even got called
+                assertEquals(-1, GeneralExternalFailureFlow.retryCount)
+            }
+        }
+    }
 }
 
 fun isQuasarAgentSpecified(): Boolean {

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
@@ -191,11 +191,10 @@ class FlowRetryTest {
         driver(DriverParameters(isDebug = true, startNodesInProcess = isQuasarAgentSpecified())) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
 
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 assertThatExceptionOfType(CordaRuntimeException::class.java).isThrownBy {
-                    it.proxy.startFlow(::GeneralExternalFailureFlow, nodeBHandle.nodeInfo.singleIdentity()).returnValue.getOrThrow()
+                    it.proxy.startFlow(::AsyncRetryFlow).returnValue.getOrThrow()
                 }.withMessageStartingWith("User not authorized to perform RPC call")
                 // This stays at -1 since the flow never even got called
                 assertEquals(-1, GeneralExternalFailureFlow.retryCount)


### PR DESCRIPTION
We'll just re-throw the exception so that it can be picked up outside of the reconnecting ops.