### PR TITLE
CORDA-3552: Reuse a single SerializerFactory when deserialising into the DJVM sandbox.

### DIFF
--- a/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/AMQPSerializationScheme.kt
+++ b/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/AMQPSerializationScheme.kt
@@ -1,162 +1,30 @@
 package net.corda.serialization.djvm
 
-import net.corda.core.internal.objectOrNewInstance
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationContext.UseCase
-import net.corda.core.serialization.SerializationWhitelist
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.utilities.ByteSequence
-import net.corda.djvm.rewiring.SandboxClassLoader
-import net.corda.serialization.djvm.deserializers.MergeWhitelists
-import net.corda.serialization.djvm.serializers.SandboxBitSetSerializer
-import net.corda.serialization.djvm.serializers.SandboxCertPathSerializer
-import net.corda.serialization.djvm.serializers.SandboxCharacterSerializer
-import net.corda.serialization.djvm.serializers.SandboxCollectionSerializer
-import net.corda.serialization.djvm.serializers.SandboxCorDappCustomSerializer
-import net.corda.serialization.djvm.serializers.SandboxCurrencySerializer
-import net.corda.serialization.djvm.serializers.SandboxDecimal128Serializer
-import net.corda.serialization.djvm.serializers.SandboxDecimal32Serializer
-import net.corda.serialization.djvm.serializers.SandboxDecimal64Serializer
-import net.corda.serialization.djvm.serializers.SandboxDurationSerializer
-import net.corda.serialization.djvm.serializers.SandboxEnumSerializer
-import net.corda.serialization.djvm.serializers.SandboxEnumSetSerializer
-import net.corda.serialization.djvm.serializers.SandboxInputStreamSerializer
-import net.corda.serialization.djvm.serializers.SandboxInstantSerializer
-import net.corda.serialization.djvm.serializers.SandboxLocalDateSerializer
-import net.corda.serialization.djvm.serializers.SandboxLocalDateTimeSerializer
-import net.corda.serialization.djvm.serializers.SandboxLocalTimeSerializer
-import net.corda.serialization.djvm.serializers.SandboxMapSerializer
-import net.corda.serialization.djvm.serializers.SandboxMonthDaySerializer
-import net.corda.serialization.djvm.serializers.SandboxOffsetDateTimeSerializer
-import net.corda.serialization.djvm.serializers.SandboxOffsetTimeSerializer
-import net.corda.serialization.djvm.serializers.SandboxOpaqueBytesSubSequenceSerializer
-import net.corda.serialization.djvm.serializers.SandboxOptionalSerializer
-import net.corda.serialization.djvm.serializers.SandboxPeriodSerializer
-import net.corda.serialization.djvm.serializers.SandboxPrimitiveSerializer
-import net.corda.serialization.djvm.serializers.SandboxPublicKeySerializer
-import net.corda.serialization.djvm.serializers.SandboxSymbolSerializer
-import net.corda.serialization.djvm.serializers.SandboxToStringSerializer
-import net.corda.serialization.djvm.serializers.SandboxUnsignedByteSerializer
-import net.corda.serialization.djvm.serializers.SandboxUnsignedIntegerSerializer
-import net.corda.serialization.djvm.serializers.SandboxUnsignedLongSerializer
-import net.corda.serialization.djvm.serializers.SandboxUnsignedShortSerializer
-import net.corda.serialization.djvm.serializers.SandboxX509CRLSerializer
-import net.corda.serialization.djvm.serializers.SandboxX509CertificateSerializer
-import net.corda.serialization.djvm.serializers.SandboxYearMonthSerializer
-import net.corda.serialization.djvm.serializers.SandboxYearSerializer
-import net.corda.serialization.djvm.serializers.SandboxZoneIdSerializer
-import net.corda.serialization.djvm.serializers.SandboxZonedDateTimeSerializer
 import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.SerializationScheme
 import net.corda.serialization.internal.amqp.DeserializationInput
 import net.corda.serialization.internal.amqp.SerializationOutput
 import net.corda.serialization.internal.amqp.SerializerFactory
-import net.corda.serialization.internal.amqp.SerializerFactoryFactory
-import net.corda.serialization.internal.amqp.addToWhitelist
 import net.corda.serialization.internal.amqp.amqpMagic
-import java.math.BigDecimal
-import java.math.BigInteger
-import java.util.Date
-import java.util.UUID
-import java.util.function.Function
 
+/**
+ * This is an ephemeral [SerializationScheme] that will only ever
+ * support a single [SerializerFactory]. The [ClassLoader] that
+ * underpins everything this scheme is deserializing is not expected
+ * to be long-lived either.
+ */
 class AMQPSerializationScheme(
-    private val classLoader: SandboxClassLoader,
-    private val sandboxBasicInput: Function<in Any?, out Any?>,
-    private val rawTaskFactory: Function<in Any, out Function<in Any?, out Any?>>,
-    private val customSerializerClassNames: Set<String>,
-    private val serializationWhitelistNames: Set<String>,
-    private val serializerFactoryFactory: SerializerFactoryFactory
+    val serializerFactory: SerializerFactory
 ) : SerializationScheme {
-
-    private fun getSerializerFactory(context: SerializationContext): SerializerFactory {
-        val taskFactory = rawTaskFactory.compose(classLoader.createSandboxFunction())
-        return serializerFactoryFactory.make(context).apply {
-            register(SandboxBitSetSerializer(classLoader, taskFactory, this))
-            register(SandboxCertPathSerializer(classLoader, taskFactory, this))
-            register(SandboxDurationSerializer(classLoader, taskFactory, this))
-            register(SandboxEnumSetSerializer(classLoader, taskFactory, this))
-            register(SandboxInputStreamSerializer(classLoader, taskFactory))
-            register(SandboxInstantSerializer(classLoader, taskFactory, this))
-            register(SandboxLocalDateSerializer(classLoader, taskFactory, this))
-            register(SandboxLocalDateTimeSerializer(classLoader, taskFactory, this))
-            register(SandboxLocalTimeSerializer(classLoader, taskFactory, this))
-            register(SandboxMonthDaySerializer(classLoader, taskFactory, this))
-            register(SandboxOffsetDateTimeSerializer(classLoader, taskFactory, this))
-            register(SandboxOffsetTimeSerializer(classLoader, taskFactory, this))
-            register(SandboxPeriodSerializer(classLoader, taskFactory, this))
-            register(SandboxYearMonthSerializer(classLoader, taskFactory, this))
-            register(SandboxYearSerializer(classLoader, taskFactory, this))
-            register(SandboxZonedDateTimeSerializer(classLoader, taskFactory, this))
-            register(SandboxZoneIdSerializer(classLoader, taskFactory, this))
-            register(SandboxOpaqueBytesSubSequenceSerializer(classLoader, taskFactory, this))
-            register(SandboxOptionalSerializer(classLoader, taskFactory, this))
-            register(SandboxPrimitiveSerializer(UUID::class.java, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(String::class.java, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Byte::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Short::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Int::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Long::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Float::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Double::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Boolean::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxPrimitiveSerializer(Date::class.javaObjectType, classLoader, sandboxBasicInput))
-            register(SandboxCharacterSerializer(classLoader, sandboxBasicInput))
-            register(SandboxCollectionSerializer(classLoader, taskFactory, this))
-            register(SandboxMapSerializer(classLoader, taskFactory, this))
-            register(SandboxEnumSerializer(classLoader, taskFactory, this))
-            register(SandboxPublicKeySerializer(classLoader, taskFactory))
-            register(SandboxToStringSerializer(BigDecimal::class.java, classLoader, rawTaskFactory, sandboxBasicInput))
-            register(SandboxToStringSerializer(BigInteger::class.java, classLoader, rawTaskFactory, sandboxBasicInput))
-            register(SandboxToStringSerializer(StringBuffer::class.java, classLoader, rawTaskFactory, sandboxBasicInput))
-            register(SandboxCurrencySerializer(classLoader, taskFactory, sandboxBasicInput))
-            register(SandboxX509CertificateSerializer(classLoader, taskFactory))
-            register(SandboxX509CRLSerializer(classLoader, taskFactory))
-            register(SandboxUnsignedLongSerializer(classLoader, taskFactory))
-            register(SandboxUnsignedIntegerSerializer(classLoader, taskFactory))
-            register(SandboxUnsignedShortSerializer(classLoader, taskFactory))
-            register(SandboxUnsignedByteSerializer(classLoader, taskFactory))
-            register(SandboxDecimal128Serializer(classLoader, taskFactory))
-            register(SandboxDecimal64Serializer(classLoader, taskFactory))
-            register(SandboxDecimal32Serializer(classLoader, taskFactory))
-            register(SandboxSymbolSerializer(classLoader, taskFactory, sandboxBasicInput))
-
-            for (customSerializerName in customSerializerClassNames) {
-                register(SandboxCorDappCustomSerializer(customSerializerName, classLoader, rawTaskFactory, this))
-            }
-            registerWhitelists(taskFactory, this)
-        }
-    }
-
-    private fun registerWhitelists(
-        taskFactory: Function<Class<out Function<*, *>>, out Function<in Any?, out Any?>>,
-        factory: SerializerFactory
-    ) {
-        if (serializationWhitelistNames.isEmpty()) {
-            return
-        }
-
-        val serializationWhitelists = serializationWhitelistNames.map { whitelistClass ->
-            classLoader.toSandboxClass(whitelistClass).kotlin.objectOrNewInstance()
-        }.toArrayOf(classLoader.toSandboxClass(SerializationWhitelist::class.java))
-        @Suppress("unchecked_cast")
-        val mergeTask = taskFactory.apply(MergeWhitelists::class.java) as Function<in Array<*>, out Array<Class<*>>>
-        factory.addToWhitelist(mergeTask.apply(serializationWhitelists).toSet())
-    }
-
-    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-    private fun Collection<*>.toArrayOf(type: Class<*>): Array<*> {
-        val typedArray = java.lang.reflect.Array.newInstance(type, 0) as Array<*>
-        return (this as java.util.Collection<*>).toArray(typedArray)
-    }
-
     override fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: SerializationContext): T {
-        val serializerFactory = getSerializerFactory(context)
         return DeserializationInput(serializerFactory).deserialize(byteSequence, clazz, context)
     }
 
     override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {
-        val serializerFactory = getSerializerFactory(context)
         return SerializationOutput(serializerFactory).serialize(obj, context)
     }
 

--- a/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/SandboxSerializationSchemeBuilder.kt
+++ b/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/SandboxSerializationSchemeBuilder.kt
@@ -1,0 +1,148 @@
+package net.corda.serialization.djvm
+
+import net.corda.core.internal.objectOrNewInstance
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationWhitelist
+import net.corda.djvm.rewiring.SandboxClassLoader
+import net.corda.serialization.djvm.deserializers.MergeWhitelists
+import net.corda.serialization.djvm.serializers.SandboxBitSetSerializer
+import net.corda.serialization.djvm.serializers.SandboxCertPathSerializer
+import net.corda.serialization.djvm.serializers.SandboxCharacterSerializer
+import net.corda.serialization.djvm.serializers.SandboxCollectionSerializer
+import net.corda.serialization.djvm.serializers.SandboxCorDappCustomSerializer
+import net.corda.serialization.djvm.serializers.SandboxCurrencySerializer
+import net.corda.serialization.djvm.serializers.SandboxDecimal128Serializer
+import net.corda.serialization.djvm.serializers.SandboxDecimal32Serializer
+import net.corda.serialization.djvm.serializers.SandboxDecimal64Serializer
+import net.corda.serialization.djvm.serializers.SandboxDurationSerializer
+import net.corda.serialization.djvm.serializers.SandboxEnumSerializer
+import net.corda.serialization.djvm.serializers.SandboxEnumSetSerializer
+import net.corda.serialization.djvm.serializers.SandboxInputStreamSerializer
+import net.corda.serialization.djvm.serializers.SandboxInstantSerializer
+import net.corda.serialization.djvm.serializers.SandboxLocalDateSerializer
+import net.corda.serialization.djvm.serializers.SandboxLocalDateTimeSerializer
+import net.corda.serialization.djvm.serializers.SandboxLocalTimeSerializer
+import net.corda.serialization.djvm.serializers.SandboxMapSerializer
+import net.corda.serialization.djvm.serializers.SandboxMonthDaySerializer
+import net.corda.serialization.djvm.serializers.SandboxOffsetDateTimeSerializer
+import net.corda.serialization.djvm.serializers.SandboxOffsetTimeSerializer
+import net.corda.serialization.djvm.serializers.SandboxOpaqueBytesSubSequenceSerializer
+import net.corda.serialization.djvm.serializers.SandboxOptionalSerializer
+import net.corda.serialization.djvm.serializers.SandboxPeriodSerializer
+import net.corda.serialization.djvm.serializers.SandboxPrimitiveSerializer
+import net.corda.serialization.djvm.serializers.SandboxPublicKeySerializer
+import net.corda.serialization.djvm.serializers.SandboxSymbolSerializer
+import net.corda.serialization.djvm.serializers.SandboxToStringSerializer
+import net.corda.serialization.djvm.serializers.SandboxUnsignedByteSerializer
+import net.corda.serialization.djvm.serializers.SandboxUnsignedIntegerSerializer
+import net.corda.serialization.djvm.serializers.SandboxUnsignedLongSerializer
+import net.corda.serialization.djvm.serializers.SandboxUnsignedShortSerializer
+import net.corda.serialization.djvm.serializers.SandboxX509CRLSerializer
+import net.corda.serialization.djvm.serializers.SandboxX509CertificateSerializer
+import net.corda.serialization.djvm.serializers.SandboxYearMonthSerializer
+import net.corda.serialization.djvm.serializers.SandboxYearSerializer
+import net.corda.serialization.djvm.serializers.SandboxZoneIdSerializer
+import net.corda.serialization.djvm.serializers.SandboxZonedDateTimeSerializer
+import net.corda.serialization.internal.SerializationScheme
+import net.corda.serialization.internal.amqp.SerializerFactory
+import net.corda.serialization.internal.amqp.SerializerFactoryFactory
+import net.corda.serialization.internal.amqp.addToWhitelist
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.Date
+import java.util.UUID
+import java.util.function.Function
+
+class SandboxSerializationSchemeBuilder(
+    private val classLoader: SandboxClassLoader,
+    private val sandboxBasicInput: Function<in Any?, out Any?>,
+    private val rawTaskFactory: Function<in Any, out Function<in Any?, out Any?>>,
+    private val customSerializerClassNames: Set<String>,
+    private val serializationWhitelistNames: Set<String>,
+    private val serializerFactoryFactory: SerializerFactoryFactory
+) {
+    fun buildFor(context: SerializationContext): SerializationScheme {
+        return AMQPSerializationScheme(getSerializerFactory(context))
+    }
+
+    private fun getSerializerFactory(context: SerializationContext): SerializerFactory {
+        val taskFactory = rawTaskFactory.compose(classLoader.createSandboxFunction())
+        return serializerFactoryFactory.make(context).apply {
+            register(SandboxBitSetSerializer(classLoader, taskFactory, this))
+            register(SandboxCertPathSerializer(classLoader, taskFactory, this))
+            register(SandboxDurationSerializer(classLoader, taskFactory, this))
+            register(SandboxEnumSetSerializer(classLoader, taskFactory, this))
+            register(SandboxInputStreamSerializer(classLoader, taskFactory))
+            register(SandboxInstantSerializer(classLoader, taskFactory, this))
+            register(SandboxLocalDateSerializer(classLoader, taskFactory, this))
+            register(SandboxLocalDateTimeSerializer(classLoader, taskFactory, this))
+            register(SandboxLocalTimeSerializer(classLoader, taskFactory, this))
+            register(SandboxMonthDaySerializer(classLoader, taskFactory, this))
+            register(SandboxOffsetDateTimeSerializer(classLoader, taskFactory, this))
+            register(SandboxOffsetTimeSerializer(classLoader, taskFactory, this))
+            register(SandboxPeriodSerializer(classLoader, taskFactory, this))
+            register(SandboxYearMonthSerializer(classLoader, taskFactory, this))
+            register(SandboxYearSerializer(classLoader, taskFactory, this))
+            register(SandboxZonedDateTimeSerializer(classLoader, taskFactory, this))
+            register(SandboxZoneIdSerializer(classLoader, taskFactory, this))
+            register(SandboxOpaqueBytesSubSequenceSerializer(classLoader, taskFactory, this))
+            register(SandboxOptionalSerializer(classLoader, taskFactory, this))
+            register(SandboxPrimitiveSerializer(UUID::class.java, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(String::class.java, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Byte::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Short::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Int::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Long::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Float::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Double::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Boolean::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxPrimitiveSerializer(Date::class.javaObjectType, classLoader, sandboxBasicInput))
+            register(SandboxCharacterSerializer(classLoader, sandboxBasicInput))
+            register(SandboxCollectionSerializer(classLoader, taskFactory, this))
+            register(SandboxMapSerializer(classLoader, taskFactory, this))
+            register(SandboxEnumSerializer(classLoader, taskFactory, this))
+            register(SandboxPublicKeySerializer(classLoader, taskFactory))
+            register(SandboxToStringSerializer(BigDecimal::class.java, classLoader, rawTaskFactory, sandboxBasicInput))
+            register(SandboxToStringSerializer(BigInteger::class.java, classLoader, rawTaskFactory, sandboxBasicInput))
+            register(SandboxToStringSerializer(StringBuffer::class.java, classLoader, rawTaskFactory, sandboxBasicInput))
+            register(SandboxCurrencySerializer(classLoader, taskFactory, sandboxBasicInput))
+            register(SandboxX509CertificateSerializer(classLoader, taskFactory))
+            register(SandboxX509CRLSerializer(classLoader, taskFactory))
+            register(SandboxUnsignedLongSerializer(classLoader, taskFactory))
+            register(SandboxUnsignedIntegerSerializer(classLoader, taskFactory))
+            register(SandboxUnsignedShortSerializer(classLoader, taskFactory))
+            register(SandboxUnsignedByteSerializer(classLoader, taskFactory))
+            register(SandboxDecimal128Serializer(classLoader, taskFactory))
+            register(SandboxDecimal64Serializer(classLoader, taskFactory))
+            register(SandboxDecimal32Serializer(classLoader, taskFactory))
+            register(SandboxSymbolSerializer(classLoader, taskFactory, sandboxBasicInput))
+
+            for (customSerializerName in customSerializerClassNames) {
+                register(SandboxCorDappCustomSerializer(customSerializerName, classLoader, rawTaskFactory, this))
+            }
+            registerWhitelists(taskFactory, this)
+        }
+    }
+
+    private fun registerWhitelists(
+        taskFactory: Function<Class<out Function<*, *>>, out Function<in Any?, out Any?>>,
+        factory: SerializerFactory
+    ) {
+        if (serializationWhitelistNames.isEmpty()) {
+            return
+        }
+
+        val serializationWhitelists = serializationWhitelistNames.map { whitelistClass ->
+            classLoader.toSandboxClass(whitelistClass).kotlin.objectOrNewInstance()
+        }.toArrayOf(classLoader.toSandboxClass(SerializationWhitelist::class.java))
+        @Suppress("unchecked_cast")
+        val mergeTask = taskFactory.apply(MergeWhitelists::class.java) as Function<in Array<*>, out Array<Class<*>>>
+        factory.addToWhitelist(mergeTask.apply(serializationWhitelists).toSet())
+    }
+
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+    private fun Collection<*>.toArrayOf(type: Class<*>): Array<*> {
+        val typedArray = java.lang.reflect.Array.newInstance(type, 0) as Array<*>
+        return (this as java.util.Collection<*>).toArray(typedArray)
+    }
+}

--- a/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/Serialization.kt
+++ b/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/Serialization.kt
@@ -49,15 +49,16 @@ fun createSandboxSerializationEnv(
          PrimitiveSerializer(clazz, sandboxBasicInput)
     }
 
+    val schemeBuilder = SandboxSerializationSchemeBuilder(
+        classLoader = classLoader,
+        sandboxBasicInput = sandboxBasicInput,
+        rawTaskFactory = rawTaskFactory,
+        customSerializerClassNames = customSerializerClassNames,
+        serializationWhitelistNames = serializationWhitelistNames,
+        serializerFactoryFactory = SandboxSerializerFactoryFactory(primitiveSerializerFactory)
+    )
     val factory = SerializationFactoryImpl(mutableMapOf()).apply {
-        registerScheme(AMQPSerializationScheme(
-            classLoader = classLoader,
-            sandboxBasicInput = sandboxBasicInput,
-            rawTaskFactory = rawTaskFactory,
-            customSerializerClassNames = customSerializerClassNames,
-            serializationWhitelistNames = serializationWhitelistNames,
-            serializerFactoryFactory = SandboxSerializerFactoryFactory(primitiveSerializerFactory)
-        ))
+        registerScheme(schemeBuilder.buildFor(p2pContext))
     }
     return SerializationEnvironment.with(factory, p2pContext = p2pContext)
 }

--- a/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/LocalTypeModelTest.kt
+++ b/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/LocalTypeModelTest.kt
@@ -1,0 +1,161 @@
+package net.corda.serialization.djvm
+
+import net.corda.core.serialization.SerializationFactory
+import net.corda.core.serialization.internal._contextSerializationEnv
+import net.corda.djvm.rewiring.SandboxClassLoader
+import net.corda.serialization.djvm.SandboxType.KOTLIN
+import net.corda.serialization.internal.SerializationFactoryImpl
+import net.corda.serialization.internal.amqp.SerializerFactory
+import net.corda.serialization.internal.model.LocalTypeInformation
+import net.corda.serialization.internal.model.LocalTypeInformation.Atomic
+import net.corda.serialization.internal.model.LocalTypeInformation.Opaque
+import org.apache.qpid.proton.amqp.Decimal128
+import org.apache.qpid.proton.amqp.Decimal32
+import org.apache.qpid.proton.amqp.Decimal64
+import org.apache.qpid.proton.amqp.Symbol
+import org.apache.qpid.proton.amqp.UnsignedByte
+import org.apache.qpid.proton.amqp.UnsignedInteger
+import org.apache.qpid.proton.amqp.UnsignedLong
+import org.apache.qpid.proton.amqp.UnsignedShort
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.Date
+import java.util.UUID
+
+@ExtendWith(LocalSerialization::class)
+class LocalTypeModelTest : TestBase(KOTLIN) {
+    private val serializerFactory: SerializerFactory get() {
+        val factory = SerializationFactory.defaultFactory as SerializationFactoryImpl
+        val scheme = factory.getRegisteredSchemes().single() as AMQPSerializationScheme
+        return scheme.serializerFactory
+    }
+
+    private inline fun <reified T> sandbox(classLoader: SandboxClassLoader): Class<*> {
+        return classLoader.toSandboxClass(T::class.java)
+    }
+
+    private inline fun <reified LOCAL: LocalTypeInformation> assertLocalType(type: Class<*>) {
+        assertLocalType(LOCAL::class.java, type)
+    }
+
+    private fun <LOCAL: LocalTypeInformation> assertLocalType(localType: Class<LOCAL>, type: Class<*>) {
+        val typeData = serializerFactory.getTypeInformation(type)
+        assertThat(typeData).isInstanceOf(localType)
+    }
+
+    @Test
+    fun testString() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<String>(classLoader))
+    }
+
+    @Test
+    fun testLong() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Long>(classLoader))
+        assertLocalType<Atomic>(Long::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun testInteger() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Int>(classLoader))
+        assertLocalType<Atomic>(Int::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun testShort() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Short>(classLoader))
+        assertLocalType<Atomic>(Short::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun testByte() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Byte>(classLoader))
+        assertLocalType<Atomic>(Byte::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun testDouble() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Double>(classLoader))
+        assertLocalType<Atomic>(Double::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun testFloat() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Float>(classLoader))
+        assertLocalType<Atomic>(Float::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun testChar() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Char>(classLoader))
+        assertLocalType<Atomic>(Char::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun testUnsignedLong() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<UnsignedLong>(classLoader))
+    }
+
+    @Test
+    fun testUnsignedInteger() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<UnsignedInteger>(classLoader))
+    }
+
+    @Test
+    fun testUnsignedShort() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<UnsignedShort>(classLoader))
+    }
+
+    @Test
+    fun testUnsignedByte() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<UnsignedByte>(classLoader))
+    }
+
+    @Test
+    fun testDecimal32() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Decimal32>(classLoader))
+    }
+
+    @Test
+    fun testDecimal64() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Decimal64>(classLoader))
+    }
+
+    @Test
+    fun testDecimal128() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Decimal128>(classLoader))
+    }
+
+    @Test
+    fun testSymbol() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Symbol>(classLoader))
+    }
+
+    @Test
+    fun testUUID() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<UUID>(classLoader))
+    }
+
+    @Test
+    fun testDate() = sandbox {
+        _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+        assertLocalType<Opaque>(sandbox<Date>(classLoader))
+    }
+}


### PR DESCRIPTION
A `SerializationScheme` expects to generate a new `SerializerFactory` for each `SerializationContext` that it sees and then reuse it. However, we are currently creating a new `SerializerFactory` to deserialize every new object. This is expensive, and prevents us from reusing caches of local type information and fingerprints.

Modify the DJVM's `SerializationScheme` so that it holds a single `SerializerFactory`. This is possible because the scheme is _specific_ to a single and ephemeral `SandboxClassLoader` instance.