### PR TITLE
[EG-75] Not handled exception when NetworkMap not accessible

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -40,7 +40,7 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
         val advertisedParametersHash = try {
             networkMapClient?.getNetworkMap()?.payload?.networkParameterHash
         } catch (e: Exception) {
-            logger.info("Unable to download network map: $e")
+            logger.warn("Unable to download network map. Node will attempt to start using network-parameters file: $e")
             // If NetworkMap is down while restarting the node, we should be still able to continue with parameters from file
             null
         }

--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -40,7 +40,7 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
         val advertisedParametersHash = try {
             networkMapClient?.getNetworkMap()?.payload?.networkParameterHash
         } catch (e: Exception) {
-            logger.info("Unable to download network map", e)
+            logger.info("Unable to download network map: $e")
             // If NetworkMap is down while restarting the node, we should be still able to continue with parameters from file
             null
         }


### PR DESCRIPTION
Instead of passing in the full exception to the log we just pass in the string representation without the stacktrace. 

At some point in 4.3 we introduced a fix that stops stack traces from being printed to the cmd by default so the other half of this bug has already been resolved. 

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
