### PR TITLE
ENT-4652: Implement attachment fix-up mechanism for broken Corda transactions.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt
@@ -3,7 +3,6 @@ package net.corda.core.contracts
 import net.corda.core.CordaInternal
 import net.corda.core.KeepForDJVM
 import net.corda.core.internal.cordapp.CordappImpl.Companion.DEFAULT_CORDAPP_VERSION
-import net.corda.core.serialization.CordaSerializable
 import java.security.PublicKey
 
 /**

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -228,6 +228,13 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
         : TransactionVerificationException(txId, "Couldn't find network parameters with hash: $missingNetworkParametersHash related to this transaction: $txId", null)
 
 
+    /**
+     * @param txId Id of the transaction that Corda is no longer able to verify.
+     */
+    @KeepForDJVM
+    class BrokenTransactionException(txId: SecureHash, message: String)
+        : TransactionVerificationException(txId, message, null)
+
     /** Whether the inputs or outputs list contains an encumbrance issue, see [TransactionMissingEncumbranceException]. */
     @CordaSerializable
     @KeepForDJVM

--- a/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
@@ -5,6 +5,7 @@ package net.corda.core.internal
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.Attachment
+import net.corda.core.contracts.ContractAttachment
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.Party
 import net.corda.core.serialization.MissingAttachmentsException
@@ -30,6 +31,12 @@ const val UNKNOWN_UPLOADER = "unknown"
 val TRUSTED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER, TESTDSL_UPLOADER)
 
 fun isUploaderTrusted(uploader: String?): Boolean = uploader in TRUSTED_UPLOADERS
+
+fun Attachment.isUploaderTrusted(): Boolean = when (this) {
+    is ContractAttachment -> isUploaderTrusted(uploader)
+    is AbstractAttachment -> isUploaderTrusted(uploader)
+    else -> false
+}
 
 @KeepForDJVM
 abstract class AbstractAttachment(dataLoader: () -> ByteArray, val uploader: String?) : Attachment {

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -1,14 +1,17 @@
+@file:Suppress("TooManyFunctions")
 package net.corda.core.internal
 
 import net.corda.core.DeleteForDJVM
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.ContractClassName
+import net.corda.core.cordapp.CordappProvider
 import net.corda.core.flows.DataVendingFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.ZoneVersionTooLowException
+import net.corda.core.node.services.AttachmentId
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.node.services.vault.AttachmentQueryCriteria
 import net.corda.core.node.services.vault.AttachmentSort
@@ -107,6 +110,13 @@ internal fun NetworkParameters.getPackageOwnerOf(contractClassName: ContractClas
 // Make sure that packages don't overlap so that ownership is clear.
 fun noPackageOverlap(packages: Collection<String>): Boolean {
     return packages.all { outer -> packages.none { inner -> inner != outer && inner.startsWith("$outer.") } }
+}
+
+/**
+ * @return The set of [AttachmentId]s after the node's fix-up rules have been applied to [attachmentIds].
+ */
+fun CordappProvider.internalFixupAttachmentIds(attachmentIds: Collection<AttachmentId>): Set<AttachmentId> {
+    return (this as CordappFixupInternal).fixupAttachmentIds(attachmentIds)
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/internal/CordappFixupInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordappFixupInternal.kt
@@ -1,0 +1,9 @@
+package net.corda.core.internal
+
+import net.corda.core.DeleteForDJVM
+import net.corda.core.node.services.AttachmentId
+
+@DeleteForDJVM
+interface CordappFixupInternal {
+    fun fixupAttachmentIds(attachmentIds: Collection<AttachmentId>): Set<AttachmentId>
+}

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -10,17 +10,13 @@ import net.corda.core.utilities.contextLogger
 
 @DeleteForDJVM
 interface TransactionVerifierServiceInternal {
-    /**
-     * Verifies the [transaction] but adds some [extraAttachments] to the classpath.
-     * Required for transactions built with Corda 3.x that might miss some dependencies due to a bug in that version.
-     */
-    fun verify(transaction: LedgerTransaction, extraAttachments: List<Attachment>): CordaFuture<*>
+    fun reverifyWithFixups(transaction: LedgerTransaction, missingClass: String?): CordaFuture<*>
 }
 
 /**
  * Defined here for visibility reasons.
  */
-fun LedgerTransaction.prepareVerify(extraAttachments: List<Attachment>) = this.internalPrepareVerify(extraAttachments)
+fun LedgerTransaction.prepareVerify(attachments: List<Attachment>) = internalPrepareVerify(attachments)
 
 /**
  * Because we create a separate [LedgerTransaction] onto which we need to perform verification, it becomes important we don't verify the

--- a/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
@@ -11,6 +11,7 @@ import java.io.InputStream
 import java.nio.file.FileAlreadyExistsException
 
 typealias AttachmentId = SecureHash
+typealias AttachmentFixup = Pair<Set<AttachmentId>, Set<AttachmentId>>
 
 /**
  * An attachment store records potentially large binary objects, identified by their hash.

--- a/core/src/main/kotlin/net/corda/core/node/services/TransactionVerifierService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/TransactionVerifierService.kt
@@ -3,7 +3,6 @@ package net.corda.core.node.services
 import net.corda.core.DeleteForDJVM
 import net.corda.core.DoNotImplement
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.contracts.Attachment
 import net.corda.core.transactions.LedgerTransaction
 
 /**

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -319,8 +319,7 @@ object AttachmentsClassLoaderBuilder {
             val transactionClassLoader = AttachmentsClassLoader(attachments, params, txId, parent)
             val serializers = createInstancesOfClassesImplementing(transactionClassLoader, SerializationCustomSerializer::class.java)
             val whitelistedClasses = ServiceLoader.load(SerializationWhitelist::class.java, transactionClassLoader)
-                    .flatMap { it.whitelist }
-                    .toList()
+                    .flatMap(SerializationWhitelist::whitelist)
 
             // Create a new serializationContext for the current transaction. In this context we will forbid
             // deserialization of objects from the future, i.e. disable forwards compatibility. This is to ensure

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/MissingSerializerException.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/MissingSerializerException.kt
@@ -1,0 +1,24 @@
+package net.corda.core.serialization.internal
+
+import net.corda.core.KeepForDJVM
+import java.io.NotSerializableException
+
+/**
+ * Thrown by the serialization framework, probably indicating that a custom serializer
+ * needs to be included in a transaction.
+ */
+@KeepForDJVM
+open class MissingSerializerException private constructor(
+    message: String,
+    val typeDescriptor: String?,
+    val typeNames: List<String>
+) : NotSerializableException(message) {
+    constructor(message: String, typeDescriptor: String) : this(message, typeDescriptor, emptyList())
+    constructor(message: String, typeNames: List<String>) : this(message, null, typeNames)
+
+    /**
+     * This constructor allows instances of this exception to escape the DJVM sandbox.
+     */
+    @Suppress("unused")
+    private constructor(message: String) : this(message, null, emptyList())
+}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,11 @@ release, see :doc:`app-upgrade-notes`.
 Unreleased
 ----------
 
+* Custom serializer classes implementing ``SerializationCustomSerializer`` should ideally be packaged in the same CorDapp as the
+  contract classes. Corda 4 could therefore fail to verify transactions created with Corda 3 if their custom serializer classes
+  had been packaged somewhere else. Add a "fallback mechanism" to Corda's transaction verification logic which will attempt to
+  include any missing custom serializers from other CorDapps within ``AttachmentStorage``.
+
 * Fix a bug in Corda 4.0 that combined commands in ``TransactionBuilder`` if they only differed by the signers list.  The behaviour is now consistent with prior Corda releases.
 
 * Disabled the default loading of ``hibernate-validator`` as a plugin by hibernate when a CorDapp depends on it. This change will in turn fix the

--- a/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/DependentContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/DependentContract.kt
@@ -1,0 +1,38 @@
+package net.corda.contracts.fixup.dependent
+
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.ContractState
+import net.corda.core.identity.AbstractParty
+import net.corda.core.transactions.LedgerTransaction
+
+class DependentContract : Contract {
+    companion object {
+        const val MAX_BEANS = 1000L
+    }
+
+    override fun verify(tx: LedgerTransaction) {
+        val states = tx.outputsOfType<State>()
+        require(states.isNotEmpty()) {
+            "Requires at least one dependent data state"
+        }
+
+        states.forEach { state ->
+            require(state.dependentData in DependentData(0)..DependentData(MAX_BEANS)) {
+                "Invalid data: $state"
+            }
+        }
+    }
+
+    @Suppress("CanBeParameter", "MemberVisibilityCanBePrivate")
+    class State(val owner: AbstractParty, val dependentData: DependentData) : ContractState {
+        override val participants: List<AbstractParty> = listOf(owner)
+
+        @Override
+        override fun toString(): String {
+            return dependentData.toString()
+        }
+    }
+
+    class Operate : CommandData
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/DependentData.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/DependentData.kt
@@ -1,0 +1,11 @@
+package net.corda.contracts.fixup.dependent
+
+data class DependentData(val value: Long) : Comparable<DependentData> {
+    override fun toString(): String {
+        return "$value beans"
+    }
+
+    override fun compareTo(other: DependentData): Int {
+        return value.compareTo(other.value)
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/DependentDataSerializer.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/DependentDataSerializer.kt
@@ -1,0 +1,11 @@
+package net.corda.contracts.fixup.dependent
+
+import net.corda.core.serialization.SerializationCustomSerializer
+
+@Suppress("unused")
+class DependentDataSerializer : SerializationCustomSerializer<DependentData, DependentDataSerializer.Proxy> {
+    data class Proxy(val value: Long)
+
+    override fun fromProxy(proxy: Proxy): DependentData = DependentData(proxy.value)
+    override fun toProxy(obj: DependentData) = Proxy(obj.value)
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/StandAloneDataSerializer.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/fixup/dependent/StandAloneDataSerializer.kt
@@ -1,0 +1,16 @@
+package net.corda.contracts.fixup.dependent
+
+import net.corda.contracts.fixup.standalone.StandAloneData
+import net.corda.core.serialization.SerializationCustomSerializer
+
+/**
+ * This custom serializer has DELIBERATELY been added to the dependent CorDapp
+ * in order to make it DEPENDENT on the classes inside the standalone CorDapp.
+ */
+@Suppress("unused")
+class StandAloneDataSerializer : SerializationCustomSerializer<StandAloneData, StandAloneDataSerializer.Proxy> {
+    data class Proxy(val value: Long)
+
+    override fun fromProxy(proxy: Proxy): StandAloneData = StandAloneData(proxy.value)
+    override fun toProxy(obj: StandAloneData) = Proxy(obj.value)
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/fixup/standalone/StandAloneContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/fixup/standalone/StandAloneContract.kt
@@ -1,0 +1,16 @@
+package net.corda.contracts.fixup.standalone
+
+import net.corda.core.contracts.Contract
+import net.corda.core.node.services.AttachmentStorage
+import net.corda.core.transactions.LedgerTransaction
+
+/**
+ * Add a [Contract] to this CorDapp so that the Node will
+ * automatically upload this CorDapp into [AttachmentStorage].
+ */
+@Suppress("unused")
+class StandAloneContract : Contract {
+    override fun verify(tx: LedgerTransaction) {
+        throw UnsupportedOperationException("Dummy contract - not used")
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/fixup/standalone/StandAloneData.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/fixup/standalone/StandAloneData.kt
@@ -1,0 +1,11 @@
+package net.corda.contracts.fixup.standalone
+
+data class StandAloneData(val value: Long) : Comparable<StandAloneData> {
+    override fun toString(): String {
+        return "$value pods"
+    }
+
+    override fun compareTo(other: StandAloneData): Int {
+        return value.compareTo(other.value)
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/serialization/custom/CustomSerializerContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/serialization/custom/CustomSerializerContract.kt
@@ -9,18 +9,18 @@ import net.corda.core.transactions.LedgerTransaction
 @Suppress("unused")
 class CustomSerializerContract : Contract {
     companion object {
-        const val MAX_CURRANT = 2000
+        const val MAX_CURRANT = 2000L
     }
 
     override fun verify(tx: LedgerTransaction) {
-        val currantsyData = tx.outputsOfType(CurrantsyState::class.java)
+        val currantsyData = tx.outputsOfType<CurrantsyState>()
         require(currantsyData.isNotEmpty()) {
             "Requires at least one currantsy state"
         }
 
         currantsyData.forEach {
-            require(it.currantsy.currants in 0..MAX_CURRANT) {
-                "Too many currants! ${it.currantsy.currants} is unraisinable!"
+            require(it.currantsy in Currantsy(0)..Currantsy(MAX_CURRANT)) {
+                "Too many currants! $it is unraisinable!"
             }
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/contracts/serialization/custom/CustomSerializerRegistry.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/serialization/custom/CustomSerializerRegistry.kt
@@ -1,7 +1,0 @@
-package net.corda.contracts.serialization.custom
-
-import net.corda.core.serialization.SerializationWhitelist
-
-class CustomSerializerRegistry : SerializationWhitelist {
-    override val whitelist: List<Class<*>> = listOf(Currantsy::class.java)
-}

--- a/node/src/integration-test/kotlin/net/corda/contracts/serialization/missing/CustomData.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/serialization/missing/CustomData.kt
@@ -1,0 +1,19 @@
+package net.corda.contracts.serialization.missing
+
+/**
+ * This class REQUIRES a custom serializer because its
+ * constructor parameter cannot be mapped to a property
+ * automatically. THIS IS DELIBERATE!
+ */
+class CustomData(initialValue: Long) : Comparable<CustomData> {
+    // DO NOT MOVE THIS PROPERTY INTO THE CONSTRUCTOR!
+    val value: Long = initialValue
+
+    override fun toString(): String {
+        return "$value bobbins"
+    }
+
+    override fun compareTo(other: CustomData): Int {
+        return value.compareTo(other.value)
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/serialization/missing/MissingSerializerContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/serialization/missing/MissingSerializerContract.kt
@@ -1,0 +1,39 @@
+package net.corda.contracts.serialization.missing
+
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.ContractState
+import net.corda.core.identity.AbstractParty
+import net.corda.core.transactions.LedgerTransaction
+
+@Suppress("unused")
+class MissingSerializerContract : Contract {
+    companion object {
+        const val MAX_VALUE = 2000L
+    }
+
+    override fun verify(tx: LedgerTransaction) {
+        val states = tx.outputsOfType<CustomDataState>()
+        require(states.isNotEmpty()) {
+            "Requires at least one custom data state"
+        }
+
+        states.forEach {
+            require(it.customData in CustomData(0)..CustomData(MAX_VALUE)) {
+                "CustomData $it exceeds maximum value!"
+            }
+        }
+    }
+
+    @Suppress("CanBeParameter", "MemberVisibilityCanBePrivate")
+    class CustomDataState(val owner: AbstractParty, val customData: CustomData) : ContractState {
+        override val participants: List<AbstractParty> = listOf(owner)
+
+        @Override
+        override fun toString(): String {
+            return customData.toString()
+        }
+    }
+
+    class Operate : CommandData
+}

--- a/node/src/integration-test/kotlin/net/corda/flows/fixup/CordappFixupFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/fixup/CordappFixupFlow.kt
@@ -1,0 +1,28 @@
+package net.corda.flows.fixup
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.contracts.fixup.dependent.DependentContract.Operate
+import net.corda.contracts.fixup.dependent.DependentContract.State
+import net.corda.contracts.fixup.dependent.DependentData
+import net.corda.core.contracts.Command
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.transactions.TransactionBuilder
+
+@InitiatingFlow
+@StartableByRPC
+class CordappFixupFlow(private val data: DependentData) : FlowLogic<SecureHash>() {
+    @Suspendable
+    override fun call(): SecureHash {
+        val notary = serviceHub.networkMapCache.notaryIdentities[0]
+        val stx = serviceHub.signInitialTransaction(
+            TransactionBuilder(notary)
+                .addOutputState(State(ourIdentity, data))
+                .addCommand(Command(Operate(), ourIdentity.owningKey))
+        )
+        stx.verify(serviceHub, checkSufficientSignatures = false)
+        return stx.id
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/flows/serialization/missing/CustomDataSerializer.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/serialization/missing/CustomDataSerializer.kt
@@ -1,0 +1,12 @@
+package net.corda.flows.serialization.missing
+
+import net.corda.contracts.serialization.missing.CustomData
+import net.corda.core.serialization.SerializationCustomSerializer
+
+@Suppress("unused")
+class CustomDataSerializer : SerializationCustomSerializer<CustomData, CustomDataSerializer.Proxy> {
+    data class Proxy(val value: Long)
+
+    override fun fromProxy(proxy: Proxy): CustomData = CustomData(proxy.value)
+    override fun toProxy(obj: CustomData) = Proxy(obj.value)
+}

--- a/node/src/integration-test/kotlin/net/corda/flows/serialization/missing/MissingSerializerBuilderFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/serialization/missing/MissingSerializerBuilderFlow.kt
@@ -1,0 +1,28 @@
+package net.corda.flows.serialization.missing
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.contracts.serialization.missing.CustomData
+import net.corda.contracts.serialization.missing.MissingSerializerContract.CustomDataState
+import net.corda.contracts.serialization.missing.MissingSerializerContract.Operate
+import net.corda.core.contracts.Command
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.transactions.TransactionBuilder
+
+@InitiatingFlow
+@StartableByRPC
+class MissingSerializerBuilderFlow(private val value: Long) : FlowLogic<SecureHash>() {
+    @Suspendable
+    override fun call(): SecureHash {
+        val notary = serviceHub.networkMapCache.notaryIdentities[0]
+        val stx = serviceHub.signInitialTransaction(
+            TransactionBuilder(notary)
+                .addOutputState(CustomDataState(ourIdentity, CustomData(value)))
+                .addCommand(Command(Operate(), ourIdentity.owningKey))
+        )
+        stx.verify(serviceHub, checkSufficientSignatures = false)
+        return stx.id
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/flows/serialization/missing/MissingSerializerFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/serialization/missing/MissingSerializerFlow.kt
@@ -1,0 +1,56 @@
+package net.corda.flows.serialization.missing
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.contracts.serialization.missing.CustomData
+import net.corda.contracts.serialization.missing.MissingSerializerContract.CustomDataState
+import net.corda.contracts.serialization.missing.MissingSerializerContract.Operate
+import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.TransactionState
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SignableData
+import net.corda.core.crypto.SignatureMetadata
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.internal.createComponentGroups
+import net.corda.core.internal.requiredContractClassName
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.WireTransaction
+
+@InitiatingFlow
+@StartableByRPC
+class MissingSerializerFlow(private val value: Long) : FlowLogic<SecureHash>() {
+    @Suspendable
+    override fun call(): SecureHash {
+        val notary = serviceHub.networkMapCache.notaryIdentities[0]
+        val legalIdentityKey = serviceHub.myInfo.legalIdentitiesAndCerts.first().owningKey
+
+        val customDataState = CustomDataState(ourIdentity, CustomData(value))
+        val wtx = WireTransaction(createComponentGroups(
+            inputs = emptyList(),
+            outputs = listOf(TransactionState(
+                data = customDataState,
+                notary = notary,
+                constraint = AlwaysAcceptAttachmentConstraint
+            )),
+            notary = notary,
+            commands = listOf(Command(Operate(), ourIdentity.owningKey)),
+            attachments = serviceHub.attachments.getLatestContractAttachments(customDataState.requiredContractClassName!!),
+            timeWindow = null,
+            references = emptyList(),
+            networkParametersHash = null
+        ))
+        val signatureMetadata = SignatureMetadata(
+            platformVersion = serviceHub.myInfo.platformVersion,
+            schemeNumberID = Crypto.findSignatureScheme(legalIdentityKey).schemeNumberID
+        )
+        val signableData = SignableData(wtx.id, signatureMetadata)
+        val sig = serviceHub.keyManagementService.sign(signableData, legalIdentityKey)
+        return with(SignedTransaction(wtx, listOf(sig))) {
+            verify(serviceHub, checkSufficientSignatures = false)
+            id
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/Assertions.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/Assertions.kt
@@ -1,0 +1,14 @@
+@file:JvmName("Assertions")
+package net.corda.node
+
+import net.corda.core.serialization.CordaSerializable
+import org.junit.Assert.assertNull
+
+inline fun <reified T> assertNotCordaSerializable() {
+    assertNotCordaSerializable(T::class.java)
+}
+
+fun assertNotCordaSerializable(clazz: Class<*>) {
+    assertNull("$clazz must NOT be annotated as @CordaSerializable!",
+        clazz.getAnnotation(CordaSerializable::class.java))
+}

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithCordappFixupTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithCordappFixupTest.kt
@@ -1,0 +1,99 @@
+package net.corda.node
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.contracts.fixup.dependent.DependentData
+import net.corda.contracts.fixup.standalone.StandAloneData
+import net.corda.core.CordaRuntimeException
+import net.corda.core.contracts.TransactionVerificationException.ContractRejection
+import net.corda.core.internal.hash
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.flows.fixup.CordappFixupFlow
+import net.corda.node.services.Permissions
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.incrementalPortAllocation
+import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.User
+import net.corda.testing.node.internal.cordappWithFixups
+import net.corda.testing.node.internal.cordappWithPackages
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+@Suppress("FunctionName")
+class ContractWithCordappFixupTest {
+    companion object {
+        const val BEANS = 10001L
+        const val DEFAULT_STARTING_PORT = 10000
+
+        val user = User("u", "p", setOf(Permissions.all()))
+        val flowCorDapp = cordappWithPackages("net.corda.flows.fixup").signed()
+        val dependentContractCorDapp = cordappWithPackages("net.corda.contracts.fixup.dependent").signed()
+        val standaloneContractCorDapp = cordappWithPackages("net.corda.contracts.fixup.standalone").signed()
+
+        fun driverParameters(cordapps: List<TestCordapp>): DriverParameters {
+            return DriverParameters(
+                portAllocation = incrementalPortAllocation(DEFAULT_STARTING_PORT),
+                startNodesInProcess = false,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                cordappsForAllNodes = cordapps,
+                systemProperties = mapOf("net.corda.transactionbuilder.missingclass.disabled" to true.toString())
+            )
+        }
+
+        @BeforeClass
+        @JvmStatic
+        fun checkData() {
+            assertNotCordaSerializable<DependentData>()
+            assertNotCordaSerializable<StandAloneData>()
+        }
+    }
+
+    /*
+     * Test that we can still build a transaction for a CorDapp with an implicit dependency.
+     */
+    @Test
+    fun `flow with missing cordapp dependency with fixup`() {
+        val dependentContractId = dependentContractCorDapp.jarFile.hash
+        val standaloneContractId = standaloneContractCorDapp.jarFile.hash
+        val fixupCorDapp = cordappWithFixups(listOf(
+            setOf(dependentContractId) to setOf(dependentContractId, standaloneContractId)
+        )).signed()
+        val data = DependentData(BEANS)
+
+        driver(driverParameters(listOf(flowCorDapp, dependentContractCorDapp, standaloneContractCorDapp, fixupCorDapp))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val ex = assertFailsWith<ContractRejection> {
+                CordaRPCClient(hostAndPort = alice.rpcAddress)
+                    .start(user.username, user.password)
+                    .use { client ->
+                        client.proxy.startFlow(::CordappFixupFlow, data).returnValue.getOrThrow()
+                    }
+            }
+            assertThat(ex).hasMessageContaining("Invalid data: $data")
+        }
+    }
+
+    /**
+     * Test that our dependency is indeed missing and so requires fixing up.
+     */
+    @Test
+    fun `flow with missing cordapp dependency without fixup`() {
+        driver(driverParameters(listOf(flowCorDapp, dependentContractCorDapp, standaloneContractCorDapp))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val ex = assertFailsWith<CordaRuntimeException> {
+                CordaRPCClient(hostAndPort = alice.rpcAddress)
+                    .start(user.username, user.password)
+                    .use { client ->
+                        client.proxy.startFlow(::CordappFixupFlow, DependentData(BEANS)).returnValue.getOrThrow()
+                    }
+            }
+            assertThat(ex).hasMessageContaining("Type ${StandAloneData::class.java.name} not present")
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithMissingCustomSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithMissingCustomSerializerTest.kt
@@ -1,0 +1,122 @@
+package net.corda.node
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.contracts.serialization.missing.CustomData
+import net.corda.contracts.serialization.missing.MissingSerializerContract.CustomDataState
+import net.corda.core.CordaRuntimeException
+import net.corda.core.contracts.TransactionVerificationException.BrokenTransactionException
+import net.corda.core.contracts.TransactionVerificationException.ContractRejection
+import net.corda.core.internal.hash
+import net.corda.core.internal.inputStream
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.flows.serialization.missing.MissingSerializerBuilderFlow
+import net.corda.flows.serialization.missing.MissingSerializerFlow
+import net.corda.node.services.Permissions
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.incrementalPortAllocation
+import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.User
+import net.corda.testing.node.internal.cordappWithFixups
+import net.corda.testing.node.internal.cordappWithPackages
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+@Suppress("FunctionName")
+class ContractWithMissingCustomSerializerTest {
+    companion object {
+        const val BOBBINS = 5000L
+        const val DEFAULT_STARTING_PORT = 10000
+
+        val user = User("u", "p", setOf(Permissions.all()))
+        val flowCorDapp = cordappWithPackages("net.corda.flows.serialization.missing").signed()
+        val contractCorDapp = cordappWithPackages("net.corda.contracts.serialization.missing").signed()
+
+        fun driverParameters(cordapps: List<TestCordapp>): DriverParameters {
+            return DriverParameters(
+                portAllocation = incrementalPortAllocation(DEFAULT_STARTING_PORT),
+                startNodesInProcess = false,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                cordappsForAllNodes = cordapps
+            )
+        }
+
+        @BeforeClass
+        @JvmStatic
+        fun checkData() {
+            assertNotCordaSerializable<CustomData>()
+        }
+    }
+
+    /*
+     * Test that we can still verify a transaction that is missing a custom serializer.
+     */
+    @Test
+    fun `flow with missing custom serializer and fixup`() {
+        val contractId = contractCorDapp.jarFile.hash
+        val flowId = flowCorDapp.jarFile.hash
+        val fixupCorDapp = cordappWithFixups(listOf(setOf(contractId) to setOf(contractId, flowId))).signed()
+
+        driver(driverParameters(listOf(flowCorDapp, contractCorDapp, fixupCorDapp))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val ex = assertFailsWith<ContractRejection> {
+                CordaRPCClient(hostAndPort = alice.rpcAddress)
+                    .start(user.username, user.password)
+                    .use { client ->
+                        with(client.proxy) {
+                            uploadAttachment(flowCorDapp.jarFile.inputStream())
+                            startFlow(::MissingSerializerFlow, BOBBINS).returnValue.getOrThrow()
+                        }
+                    }
+            }
+            assertThat(ex).hasMessageContaining("Data $BOBBINS bobbins exceeds maximum value!")
+        }
+    }
+
+    /*
+     * Test we fail properly when we cannot fix-up a missing serializer.
+     */
+    @Test
+    fun `flow with missing custom serializer but without fixup`() {
+        driver(driverParameters(listOf(flowCorDapp, contractCorDapp))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val ex = assertFailsWith<BrokenTransactionException> {
+                CordaRPCClient(hostAndPort = alice.rpcAddress)
+                    .start(user.username, user.password)
+                    .use { client ->
+                        client.proxy.startFlow(::MissingSerializerFlow, BOBBINS)
+                            .returnValue
+                            .getOrThrow()
+                    }
+            }
+            assertThat(ex).hasMessageContaining("No fix-up rules provided for broken attachments:")
+        }
+    }
+
+    /*
+     * Test that TransactionBuilder prevents us from creating a
+     * transaction that has a custom serializer missing.
+     */
+    @Test
+    fun `transaction builder flow with missing custom serializer by rpc`() {
+        driver(driverParameters(listOf(flowCorDapp, contractCorDapp))) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val ex = assertFailsWith<CordaRuntimeException> {
+                CordaRPCClient(hostAndPort = alice.rpcAddress)
+                    .start(user.username, user.password)
+                    .use { client ->
+                        client.proxy.startFlow(::MissingSerializerBuilderFlow, BOBBINS)
+                            .returnValue
+                            .getOrThrow()
+                    }
+            }
+            assertThat(ex).hasMessageContaining(CustomDataState::class.java.name)
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -200,7 +200,11 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             networkParametersStorage
     ).closeOnStop()
     @Suppress("LeakingThis")
-    val transactionVerifierService = InMemoryTransactionVerifierService(transactionVerifierWorkerCount).tokenize()
+    val transactionVerifierService = InMemoryTransactionVerifierService(
+        numberOfWorkers = transactionVerifierWorkerCount,
+        cordappProvider = cordappProvider,
+        attachments = attachments
+    ).tokenize()
     val contractUpgradeService = ContractUpgradeServiceImpl(cacheFactory).tokenize()
     val auditService = DummyAuditService().tokenize()
     @Suppress("LeakingThis")

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -51,7 +51,11 @@ import net.corda.node.services.rpc.ArtemisRpcBroker
 import net.corda.node.services.rpc.InternalRPCMessagingClient
 import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.node.services.statemachine.StateMachineManager
-import net.corda.node.utilities.*
+import net.corda.node.utilities.AddressUtils
+import net.corda.node.utilities.AffinityExecutor
+import net.corda.node.utilities.BindableNamedCacheFactory
+import net.corda.node.utilities.DefaultNamedCacheFactory
+import net.corda.node.utilities.DemoClock
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.INTERNAL_SHELL_USER
 import net.corda.nodeapi.internal.ShutdownHook
 import net.corda.nodeapi.internal.addShutdownHook

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
@@ -1,6 +1,8 @@
+@file:Suppress("TooManyFunctions")
 package net.corda.node.internal.cordapp
 
 import com.google.common.collect.HashBiMap
+import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.cordapp.CordappContext
@@ -8,14 +10,19 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
 import net.corda.core.internal.cordapp.CordappImpl
+import net.corda.core.internal.isUploaderTrusted
+import net.corda.core.node.services.AttachmentFixup
 import net.corda.core.node.services.AttachmentId
 import net.corda.core.node.services.AttachmentStorage
+import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.contextLogger
 import net.corda.nodeapi.internal.cordapp.CordappLoader
 import net.corda.node.services.persistence.AttachmentStorageInternal
+import java.net.JarURLConnection
 import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
+import java.util.jar.JarFile
 
 /**
  * Cordapp provider and store. For querying CorDapps for their attachment and vice versa.
@@ -24,11 +31,13 @@ open class CordappProviderImpl(val cordappLoader: CordappLoader,
                                private val cordappConfigProvider: CordappConfigProvider,
                                private val attachmentStorage: AttachmentStorage) : SingletonSerializeAsToken(), CordappProviderInternal {
     companion object {
+        const val COMMENT_MARKER = '#'
         private val log = contextLogger()
     }
 
     private val contextCache = ConcurrentHashMap<Cordapp, CordappContext>()
     private val cordappAttachments = HashBiMap.create<SecureHash, URL>()
+    private val attachmentFixups = arrayListOf<AttachmentFixup>()
 
     /**
      * Current known CorDapps loaded on this node
@@ -38,6 +47,8 @@ open class CordappProviderImpl(val cordappLoader: CordappLoader,
     fun start() {
         cordappAttachments.putAll(loadContractsIntoAttachmentStore())
         verifyInstalledCordapps()
+        // Load the fix-ups after uploading any new contracts into attachment storage.
+        attachmentFixups.addAll(loadAttachmentFixups())
     }
 
     private fun verifyInstalledCordapps() {
@@ -85,6 +96,92 @@ open class CordappProviderImpl(val cordappLoader: CordappLoader,
                     }
                 } to it.jarPath
             }.toMap()
+
+    /**
+     * Loads the "fixup" rules from all META-INF/Corda-Fixups files.
+     * These files have the following format:
+     *     <AttachmentId>,<AttachmentId>...=><AttachmentId>,<AttachmentId>,...
+     * where each <AttachmentId> is the SHA256 of a CorDapp JAR that
+     * [net.corda.core.transactions.TransactionBuilder] will expect to find
+     * inside [AttachmentStorage].
+     *
+     * These rules are for repairing broken CorDapps. A correctly written
+     * CorDapp should not require them.
+     */
+    private fun loadAttachmentFixups(): List<AttachmentFixup> {
+         return cordappLoader.appClassLoader.getResources("META-INF/Corda-Fixups").asSequence()
+            .mapNotNull { fixup ->
+                fixup.openConnection() as? JarURLConnection
+            }.filter { fixupConnection ->
+                isValidFixup(fixupConnection.jarFile)
+            }.flatMapTo(ArrayList()) { fixupConnection ->
+                fixupConnection.inputStream.bufferedReader().useLines { lines ->
+                    lines.map { it.substringBefore(COMMENT_MARKER) }.map(String::trim).filterNot(String::isEmpty).map { line ->
+                        val tokens = line.split("=>")
+                        require(tokens.size == 2) {
+                            "Invalid fix-up line '$line' in '${fixupConnection.jarFile.name}'"
+                        }
+                        val source = parseIds(tokens[0])
+                        require(source.isNotEmpty()) {
+                            "Forbidden empty list of source attachment IDs in '${fixupConnection.jarFile.name}'"
+                        }
+                        val target = parseIds(tokens[1])
+                        Pair(source, target)
+                    }.toList().asSequence()
+                }
+            }
+    }
+
+    private fun isValidFixup(jarFile: JarFile): Boolean {
+        return jarFile.entries().asSequence().all { it.name.startsWith("META-INF/") }.also { isValid ->
+            if (!isValid) {
+                log.warn("FixUp '{}' contains files outside META-INF/ - IGNORING!", jarFile.name)
+            }
+        }
+    }
+
+    private fun parseIds(ids: String): Set<AttachmentId> {
+        return ids.split(",").map(String::trim)
+            .filterNot(String::isEmpty)
+            .mapTo(LinkedHashSet(), SecureHash.Companion::parse)
+    }
+
+    /**
+     * Apply this node's attachment fix-up rules to the given attachment IDs.
+     *
+     * @param attachmentIds A collection of [AttachmentId]s, e.g. as provided by a transaction.
+     * @return The [attachmentIds] with the fix-up rules applied.
+     */
+    override fun fixupAttachmentIds(attachmentIds: Collection<AttachmentId>): Set<AttachmentId> {
+        val replacementIds = LinkedHashSet(attachmentIds)
+        attachmentFixups.forEach { (source, target) ->
+            if (replacementIds.containsAll(source)) {
+                replacementIds.removeAll(source)
+                replacementIds.addAll(target)
+            }
+        }
+        return replacementIds
+    }
+
+    /**
+     * Apply this node's attachment fix-up rules to the given attachments.
+     *
+     * @param attachments A collection of [Attachment] objects, e.g. as provided by a transaction.
+     * @return The [attachments] with the node's fix-up rules applied.
+     */
+    override fun fixupAttachments(attachments: Collection<Attachment>): Collection<Attachment> {
+        val attachmentsById = attachments.associateByTo(LinkedHashMap(), Attachment::id)
+        val replacementIds = fixupAttachmentIds(attachmentsById.keys)
+        attachmentsById.keys.retainAll(replacementIds)
+        (replacementIds - attachmentsById.keys).forEach { extraId ->
+            val extraAttachment = attachmentStorage.openAttachment(extraId)
+            if (extraAttachment == null || !extraAttachment.isUploaderTrusted()) {
+                throw MissingAttachmentsException(listOf(extraId))
+            }
+            attachmentsById[extraId] = extraAttachment
+        }
+        return attachmentsById.values
+    }
 
     /**
      * Get the current cordapp context for the given CorDapp

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderInternal.kt
@@ -1,11 +1,14 @@
 package net.corda.node.internal.cordapp
 
+import net.corda.core.contracts.Attachment
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.cordapp.CordappProvider
 import net.corda.core.flows.FlowLogic
+import net.corda.core.internal.CordappFixupInternal
 import net.corda.core.internal.cordapp.CordappImpl
 
-interface CordappProviderInternal : CordappProvider {
+interface CordappProviderInternal : CordappProvider, CordappFixupInternal {
     val cordapps: List<CordappImpl>
     fun getCordappForFlow(flowLogic: FlowLogic<*>): Cordapp?
+    fun fixupAttachments(attachments: Collection<Attachment>): Collection<Attachment>
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt
@@ -2,21 +2,113 @@ package net.corda.node.services.transactions
 
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.Attachment
+import net.corda.core.contracts.TransactionVerificationException.BrokenTransactionException
 import net.corda.core.internal.TransactionVerifierServiceInternal
 import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.internalFindTrustedAttachmentForClass
 import net.corda.core.internal.prepareVerify
+import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.node.services.TransactionVerifierService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.utilities.contextLogger
+import net.corda.node.internal.cordapp.CordappProviderInternal
 import net.corda.nodeapi.internal.persistence.withoutDatabaseAccess
 
-class InMemoryTransactionVerifierService(numberOfWorkers: Int) : SingletonSerializeAsToken(), TransactionVerifierService, TransactionVerifierServiceInternal, AutoCloseable {
-    override fun verify(transaction: LedgerTransaction): CordaFuture<Unit> = this.verify(transaction, emptyList())
+class InMemoryTransactionVerifierService(
+    @Suppress("UNUSED_PARAMETER") numberOfWorkers: Int,
+    private val cordappProvider: CordappProviderInternal,
+    private val attachments: AttachmentStorage
+) : SingletonSerializeAsToken(), TransactionVerifierService, TransactionVerifierServiceInternal, AutoCloseable {
+    companion object {
+        private val SEPARATOR = System.lineSeparator() + "-> "
+        private val log = contextLogger()
 
-    override fun verify(transaction: LedgerTransaction, extraAttachments: List<Attachment>): CordaFuture<Unit> {
+        fun Collection<*>.deepEquals(other: Collection<*>): Boolean {
+            return size == other.size && containsAll(other) && other.containsAll(this)
+        }
+
+        fun Collection<Attachment>.toPrettyString(): String {
+            return joinToString(separator = SEPARATOR, prefix = SEPARATOR, postfix = System.lineSeparator()) { attachment ->
+                attachment.id.toString()
+            }
+        }
+    }
+
+    override fun verify(transaction: LedgerTransaction): CordaFuture<*> {
         return openFuture<Unit>().apply {
             capture {
-                val verifier = transaction.prepareVerify(extraAttachments)
+                val verifier = transaction.prepareVerify(transaction.attachments)
+                withoutDatabaseAccess {
+                    verifier.verify()
+                }
+            }
+        }
+    }
+
+    private fun computeReplacementAttachmentsFor(ltx: LedgerTransaction, missingClass: String?): Collection<Attachment> {
+        val replacements = cordappProvider.fixupAttachments(ltx.attachments)
+        return if (replacements.deepEquals(ltx.attachments)) {
+            /*
+             * We cannot continue unless we have some idea which
+             * class is missing from the attachments.
+             */
+            if (missingClass == null) {
+                throw BrokenTransactionException(
+                    txId = ltx.id,
+                    message = "No fix-up rules provided for broken attachments:${replacements.toPrettyString()}"
+                )
+            }
+
+            /*
+             * The Node's fix-up rules have not been able to adjust the transaction's attachments,
+             * so resort to the original mechanism of trying to find an attachment that contains
+             * the missing class. (Do you feel lucky, Punk?)
+             */
+            val extraAttachment = requireNotNull(attachments.internalFindTrustedAttachmentForClass(missingClass)) {
+                """Transaction $ltx is incorrectly formed. Most likely it was created during version 3 of Corda
+                |when the verification logic was more lenient. Attempted to find local dependency for class: $missingClass,
+                |but could not find one.
+                |If you wish to verify this transaction, please contact the originator of the transaction and install the
+                |provided missing JAR.
+                |You can install it using the RPC command: `uploadAttachment` without restarting the node.
+                |""".trimMargin()
+            }
+
+            replacements.toMutableSet().apply {
+                /*
+                 * Check our transaction doesn't already contain this extra attachment.
+                 * It seems unlikely that we would, but better safe than sorry!
+                 */
+                if (!add(extraAttachment)) {
+                    throw BrokenTransactionException(
+                        txId = ltx.id,
+                        message = "Unlinkable class $missingClass inside broken attachments:${replacements.toPrettyString()}"
+                    )
+                }
+
+                log.warn("""Detected that transaction $ltx does not contain all cordapp dependencies.
+                    |This may be the result of a bug in a previous version of Corda.
+                    |Attempting to verify using the additional trusted dependency: $extraAttachment for class $missingClass.
+                    |Please check with the originator that this is a valid transaction.
+                    |YOU ARE ONLY SEEING THIS MESSAGE BECAUSE THE CORDAPPS THAT CREATED THIS TRANSACTION ARE BROKEN!
+                    |WE HAVE TRIED TO REPAIR THE TRANSACTION AS BEST WE CAN, BUT CANNOT GUARANTEE WE HAVE SUCCEEDED!
+                    |PLEASE FIX THE CORDAPPS AND MIGRATE THESE BROKEN TRANSACTIONS AS SOON AS POSSIBLE!
+                    |THIS MESSAGE IS **SUPPOSED** TO BE SCARY!!
+                    |""".trimMargin()
+                )
+            }
+        } else {
+            replacements
+        }
+    }
+
+    override fun reverifyWithFixups(transaction: LedgerTransaction, missingClass: String?): CordaFuture<*> {
+        return openFuture<Unit>().apply {
+            capture {
+                val replacementAttachments = computeReplacementAttachmentsFor(transaction, missingClass)
+                log.warn("Reverifying transaction {} with attachments:{}", transaction.id, replacementAttachments.toPrettyString())
+                val verifier = transaction.prepareVerify(replacementAttachments.toList())
                 withoutDatabaseAccess {
                     verifier.verify()
                 }

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt
@@ -1,7 +1,9 @@
+@file:Suppress("TooManyFunctions")
 package net.corda.node.internal.cordapp
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import net.corda.core.node.services.AttachmentId
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.node.VersionInfo
 import net.corda.testing.common.internal.testNetworkParameters
@@ -11,7 +13,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import java.io.File
+import java.io.FileOutputStream
 import java.net.URL
+import java.util.jar.JarOutputStream
+import java.util.zip.Deflater.NO_COMPRESSION
+import java.util.zip.ZipEntry
+import java.util.zip.ZipEntry.DEFLATED
+import java.util.zip.ZipEntry.STORED
+import kotlin.test.assertFailsWith
 
 class CordappProviderImplTests {
     private companion object {
@@ -21,8 +31,28 @@ class CordappProviderImplTests {
         val emptyJAR: URL = this::class.java.getResource("empty.jar")
         val validConfig: Config = ConfigFactory.parseString("key=value")
 
+        @JvmField
+        val ID1 = AttachmentId.randomSHA256()
+        @JvmField
+        val ID2 = AttachmentId.randomSHA256()
+        @JvmField
+        val ID3 = AttachmentId.randomSHA256()
+        @JvmField
+        val ID4 = AttachmentId.randomSHA256()
+
         val stubConfigProvider = object : CordappConfigProvider {
             override fun getConfigByName(name: String): Config = ConfigFactory.empty()
+        }
+
+        fun directoryEntry(internalName: String) = ZipEntry("$internalName/").apply {
+            method = STORED
+            compressedSize = 0
+            size = 0
+            crc = 0
+        }
+
+        fun fileEntry(internalName: String) = ZipEntry(internalName).apply {
+            method = DEFLATED
         }
     }
 
@@ -82,6 +112,97 @@ class CordappProviderImplTests {
         val expected = provider.getAppContext(provider.cordapps.first()).config
 
         assertThat(expected.getString("key")).isEqualTo("value")
+    }
+
+    @Test
+    fun `test fixup rule that adds attachment`() {
+        val fixupJar = File.createTempFile("cordapp", ".jar")
+            .writeFixupRules("$ID1 => $ID2, $ID3")
+        val fixedIDs = with(newCordappProvider(fixupJar.toURI().toURL())) {
+            start()
+            fixupAttachmentIds(listOf(ID1))
+        }
+        assertThat(fixedIDs).containsExactly(ID2, ID3)
+    }
+
+    @Test
+    fun `test fixup rule that deletes attachment`() {
+        val fixupJar = File.createTempFile("cordapp", ".jar")
+            .writeFixupRules("$ID1 =>")
+        val fixedIDs = with(newCordappProvider(fixupJar.toURI().toURL())) {
+            start()
+            fixupAttachmentIds(listOf(ID1))
+        }
+        assertThat(fixedIDs).isEmpty()
+    }
+
+    @Test
+    fun `test fixup rule with blank LHS`() {
+        val fixupJar = File.createTempFile("fixup", ".jar")
+            .writeFixupRules(" => $ID2")
+        val ex = assertFailsWith<IllegalArgumentException> {
+            newCordappProvider(fixupJar.toURI().toURL()).start()
+        }
+        assertThat(ex).hasMessageContaining(
+            "Forbidden empty list of source attachment IDs in '${fixupJar.absolutePath}'"
+        )
+    }
+
+    @Test
+    fun `test fixup rule without arrows`() {
+        val rule = " $ID1 "
+        val fixupJar = File.createTempFile("fixup", ".jar")
+            .writeFixupRules(rule)
+        val ex = assertFailsWith<IllegalArgumentException> {
+            newCordappProvider(fixupJar.toURI().toURL()).start()
+        }
+        assertThat(ex).hasMessageContaining(
+            "Invalid fix-up line '${rule.trim()}' in '${fixupJar.absolutePath}'"
+        )
+    }
+
+    @Test
+    fun `test fixup rule with too many arrows`() {
+        val rule = " $ID1 => $ID2 => $ID3 "
+        val fixupJar = File.createTempFile("fixup", ".jar")
+            .writeFixupRules(rule)
+        val ex = assertFailsWith<IllegalArgumentException> {
+            newCordappProvider(fixupJar.toURI().toURL()).start()
+        }
+        assertThat(ex).hasMessageContaining(
+            "Invalid fix-up line '${rule.trim()}' in '${fixupJar.absolutePath}'"
+        )
+    }
+
+    @Test
+    fun `test fixup file containing multiple rules and comments`() {
+        val fixupJar = File.createTempFile("cordapp", ".jar").writeFixupRules(
+            "# Whole line comment",
+            "\t$ID1,$ID2 =>  $ID2,,  $ID3 # EOl comment",
+            "   # Empty line with comment",
+            "",
+            "$ID3 => $ID4"
+        )
+        val fixedIDs = with(newCordappProvider(fixupJar.toURI().toURL())) {
+            start()
+            fixupAttachmentIds(listOf(ID2, ID1))
+        }
+        assertThat(fixedIDs).containsExactlyInAnyOrder(ID2, ID4)
+    }
+
+    private fun File.writeFixupRules(vararg lines: String): File {
+        JarOutputStream(FileOutputStream(this)).use { jar ->
+            jar.setMethod(DEFLATED)
+            jar.setLevel(NO_COMPRESSION)
+            jar.putNextEntry(directoryEntry("META-INF"))
+            jar.putNextEntry(fileEntry("META-INF/Corda-Fixups"))
+            for (line in lines) {
+                jar.write(line.toByteArray())
+                jar.write('\r'.toInt())
+                jar.write('\n'.toInt())
+            }
+        }
+        return this
     }
 
     private fun newCordappProvider(vararg urls: URL): CordappProviderImpl {

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -3,6 +3,24 @@ apply plugin: 'net.corda.plugins.cordapp'
 def javaHome = System.getProperty('java.home')
 def shrinkJar = file("$buildDir/libs/${project.name}-${project.version}-tiny.jar")
 
+import java.security.NoSuchAlgorithmException
+import java.security.MessageDigest
+
+static String sha256(File jarFile) throws FileNotFoundException, NoSuchAlgorithmException {
+    InputStream input = new FileInputStream(jarFile)
+    try {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256")
+        byte[] buffer = new byte[8192]
+        int bytesRead
+        while ((bytesRead = input.read(buffer)) != -1) {
+            digest.update(buffer, 0, bytesRead)
+        }
+        return digest.digest().encodeHex().toString()
+    } finally {
+        input.close()
+    }
+}
+
 cordapp {
     targetPlatformVersion = corda_platform_version.toInteger()
     minimumPlatformVersion 1
@@ -41,6 +59,18 @@ dependencies {
     compile "com.opengamma.strata:strata-product:$strata_version"
     compile "com.opengamma.strata:strata-market:$strata_version"
 }
+
+def cordappDependencies = file("${sourceSets['main'].output.resourcesDir}/META-INF/Cordapp-Dependencies")
+task generateDependencies {
+    dependsOn project(':finance:contracts').tasks.jar
+    outputs.files(cordappDependencies)
+    doLast {
+        configurations.cordapp.forEach { cordapp ->
+            cordappDependencies << sha256(cordapp) << System.lineSeparator()
+        }
+    }
+}
+processResources.finalizedBy generateDependencies
 
 jar {
     classifier = 'fat'

--- a/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/CordappDependencies.kt
+++ b/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/CordappDependencies.kt
@@ -1,0 +1,35 @@
+@file:JvmName("CordappDependencies")
+@file:Suppress("TopLevelPropertyNaming")
+package net.corda.vega.contracts
+
+import net.corda.core.crypto.SecureHash
+import net.corda.core.transactions.TransactionBuilder
+import java.net.URLClassLoader
+
+/**
+ * This is a crude, home-grown Cordapp dependency mechanism.
+ */
+private val EXTERNAL_CORDAPPS: List<SecureHash> by lazy {
+    loadDependencies()
+}
+
+/**
+ * Locate any META-INF/Cordapp-Dependencies file that
+ * is part of this particular CorDapp.
+ */
+private fun loadDependencies(): List<SecureHash> {
+    val cordappURL = object {}::class.java.protectionDomain.codeSource.location
+    return URLClassLoader(arrayOf(cordappURL), null).use { cl ->
+        val deps = cl.getResource("META-INF/Cordapp-Dependencies") ?: return emptyList()
+        deps.openStream().bufferedReader().useLines { lines ->
+            lines.filterNot(String::isBlank).map(SecureHash.Companion::parse).toList()
+        }
+    }
+}
+
+fun TransactionBuilder.withExternalCordapps(): TransactionBuilder {
+    for (cordapp in EXTERNAL_CORDAPPS) {
+        addAttachment(cordapp)
+    }
+    return this
+}

--- a/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
+++ b/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
@@ -23,6 +23,8 @@ data class IRSState(val swap: SwapData,
 
     override fun generateAgreement(notary: Party): TransactionBuilder {
         val state = IRSState(swap, buyer, seller)
-        return TransactionBuilder(notary).withItems(StateAndContract(state, IRS_PROGRAM_ID), Command(OGTrade.Commands.Agree(), participants.map { it.owningKey }))
+        return TransactionBuilder(notary)
+            .withItems(StateAndContract(state, IRS_PROGRAM_ID), Command(OGTrade.Commands.Agree(), participants.map { it.owningKey }))
+            .withExternalCordapps()
     }
 }

--- a/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
+++ b/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
@@ -37,7 +37,10 @@ data class PortfolioState(val portfolio: List<StateRef>,
     }
 
     override fun generateAgreement(notary: Party): TransactionBuilder {
-        return TransactionBuilder(notary).withItems(StateAndContract(copy(), PORTFOLIO_SWAP_PROGRAM_ID), Command(PortfolioSwap.Commands.Agree(), participants.map { it.owningKey }))
+        val command = Command(PortfolioSwap.Commands.Agree(), participants.map { it.owningKey })
+        return TransactionBuilder(notary)
+            .withItems(StateAndContract(copy(), PORTFOLIO_SWAP_PROGRAM_ID), command)
+            .withExternalCordapps()
     }
 
     override fun generateRevision(notary: Party, oldState: StateAndRef<*>, updatedValue: Update): TransactionBuilder {
@@ -49,6 +52,7 @@ data class PortfolioState(val portfolio: List<StateRef>,
         tx.addInputState(oldState)
         tx.addOutputState(copy(portfolio = portfolio, valuation = valuation), PORTFOLIO_SWAP_PROGRAM_ID)
         tx.addCommand(PortfolioSwap.Commands.Update(), participants.map { it.owningKey })
+        tx.withExternalCordapps()
         return tx
     }
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/RemoteSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/RemoteSerializerFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.serialization.internal.amqp
 
 import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.internal.MissingSerializerException
 import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.model.*
 import org.hibernate.type.descriptor.java.ByteTypeDescriptor
@@ -80,8 +81,10 @@ class DefaultRemoteSerializerFactory(
             }
 
             // Return the specific serializer the caller asked for.
-            serializers[typeDescriptor] ?: throw NotSerializableException(
-                    "Could not find type matching descriptor $typeDescriptor.")
+            serializers[typeDescriptor] ?: throw MissingSerializerException(
+                message = "Could not find type matching descriptor $typeDescriptor.",
+                typeDescriptor = typeDescriptor
+            )
         }
 
     private fun getUncached(

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -72,7 +72,7 @@ open class MockServices private constructor(
         private val cordappLoader: CordappLoader,
         override val validatedTransactions: TransactionStorage,
         override val identityService: IdentityService,
-        private val initialNetworkParameters: NetworkParameters,
+        initialNetworkParameters: NetworkParameters,
         private val initialIdentity: TestIdentity,
         private val moreKeys: Array<out KeyPair>,
         override val keyManagementService: KeyManagementService = MockKeyManagementService(identityService, *arrayOf(initialIdentity.keyPair) + moreKeys)
@@ -385,10 +385,14 @@ open class MockServices private constructor(
         get() {
             return NodeInfo(listOf(NetworkHostAndPort("mock.node.services", 10000)), listOf(initialIdentity.identity), 1, serial = 1L)
         }
-    override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
     private val mockCordappProvider: MockCordappProvider = MockCordappProvider(cordappLoader, attachments).also {
         it.start()
     }
+    override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(
+        numberOfWorkers = 2,
+        cordappProvider = mockCordappProvider,
+        attachments = attachments
+    )
     override val cordappProvider: CordappProvider get() = mockCordappProvider
     override var networkParametersService: NetworkParametersService = MockNetworkParametersStorage(initialNetworkParameters)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -13,6 +13,7 @@ import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.div
 import net.corda.core.internal.times
 import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.node.services.AttachmentFixup
 import net.corda.core.serialization.internal.SerializationEnvironment
 import net.corda.core.serialization.internal._allEnabledSerializationEnvs
 import net.corda.core.serialization.internal._driverSerializationEnv
@@ -93,6 +94,8 @@ fun cordappWithPackages(vararg packageNames: String): CustomCordapp = CustomCord
 /** Create a *custom* CorDapp which contains just the given classes. */
 // TODO Rename to cordappWithClasses
 fun cordappForClasses(vararg classes: Class<*>): CustomCordapp = CustomCordapp(packages = emptySet(), classes = classes.toSet())
+
+fun cordappWithFixups(fixups: List<AttachmentFixup>) = CustomCordapp(fixups = fixups)
 
 /**
  * Find the single CorDapp jar on the current classpath which contains the given package. This is a convenience method for

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
@@ -26,7 +26,7 @@ data class TestCordappImpl(val scanPackage: String, override val config: Map<Str
 
     override val jarFile: Path
         get() {
-            val jars = TestCordappImpl.findJars(scanPackage)
+            val jars = findJars(scanPackage)
             when (jars.size) {
                 0 -> throw IllegalArgumentException("There are no CorDapps containing the package $scanPackage on the classpath. Make sure " +
                         "the package name is correct and that the CorDapp is added as a gradle dependency.")
@@ -54,13 +54,13 @@ data class TestCordappImpl(val scanPackage: String, override val config: Map<Str
 
         private fun findRootPaths(scanPackage: String): Set<Path> {
             return packageToRootPaths.computeIfAbsent(scanPackage) {
-                ClassGraph().whitelistPackages(scanPackage).pooledScan().use { result ->
-                    result.allResources
+                val classGraph = ClassGraph().whitelistPaths(scanPackage.replace('.', '/'))
+                classGraph.pooledScan().use { scanResult ->
+                    scanResult.allResources
                         .asSequence()
                         .map { it.classpathElementFile.toPath() }
                         .filterNot { it.toString().endsWith("-tests.jar") }
-                        .map { if (it.toString().endsWith(".jar")) it else findProjectRoot(it) }
-                        .toSet()
+                        .mapTo(LinkedHashSet()) { if (it.toString().endsWith(".jar")) it else findProjectRoot(it) }
                 }
             }
         }


### PR DESCRIPTION
* Do not register cordapp custom serialisers when using attachment classloader.
* Record the URLs of CorDapp JARs that contain custom serialisers. Include these JARs as extra attachments if we discover that we're missing a custom serialiser during transaction verification.
* Check for disabled serializer when explicitly requesting a custom serializer.
Refactor test case to force use of a custom serializer.
* Tidy up basic custom serializer test.
* Also test that TransactionBuilder rejects missing custom serializers.
* Remove test whitelists, which should not be needed with custom serialisers.
* Add changelog entry. Also align TestCordappImpl.findRoots() with OS backports.
* Second approach based around CorDapps inside AttachmentStorage - report missing type descriptor or any non-composable types.
* Initial implementation of Corda-Fixup rules inside a CorDapp jar.
* Replace original "automatic attachment fixing" mechanism completely.
* First review comments: restore "missing class" logic to TransactionBuilder.
* Restore "missing class" mechanism as fallback for SignedTransaction too.