### PR TITLE
ENT-3828: Remove ability to SSH into standalone shell

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -105,6 +105,10 @@ Unreleased
 
 * SSH server in the :doc:`shell` has been updated to remove outdated weak ciphers and algorithms.
 
+* Removed support for external SSH connections to the standalone shell. As a result, ``--sshd-port`` and ``--sshd-hostkey-directory``
+  options, as well as ``extensions.sshd`` configuration entry, have been removed from the standalone shell.
+  Available alternatives are either to use the standalone shell directly, or connect to the node embedded shell via SSH.
+
 .. _changelog_v4.1:
 
 Version 4.1

--- a/docs/source/shell.rst
+++ b/docs/source/shell.rst
@@ -110,8 +110,7 @@ Run the following command from the terminal:
 .. code:: bash
 
     corda-shell [-hvV] [--logging-level=<loggingLevel>] [--password=<password>]
-                [--sshd-hostkey-directory=<sshdHostKeyDirectory>]
-                [--sshd-port=<sshdPort>] [--truststore-file=<trustStoreFile>]
+                [--truststore-file=<trustStoreFile>]
                 [--truststore-password=<trustStorePassword>]
                 [--truststore-type=<trustStoreType>] [--user=<user>] [-a=<host>]
                 [-c=<cordappDirectory>] [-f=<configFile>] [-o=<commandsDirectory>]
@@ -126,8 +125,6 @@ Where:
 * ``--port``, ``-p``: The RPC port of the Corda node.
 * ``--user=<user>``: The RPC user name.
 * ``--password=<password>`` The RPC user password. If not provided it will be prompted for on startup.
-* ``--sshd-port=<sshdPort>`` Enables SSH server for shell.
-* ``--sshd-hostkey-directory=<sshHostKeyDirectory``: The directory containing the hostkey.pem file for the SSH server.
 * ``--truststore-password=<trustStorePassword>``: The password to unlock the TrustStore file.
 * ``--truststore-file=<trustStoreFile>``: The path to the TrustStore file.
 * ``--truststore-type=<trustStoreType>``: The type of the TrustStore (e.g. JKS).
@@ -157,10 +154,6 @@ The format of ``config-file``:
         cordapps {
             path : /path/to/cordapps/dir
         }
-        sshd {
-            enabled : "false"
-            port : 2223
-        }
     }
     ssl {
         keystore {
@@ -177,13 +170,7 @@ The format of ``config-file``:
     user : demo
     password : demo
 
-
-Standalone Shell via SSH
-------------------------
-The standalone shell can embed an SSH server which redirects interactions via RPC calls to the Corda node.
-To run SSH server use ``--sshd-port`` option when starting standalone shell or ``extensions.sshd`` entry in the configuration file.
-For connection to SSH refer to `Connecting to the shell`_.
-Certain operations (like starting Flows) will require Shell's ``--cordpass-directory`` to be configured correctly (see `Starting the standalone shell`_).
+.. note:: SSH server is not supported inside the standalone shell.
 
 Shell Safe Mode
 ---------------

--- a/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/ShellCmdLineOptions.kt
+++ b/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/ShellCmdLineOptions.kt
@@ -56,18 +56,6 @@ class ShellCmdLineOptions {
 
 
     @Option(
-            names = ["--sshd-port"],
-            description = ["Enables SSH server for shell."]
-    )
-    var sshdPort: String? = null
-
-    @Option(
-            names = ["--sshd-hostkey-directory"],
-            description = ["The directory with hostkey.pem file for SSH server."]
-    )
-    var sshdHostKeyDirectory: Path? = null
-
-    @Option(
             names = ["--truststore-password"],
             description = ["The password to unlock the TrustStore file."]
     )
@@ -100,11 +88,6 @@ class ShellCmdLineOptions {
         trustStoreFile?.apply { cmdOpts["ssl.truststore.path"] = this.toString() }
         trustStorePassword?.apply { cmdOpts["ssl.truststore.password"] = this }
         trustStoreType?.apply { cmdOpts["ssl.truststore.type"] = this }
-        sshdPort?.apply {
-            cmdOpts["extensions.sshd.port"] = this
-            cmdOpts["extensions.sshd.enabled"] = true
-        }
-        sshdHostKeyDirectory?.apply { cmdOpts["extensions.sshd.hostkeypath"] = this.toString() }
 
         return ConfigFactory.parseMap(cmdOpts)
     }
@@ -140,19 +123,12 @@ private class ShellConfigurationFile {
             val path: String
     )
 
-    data class Sshd(
-            val enabled: Boolean,
-            val port: Int,
-            val hostkeypath: String?
-    )
-
     data class Commands(
             val path: String
     )
 
     data class Extensions(
             val cordapps: Cordapps?,
-            val sshd: Sshd?,
             val commands: Commands?
     )
 
@@ -187,9 +163,7 @@ private class ShellConfigurationFile {
                     user = node.user ?: "",
                     password = node.password ?: "",
                     hostAndPort = NetworkHostAndPort(node.addresses.rpc.host, node.addresses.rpc.port),
-                    ssl = sslOptions,
-                    sshdPort = extensions?.sshd?.let { if (it.enabled) it.port else null },
-                    sshHostKeyDirectory = extensions?.sshd?.let { if (it.enabled && it.hostkeypath != null) Paths.get(it.hostkeypath) else null })
+                    ssl = sslOptions)
         }
     }
 }

--- a/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt
+++ b/tools/shell-cli/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt
@@ -105,7 +105,6 @@ class StandaloneShell : CordaCliWrapper("corda-shell", "The Corda standalone she
         InteractiveShell.runLocalShell {
             exit.countDown()
         }
-        configuration.sshdPort?.apply{ println("SSH server listening on port $this.") }
 
         exit.await()
         // because we can't clean certain Crash Shell threads that block on read()

--- a/tools/shell-cli/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt
+++ b/tools/shell-cli/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt
@@ -21,7 +21,6 @@ class StandaloneShellArgsParserTest {
         assertEquals(expectedOptions.port, null)
         assertEquals(expectedOptions.user, null)
         assertEquals(expectedOptions.password, null)
-        assertEquals(expectedOptions.sshdPort, null)
     }
 
     @Test
@@ -34,8 +33,6 @@ class StandaloneShellArgsParserTest {
         options.port = "1234"
         options.user = "demo"
         options.password = "abcd1234"
-        options.sshdPort = "2223"
-        options.sshdHostKeyDirectory = Paths.get("/x/y/ssh")
         options.trustStorePassword = "pass2"
         options.trustStoreFile = Paths.get("/x/y/truststore.jks")
         options.trustStoreType = "dummy"
@@ -50,8 +47,8 @@ class StandaloneShellArgsParserTest {
                 password = "abcd1234",
                 hostAndPort = NetworkHostAndPort("alocalhost", 1234),
                 ssl = expectedSsl,
-                sshdPort = 2223,
-                sshHostKeyDirectory = Paths.get("/x/y/ssh"),
+                sshdPort = null,
+                sshHostKeyDirectory = null,
                 noLocalShell = false)
 
         val config = options.toConfig()
@@ -69,8 +66,6 @@ class StandaloneShellArgsParserTest {
         options.port = null
         options.user = null
         options.password = null
-        options.sshdPort = null
-        options.sshdHostKeyDirectory = null
         options.trustStorePassword = null
         options.trustStoreFile = null
         options.trustStoreType = null
@@ -84,7 +79,7 @@ class StandaloneShellArgsParserTest {
                 ssl = ClientRpcSslOptions(
                         trustStorePath = Paths.get("/x/y/truststore.jks"),
                         trustStorePassword = "pass2"),
-                sshdPort = 2223)
+                sshdPort = null)
 
         val config = options.toConfig()
 
@@ -100,8 +95,6 @@ class StandaloneShellArgsParserTest {
         options.port = null
         options.user = null
         options.password = "blabla"
-        options.sshdPort = null
-        options.sshdHostKeyDirectory = null
         options.trustStorePassword = null
         options.trustStoreFile = null
         options.trustStoreType = null
@@ -116,7 +109,7 @@ class StandaloneShellArgsParserTest {
                 password = "blabla",
                 hostAndPort = NetworkHostAndPort("alocalhost", 1234),
                 ssl = expectedSsl,
-                sshdPort = 2223)
+                sshdPort = null)
 
         val config = options.toConfig()
 

--- a/tools/shell-cli/src/test/resources/config.conf
+++ b/tools/shell-cli/src/test/resources/config.conf
@@ -12,10 +12,6 @@ extensions {
         cordapps {
             path : "/x/y/cordapps"
         }
-        sshd {
-            enabled : "true"
-            port : 2223
-        }
         commands {
             path : /x/y/commands
         }

--- a/tools/shell-cli/src/test/resources/net.corda.tools.shell.StandaloneShell.yml
+++ b/tools/shell-cli/src/test/resources/net.corda.tools.shell.StandaloneShell.yml
@@ -46,16 +46,6 @@
     required: false
     multiParam: false
     acceptableValues: []
-  - parameterName: "--sshd-hostkey-directory"
-    parameterType: "java.nio.file.Path"
-    required: false
-    multiParam: true
-    acceptableValues: []
-  - parameterName: "--sshd-port"
-    parameterType: "java.lang.String"
-    required: false
-    multiParam: false
-    acceptableValues: []
   - parameterName: "--truststore-file"
     parameterType: "java.nio.file.Path"
     required: false


### PR DESCRIPTION
Removing support for external SSH connections to the standalone shell due to security reasons mentioned in ENT-3828. 

``--sshd-port`` and ``--sshd-hostkey-directory`` options, as well as ``extensions.sshd`` configuration entry, are removed from the standalone shell.