### PR TITLE
Strategic fix for allure report generation memory issues

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -65,22 +65,13 @@ pipeline {
                      * copied to avoid collisions between files where the same test
                      * classes have run on multiple pods.
                      */
-                    sh label: 'Compact test results',
-                       script:
-                           '''#!/bin/bash
-                              shopt -s globstar
-                              rm -rf allure-input
-                              mkdir allure-input
-
-                              for i in **/test-results-xml/**/test-runs/test-reports/**
-                              do
-                                  [ -f $i ] &&
-                                  cp $i allure-input/$(echo $i | sed -e \\
-                                      \'s/.*test-results-xml\\/.*-\\(.*\\)\\/test-runs\\/.*\\/\\(.*\\)$/\\1\\-\\2/\')
-                              done
-
-                              echo "Finished compacting JUnit results"
-                       '''
+                    fileOperations([fileCopyOperation(
+                            includes: '**/test-results-xml/**/test-runs/test-reports/**',
+                            targetLocation: 'allure-input',
+                            flattenFiles: true,
+                            renameFiles: true,
+                            sourceCaptureExpression: '.*test-results-xml/.*-([\\d]+)/.*/([^/]+)$',
+                            targetNameExpression: '$1-$2')])
                     allure includeProperties: false,
                            jdk: '',
                            results: [[path: '**/allure-input']]


### PR DESCRIPTION
Replaces the inline shell script with the file operations plugin.

Note that this currently uses a forked version of the plugin that supports file renaming, as the existing release version does not handle different subdirectories that contain files of the same name. The forked version can be found here:

https://github.com/relyafi/file-operations-plugin

A separate PR has been raised to get these changes committed to the main plugin repo.
