### PR TITLE
NOTICK disable max line length check in detekt.

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -172,7 +172,7 @@ style:
     ignoreNamedArgument: true
     ignoreEnums: true
   MaxLineLength:
-    active: true
+    active: false
     excludes: "**/buildSrc/**"
     maxLineLength: 140
     excludePackageStatements: true


### PR DESCRIPTION
Removing the check for maximal line length from detekt
This settings causes more problems than it solves - the two main issues are:
- It often enough disagrees with the kotlin style guide that prefers assignments on one line even if they involve invoking a method or an if/else statement.
- It leads to a lot of extra line break refactorings when touching any file in the code base, leading to code reviews where the actual, functional changes is night impossible to detect when reviewing. This poses a real risk of nasty bugs/mistakes slipping through the code review process.

