### PR TITLE
CORDA-3520, CORDA-3550: SSH memory leak and security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ buildscript {
     ext.dependency_checker_version = '5.2.0'
     ext.commons_collections_version = '4.3'
     ext.beanutils_version = '1.9.3'
-    ext.crash_version = '1.7.1'
+    ext.crash_version = '1.7.2'
     ext.jsr305_version = constants.getProperty("jsr305Version")
     ext.shiro_version = '1.4.1'
     ext.artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -102,6 +102,8 @@ Unreleased
 * Environment variables and system properties can now be provided with underscore separators instead of dots. Neither are case sensitive.
   See :ref:`overriding config values <corda_configuration_file_overriding_config>` for more information.
 
+* SSH server in the :doc:`shell` has been updated to remove outdated weak ciphers and algorithms.
+
 .. _changelog_v4.1:
 
 Version 4.1

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaDisconnectPlugin.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaDisconnectPlugin.kt
@@ -1,0 +1,13 @@
+package net.corda.tools.shell
+
+import org.crsh.auth.AuthInfo
+import org.crsh.auth.DisconnectPlugin
+import org.crsh.plugin.CRaSHPlugin
+
+class CordaDisconnectPlugin : CRaSHPlugin<DisconnectPlugin>(), DisconnectPlugin {
+    override fun getImplementation() = this
+
+    override fun onDisconnect(userName: String?, authInfo: AuthInfo?) {
+        (authInfo as? CordaSSHAuthInfo)?.rpcConn?.forceClose()
+    }
+}

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaSSHAuthInfo.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaSSHAuthInfo.kt
@@ -1,12 +1,14 @@
 package net.corda.tools.shell
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import net.corda.client.rpc.CordaRPCConnection
 import net.corda.core.internal.messaging.InternalCordaRPCOps
 import net.corda.tools.shell.InteractiveShell.createYamlInputMapper
 import net.corda.tools.shell.utlities.ANSIProgressRenderer
 import org.crsh.auth.AuthInfo
 
-class CordaSSHAuthInfo(val successful: Boolean, val rpcOps: InternalCordaRPCOps, val ansiProgressRenderer: ANSIProgressRenderer? = null, val isSsh: Boolean = false) : AuthInfo {
+class CordaSSHAuthInfo(val successful: Boolean, val rpcOps: InternalCordaRPCOps, val ansiProgressRenderer: ANSIProgressRenderer? = null,
+                       val isSsh: Boolean = false, val rpcConn: CordaRPCConnection? = null) : AuthInfo {
     override fun isSuccessful(): Boolean = successful
 
     val yamlInputMapper: ObjectMapper by lazy {


### PR DESCRIPTION
CORDA-3520: Closing RPC connection on SSH disconnect
CORDA-3550: Remove support for outdated ciphers and algorithms from SSH

Upgrade to CRaSH 1.7.2.

`CordaRPCConnection` is now stored in `AuthInfo` and closed on SSH disconnect via newly introduced `DisconnectPlugin`.

Performed manual tests for SSH disconnects (incl. shell mode and command mode) as well as for Node shutdown. Done sanity check for memory consumption and a number of file descriptors.