### PR TITLE
CORDA-2942: Improve tests coverage for Checkpoint dumper

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/DumpCheckpointsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/DumpCheckpointsTest.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.rpc
 
+import co.paralleluniverse.fibers.Suspendable
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
@@ -53,6 +54,7 @@ class DumpCheckpointsTest {
 
     @StartableByRPC
     class GetNumberOfCheckpointsFlow : FlowLogic<Int>() {
+        @Suspendable
         override fun call(): Int {
             var count = 0
             serviceHub.jdbcSession().prepareStatement("select * from node_checkpoints").use { ps ->
@@ -62,9 +64,14 @@ class DumpCheckpointsTest {
                     }
                 }
             }
+            syncUp()
+            return count
+        }
+
+        @Suspendable
+        private fun syncUp() {
             dumpCheckPointLatch.countDown()
             flowProceedLatch.await()
-            return count
         }
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/DumpCheckpointsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/DumpCheckpointsTest.kt
@@ -1,12 +1,18 @@
 package net.corda.node.services.rpc
 
 import co.paralleluniverse.fibers.Suspendable
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
+import net.corda.core.internal.inputStream
+import net.corda.core.internal.isRegularFile
+import net.corda.core.internal.list
 import net.corda.core.internal.messaging.InternalCordaRPCOps
+import net.corda.core.internal.readFully
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.NodeStartup
@@ -18,7 +24,9 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.Test
+import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
+import java.util.zip.ZipInputStream
 import kotlin.test.assertEquals
 
 class DumpCheckpointsTest {
@@ -29,10 +37,9 @@ class DumpCheckpointsTest {
     }
 
     @Test
-    fun `Verify checkpoint dump via RPC`() {
+    fun `verify checkpoint dump via RPC`() {
         val user = User("mark", "dadada", setOf(Permissions.all()))
-        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true, inMemoryDB = false,
-                cordappsForAllNodes = listOf(enclosedCordapp()))) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true, cordappsForAllNodes = listOf(enclosedCordapp()))) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
 
@@ -42,13 +49,27 @@ class DumpCheckpointsTest {
                 // 1 for GetNumberOfCheckpointsFlow itself
                 val checkPointCountFuture = proxy.startFlow(::GetNumberOfCheckpointsFlow).returnValue
 
-                (nodeAHandle.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).createDirectories()
+                val logDirPath = nodeAHandle.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
+                logDirPath.createDirectories()
                 dumpCheckPointLatch.await()
                 proxy.dumpCheckpoints()
 
                 flowProceedLatch.countDown()
                 assertEquals(1, checkPointCountFuture.get())
+                checkDumpFile(logDirPath)
             }
+        }
+    }
+
+    private fun checkDumpFile(dir: Path) {
+        // The directory supposed to contain a single ZIP file
+        val file = dir.list().single { it.isRegularFile() }
+
+        ZipInputStream(file.inputStream()).use { zip ->
+            val entry = zip.nextEntry
+            assertThat(entry.name, containsSubstring("json"))
+            val content = zip.readFully()
+            assertThat(String(content), containsSubstring(GetNumberOfCheckpointsFlow::class.java.name))
         }
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/DumpCheckpointsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/DumpCheckpointsTest.kt
@@ -1,0 +1,95 @@
+package net.corda.node.services.rpc
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.CordaRuntimeException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.internal.createDirectories
+import net.corda.core.internal.div
+import net.corda.core.internal.messaging.InternalCordaRPCOps
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.unwrap
+import net.corda.node.internal.NodeStartup
+import net.corda.node.services.Permissions
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.User
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DumpCheckpointsTest {
+
+    @Test
+    fun `Verify checkpoint dump via RPC`() {
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                val proxy = it.proxy as InternalCordaRPCOps
+                assertFailsWith<CordaRuntimeException> {
+                    proxy.startFlow(::GeneralExternalFailureFlow, nodeBHandle.nodeInfo.singleIdentity()).returnValue.getOrThrow()
+                }
+                assertEquals(0, GeneralExternalFailureFlow.retryCount)
+                // 1 for the errored flow kept for observation and another for GetNumberOfCheckpointsFlow
+                assertEquals(1, proxy.startFlow(::GetNumberOfCheckpointsFlow).returnValue.get())
+
+                (nodeAHandle.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).createDirectories()
+                proxy.dumpCheckpoints()
+            }
+        }
+    }
+}
+
+@StartableByRPC
+@InitiatingFlow
+class GeneralExternalFailureFlow(private val party: Party) : FlowLogic<Unit>() {
+    companion object {
+        // start negative due to where it is incremented
+        var retryCount = -1
+    }
+
+    @Suspendable
+    override fun call() {
+        initiateFlow(party).send("hello there")
+        // checkpoint will restart the flow after the send
+        retryCount += 1
+        throw IllegalStateException("Some user general exception")
+    }
+}
+
+@InitiatedBy(GeneralExternalFailureFlow::class)
+class GeneralExternalFailureResponder(private val session: FlowSession) : FlowLogic<Unit>() {
+
+    @Suspendable
+    override fun call() {
+        session.receive<String>().unwrap { it }
+    }
+}
+
+@StartableByRPC
+class GetNumberOfCheckpointsFlow : FlowLogic<Int>() {
+    override fun call(): Int {
+        var count = 0
+        serviceHub.jdbcSession().prepareStatement("select * from node_checkpoints").use { ps ->
+            ps.executeQuery().use { rs ->
+                while(rs.next()) {
+                    count++
+                }
+            }
+        }
+        return count
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumper.kt
@@ -58,7 +58,7 @@ import java.util.zip.ZipOutputStream
 
 class CheckpointDumper(private val checkpointStorage: CheckpointStorage, private val database: CordaPersistence, private val serviceHub: ServiceHub, val baseDirectory: Path) {
     companion object {
-        private val TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(UTC)
+        internal val TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(UTC)
         private val log = contextLogger()
     }
 


### PR DESCRIPTION
This PR improves existing unit test and adds an integration test to verify that it is possible to invoke dump checkpoints via RPC.