### PR TITLE
NOTICK disable max line length check in detekt. (#5882)

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -172,7 +172,7 @@ style:
     ignoreNamedArgument: true
     ignoreEnums: true
   MaxLineLength:
-    active: true
+    active: false
     excludes: "**/buildSrc/**"
     maxLineLength: 140
     excludePackageStatements: true


### PR DESCRIPTION
Merge this specific changes from OS 4.3 to 4.4