### PR TITLE
CORDA-3555: Testing need for Suspendable annotation when using Java 11.

### DIFF
--- a/core-tests/src/test/java/net/corda/coretests/flows/SuspendableInJavaTest.java
+++ b/core-tests/src/test/java/net/corda/coretests/flows/SuspendableInJavaTest.java
@@ -1,0 +1,44 @@
+package net.corda.coretests.flows;
+
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.SuspendExecution;
+import co.paralleluniverse.strands.SuspendableCallable;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+/*
+Test that the Suspendable annotation is needed for functions but not for Java lambdas.
+I have commented out where the @Suspendable annotation would be needed.
+If ever in the future Suspendable is not needed then the test will fail.
+The test assumes runtime instrumentation using the Java agent.
+ */
+public class SuspendableInJavaTest {
+
+    private class FiberTask implements SuspendableCallable<Void> {
+
+        /* @Suspendable */
+        @Override
+        public Void run() {
+            try {
+                Fiber.sleep(1);
+                return null;
+            }
+            catch (InterruptedException | SuspendExecution ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testSuspendableAnnotationIsNeededInJavaForAFunction() throws Exception {
+        Fiber<Void> f = new Fiber<>(new FiberTask());
+        f.start().get();
+    }
+
+    @Test
+    public void testSuspendableAnnotationNotNeededForJavaWhenUsingALamda() throws ExecutionException, InterruptedException {
+        Fiber<Void> fiber = new Fiber<> (() -> Fiber.sleep(100));
+        fiber.start().join();
+    }
+}

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/SuspendableTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/SuspendableTest.kt
@@ -1,0 +1,34 @@
+package net.corda.coretests.flows
+
+import co.paralleluniverse.fibers.Fiber
+import co.paralleluniverse.fibers.VerifyInstrumentationException
+import co.paralleluniverse.strands.SuspendableCallable
+import org.junit.Test
+
+/*
+Test that the Suspendable annotation is needed for functions and lambdas.
+I have commented out where the @Suspendable annotation would be needed.
+If ever in the future Suspendable is not needed then the test will fail.
+The test assumes runtime instrumentation using the Java agent.
+ */
+class SuspendableTest {
+
+    private class FiberTask : SuspendableCallable<Unit> {
+        // @Suspendable
+        override fun run(): Unit {
+            Fiber.sleep(1)
+        }
+    }
+
+    @Test(expected = VerifyInstrumentationException::class)
+    fun `test Suspendable annotation is needed in Kotlin when using a function`() {
+        val fiber: Fiber<Unit> = Fiber(FiberTask())
+        fiber.start().get()
+    }
+
+    @Test(expected = VerifyInstrumentationException::class)
+    fun `test Suspendable annotation is needed in Kotlin when using a lamda`() {
+        val fiber: Fiber<Boolean> = Fiber /* @Suspendable */ { Fiber.sleep(1)}
+        fiber.start().get()
+    }
+}


### PR DESCRIPTION
Purpose of this PR was to investigate the need for Suspendable annotation in Quasar with JDK 11 and create some tests to demonstrate.
In summary it appears nothing major has changed in Quasar with respect to JDK 11 and Suspendable. We still need to mark the code (via Suspendable annotation or throws SuspendException). At runtime the quasar agent will instrument these points in the code.
There was some work done in Quasar to enable live instrumentation. This work is currently in the JDK9 branch and it appears to be work in progress. I managed to get quasar core built on this branch, but could not run due to it dynamically accessing some non existent methods (type() on PrimitiveSlot).

Note that it is possible for Quasar to do auto suspendables detection without marking them. This is described in the doc. This is done via a build time SuspendableScanner ant task that inspects the call graph.

The tests added show that Suspendable is needed for Kotlin and Java methods and Kotlin Lamdas.
Java lambas do not need to be annotated they are treated as always Suspendable. This is also mentioned in the doc and tested here.


