### PR TITLE
Notary logs warning on startup when it's not in the whitelist

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/node/NetworkParametersTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/NetworkParametersTest.kt
@@ -98,11 +98,11 @@ class NetworkParametersTest {
     // Notaries tests
     @Test
     fun `choosing notary not specified in network parameters will fail`() {
-        val fakeNotaryId = Party(BOB_NAME, NullKeys.NullPublicKey)
         val alice = mockNet.createPartyNode(ALICE_NAME)
-        assertThat(alice.services.networkMapCache.notaryIdentities).doesNotContain(fakeNotaryId)
+        val fakeNotary = mockNet.createPartyNode(BOB_NAME)
+        assertThat(alice.services.networkMapCache.notaryIdentities).doesNotContain(fakeNotary.info.singleIdentity())
         assertFails {
-            alice.services.startFlow(CashIssueFlow(500.DOLLARS, OpaqueBytes.of(0x01), fakeNotaryId)).resultFuture.getOrThrow()
+            alice.services.startFlow(CashIssueFlow(500.DOLLARS, OpaqueBytes.of(0x01), fakeNotary.info.singleIdentity())).resultFuture.getOrThrow()
         }
     }
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/node/NetworkParametersTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/NetworkParametersTest.kt
@@ -98,25 +98,19 @@ class NetworkParametersTest {
     // Notaries tests
     @Test
     fun `choosing notary not specified in network parameters will fail`() {
+        val fakeNotary = mockNet.createNode(
+                InternalMockNodeParameters(
+                        legalName = BOB_NAME,
+                        configOverrides = {
+                            doReturn(NotaryConfig(validating = false)).whenever(it).notary
+                        }
+                )
+        )
+        val fakeNotaryId = fakeNotary.info.singleIdentity()
         val alice = mockNet.createPartyNode(ALICE_NAME)
-        val fakeNotary = mockNet.createPartyNode(BOB_NAME)
-        assertThat(alice.services.networkMapCache.notaryIdentities).doesNotContain(fakeNotary.info.singleIdentity())
+        assertThat(alice.services.networkMapCache.notaryIdentities).doesNotContain(fakeNotaryId)
         assertFails {
-            alice.services.startFlow(CashIssueFlow(500.DOLLARS, OpaqueBytes.of(0x01), fakeNotary.info.singleIdentity())).resultFuture.getOrThrow()
-        }
-    }
-
-    @Test
-    fun `notary not specified in network parameters won't start`() {
-        assertFails("Provided notary identity is not in whitelist") {
-            mockNet.createNode(
-                    InternalMockNodeParameters(
-                            legalName = BOB_NAME,
-                            configOverrides = {
-                                doReturn(NotaryConfig(validating = false)).whenever(it).notary
-                            }
-                    )
-            )
+            alice.services.startFlow(CashIssueFlow(500.DOLLARS, OpaqueBytes.of(0x01), fakeNotaryId)).resultFuture.getOrThrow()
         }
     }
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/node/NetworkParametersTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/NetworkParametersTest.kt
@@ -2,9 +2,7 @@ package net.corda.coretests.node
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
-import net.corda.core.crypto.NullKeys
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.identity.Party
 import net.corda.core.internal.getPackageOwnerOf
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo

--- a/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
@@ -20,8 +20,6 @@ class NotaryLoader(
         private val config: NotaryConfig,
         versionInfo: VersionInfo
 ) {
-    class UnknownIdentityException : IllegalArgumentException("Could not establish notary identity of this node.")
-
     companion object {
         private val log = contextLogger()
     }
@@ -90,15 +88,18 @@ class NotaryLoader(
         }
     }
 
-    /** Validates that the notary is correctly configured by comparing the configured type against the type advertised in the network map cache */
+    /**
+     * Validates that the notary is correctly configured by comparing the configured type against the
+     * type advertised in the network map cache.
+     */
     private fun validateNotaryType(myNotaryIdentity: PartyAndCertificate, services: ServiceHubInternal) {
         var configuredAsValidatingNotary = services.configuration.notary?.validating
         val notaryParty = myNotaryIdentity.party
         var validatingNotaryInNetworkMapCache = services.networkMapCache.isValidatingNotary(notaryParty)
         
         if(configuredAsValidatingNotary != validatingNotaryInNetworkMapCache) {
-            log.warn("There is a discrepancy in the configured notary type and the one advertised in the network parameters - shutting down. "
-            + "Configured as validating: ${configuredAsValidatingNotary}. Advertised as validating: ${validatingNotaryInNetworkMapCache}")    
+            log.warn("There is a discrepancy in the configured notary type and the one advertised in the network parameters. " +
+            "Configured as validating: ${configuredAsValidatingNotary}. Advertised as validating: ${validatingNotaryInNetworkMapCache}")
         }
     }
     

--- a/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NotaryLoader.kt
@@ -60,7 +60,7 @@ class NotaryLoader(
         val notaryKey = myNotaryIdentity?.owningKey
                 ?: throw IllegalArgumentException("Unable to start notary service: notary identity not found")
 
-        validateNotaryInWhitelist(myNotaryIdentity, services)
+        warnIfNotaryNotWhitelisted(myNotaryIdentity, services)
         validateNotaryType(myNotaryIdentity, services)
 
         val serviceClass = builtInServiceClass ?: scanCorDapps(cordappLoader)
@@ -80,8 +80,8 @@ class NotaryLoader(
         }
     }
 
-    /** Ensures the notary is in the network map whitelist on startup.*/
-    private fun validateNotaryInWhitelist(myNotaryIdentity: PartyAndCertificate, services: ServiceHubInternal) {
+    /** Log a warning if the notary is not whitelisted in the network parameters. */
+    private fun warnIfNotaryNotWhitelisted(myNotaryIdentity: PartyAndCertificate, services: ServiceHubInternal) {
         val ourParty = myNotaryIdentity.party
         if (!services.networkMapCache.isNotary(ourParty)) {
             log.warn("Provided notary identity is not in whitelist")
@@ -93,13 +93,13 @@ class NotaryLoader(
      * type advertised in the network map cache.
      */
     private fun validateNotaryType(myNotaryIdentity: PartyAndCertificate, services: ServiceHubInternal) {
-        var configuredAsValidatingNotary = services.configuration.notary?.validating
+        val configuredAsValidatingNotary = services.configuration.notary?.validating
         val notaryParty = myNotaryIdentity.party
-        var validatingNotaryInNetworkMapCache = services.networkMapCache.isValidatingNotary(notaryParty)
+        val validatingNotaryInNetworkMapCache = services.networkMapCache.isValidatingNotary(notaryParty)
         
         if(configuredAsValidatingNotary != validatingNotaryInNetworkMapCache) {
             log.warn("There is a discrepancy in the configured notary type and the one advertised in the network parameters. " +
-            "Configured as validating: ${configuredAsValidatingNotary}. Advertised as validating: ${validatingNotaryInNetworkMapCache}")
+            "Configured as validating: $configuredAsValidatingNotary. Advertised as validating: $validatingNotaryInNetworkMapCache")
         }
     }
     


### PR DESCRIPTION
* Log a warning if the notary is not on the whitelist on startup.
* No longer prevent node startup when the notary type is different from the one configured in the network parameters. This allows to start notaries that are not whitelisted, for example after a network merge.