### PR TITLE
ENT-4368 - Improve error handling when required include not found in config

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -36,6 +36,10 @@ This prevents configuration errors when mixing keys containing ``.`` wrapped wit
 By default the node will fail to start in presence of unknown property keys.
 To alter this behaviour, the ``on-unknown-config-keys`` command-line argument can be set to ``IGNORE`` (default is ``FAIL``).
 
+.. note:: As noted in the HOCON documentation, the default behaviour for resources referenced within a config file is to silently
+   ignore them if missing. Therefore it is strongly recommended to utilise the ``required`` syntax for includes. See HOCON documentation
+   for more information.
+
 Overriding configuration values
 -------------------------------
 

--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -74,15 +74,16 @@ open class SharedNodeCmdLineOptions {
         }
         errors.forEach { error ->
             when (error) {
-                is ConfigException.IO -> logger.error(configFileNotFoundMessage(configFile))
+                is ConfigException.IO -> logger.error(configFileNotFoundMessage(configFile, error.cause))
                 else -> logger.error(error.message)
             }
         }
     }
 
-    private fun configFileNotFoundMessage(configFile: Path): String {
+    private fun configFileNotFoundMessage(configFile: Path, cause: Throwable?): String {
         return """
                 Unable to load the node config file from '$configFile'.
+                ${cause?.message?.let { "Cause: $it" } ?: ""}
 
                 Try setting the --base-directory flag to change which directory the node
                 is looking in, or use the --config-file flag to specify it explicitly.


### PR DESCRIPTION
# Issue
In certain scenarios the `include "<example-config-name>"` configuration file syntax can behave unexpectedly.

# Explanation 
Any includes specified in a config file are expected to live in the same directory as the config file. However using the `-f` or `--config-file` commandline argument to specify the config file name without using the full path or reference to the current directory results in the config parser not knowing where to look for included config files.

The HOCON spec is designed such that included resources are optional by default. As a consequnce, if an included resource cannot be found then it is silently ignored.

This is not a major issue if the included resource contains required config parameters. However, certain config blocks such as the database parameters are optional so the above scenario can cause a situation where come external DB settings present in some `db.conf` file are silently skipped and the default H2 DB is created instead.

# Fix
To improve this situation some minor tweaks have been done:
* Update docs to recommend using the `required` syntax when using includes. This ensures that missing resources cause an exception to be thrown.
* Improve error handling/logging to produce a more useful message so the user knows what went wrong. Previously the message was a generic `Could not load node.conf`.

A more involved fix was considered to always resolve a config file path to its absolute path, however in some edge case situations this could _potentially_ throw an exception if the filesystem is locked down.

# Screenshots
When the base configuration file cannot be found:
<img width="914" alt="Screenshot 2020-01-29 at 16 48 04" src="https://user-images.githubusercontent.com/12070000/73377604-35f63e00-42b7-11ea-98f3-b0dd730c7648.png">

When a required include cannot be found:
<img width="914" alt="Screenshot 2020-01-29 at 16 47 54" src="https://user-images.githubusercontent.com/12070000/73377636-3ee70f80-42b7-11ea-8a5f-c7affc5b5d26.png">
