### PR TITLE
Cache results from KeyStore #5832

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/X509NameConstraintsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/X509NameConstraintsTest.kt
@@ -145,6 +145,15 @@ class X509NameConstraintsTest {
 
         val privateKey = keystore.getPrivateKey(X509Utilities.CORDA_CLIENT_TLS, keyPassword)
         assertEquals(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME.algorithmName, privateKey.algorithm)
+    }
+
+    @Test
+    fun `test private key retrieval with invalid key`() {
+        val acceptableNames = listOf("CN=Bank A TLS, UID=", "O=Bank A")
+                .map { GeneralSubtree(GeneralName(X500Name(it))) }.toTypedArray()
+
+        val nameConstraints = NameConstraints(acceptableNames, arrayOf())
+        val (keystore, _) = makeKeyStores(X500Name("CN=Bank A"), nameConstraints)
 
         assertFailsWith(UnrecoverableKeyException::class) {
             keystore.getPrivateKey(X509Utilities.CORDA_CLIENT_TLS, "gibberish")


### PR DESCRIPTION
The Java Keystore is a facility depending on the underlying JDK and the used format/algorithms. Reading and instantiating a PrivateKey can be an expensive operation. It may involve math operations. It may take as much time as singing a message, greatly impacting performance. For this reason reading a PrivateKey should be cached. This commit introduces a cache to the Corda `X509KeyStore` Keystore wrapper by caching successfully created PrivateKeys.