### PR TITLE
TM-170 Generic on-demand-test configuration

### DIFF
--- a/.ci/dev/integration/Jenkinsfile
+++ b/.ci/dev/integration/Jenkinsfile
@@ -1,5 +1,5 @@
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
-@Library('existing-build-control')
+@Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())

--- a/.ci/dev/nightly-regression/Jenkinsfile
+++ b/.ci/dev/nightly-regression/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('existing-build-control')
+@Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())

--- a/.ci/dev/on-demand-tests/Jenkinsfile
+++ b/.ci/dev/on-demand-tests/Jenkinsfile
@@ -1,0 +1,6 @@
+@Library('corda-shared-build-pipeline-steps') _
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+onDemandTestPipeline('k8s', '.ci/dev/on-demand-tests/commentMappings.yml')

--- a/.ci/dev/on-demand-tests/commentMappings.yml
+++ b/.ci/dev/on-demand-tests/commentMappings.yml
@@ -1,0 +1,4 @@
+integration: { allParallelIntegrationTest }
+pr-merge: { parallelRegressionTest }
+smoke: { allParallelSmokeTest }
+unit: { allParallelUnitTest }

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('existing-build-control')
+@Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())

--- a/.ci/dev/smoke/Jenkinsfile
+++ b/.ci/dev/smoke/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('existing-build-control')
+@Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())

--- a/.ci/dev/unit/Jenkinsfile
+++ b/.ci/dev/unit/Jenkinsfile
@@ -1,5 +1,5 @@
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
-@Library('existing-build-control')
+@Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
-@Library('existing-build-control')
+@Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())


### PR DESCRIPTION
Single Jenkins configuration for all on-demand tests, utilising the new shared pipeline:

https://github.com/corda/corda-shared-build-pipeline-steps/pull/2

In OS 4.3, this deprecates the "smoke" tests configuration, which can be deleted after this new version has been proven to work reliably.

Note that this change also "renames" the shared library used in existing Jenkinsfiles from "existing-build-control" to "corda-shared-build-pipeline-steps" to match the underlying repo name and provide a more general name that makes sense going forward. In practice, this is a "magic" string that is configured at the Jenkins system level so this doesn't matter too much.