### PR TITLE
[NOTICK] Print out local version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,6 +234,7 @@ logger.lifecycle("Java source compatibility: {}", sourceCompatibility)
 logger.lifecycle("Java target compatibility: {}", targetCompatibility)
 logger.lifecycle("Quasar version: {}", quasar_version)
 logger.lifecycle("Quasar classifier: {}", quasar_classifier.toString())
+logger.lifecycle("Building Corda version: {}", corda_release_version)
 
 allprojects {
     apply plugin: 'kotlin'
@@ -678,10 +679,3 @@ task allParallelSmokeTest(type: ParallelTestGroup) {
 }
 apply plugin: 'com.r3.testing.distributed-testing'
 apply plugin: 'com.r3.testing.image-building'
-
-task printLocalVersion {
-    logger.lifecycle("Publishing local version $corda_release_version")
-}
-
-publishToMavenLocal.finalizedBy(printLocalVersion)
-

--- a/build.gradle
+++ b/build.gradle
@@ -678,3 +678,10 @@ task allParallelSmokeTest(type: ParallelTestGroup) {
 }
 apply plugin: 'com.r3.testing.distributed-testing'
 apply plugin: 'com.r3.testing.image-building'
+
+task printLocalVersion {
+    logger.lifecycle("Publishing local version $corda_release_version")
+}
+
+publishToMavenLocal.finalizedBy(printLocalVersion)
+


### PR DESCRIPTION
Make gradle output the version string it is about to install  when running install or publishToMavenLocal so it can be used as a local dependency.