### PR TITLE
ENT-4911: Split network verifier's sealed CorDapps into separate packages,

### DIFF
--- a/samples/network-verifier/contracts/src/main/kotlin/net/corda/verification/contracts/CommsContracts.kt
+++ b/samples/network-verifier/contracts/src/main/kotlin/net/corda/verification/contracts/CommsContracts.kt
@@ -1,4 +1,4 @@
-package net.corda.verification
+package net.corda.verification.contracts
 
 import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.CommandData

--- a/samples/network-verifier/contracts/src/main/kotlin/net/corda/verification/contracts/NotaryTestContracts.kt
+++ b/samples/network-verifier/contracts/src/main/kotlin/net/corda/verification/contracts/NotaryTestContracts.kt
@@ -1,4 +1,4 @@
-package net.corda.verification
+package net.corda.verification.contracts
 
 import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.Contract

--- a/samples/network-verifier/workflows/src/main/kotlin/net/corda/verification/flows/TestCommsFlow.kt
+++ b/samples/network-verifier/workflows/src/main/kotlin/net/corda/verification/flows/TestCommsFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.verification
+package net.corda.verification.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.*
@@ -7,6 +7,9 @@ import net.corda.core.identity.Party
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
+import net.corda.verification.contracts.CommsTestCommand
+import net.corda.verification.contracts.CommsTestContract
+import net.corda.verification.contracts.CommsTestState
 
 @StartableByRPC
 @InitiatingFlow

--- a/samples/network-verifier/workflows/src/main/kotlin/net/corda/verification/flows/TestNotaryFlow.kt
+++ b/samples/network-verifier/workflows/src/main/kotlin/net/corda/verification/flows/TestNotaryFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.verification
+package net.corda.verification.flows
 
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
@@ -6,6 +6,9 @@ import net.corda.core.flows.StartableByRPC
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.verification.contracts.NotaryTestCommand
+import net.corda.verification.contracts.NotaryTestContract
+import net.corda.verification.contracts.NotaryTestState
 
 @StartableByRPC
 class TestNotaryFlow : FlowLogic<String>() {

--- a/samples/network-verifier/workflows/src/test/kotlin/net/corda/configsample/TestCommsFlowInitiatorTest.kt
+++ b/samples/network-verifier/workflows/src/test/kotlin/net/corda/configsample/TestCommsFlowInitiatorTest.kt
@@ -4,7 +4,7 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.TestIdentity
-import net.corda.verification.TestCommsFlowInitiator
+import net.corda.verification.flows.TestCommsFlowInitiator
 import org.junit.Assert
 import org.junit.Test
 


### PR DESCRIPTION
This sample's CorDapps are sealed, and so their contents can no longer share the same package.