### PR TITLE
NO-TICK Cap the default size of the external operation thread pool

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -314,10 +314,10 @@ extraNetworkMapKeys
 .. _corda_configuration_flow_external_operation_thread_pool_size:
 
 flowExternalOperationThreadPoolSize
-  The number of threads available to execute external operations called from flows. See the documentation on
-  :ref:`calling external systems inside of flows <api_flows_external_operations>` for more information.
+  The number of threads available to execute external operations that have been called from flows. See the documentation on
+  :ref:`calling external systems inside flows <api_flows_external_operations>` for more information.
 
-  *Default:* Set to the number of available cores on the machine the node is running on
+*Default:* Set to the lesser of either the maximum number of cores allocated to the node, or 10.
 
 flowMonitorPeriodMillis
   Duration of the period suspended flows waiting for IO are logged.

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -23,11 +23,14 @@ import net.corda.nodeapi.internal.loadDevCaTrustStore
 import net.corda.nodeapi.internal.registerDevP2pCertificates
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
+import kotlin.math.min
 
 fun configOf(vararg pairs: Pair<String, Any?>): Config = ConfigFactory.parseMap(mapOf(*pairs))
 operator fun Config.plus(overrides: Map<String, Any?>): Config = ConfigFactory.parseMap(overrides).withFallback(this)
 
 object ConfigHelper {
+
+    private const val FLOW_EXTERNAL_OPERATION_THREAD_POOL_SIZE_MAX = 10
 
     private const val CORDA_PROPERTY_PREFIX = "corda."
     private const val UPPERCASE_PROPERTY_PREFIX = "CORDA."
@@ -47,7 +50,9 @@ object ConfigHelper {
 
         // Detect the number of cores
         val coreCount = Runtime.getRuntime().availableProcessors()
-        val multiThreadingConfig = configOf("flowExternalOperationThreadPoolSize" to coreCount.toString())
+        val multiThreadingConfig = configOf(
+                "flowExternalOperationThreadPoolSize" to min(coreCount, FLOW_EXTERNAL_OPERATION_THREAD_POOL_SIZE_MAX).toString()
+        )
 
         val systemOverrides = ConfigFactory.systemProperties().cordaEntriesOnly()
         val environmentOverrides = ConfigFactory.systemEnvironment().cordaEntriesOnly()


### PR DESCRIPTION
Cap the default size of the external operation thread pool to 10 or
the maximum number of available processors, whichever is smaller.

Set the minimum size of the thread pool to 1. Meaning that only a
single thread is used unless the node actually starts to use
`FlowExternalOperation` which consumes threads from this pool.