### PR TITLE
ENT-4474 O/S Changes to support bulk backchain fetching

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -1,12 +1,49 @@
 package net.corda.core.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.NamedByHash
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.*
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.SerializedBytes
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
 
+/**
+ * In the words of Matt Nesbit on 26/09/19 working code is more important then pretty code. This class that contains code that may
+ * be serialized. If it were always serialized then the local disk fetch would need to serialize then de-serialize
+ * which wastes time. However over the wire we get MULTI fetch items serialized. This is because we need to get the exact
+ * length of the objects to pack them into the 10MB max message size buffer. We do not want to serialize them multiple times
+ * so it's a lot more efficient to send the byte stream.
+ */
+//++++ added start
+@CordaSerializable
+class MaybeSerializedSignedTransaction(override val id: SecureHash, val serialized: SerializedBytes<SignedTransaction>?,
+                                       val nonSerialised: SignedTransaction?) : NamedByHash {
+    fun get(): SignedTransaction {
+        return if (nonSerialised != null) {
+            nonSerialised
+        } else if (serialized != null) {
+            val tranBytes = SerializedBytes<SignedTransaction>(serialized.bytes)
+            tranBytes.deserialize()
+            //++++ assign here?
+        } else {
+            throw Exception("MaybeSerializedSignedTransaction.get(${id}): May not be called with null object content.")
+        }
+    }
+    fun isNull(): Boolean {
+        return serialized == null && nonSerialised == null
+    }
+    fun serializedByteCount(): Int {
+        return if (serialized == null) { 0 } else { serialized.bytes.size }
+    }
+}
+//++++ added end
+
+val DEFAULT_MAX_MULTI_TRAN_BYTE_COUNT = 500001 //+++++ make 0.5MB zero // Unsupported in O/S
 /**
  * The [SendTransactionFlow] should be used to send a transaction to another peer that wishes to verify that transaction's
  * integrity by resolving and checking the dependencies as well. The other side should invoke [ReceiveTransactionFlow] at
@@ -38,8 +75,13 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any) 
         // User can override this method to perform custom request verification.
     }
 
+    public var maxMultiTranByteCount = DEFAULT_MAX_MULTI_TRAN_BYTE_COUNT //++++
+
     @Suspendable
     override fun call(): Void? {
+        val plt = payload.javaClass.typeName //++++
+        println("\n >>>>>> DataVendingFlow++++: Call: PLT1=$plt: MAX-TRAN-SIZE = $maxMultiTranByteCount")//++++
+
         // The first payload will be the transaction data, subsequent payload will be the transaction/attachment/network parameters data.
         var payload = payload
 
@@ -64,6 +106,120 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any) 
         // This loop will receive [FetchDataFlow.Request] continuously until the `otherSideSession` has all the data they need
         // to resolve the transaction, a [FetchDataFlow.EndRequest] will be sent from the `otherSideSession` to indicate end of
         // data request.
+        var cntxxxx = 0 //++++
+        while (true) {
+            println("\nXXXX++++ WHILE [$cntxxxx]...") ; cntxxxx++//++++
+            val dataRequest = sendPayloadAndReceiveDataRequest(otherSideSession, payload).unwrap { request ->
+                val rqt = request.javaClass.name//++++
+                //++++val nmx = request.namexxxx()
+                println("sendPayloadAndReceiveDataRequest()++++ $rqt")//++++
+                when (request) {
+                    is FetchDataFlow.Request.Data -> {
+                        // Security TODO: Check for abnormally large or malformed data requests
+                        verifyDataRequest(request)
+                        request
+                    }
+                    FetchDataFlow.Request.End -> {
+                        println("<<<<<< DataVendingFlow++++: END"); return null } //++++
+                }
+            }
+
+            val st = dataRequest.dataType.name
+            println("send stuff++++ $st")//++++
+            var failCntInd = 0 //++++ remove for test reject third item
+            var maxByteCount = maxMultiTranByteCount // Sample once before the loop
+            var totalByteCount = 0
+            var firstItem = true
+            var multiFetchCountExceeded = false
+            var numSent = 0
+            payload = when (dataRequest.dataType) {
+                FetchDataFlow.DataType.TRANSACTION -> dataRequest.hashes.map { txId ->
+                    val sz1=dataRequest.hashes.size //++++
+                    println("send stuff TRANSACTION++++ (dataRequest.hashes.size=$sz1)")//++++
+                    if (!authorisedTransactions.isAuthorised(txId)) {
+                        throw FetchDataFlow.IllegalTransactionRequest(txId)
+                    }
+                    val tx = serviceHub.validatedTransactions.getTransaction(txId)
+                            ?: throw FetchDataFlow.HashNotFound(txId)
+                    authorisedTransactions.removeAuthorised(tx.id)
+                    authorisedTransactions.addAuthorised(getInputTransactions(tx))
+                    tx
+                }
+                FetchDataFlow.DataType.MULTI_TRANSACTION -> dataRequest.hashes.map { txId -> //++++
+                    val sz1=dataRequest.hashes.size //++++
+                    val txs = txId.toString() //++++
+                    //++++  val sendItem = failCntInd != 2 && failCntInd != 3 //++++ test fail
+
+                    println("[$failCntInd]send stuff MULTI_TRANSACTION Exceed=${multiFetchCountExceeded} [$txId]++++ (num=$sz1): '$txs'")//++++
+                    if (!authorisedTransactions.isAuthorised(txId)) {
+                        //++++if (sendItem && !authorisedTransactions.isAuthorised(txId)) {
+                        throw FetchDataFlow.IllegalTransactionRequest(txId)
+                    }
+                    //++++ we should not just throw here as it's not recoverable on the client side. Might be better to send a reason code or
+                    // remove the restriction on sending once.
+                    println("Auth OK '$txs'")//++++
+                    // ++++   var sendItem = false
+                    var serialized: SerializedBytes<SignedTransaction>? = null
+                    if (!multiFetchCountExceeded) {
+                        // Only fetch and serialize if we have not already exceeded the maximum byte count. Once we have, no more fetching
+                        // is required, just reject all additional items.
+                        val tx = serviceHub.validatedTransactions.getTransaction(txId)
+                                ?: throw FetchDataFlow.HashNotFound(txId) //++++ how do we handle not found on one item?
+                        println("Get OK '$txs'")//++++
+                        serialized = tx.serialize() //++++zzzz might break the code
+
+                        val itemByteCount = serialized.size
+                        println("CHK first=$firstItem total=$totalByteCount item=$itemByteCount max=$maxByteCount")//++++
+                        if (firstItem || (totalByteCount + itemByteCount) < maxByteCount) {
+                            totalByteCount += itemByteCount
+                            numSent++
+                            // Always include at least one item else if the max is set too low nothing will ever get returned.
+                            // Splitting items will be a separate Jira if need be
+                            //++++ sendItem = true
+                            authorisedTransactions.removeAuthorised(tx.id)
+                            authorisedTransactions.addAuthorised(getInputTransactions(tx))
+                            //++++SerializedBytes<SignedTransaction>
+                            //++++println("adding to return set ++++ ${tx.javaClass.name}")//++++
+                            println("adding to return set ++++ ${serialized.javaClass.name} ${txId}")//++++
+                        } else {
+                            println("EXCEEDED -> TRUE")
+                            multiFetchCountExceeded = true
+                        }
+                    }
+
+                    //++++if (!multiFetchCountExceeded) {
+                    //++++    println("NOT adding to return set ++++ $txId")//++++
+                    //++++}
+                    //val serTran = SerializedSignedTransaction(txId, serialized)
+//++++ put back                    val maybeser = MaybeSerializedSignedTransaction(txId, serialized, null)
+                    if (multiFetchCountExceeded) { println("TEST-EXCLUDE++++ '${txId} (") }
+                    // Send null if limit is exceeded
+                    val maybeser = MaybeSerializedSignedTransaction(txId, if (multiFetchCountExceeded) { null } else { serialized }, null)
+                    firstItem = false
+                    failCntInd++//REMOVE++++
+                    maybeser
+                }
+                FetchDataFlow.DataType.ATTACHMENT -> dataRequest.hashes.map {
+                    println("send stuff ATTACHMENT++++")//++++
+                    serviceHub.attachments.openAttachment(it)?.open()?.readFully()
+                            ?: throw FetchDataFlow.HashNotFound(it)
+                }
+                FetchDataFlow.DataType.PARAMETERS -> dataRequest.hashes.map {
+                    println("send stuff PARAMETERS++++")//++++
+                    (serviceHub.networkParametersService as NetworkParametersStorage).lookupSigned(it)
+                            ?: throw FetchDataFlow.MissingNetworkParameters(it)
+                }
+                FetchDataFlow.DataType.UNKNOWN -> dataRequest.hashes.map {
+                    println("Message from from future version of Corda with UNKNOWN enum value for FetchDataFlow.DataType")//++++throw?
+                }
+            }
+            println("BLOCK TOTAL SIZE ${totalByteCount} (${numSent} / ${dataRequest.hashes.size})")//++++
+            val pls = payload.javaClass.name//++++
+            val als = payload.size
+            println("send stuff PLS++++ sz=$als $pls")//++++
+        }
+
+        /*++++ remove old impl
         while (true) {
             val dataRequest = sendPayloadAndReceiveDataRequest(otherSideSession, payload).unwrap { request ->
                 when (request) {
@@ -97,6 +253,8 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any) 
                 }
             }
         }
+
+        +++++ */
     }
 
     @Suspendable

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -11,7 +11,7 @@ import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
-import org.slf4j.Logger
+import net.corda.core.utilities.trace
 
 /**
  * In the words of Matt working code is more important then pretty code. This class that contains code that may
@@ -39,10 +39,6 @@ class MaybeSerializedSignedTransaction(override val id: SecureHash, val serializ
     fun serializedByteCount(): Int {
         return if (serialized == null) { 0 } else { serialized.bytes.size }
     }
-}
-
-inline fun Logger.trace(msg: () -> String) {
-    if (isTraceEnabled) trace(msg())
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -22,7 +22,7 @@ import net.corda.core.utilities.trace
  */
 @CordaSerializable
 class MaybeSerializedSignedTransaction(override val id: SecureHash, val serialized: SerializedBytes<SignedTransaction>?,
-                                       val nonSerialised: SignedTransaction?): NamedByHash {
+                                       val nonSerialised: SignedTransaction?) : NamedByHash {
     init {
         check(serialized == null || nonSerialised == null) {
             "MaybeSerializedSignedTransaction: Serialized and non-serialized may not both be non-null."
@@ -39,17 +39,22 @@ class MaybeSerializedSignedTransaction(override val id: SecureHash, val serializ
             null
         }
     }
+
     fun isNull(): Boolean {
         return serialized == null && nonSerialised == null
     }
+
     fun serializedByteCount(): Int {
         return serialized?.bytes?.size ?: 0
     }
+
     fun payloadContentDescription(): String {
         val tranSize = serializedByteCount()
         val isSer = serialized != null
         val isObj = nonSerialised != null
-        return if (isNull()) { "<Null>" } else "size = $tranSize, serialized = $isSer, isObj = $isObj"
+        return if (isNull()) {
+            "<Null>"
+        } else "size = $tranSize, serialized = $isSer, isObj = $isObj"
     }
 }
 
@@ -62,7 +67,7 @@ class MaybeSerializedSignedTransaction(override val id: SecureHash, val serializ
  * @param otherSide the target party.
  * @param stx the [SignedTransaction] being sent to the [otherSideSession].
  */
-open class SendTransactionFlow(otherSide: FlowSession, stx: SignedTransaction): DataVendingFlow(otherSide, stx)
+open class SendTransactionFlow(otherSide: FlowSession, stx: SignedTransaction) : DataVendingFlow(otherSide, stx)
 
 /**
  * The [SendStateAndRefFlow] should be used to send a list of input [StateAndRef] to another peer that wishes to verify
@@ -73,9 +78,9 @@ open class SendTransactionFlow(otherSide: FlowSession, stx: SignedTransaction): 
  * @param otherSideSession the target session.
  * @param stateAndRefs the list of [StateAndRef] being sent to the [otherSideSession].
  */
-open class SendStateAndRefFlow(otherSideSession: FlowSession, stateAndRefs: List<StateAndRef<*>>): DataVendingFlow(otherSideSession, stateAndRefs)
+open class SendStateAndRefFlow(otherSideSession: FlowSession, stateAndRefs: List<StateAndRef<*>>) : DataVendingFlow(otherSideSession, stateAndRefs)
 
-open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any): FlowLogic<Void?>() {
+open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any) : FlowLogic<Void?>() {
     @Suspendable
     protected open fun sendPayloadAndReceiveDataRequest(otherSideSession: FlowSession, payload: Any) = otherSideSession.sendAndReceive<FetchDataFlow.Request>(payload)
 
@@ -128,8 +133,9 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any):
                         request
                     }
                     FetchDataFlow.Request.End -> {
-                        logger.trace {"DataVendingFlow: END" }
-                        return null }
+                        logger.trace { "DataVendingFlow: END" }
+                        return null
+                    }
                 }
             }
 
@@ -190,7 +196,11 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any):
                     }
 
                     // Send null if limit is exceeded
-                    val maybeserialized = MaybeSerializedSignedTransaction(txId, if (batchFetchCountExceeded) { null } else { serialized },null)
+                    val maybeserialized = MaybeSerializedSignedTransaction(txId, if (batchFetchCountExceeded) {
+                        null
+                    } else {
+                        serialized
+                    }, null)
                     firstItem = false
                     maybeserialized
                 } // Batch response loop end

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -185,7 +185,7 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any) 
                     }
 
                     // Send null if limit is exceeded
-                    val maybeserialized = MaybeSerializedSignedTransaction(txId, if (batchFetchCountExceeded) { null } else { serialized }, null)
+                    val maybeserialized = MaybeSerializedSignedTransaction(txId, if (batchFetchCountExceeded) { null } else { serialized },null)
                     firstItem = false
                     maybeserialized
                 } // Batch response loop end

--- a/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
@@ -8,10 +8,13 @@ import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
+import net.corda.core.flows.MaybeSerializedSignedTransaction
 import net.corda.core.internal.FetchDataFlow.DownloadedVsRequestedDataMismatch
 import net.corda.core.internal.FetchDataFlow.HashNotFound
 import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.CordaSerializationTransformEnumDefault
+import net.corda.core.serialization.CordaSerializationTransformEnumDefaults
 import net.corda.core.serialization.SerializationToken
 import net.corda.core.serialization.SerializeAsToken
 import net.corda.core.serialization.SerializeAsTokenContext
@@ -39,10 +42,18 @@ import java.util.*
  * @param T The ultimate type of the data being fetched.
  * @param W The wire type of the data being fetched, for when it isn't the same as the ultimate type.
  */
+
+val DEFAULT_MAX_TRANSACTION_SIZE = 499 //++++ make 10MB once tested.
+
 sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
         protected val requests: Set<SecureHash>,
         protected val otherSideSession: FlowSession,
-        protected val dataType: DataType) : FlowLogic<FetchDataFlow.Result<T>>() {
+        protected val dataType: DataType,
+        protected val maxTransactionSize: Int /*++++*/) : FlowLogic<FetchDataFlow.Result<T>>() {
+
+/*++++    companion object {
+        protected val DEFAULT_MAX_TRANSACTION_SIZE = 499999 //++++ make 10MB once tested.
+    }*/
 
     @CordaSerializable
     class DownloadedVsRequestedDataMismatch(val requested: SecureHash, val got: SecureHash) : IllegalArgumentException()
@@ -65,9 +76,19 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
         object End : Request()
     }
 
+    //++++ add annotation regarding default usage. Also add value for does not match.
+    // https://docs.corda.net/serialization-enum-evolution.html
+    // Below annotations added to map two new enum values (MULTI_TRANSACTION and UNKNOWN) onto  TRANSACTION. The effect of this is that
+    // if a that does not have these enum values receives it will not throw an error during deserialization. The purpose of adding
+    // UNKNOWN is such that future additions can default to UNKNOWN rather than an existing value. In this instance we are protecting
+    // against not having unknown by using the platform version as a guard.
+    @CordaSerializationTransformEnumDefaults(
+            CordaSerializationTransformEnumDefault("MULTI_TRANSACTION", "TRANSACTION"),
+            CordaSerializationTransformEnumDefault("UNKNOWN", "TRANSACTION")
+    )
     @CordaSerializable
     enum class DataType {
-        TRANSACTION, ATTACHMENT, PARAMETERS
+        TRANSACTION, ATTACHMENT, PARAMETERS, MULTI_TRANSACTION, UNKNOWN
     }
 
     @Suspendable
@@ -75,8 +96,13 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
     override fun call(): Result<T> {
         // Load the items we have from disk and figure out which we're missing.
         val (fromDisk, toFetch) = loadWhatWeHave()
+        val fds = fromDisk.size //++++ remove
+        val tofs = toFetch.size //++++ remove
+        println("\nFetchDataFlow.call(): From disk size = $fds, to fetch size = $tofs, Max-Transactions Size = $maxTransactionSize")//++++ remove
+
 
         return if (toFetch.isEmpty()) {
+            println("return early (empty).++++") //++++ trace message
             val loadedFromDisk = loadExpected(fromDisk)
             Result(loadedFromDisk, emptyList())
         } else {
@@ -89,19 +115,89 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
             // configured Artemis to not fragment messages up to 10mb so we can send 10mb messages without problems.
             // Above that, we start losing authentication data on the message fragments and take exceptions in the
             // network layer.
-            val maybeItems = ArrayList<W>(toFetch.size)
+            val maybeItems = ArrayList<W>()
+
+//++++            val maybeItems = ArrayList<W>(toFetch.size)
+
+
+
+           // val platformVersion = otherSideSession.getCounterpartyFlowInfo().flowVersion // For system flows this is platform version
+           // println("PLAT VER OTHER SIDE = '${platformVersion}'")//++++ trace
+            //++++ include platform version test ....
+            if (toFetch.size == 1) {
+                for (hash in toFetch) {
+                    // Technically not necessary to loop when the outer test is for one item only. Safer than toFetch[0]
+                    // We skip the validation here (with unwrap { it }) because we will do it below in validateFetchResponse.
+                    // The only thing checked is the object type. It is a protocol violation to send results out of order.
+                    // TODO We need to page here after large messages will work.
+                    println("otherSideSession.sendAndReceive($hash)")//++++
+                    // should only pass single item dataType below.
+                    maybeItems += otherSideSession.sendAndReceive<List<W>>(Request.Data(NonEmptySet.of(hash), dataType)).unwrap { it }
+                    println("FetchDataFlow.call3b ++++ $hash : ${dataType.name}")
+                }
+            } else { //++++ XXXX
+                // val tofs = toFetch.size
+                // println("FOR START ++++($tofs)")
+                //++++var index: Int = 0
+
+                val fetchSet = LinkedHashSet<SecureHash>()
+                for (hash in toFetch) {
+                    fetchSet.add(hash)
+                }
+                println("END FOR ++++(${fetchSet.size})")
+
+                //val fetchItems = NonEmptySet<SecureHash>.copyOf(toFetch)
+                println("otherSideSession.sendAndReceive(list of ${fetchSet.size})")//++++
+                maybeItems += otherSideSession.sendAndReceive<List<W>>(Request.Data(NonEmptySet.copyOf(fetchSet), dataType))
+                        .unwrap { it }
+                println("FetchDataFlow.call3b ++++ : ${dataType.name}")
+
+                //++++    maybeItems += otherSideSession.sendAndReceive<List<W>>(Request.Data(NonEmptySet.of(toFetch.get(0), toFetch.get(1)), dataType))
+                //++++ .unwrap { it } //++++ nasty POC hack use 2 items
+                val mb1 = maybeItems.size
+                println("FetchDataFlow.otherSideSession.sendAndReceive done ($mb1) ++++ ${dataType.name}")
+            }
+
+
+
+
+/*OLD - remove +++++
             for (hash in toFetch) {
                 // We skip the validation here (with unwrap { it }) because we will do it below in validateFetchResponse.
                 // The only thing checked is the object type. It is a protocol violation to send results out of order.
                 // TODO We need to page here after large messages will work.
                 maybeItems += otherSideSession.sendAndReceive<List<W>>(Request.Data(NonEmptySet.of(hash), dataType)).unwrap { it }
             }
+
+ ++++*/
+
+            //++++ remove copy // Check for a buggy/malicious peer answering with something that we didn't ask for.
+//++++ remove old            val downloaded = validateFetchResponse(UntrustworthyData(maybeItems), toFetch)
+
             // Check for a buggy/malicious peer answering with something that we didn't ask for.
+            val mb2 = maybeItems.size//++++
+            println("validating fetch response ++++maybe2_sz=$mb2, tofetch_sz=$tofs")
             val downloaded = validateFetchResponse(UntrustworthyData(maybeItems), toFetch)
+            println("downloaded fetch response ++++(downloaded_sz=${downloaded.size}) maybe2=$mb2, cls=${downloaded.javaClass.name}")
+
+
+
+
             logger.debug { "Fetched ${downloaded.size} elements from ${otherSideSession.counterparty.name}" }
             maybeWriteToDisk(downloaded)
             // Re-load items already present before the download procedure. This ensures these objects are not unnecessarily checkpointed.
             val loadedFromDisk = loadExpected(fromDisk)
+
+
+            for (dnd in loadedFromDisk) {
+                println("DN-DISK = '${dnd.javaClass.name} '${dnd.id}'")//++++
+            }
+            for (dnl in downloaded) {
+                println("DN-REMO = '${dnl.javaClass.name} '${dnl.id}'")//++++
+            }
+
+
+
             Result(loadedFromDisk, downloaded)
         }
     }
@@ -118,8 +214,8 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
             if (stx == null)
                 toFetch += txid
             else
-            // Although the full object is loaded here, only return the id. This prevents the full set of objects already present from
-            // being checkpointed every time a request is made to download an object the node does not yet have.
+                // Although the full object is loaded here, only return the id. This prevents the full set of objects already present from
+                // being checkpointed every time a request is made to download an object the node does not yet have.
                 fromDisk += txid
         }
         return Pair(fromDisk, toFetch)
@@ -140,6 +236,55 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
     private fun validateFetchResponse(maybeItems: UntrustworthyData<ArrayList<W>>,
                                       requests: List<SecureHash>): List<T> {
         return maybeItems.unwrap { response ->
+            println("PT U0++++ ${response.size} ${requests.size}")//++++
+            if (response.size != requests.size) {
+                println("PT U1++++ response.size != requests.size")
+                throw DownloadedVsRequestedSizeMismatch(requests.size, response.size)
+            }
+            println("U0a: type=${response.javaClass.name} ++++")
+            for (rr in response) { //++++
+                println("  RespType = ${rr.javaClass.name}") // ++++ make trace level
+            }
+
+            val answers = response.map { convert(it) }
+            println("PT U2++++ ans=${answers.javaClass.name} ${answers.size}")//++++
+            for (aa in answers) {
+                if (aa is SignedTransaction) {
+                    println("PT U2a++++ ${aa.javaClass.name}: SignedTran: tx size = ${aa.txBits.size}")
+                } else if (aa is MaybeSerializedSignedTransaction) {
+                    val cnt = if (aa.isNull()) { "<Null>" } else if (aa.serialized != null) { aa.serialized.size } else { -1 }
+                    println("PT U2a++++ ${aa.javaClass.name}: MayBe: tx size = $cnt")
+                } else {
+                    println("PT U2a++++ ${aa.javaClass.name}: Unknown")
+                }
+            }
+            for (req in requests) {
+                println("REQ = '${req}")//++++
+            }
+
+            println("PT U3++++ ${answers.size}")
+            // Check transactions actually hash to what we requested, if this fails the remote node
+            // is a malicious flow violator or buggy.
+            var badDataIndex = -1
+            var badDataId : SecureHash? = null //++++SecureHash("NOT-SET"
+            for ((index, item) in answers.withIndex()) {
+                println("PT U5++++ Index='${requests[index]}' item='${item.id}'")
+
+                if (item.id != requests[index]) {
+                    println("PT U5t++++ ${item.id} ${requests[index]}")
+                    badDataIndex = index //++++
+                    badDataId = item.id
+                    println("Will Throw: DownloadedVsRequestedDataMismatch(${requests[index]}, ${item.id}")
+                }
+            }
+            if (badDataIndex >= 0 && badDataId != null) {
+                throw DownloadedVsRequestedDataMismatch(requests[badDataIndex], badDataId)
+            }
+
+            answers
+        }
+/* ++++ remove old
+        return maybeItems.unwrap { response ->
             if (response.size != requests.size)
                 throw DownloadedVsRequestedSizeMismatch(requests.size, response.size)
             val answers = response.map { convert(it) }
@@ -151,6 +296,8 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
             }
             answers
         }
+
+ ++++*/
     }
 }
 
@@ -159,7 +306,7 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
  * attachments are saved to local storage automatically.
  */
 class FetchAttachmentsFlow(requests: Set<SecureHash>,
-                           otherSide: FlowSession) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide, DataType.ATTACHMENT) {
+                           otherSide: FlowSession) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide, DataType.ATTACHMENT, DEFAULT_MAX_TRANSACTION_SIZE) {
 
     private val uploader = "$P2P_UPLOADER:${otherSideSession.counterparty.name}"
 
@@ -207,10 +354,27 @@ class FetchAttachmentsFlow(requests: Set<SecureHash>,
  * Note that returned transactions are not inserted into the database, because it's up to the caller to actually verify the transactions are valid.
  */
 class FetchTransactionsFlow(requests: Set<SecureHash>, otherSide: FlowSession) :
-        FetchDataFlow<SignedTransaction, SignedTransaction>(requests, otherSide, DataType.TRANSACTION) {
+        FetchDataFlow<SignedTransaction, SignedTransaction>(requests, otherSide, DataType.TRANSACTION, DEFAULT_MAX_TRANSACTION_SIZE) {
 
     override fun load(txid: SecureHash): SignedTransaction? = serviceHub.validatedTransactions.getTransaction(txid)
 }
+
+//++++ added start: Move to enterprise?
+class FetchMultiTransactionsFlow(requests: Set<SecureHash>, otherSide: FlowSession, maxTransactionSize: Int) : //++++
+        FetchDataFlow<MaybeSerializedSignedTransaction, MaybeSerializedSignedTransaction>(requests, otherSide, DataType.MULTI_TRANSACTION, maxTransactionSize) { //++++
+
+    //override fun namexxxx() : String { return "FetchMultiTransactionsFlow"} //++++
+    //override fun load(txid: SecureHash): SignedTransaction? = serviceHub.validatedTransactions.getTransaction(txid)
+    override fun load(txid: SecureHash): MaybeSerializedSignedTransaction? {
+        val tran = serviceHub.validatedTransactions.getTransaction(txid)
+        return if (tran == null) {
+            null
+        } else {
+            MaybeSerializedSignedTransaction(txid, null, tran)
+        }
+    }
+}
+//++++ added end
 
 /**
  * Given a set of hashes either loads from local network parameters storage or requests them from the other peer. Downloaded
@@ -218,7 +382,9 @@ class FetchTransactionsFlow(requests: Set<SecureHash>, otherSide: FlowSession) :
  * Nodes on lower versions won't respond to this flow.
  */
 class FetchNetworkParametersFlow(requests: Set<SecureHash>,
-                                 otherSide: FlowSession) : FetchDataFlow<SignedDataWithCert<NetworkParameters>, SignedDataWithCert<NetworkParameters>>(requests, otherSide, DataType.PARAMETERS) {
+                                 otherSide: FlowSession) : FetchDataFlow<SignedDataWithCert<NetworkParameters>,
+                                 SignedDataWithCert<NetworkParameters>>(requests, otherSide, DataType.PARAMETERS,
+                                 DEFAULT_MAX_TRANSACTION_SIZE) {
     override fun load(txid: SecureHash): SignedDataWithCert<NetworkParameters>? {
         return (serviceHub.networkParametersService as NetworkParametersStorage).lookupSigned(txid)
     }

--- a/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
@@ -23,7 +23,7 @@ import net.corda.core.utilities.NonEmptySet
 import net.corda.core.utilities.UntrustworthyData
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.unwrap
-import org.slf4j.Logger
+import net.corda.core.utilities.trace
 import java.nio.file.FileAlreadyExistsException
 import java.util.*
 
@@ -60,10 +60,6 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
     class MissingNetworkParameters(val requested: SecureHash) : FlowException("Failed to fetch network parameters with hash: $requested")
 
     class IllegalTransactionRequest(val requested: SecureHash) : FlowException("Illegal attempt to request a transaction (${requested}) that is not in the transitive dependency graph of the sent transaction.")
-
-    inline fun Logger.trace(msg: () -> String) {
-        if (isTraceEnabled) trace(msg())
-    }
 
     @CordaSerializable
     data class Result<out T : NamedByHash>(val fromDisk: List<T>, val downloaded: List<T>)
@@ -110,7 +106,6 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
             // Above that, we start losing authentication data on the message fragments and take exceptions in the
             // network layer.
             val maybeItems = ArrayList<W>()
-
             if (toFetch.size == 1) {
                 for (hash in toFetch) {
                     // Technically not necessary to loop when the outer test is for one item only. Safer than toFetch[0]

--- a/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
@@ -44,31 +44,31 @@ import java.util.*
  * @param W The wire type of the data being fetched, for when it isn't the same as the ultimate type.
  */
 
-sealed class FetchDataFlow<T: NamedByHash, in W: Any>(
+sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
         protected val requests: Set<SecureHash>,
         protected val otherSideSession: FlowSession,
-        protected val dataType: DataType): FlowLogic<FetchDataFlow.Result<T>>() {
+        protected val dataType: DataType) : FlowLogic<FetchDataFlow.Result<T>>() {
 
     @CordaSerializable
-    class DownloadedVsRequestedDataMismatch(val requested: SecureHash, val got: SecureHash): IllegalArgumentException()
+    class DownloadedVsRequestedDataMismatch(val requested: SecureHash, val got: SecureHash) : IllegalArgumentException()
 
     @CordaSerializable
-    class DownloadedVsRequestedSizeMismatch(val requested: Int, val got: Int): IllegalArgumentException()
+    class DownloadedVsRequestedSizeMismatch(val requested: Int, val got: Int) : IllegalArgumentException()
 
-    class HashNotFound(val requested: SecureHash): FlowException()
+    class HashNotFound(val requested: SecureHash) : FlowException()
 
-    class MissingNetworkParameters(val requested: SecureHash): FlowException("Failed to fetch network parameters with hash: $requested")
+    class MissingNetworkParameters(val requested: SecureHash) : FlowException("Failed to fetch network parameters with hash: $requested")
 
-    class IllegalTransactionRequest(val requested: SecureHash): FlowException("Illegal attempt to request a transaction ($requested)"
+    class IllegalTransactionRequest(val requested: SecureHash) : FlowException("Illegal attempt to request a transaction ($requested)"
             + " that is not in the transitive dependency graph of the sent transaction.")
 
     @CordaSerializable
-    data class Result<out T: NamedByHash>(val fromDisk: List<T>, val downloaded: List<T>)
+    data class Result<out T : NamedByHash>(val fromDisk: List<T>, val downloaded: List<T>)
 
     @CordaSerializable
     sealed class Request {
-        data class Data(val hashes: NonEmptySet<SecureHash>, val dataType: DataType): Request()
-        object End: Request()
+        data class Data(val hashes: NonEmptySet<SecureHash>, val dataType: DataType) : Request()
+        object End : Request()
     }
 
     // https://docs.corda.net/serialization-enum-evolution.html
@@ -145,8 +145,8 @@ sealed class FetchDataFlow<T: NamedByHash, in W: Any>(
             if (stx == null)
                 toFetch += txid
             else
-                // Although the full object is loaded here, only return the id. This prevents the full set of objects already present from
-                // being checkpointed every time a request is made to download an object the node does not yet have.
+            // Although the full object is loaded here, only return the id. This prevents the full set of objects already present from
+            // being checkpointed every time a request is made to download an object the node does not yet have.
                 fromDisk += txid
         }
         return Pair(fromDisk, toFetch)
@@ -220,7 +220,7 @@ sealed class FetchDataFlow<T: NamedByHash, in W: Any>(
  * attachments are saved to local storage automatically.
  */
 class FetchAttachmentsFlow(requests: Set<SecureHash>,
-                           otherSide: FlowSession): FetchDataFlow<Attachment, ByteArray>(requests, otherSide, DataType.ATTACHMENT) {
+                           otherSide: FlowSession) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide, DataType.ATTACHMENT) {
 
     private val uploader = "$P2P_UPLOADER:${otherSideSession.counterparty.name}"
 
@@ -246,10 +246,10 @@ class FetchAttachmentsFlow(requests: Set<SecureHash>,
         }
     }
 
-    private class FetchedAttachment(dataLoader: () -> ByteArray, uploader: String?): AbstractAttachment(dataLoader, uploader), SerializeAsToken {
+    private class FetchedAttachment(dataLoader: () -> ByteArray, uploader: String?) : AbstractAttachment(dataLoader, uploader), SerializeAsToken {
         override val id: SecureHash by lazy { attachmentData.sha256() }
 
-        private class Token(private val id: SecureHash, private val uploader: String?): SerializationToken {
+        private class Token(private val id: SecureHash, private val uploader: String?) : SerializationToken {
             override fun fromToken(context: SerializeAsTokenContext) = FetchedAttachment(context.attachmentDataLoader(id), uploader)
         }
 
@@ -292,8 +292,8 @@ class FetchBatchTransactionsFlow(requests: Set<SecureHash>, otherSide: FlowSessi
  * Nodes on lower versions won't respond to this flow.
  */
 class FetchNetworkParametersFlow(requests: Set<SecureHash>,
-                                 otherSide: FlowSession): FetchDataFlow<SignedDataWithCert<NetworkParameters>,
-                                 SignedDataWithCert<NetworkParameters>>(requests, otherSide, DataType.PARAMETERS) {
+                                 otherSide: FlowSession) : FetchDataFlow<SignedDataWithCert<NetworkParameters>,
+        SignedDataWithCert<NetworkParameters>>(requests, otherSide, DataType.PARAMETERS) {
     override fun load(txid: SecureHash): SignedDataWithCert<NetworkParameters>? {
         return (serviceHub.networkParametersService as NetworkParametersStorage).lookupSigned(txid)
     }

--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -42,9 +42,12 @@ class ResolveTransactionsFlow private constructor(
         val counterpartyPlatformVersion = checkNotNull(serviceHub.networkMapCache.getNodeByLegalIdentity(otherSide.counterparty)?.platformVersion) {
             "Couldn't retrieve party's ${otherSide.counterparty} platform version from NetworkMapCache"
         }
+//++++        val opv = counterpartyPlatformVersion//++++
         // Fetch missing parameters flow was added in version 4. This check is needed so we don't end up with node V4 sending parameters
         // request to node V3 that doesn't know about this protocol.
         fetchNetParamsFromCounterpart = counterpartyPlatformVersion >= 4
+        val multiMode = counterpartyPlatformVersion >= 6
+        println("ResolveTransactionsFlow.call(): Otherside Platform Version++++ = '$counterpartyPlatformVersion': Multi=$multiMode")
 
         if (initialTx != null) {
             fetchMissingAttachments(initialTx)
@@ -52,9 +55,15 @@ class ResolveTransactionsFlow private constructor(
         }
 
         val resolver = (serviceHub as ServiceHubCoreInternal).createTransactionsResolver(this)
-        resolver.downloadDependencies()
+        resolver.downloadDependencies(multiMode)
 
+
+        val ost = otherSide.javaClass.name //++++
+        println("\n\n\n --- ResolveTransactionsFlow 1s ++++ --- $ost") //++++
         otherSide.send(FetchDataFlow.Request.End) // Finish fetching data.
+        println("--- ResolveTransactionsFlow 1e ++++ ---\n\n\n") //++++
+
+
 
         // If transaction resolution is performed for a transaction where some states are relevant, then those should be
         // recorded if this has not already occurred.

--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -22,7 +22,7 @@ class ResolveTransactionsFlow private constructor(
         val txHashes: Set<SecureHash>,
         val otherSide: FlowSession,
         val statesToRecord: StatesToRecord
-): FlowLogic<Unit>() {
+) : FlowLogic<Unit>() {
 
     constructor(txHashes: Set<SecureHash>, otherSide: FlowSession, statesToRecord: StatesToRecord = StatesToRecord.NONE)
             : this(null, txHashes, otherSide, statesToRecord)

--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -48,8 +48,8 @@ class ResolveTransactionsFlow private constructor(
         // Fetch missing parameters flow was added in version 4. This check is needed so we don't end up with node V4 sending parameters
         // request to node V3 that doesn't know about this protocol.
         fetchNetParamsFromCounterpart = counterpartyPlatformVersion >= 4
-        val multiMode = counterpartyPlatformVersion >= 6
-        logger.debug { "ResolveTransactionsFlow.call(): Otherside Platform Version = '$counterpartyPlatformVersion': Multi mode = $multiMode" }
+        val batchMode = counterpartyPlatformVersion >= 6
+        logger.debug { "ResolveTransactionsFlow.call(): Otherside Platform Version = '$counterpartyPlatformVersion': Batch mode = $batchMode" }
 
         if (initialTx != null) {
             fetchMissingAttachments(initialTx)
@@ -57,7 +57,7 @@ class ResolveTransactionsFlow private constructor(
         }
 
         val resolver = (serviceHub as ServiceHubCoreInternal).createTransactionsResolver(this)
-        resolver.downloadDependencies(multiMode)
+        resolver.downloadDependencies(batchMode)
 
         logger.trace { "ResolveTransactionsFlow: Sending END." }
         otherSide.send(FetchDataFlow.Request.End) // Finish fetching data.

--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -42,12 +42,12 @@ class ResolveTransactionsFlow private constructor(
         val counterpartyPlatformVersion = checkNotNull(serviceHub.networkMapCache.getNodeByLegalIdentity(otherSide.counterparty)?.platformVersion) {
             "Couldn't retrieve party's ${otherSide.counterparty} platform version from NetworkMapCache"
         }
-//++++        val opv = counterpartyPlatformVersion//++++
+
         // Fetch missing parameters flow was added in version 4. This check is needed so we don't end up with node V4 sending parameters
         // request to node V3 that doesn't know about this protocol.
         fetchNetParamsFromCounterpart = counterpartyPlatformVersion >= 4
         val multiMode = counterpartyPlatformVersion >= 6
-        println("ResolveTransactionsFlow.call(): Otherside Platform Version++++ = '$counterpartyPlatformVersion': Multi=$multiMode")
+        println("ResolveTransactionsFlow.call(): Otherside Platform Version = '$counterpartyPlatformVersion': Multi mode = $multiMode")
 
         if (initialTx != null) {
             fetchMissingAttachments(initialTx)
@@ -57,13 +57,8 @@ class ResolveTransactionsFlow private constructor(
         val resolver = (serviceHub as ServiceHubCoreInternal).createTransactionsResolver(this)
         resolver.downloadDependencies(multiMode)
 
-
-        val ost = otherSide.javaClass.name //++++
-        println("\n\n\n --- ResolveTransactionsFlow 1s ++++ --- $ost") //++++
+        println("ResolveTransactionsFlow: Sending END.") //++++
         otherSide.send(FetchDataFlow.Request.End) // Finish fetching data.
-        println("--- ResolveTransactionsFlow 1e ++++ ---\n\n\n") //++++
-
-
 
         // If transaction resolution is performed for a transaction where some states are relevant, then those should be
         // recorded if this has not already occurred.

--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -9,7 +9,8 @@ import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.ContractUpgradeWireTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
-import org.slf4j.Logger
+import net.corda.core.utilities.debug
+import net.corda.core.utilities.trace
 
 /**
  * Resolves transactions for the specified [txHashes] along with their full history (dependency graph) from [otherSide].
@@ -37,10 +38,6 @@ class ResolveTransactionsFlow private constructor(
 
     private var fetchNetParamsFromCounterpart = false
 
-    inline fun Logger.trace(msg: () -> String) {
-        if (isTraceEnabled) trace(msg())
-    }
-
     @Suspendable
     override fun call() {
         // TODO This error should actually cause the flow to be sent to the flow hospital to be retried
@@ -52,7 +49,7 @@ class ResolveTransactionsFlow private constructor(
         // request to node V3 that doesn't know about this protocol.
         fetchNetParamsFromCounterpart = counterpartyPlatformVersion >= 4
         val multiMode = counterpartyPlatformVersion >= 6
-        logger.trace { "ResolveTransactionsFlow.call(): Otherside Platform Version = '$counterpartyPlatformVersion': Multi mode = $multiMode" }
+        logger.debug { "ResolveTransactionsFlow.call(): Otherside Platform Version = '$counterpartyPlatformVersion': Multi mode = $multiMode" }
 
         if (initialTx != null) {
             fetchMissingAttachments(initialTx)

--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -22,7 +22,7 @@ class ResolveTransactionsFlow private constructor(
         val txHashes: Set<SecureHash>,
         val otherSide: FlowSession,
         val statesToRecord: StatesToRecord
-) : FlowLogic<Unit>() {
+): FlowLogic<Unit>() {
 
     constructor(txHashes: Set<SecureHash>, otherSide: FlowSession, statesToRecord: StatesToRecord = StatesToRecord.NONE)
             : this(null, txHashes, otherSide, statesToRecord)
@@ -38,6 +38,7 @@ class ResolveTransactionsFlow private constructor(
 
     private var fetchNetParamsFromCounterpart = false
 
+    @Suppress("MagicNumber")
     @Suspendable
     override fun call() {
         // TODO This error should actually cause the flow to be sent to the flow hospital to be retried

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -19,7 +19,7 @@ interface ServiceHubCoreInternal : ServiceHub {
 
 interface TransactionsResolver {
     @Suspendable
-    fun downloadDependencies(multiMode : Boolean) //++++ added param for batch fetch
+    fun downloadDependencies(multiMode : Boolean)
 
     fun recordDependencies(usedStatesToRecord: StatesToRecord)
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -19,7 +19,7 @@ interface ServiceHubCoreInternal : ServiceHub {
 
 interface TransactionsResolver {
     @Suspendable
-    fun downloadDependencies(multiMode : Boolean)
+    fun downloadDependencies(batchMode : Boolean)
 
     fun recordDependencies(usedStatesToRecord: StatesToRecord)
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ExecutorService
 
 // TODO: This should really be called ServiceHubInternal but that name is already taken by net.corda.node.services.api.ServiceHubInternal.
 @DeleteForDJVM
-interface ServiceHubCoreInternal : ServiceHub {
+interface ServiceHubCoreInternal: ServiceHub {
 
     val externalOperationExecutor: ExecutorService
 
@@ -19,7 +19,6 @@ interface ServiceHubCoreInternal : ServiceHub {
 
 interface TransactionsResolver {
     @Suspendable
-    fun downloadDependencies(batchMode : Boolean)
-
+    fun downloadDependencies(batchMode: Boolean)
     fun recordDependencies(usedStatesToRecord: StatesToRecord)
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ExecutorService
 
 // TODO: This should really be called ServiceHubInternal but that name is already taken by net.corda.node.services.api.ServiceHubInternal.
 @DeleteForDJVM
-interface ServiceHubCoreInternal: ServiceHub {
+interface ServiceHubCoreInternal : ServiceHub {
 
     val externalOperationExecutor: ExecutorService
 
@@ -20,5 +20,6 @@ interface ServiceHubCoreInternal: ServiceHub {
 interface TransactionsResolver {
     @Suspendable
     fun downloadDependencies(batchMode: Boolean)
+
     fun recordDependencies(usedStatesToRecord: StatesToRecord)
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -19,7 +19,7 @@ interface ServiceHubCoreInternal : ServiceHub {
 
 interface TransactionsResolver {
     @Suspendable
-    fun downloadDependencies()
+    fun downloadDependencies(multiMode : Boolean) //++++ added param for batch fetch
 
     fun recordDependencies(usedStatesToRecord: StatesToRecord)
 }

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -3,6 +3,7 @@ package net.corda.node.services
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
+import net.corda.core.internal.FetchMultiTransactionsFlow
 import net.corda.core.internal.FetchTransactionsFlow
 import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.internal.TransactionsResolver
@@ -12,6 +13,8 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.seconds
 import net.corda.node.services.api.WritableTransactionStorage
+import net.corda.nodeapi.internal.persistence.contextTransaction
+import sun.management.snmp.jvminstr.JvmThreadInstanceEntryImpl.ThreadStateMap.Byte0.suspended
 import java.util.*
 
 class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : TransactionsResolver {
@@ -19,7 +22,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
     private val logger = flow.logger
 
     @Suspendable
-    override fun downloadDependencies() {
+    override fun downloadDependencies(multiMode : Boolean) {
         logger.debug { "Downloading dependencies for transactions ${flow.txHashes}" }
         val transactionStorage = flow.serviceHub.validatedTransactions as WritableTransactionStorage
 
@@ -39,10 +42,102 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
         // the db contain the identities that were resolved when the transaction was first checked, or should we
         // accept this kind of change is possible? Most likely solution is for identity data to be an attachment.
 
-        val nextRequests = LinkedHashSet<SecureHash>(flow.txHashes)   // Keep things unique but ordered, for unit test stability.
+        val nextRequests = LinkedHashSet<SecureHash>(flow.txHashes) // Keep things unique but ordered, for unit test stability.
         val topologicalSort = TopologicalSort()
 
+        println("O/S DbTransactionsResolver.downloadDependencies(MultiMode=${multiMode})") //++++
+
+/*++++ remove new
+        val maxFetchBlockSize = 50 //++++ make parameter
+        var batchInd: Int = 0//+++
         while (nextRequests.isNotEmpty()) {
+            println("DbTransactionsResolver.downloadDependencies(): Main while (count=${nextRequests.size})")//++++
+            // Don't re-download the same tx when we haven't verified it yet but it's referenced multiple times in the
+            // graph we're traversing.
+            nextRequests.removeAll(topologicalSort.transactionIds)
+            if (nextRequests.isEmpty()) {
+                // Done early.
+                break
+            }
+//++++ comment below check actual platform version
+            // In addition to fetchRequiredTransactions not working in batch mode when the platform version is below 7, as also
+            // only want to fetch one at a time in this main loop to keep the footprint size down for checkpointing lest we
+            // rollback the previous performance enhancement in this area (one at a time).
+            val ind = batchInd++//++++
+            println("\n\n[batch_ind=$ind] Fetch start++++ ************************************************************************************")//++++
+            val requestItems = LinkedHashSet<SecureHash>()
+            var index = 0
+            while (nextRequests.size > 0 && requestItems.size < maxFetchBlockSize) {
+                val item = nextRequests.first()
+                nextRequests.remove(item)
+                requestItems.add(item)
+                val itemStr = item.toString()
+                println("  ITEM[$index]: '$itemStr'")
+                index++
+            }
+
+            // missingItems has been added to the return of fetchRequiredTransactions: This contains transactions that were not able
+            // to be sent back due to the maximum message size (nominally 10MB) being breached. In this instance we re-request them.
+            val (existingTxIds, downloadedTxs, missingItems) = fetchRequiredTransactions(requestItems) // Fetch a batch at a time
+           //++++ val extSize = existingTxIds.size
+           //++++ val downLdSz = downloadedTxs.size
+            for (missing in missingItems) {
+                println("Adding back missing item '${missing}'")
+                nextRequests.add(missing)
+            }
+
+            println("[$ind] Fetch end++++ (existing_sz=${existingTxIds.size}, downloaded_sz=${downloadedTxs.size}) ************************************************************************************")//++++
+
+            // When acquiring the write locks for the transaction chain, it is important that all required locks are acquired in the same
+            // order when recording both verified and unverified transactions. In the verified case, the transactions must be recorded in
+            // back chain order (i.e. oldest first), so this must also happen for unverified transactions. This sort ensures that locks are
+            // acquired in the right order in the case the transactions should be stored in the database as unverified. The main topological
+            // sort is also updated here to ensure that this contains everything that needs locking in cases where the resolver switches
+            // from checkpointing to storing unverified transactions in the database.
+          //++++ keep for enterprise:  val lockingSort = TopologicalSort()
+            for (tx in downloadedTxs) {
+                val dependencies = tx.dependencies
+                //++++ keep for enterprise:      lockingSort.add(tx.id, dependencies)
+                topologicalSort.add(tx.id, dependencies)
+            }
+
+            var suspended = true
+            for (downloaded in downloadedTxs) {
+                suspended = false
+                val dependencies = downloaded.dependencies
+                // Do not keep in memory as this bloats the checkpoint. Write each item to the database.
+                //++++ keep for enterprise: transactionStorage.lockObjectsForWrite(lockingSort.complete(), contextTransaction, false) {
+                transactionStorage.addUnverifiedTransaction(downloaded)
+                //++++ keep for enterprise: }
+
+
+                // The write locks are only released over a suspend, so need to keep track of whether the flow has been suspended to ensure
+                // that locks are not held beyond each while loop iteration (as doing this would result in a deadlock due to claiming locks
+                // in the wrong order)
+                val suspendedViaAttachments = flow.fetchMissingAttachments(downloaded)
+                val suspendedViaParams = flow.fetchMissingNetworkParameters(downloaded)
+                suspended = suspended || suspendedViaAttachments || suspendedViaParams
+
+                // Add all input states and reference input states to the work queue.
+                nextRequests.addAll(dependencies)
+            }
+
+            // If the flow did not suspend on the last iteration of the downloaded loop above, perform a suspend here to ensure no write
+            // locks are held going into the next while loop iteration.
+            //++++ update comment above to the effect that the database is flushed..... (O/S)
+            if (!suspended) {
+                FlowLogic.sleep(0.seconds)
+            }
+
+            // It's possible that the node has a transaction in storage already. Dependencies should also be present for this transaction,
+            // so just remove these IDs from the set of next requests.
+            nextRequests.removeAll(existingTxIds)
+        }
+*/
+
+// ++++ keep old
+        while (nextRequests.isNotEmpty()) {
+            println("DbTransactionsResolver.downloadDependencies(): Main while (count=${nextRequests.size})")//++++
             // Don't re-download the same tx when we haven't verified it yet but it's referenced multiple times in the
             // graph we're traversing.
             nextRequests.removeAll(topologicalSort.transactionIds)
@@ -76,8 +171,8 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
                 nextRequests.addAll(dependencies)
             }
 
-            // If the flow did not suspend on the last iteration of the downloaded loop above, perform a suspend here to ensure no write
-            // locks are held going into the next while loop iteration.
+            // If the flow did not suspend on the last iteration of the downloaded loop above, perform a suspend here to ensure that
+            // all data is flushed to the database.
             if (!suspended) {
                 FlowLogic.sleep(0.seconds)
             }
@@ -111,11 +206,54 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
 
     // The transactions already present in the database do not need to be checkpointed on every iteration of downloading
     // dependencies for other transactions, so strip these down to just the IDs here.
+    /*++++ remove new
+    @Suspendable
+    private fun fetchRequiredTransactions(requests: Set<SecureHash>): Triple<List<SecureHash>, List<SignedTransaction>, List<SecureHash>> {
+        val sz = requests.size//++++
+        //++++val ost = flow.otherSide.javaClass.name
+        //++++println("fetchRequiredTransactions X ++++ size=$sz $ost")
+        var missingItems = ArrayList<SecureHash>() // Items that were not returned by a batch call
+        if (requests.size == 1) {
+            println("fetchRequiredTransactions (Single): size=$sz")//++++
+            // We should probably put the test here for whether we're using multi fetch (batch size > 1 and same plat version).
+            val requestedTxs = flow.subFlow(FetchTransactionsFlow(requests, flow.otherSide))
+            return Triple(requestedTxs.fromDisk.map { it.id }, requestedTxs.downloaded, missingItems)
+        } else {
+            var byteCountRecv = 0
+            var numRecv = 0
+            println("fetchRequiredTransactions (Multiple): size=$sz")//++++
+            val requestedTxs = flow.subFlow(FetchMultiTransactionsFlow(requests, flow.otherSide))
+            var downloaded = ArrayList<SignedTransaction>()
+            for (mTran in requestedTxs.downloaded) {
+                if (mTran.isNull()) {
+                    println("Failed to get transaction++++ ${mTran.id}")
+                    missingItems.add(mTran.id)
+                } else {
+                    byteCountRecv += mTran.serializedByteCount()
+                    downloaded.add(mTran.get())
+                    numRecv++
+                }
+            }
+            println("fetchRequiredTransactions (Multiple-end): Byte count=${byteCountRecv} (${numRecv} / ${requests.size})")//++++
+            for (muld in downloaded) {
+                println("MUL-DLD = '$muld.id': ${muld.javaClass.name}")
+            }
+            return Triple(requestedTxs.fromDisk.map { it.id }, downloaded, missingItems)
+        }
+//++++        println("fetchRequiredTransactions Y ++++ size=$sz")
+//++++        return Pair(requestedTxs.fromDisk.map { it.id }, requestedTxs.downloaded)
+    }
+
+    //++++ */
+//++++ keep old
+    // The transactions already present in the database do not need to be checkpointed on every iteration of downloading
+    // dependencies for other transactions, so strip these down to just the IDs here.
     @Suspendable
     private fun fetchRequiredTransactions(requests: Set<SecureHash>): Pair<List<SecureHash>, List<SignedTransaction>> {
         val requestedTxs = flow.subFlow(FetchTransactionsFlow(requests, flow.otherSide))
         return Pair(requestedTxs.fromDisk.map { it.id }, requestedTxs.downloaded)
     }
+
 
     /**
      * Provides a way to topologically sort SignedTransactions represented just their [SecureHash] IDs. This means that given any two transactions

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -3,7 +3,6 @@ package net.corda.node.services
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
-import net.corda.core.internal.FetchMultiTransactionsFlow
 import net.corda.core.internal.FetchTransactionsFlow
 import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.internal.TransactionsResolver
@@ -11,10 +10,9 @@ import net.corda.core.internal.dependencies
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.debug
+import net.corda.core.utilities.trace
 import net.corda.core.utilities.seconds
 import net.corda.node.services.api.WritableTransactionStorage
-import net.corda.nodeapi.internal.persistence.contextTransaction
-import sun.management.snmp.jvminstr.JvmThreadInstanceEntryImpl.ThreadStateMap.Byte0.suspended
 import java.util.*
 
 class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : TransactionsResolver {
@@ -44,8 +42,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
 
         val nextRequests = LinkedHashSet<SecureHash>(flow.txHashes) // Keep things unique but ordered, for unit test stability.
         val topologicalSort = TopologicalSort()
-
-        logger.debug { "O/S DbTransactionsResolver.downloadDependencies(MultiMode=${multiMode})" }
+        logger.debug { "DbTransactionsResolver.downloadDependencies(MultiMode=${multiMode})" }
 
         while (nextRequests.isNotEmpty()) {
             logger.debug { "Main fetch loop: size_remaining=${nextRequests.size}" }
@@ -99,7 +96,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
 
     override fun recordDependencies(usedStatesToRecord: StatesToRecord) {
         val sortedDependencies = checkNotNull(this.sortedDependencies)
-        logger.debug { "Recording ${sortedDependencies.size} dependencies for ${flow.txHashes.size} transactions" }
+        logger.trace { "Recording ${sortedDependencies.size} dependencies for ${flow.txHashes.size} transactions" }
         val transactionStorage = flow.serviceHub.validatedTransactions as WritableTransactionStorage
         for (txId in sortedDependencies) {
             // Retrieve and delete the transaction from the unverified store.

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -15,12 +15,12 @@ import net.corda.core.utilities.seconds
 import net.corda.node.services.api.WritableTransactionStorage
 import java.util.*
 
-class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : TransactionsResolver {
+class DbTransactionsResolver(private val flow: ResolveTransactionsFlow): TransactionsResolver {
     private var sortedDependencies: List<SecureHash>? = null
     private val logger = flow.logger
 
     @Suspendable
-    override fun downloadDependencies(batchMode : Boolean) {
+    override fun downloadDependencies(batchMode: Boolean) {
         logger.debug { "Downloading dependencies for transactions ${flow.txHashes}" }
         val transactionStorage = flow.serviceHub.validatedTransactions as WritableTransactionStorage
 
@@ -42,7 +42,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
 
         val nextRequests = LinkedHashSet<SecureHash>(flow.txHashes) // Keep things unique but ordered, for unit test stability.
         val topologicalSort = TopologicalSort()
-        logger.debug { "DbTransactionsResolver.downloadDependencies(batchMode=${batchMode})" }
+        logger.debug { "DbTransactionsResolver.downloadDependencies(batchMode=$batchMode)" }
 
         while (nextRequests.isNotEmpty()) {
             logger.debug { "Main fetch loop: size_remaining=${nextRequests.size}" }

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -15,7 +15,7 @@ import net.corda.core.utilities.seconds
 import net.corda.node.services.api.WritableTransactionStorage
 import java.util.*
 
-class DbTransactionsResolver(private val flow: ResolveTransactionsFlow): TransactionsResolver {
+class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : TransactionsResolver {
     private var sortedDependencies: List<SecureHash>? = null
     private val logger = flow.logger
 

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -20,7 +20,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
     private val logger = flow.logger
 
     @Suspendable
-    override fun downloadDependencies(multiMode : Boolean) {
+    override fun downloadDependencies(batchMode : Boolean) {
         logger.debug { "Downloading dependencies for transactions ${flow.txHashes}" }
         val transactionStorage = flow.serviceHub.validatedTransactions as WritableTransactionStorage
 
@@ -42,7 +42,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
 
         val nextRequests = LinkedHashSet<SecureHash>(flow.txHashes) // Keep things unique but ordered, for unit test stability.
         val topologicalSort = TopologicalSort()
-        logger.debug { "DbTransactionsResolver.downloadDependencies(MultiMode=${multiMode})" }
+        logger.debug { "DbTransactionsResolver.downloadDependencies(batchMode=${batchMode})" }
 
         while (nextRequests.isNotEmpty()) {
             logger.debug { "Main fetch loop: size_remaining=${nextRequests.size}" }

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -45,10 +45,10 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
         val nextRequests = LinkedHashSet<SecureHash>(flow.txHashes) // Keep things unique but ordered, for unit test stability.
         val topologicalSort = TopologicalSort()
 
-        println("O/S DbTransactionsResolver.downloadDependencies(MultiMode=${multiMode})") //++++
+        logger.debug { "O/S DbTransactionsResolver.downloadDependencies(MultiMode=${multiMode})" }
 
         while (nextRequests.isNotEmpty()) {
-            println("Main fetch loop: size_remaining=${nextRequests.size}")//++++
+            logger.debug { "Main fetch loop: size_remaining=${nextRequests.size}" }
             // Don't re-download the same tx when we haven't verified it yet but it's referenced multiple times in the
             // graph we're traversing.
             nextRequests.removeAll(topologicalSort.transactionIds)

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -47,97 +47,8 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
 
         println("O/S DbTransactionsResolver.downloadDependencies(MultiMode=${multiMode})") //++++
 
-/*++++ remove new
-        val maxFetchBlockSize = 50 //++++ make parameter
-        var batchInd: Int = 0//+++
         while (nextRequests.isNotEmpty()) {
-            println("DbTransactionsResolver.downloadDependencies(): Main while (count=${nextRequests.size})")//++++
-            // Don't re-download the same tx when we haven't verified it yet but it's referenced multiple times in the
-            // graph we're traversing.
-            nextRequests.removeAll(topologicalSort.transactionIds)
-            if (nextRequests.isEmpty()) {
-                // Done early.
-                break
-            }
-//++++ comment below check actual platform version
-            // In addition to fetchRequiredTransactions not working in batch mode when the platform version is below 7, as also
-            // only want to fetch one at a time in this main loop to keep the footprint size down for checkpointing lest we
-            // rollback the previous performance enhancement in this area (one at a time).
-            val ind = batchInd++//++++
-            println("\n\n[batch_ind=$ind] Fetch start++++ ************************************************************************************")//++++
-            val requestItems = LinkedHashSet<SecureHash>()
-            var index = 0
-            while (nextRequests.size > 0 && requestItems.size < maxFetchBlockSize) {
-                val item = nextRequests.first()
-                nextRequests.remove(item)
-                requestItems.add(item)
-                val itemStr = item.toString()
-                println("  ITEM[$index]: '$itemStr'")
-                index++
-            }
-
-            // missingItems has been added to the return of fetchRequiredTransactions: This contains transactions that were not able
-            // to be sent back due to the maximum message size (nominally 10MB) being breached. In this instance we re-request them.
-            val (existingTxIds, downloadedTxs, missingItems) = fetchRequiredTransactions(requestItems) // Fetch a batch at a time
-           //++++ val extSize = existingTxIds.size
-           //++++ val downLdSz = downloadedTxs.size
-            for (missing in missingItems) {
-                println("Adding back missing item '${missing}'")
-                nextRequests.add(missing)
-            }
-
-            println("[$ind] Fetch end++++ (existing_sz=${existingTxIds.size}, downloaded_sz=${downloadedTxs.size}) ************************************************************************************")//++++
-
-            // When acquiring the write locks for the transaction chain, it is important that all required locks are acquired in the same
-            // order when recording both verified and unverified transactions. In the verified case, the transactions must be recorded in
-            // back chain order (i.e. oldest first), so this must also happen for unverified transactions. This sort ensures that locks are
-            // acquired in the right order in the case the transactions should be stored in the database as unverified. The main topological
-            // sort is also updated here to ensure that this contains everything that needs locking in cases where the resolver switches
-            // from checkpointing to storing unverified transactions in the database.
-          //++++ keep for enterprise:  val lockingSort = TopologicalSort()
-            for (tx in downloadedTxs) {
-                val dependencies = tx.dependencies
-                //++++ keep for enterprise:      lockingSort.add(tx.id, dependencies)
-                topologicalSort.add(tx.id, dependencies)
-            }
-
-            var suspended = true
-            for (downloaded in downloadedTxs) {
-                suspended = false
-                val dependencies = downloaded.dependencies
-                // Do not keep in memory as this bloats the checkpoint. Write each item to the database.
-                //++++ keep for enterprise: transactionStorage.lockObjectsForWrite(lockingSort.complete(), contextTransaction, false) {
-                transactionStorage.addUnverifiedTransaction(downloaded)
-                //++++ keep for enterprise: }
-
-
-                // The write locks are only released over a suspend, so need to keep track of whether the flow has been suspended to ensure
-                // that locks are not held beyond each while loop iteration (as doing this would result in a deadlock due to claiming locks
-                // in the wrong order)
-                val suspendedViaAttachments = flow.fetchMissingAttachments(downloaded)
-                val suspendedViaParams = flow.fetchMissingNetworkParameters(downloaded)
-                suspended = suspended || suspendedViaAttachments || suspendedViaParams
-
-                // Add all input states and reference input states to the work queue.
-                nextRequests.addAll(dependencies)
-            }
-
-            // If the flow did not suspend on the last iteration of the downloaded loop above, perform a suspend here to ensure no write
-            // locks are held going into the next while loop iteration.
-            //++++ update comment above to the effect that the database is flushed..... (O/S)
-            if (!suspended) {
-                FlowLogic.sleep(0.seconds)
-            }
-
-            // It's possible that the node has a transaction in storage already. Dependencies should also be present for this transaction,
-            // so just remove these IDs from the set of next requests.
-            nextRequests.removeAll(existingTxIds)
-        }
-*/
-
-// ++++ keep old
-        while (nextRequests.isNotEmpty()) {
-            println("DbTransactionsResolver.downloadDependencies(): Main while (count=${nextRequests.size})")//++++
+            println("Main fetch loop: size_remaining=${nextRequests.size}")//++++
             // Don't re-download the same tx when we haven't verified it yet but it's referenced multiple times in the
             // graph we're traversing.
             nextRequests.removeAll(topologicalSort.transactionIds)
@@ -206,54 +117,11 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
 
     // The transactions already present in the database do not need to be checkpointed on every iteration of downloading
     // dependencies for other transactions, so strip these down to just the IDs here.
-    /*++++ remove new
-    @Suspendable
-    private fun fetchRequiredTransactions(requests: Set<SecureHash>): Triple<List<SecureHash>, List<SignedTransaction>, List<SecureHash>> {
-        val sz = requests.size//++++
-        //++++val ost = flow.otherSide.javaClass.name
-        //++++println("fetchRequiredTransactions X ++++ size=$sz $ost")
-        var missingItems = ArrayList<SecureHash>() // Items that were not returned by a batch call
-        if (requests.size == 1) {
-            println("fetchRequiredTransactions (Single): size=$sz")//++++
-            // We should probably put the test here for whether we're using multi fetch (batch size > 1 and same plat version).
-            val requestedTxs = flow.subFlow(FetchTransactionsFlow(requests, flow.otherSide))
-            return Triple(requestedTxs.fromDisk.map { it.id }, requestedTxs.downloaded, missingItems)
-        } else {
-            var byteCountRecv = 0
-            var numRecv = 0
-            println("fetchRequiredTransactions (Multiple): size=$sz")//++++
-            val requestedTxs = flow.subFlow(FetchMultiTransactionsFlow(requests, flow.otherSide))
-            var downloaded = ArrayList<SignedTransaction>()
-            for (mTran in requestedTxs.downloaded) {
-                if (mTran.isNull()) {
-                    println("Failed to get transaction++++ ${mTran.id}")
-                    missingItems.add(mTran.id)
-                } else {
-                    byteCountRecv += mTran.serializedByteCount()
-                    downloaded.add(mTran.get())
-                    numRecv++
-                }
-            }
-            println("fetchRequiredTransactions (Multiple-end): Byte count=${byteCountRecv} (${numRecv} / ${requests.size})")//++++
-            for (muld in downloaded) {
-                println("MUL-DLD = '$muld.id': ${muld.javaClass.name}")
-            }
-            return Triple(requestedTxs.fromDisk.map { it.id }, downloaded, missingItems)
-        }
-//++++        println("fetchRequiredTransactions Y ++++ size=$sz")
-//++++        return Pair(requestedTxs.fromDisk.map { it.id }, requestedTxs.downloaded)
-    }
-
-    //++++ */
-//++++ keep old
-    // The transactions already present in the database do not need to be checkpointed on every iteration of downloading
-    // dependencies for other transactions, so strip these down to just the IDs here.
     @Suspendable
     private fun fetchRequiredTransactions(requests: Set<SecureHash>): Pair<List<SecureHash>, List<SignedTransaction>> {
         val requestedTxs = flow.subFlow(FetchTransactionsFlow(requests, flow.otherSide))
         return Pair(requestedTxs.fromDisk.map { it.id }, requestedTxs.downloaded)
     }
-
 
     /**
      * Provides a way to topologically sort SignedTransactions represented just their [SecureHash] IDs. This means that given any two transactions


### PR DESCRIPTION
This requirement focuses on improving the time taken to fetch backchain by requesting items in bulk.

These changes are required to open source to handle generating the correct response from O/S at Platform version 6. Also the code is re-used in Enterprise which also will need to handle the correct response with multiple items being returned.

In the event that the resulting message would exceed half the max message size, then only items up to this limit will be returned with a minimum of one item.

Only items that are returned are removed from the permission list. Any item not returned as a result of message size overflow may be safely re-requested.

This change is backwardly compatible with existing single backchain item requests.

These changes have been tested in Enterprise with the following permutations: 4.4->4.4, 4.4->4.3, 4.3->4.4
