### PR TITLE
[EG-73] Remove postgres dependency from the node and update docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ buildscript {
     ext.jansi_version = '1.18'
     ext.hibernate_version = '5.4.3.Final'
     ext.h2_version = '1.4.199' // Update docs if renamed or removed.
-    ext.postgresql_version = '42.2.8'
     ext.rxjava_version = '1.3.8'
     ext.dokka_version = '0.9.17'
     ext.eddsa_version = '0.3.0'

--- a/docs/source/node-database.rst
+++ b/docs/source/node-database.rst
@@ -15,7 +15,7 @@ The Corda continuous integration pipeline does not run unit tests or integration
 
 PostgreSQL
 ----------
-Nodes can also be configured to use PostgreSQL 9.6, using PostgreSQL JDBC Driver 42.1.4. Here is an example node
+Nodes can also be configured to use PostgreSQL 9.6, using PostgreSQL JDBC Driver 42.2.8. Here is an example node
 configuration for PostgreSQL:
 
 .. sourcecode:: groovy
@@ -45,6 +45,7 @@ Note that:
   .. sourcecode:: groovy
 
     CREATE SEQUENCE my_schema.hibernate_sequence INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 8 CACHE 1 NO CYCLE;
+* The PostgreSQL JDBC database driver must be placed in the ``drivers`` directory in the node.
 
 SQLServer
 ---------

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -182,9 +182,6 @@ dependencies {
     // For H2 database support in persistence
     compile "com.h2database:h2:$h2_version"
 
-    // For Postgres database support in persistence
-    compile "org.postgresql:postgresql:$postgresql_version"
-
     // SQL connection pooling library
     compile "com.zaxxer:HikariCP:${hikari_version}"
 


### PR DESCRIPTION
Corda OS has an experimental implementation of postgres support. This appears to have been implemented using a compile time dependency on the postgres driver, which causes it to be packaged inside the Corda fat jar. In general, database drivers should be placed inside the `drivers` directory in the node and not packaged with the node itself. This PR removes the driver from the node fat jar and updates the docs to make it clear that the database driver needs to be provided in the `drivers` directory.

## Testing

 - Start the node with the postgres driver in the drivers directory and verify that it can connect to the database and create the required tables
 - Verify that the postgres driver jar is no longer in the Corda fat jar.
