### PR TITLE
Gradle version 5.4.1 is used in all samples and cordapp templates. Ad…

### DIFF
--- a/docs/source/getting-set-up.rst
+++ b/docs/source/getting-set-up.rst
@@ -22,7 +22,7 @@ There are four pieces of required software for CorDapp development: the Java 8 J
 
 4. Install `Gradle <https://gradle.org/install/>`_. If you are using a supported Corda sample, the included ``gradlew`` script should install Gradle automatically.
 
-  Please note: Corda requires Gradle version 5.4.1 at a minimum.
+  Please note: Corda 4.x requires Gradle version 4.10 while Corda 5.x requires 5.4.1.
 
 Next steps
 ----------

--- a/docs/source/getting-set-up.rst
+++ b/docs/source/getting-set-up.rst
@@ -20,9 +20,9 @@ There are four pieces of required software for CorDapp development: the Java 8 J
 
 3. Install `git <https://git-scm.com/>`_.
 
-4. Install `Gradle version 4.10 <https://gradle.org/install/>`_. If you are using a supported Corda sample, the included ``gradlew`` script should install Gradle automatically.
+4. Install `Gradle <https://gradle.org/install/>`_. If you are using a supported Corda sample, the included ``gradlew`` script should install Gradle automatically.
 
-  Please note: Corda requires Gradle version 4.10, and does not support any other version of Gradle.
+  Please note: Corda requires Gradle version 5.4.1 at a minimum.
 
 Next steps
 ----------


### PR DESCRIPTION
Documentation change only: Gradle version 5.4.1 is used in all samples and cordapp templates. Additionally, the link in the docs for 4.10 is actually pointing to gradle 6.0.1

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
