### PR TITLE
CORDA-2942: Disable flaky test for now.

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleFatalTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleFatalTests.kt
@@ -12,9 +12,11 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.ListenProcessDeathException
 import net.corda.testing.node.internal.enclosedCordapp
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
+@Ignore("Test is proven to be flaky and disabled for now. Future investigation will be done under: CORDA-3549")
 class CordaServiceLifecycleFatalTests {
 
     companion object {


### PR DESCRIPTION
This is a newly introduced test that appears to be flaky under Windows and Linux. Separate investigation will be done under: https://r3-cev.atlassian.net/browse/CORDA-3549
