### PR TITLE
NOTICK - Add tests for handling of user errors in reconnecting observables

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingObservable.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingObservable.kt
@@ -1,5 +1,6 @@
 package net.corda.client.rpc.internal
 
+import net.corda.client.rpc.ConnectionFailureException
 import net.corda.core.messaging.DataFeed
 import rx.Observable
 import rx.Subscriber
@@ -54,16 +55,30 @@ class ReconnectingObservable<T> private constructor(subscriber: ReconnectingSubs
             }
         }
 
+        /**
+         * Depending on the type of error, the reaction is different:
+         * - If the error is coming from a connection disruption, we establish a new connection and re-wire the observable
+         *   without letting the client notice at all.
+         * - In any other case, we let the error propagate to the client's observable. Both of the observables
+         *   (this one and the client's one) will be automatically unsubscribed, since that's the semantics of onError.
+         */
         private fun scheduleResubscribe(error: Throwable) {
             if (unsubscribed) return
-            reconnectingRPCConnection.observersPool.execute {
-                if (unsubscribed || reconnectingRPCConnection.isClosed()) return@execute
-                reconnectingRPCConnection.reconnectOnError(error)
-                // It can take a while to reconnect so we might find that we've shutdown in in the meantime
-                if (unsubscribed || reconnectingRPCConnection.isClosed()) return@execute
-                val newDataFeed = createDataFeed()
-                subscribeImmediately(newDataFeed)
+
+            if (error is ConnectionFailureException) {
+                reconnectingRPCConnection.observersPool.execute {
+                    if (unsubscribed || reconnectingRPCConnection.isClosed()) return@execute
+                    reconnectingRPCConnection.reconnectOnError(error)
+                    // It can take a while to reconnect so we might find that we've shutdown in in the meantime
+                    if (unsubscribed || reconnectingRPCConnection.isClosed()) return@execute
+                    val newDataFeed = createDataFeed()
+                    subscribeImmediately(newDataFeed)
+                }
+            } else {
+                val subscriber = checkNotNull(this.subscriber.get())
+                subscriber.onError(error)
             }
+
         }
     }
 }

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1656,6 +1656,7 @@
     <ID>TooGenericExceptionThrown:ClassLoadingUtilsTest.kt$ClassLoadingUtilsTest$throw RuntimeException()</ID>
     <ID>TooGenericExceptionThrown:CommandParsers.kt$AzureParser.RegionConverter$throw Error("Unknown azure region: $value")</ID>
     <ID>TooGenericExceptionThrown:ContractHierarchyTest.kt$ContractHierarchyTest.IndirectContractParent$throw RuntimeException("Boom!")</ID>
+    <ID>TooGenericExceptionThrown:CordaRPCClientReconnectionTest.kt$CordaRPCClientReconnectionTest$throw RuntimeException()</ID>
     <ID>TooGenericExceptionThrown:CrossCashTest.kt$throw Exception( "Generated exit of ${request.amount} from $issuer, however there is no cash to exit!" )</ID>
     <ID>TooGenericExceptionThrown:CrossCashTest.kt$throw Exception( "Generated payment of ${request.amount} from $issuer, " + "however they only have $issuerQuantity!" )</ID>
     <ID>TooGenericExceptionThrown:CrossCashTest.kt$throw Exception( "Generated payment of ${request.amount} from ${node.mainIdentity}, " + "however there is no cash from $issuer!" )</ID>


### PR DESCRIPTION
This change relates to how reconnecting observables react to user-code errors. 
- While looking at the code a few days ago, I realised that it was one of the scenarios that was not explicitly tested. So, this PR adds a test exercising this scenario. 
- I also realised that we were performing automatic reconnection on all kinds of errors, while it should be done only on errors coming from a broken connection. So, this PR also tightens up this logic a bit to do this. 

The reason it was working before is due to the way subscribers are wired up, RxJava is able to route the errors directly to the client observable, without our intermediate observable getting a chance to propagate it. Because of this, I also think there's no easy way to exercise the new path through a test.