### PR TITLE
ENT-4915, ENT-4926, CORDA-3585: Update docs for X500 name and SSH hostkey

### DIFF
--- a/docs/source/node-naming.rst
+++ b/docs/source/node-naming.rst
@@ -27,9 +27,11 @@ The name must also obey the following constraints:
 
 * The ``organisation``, ``locality`` and ``country`` attributes are present
 
-    * The ``state``, ``organisational-unit`` and ``common name`` attributes are optional
+* The ``state``, ``organisational-unit`` and ``common name`` attributes are optional
 
-* The fields of the name have the following maximum character lengths:
+* The maximum number of characters in the whole x500 name string is 128 characters
+
+* The fields of the name have character lengths **less** than the following maximum values:
 
     * Common name: 64
     * Organisation: 128
@@ -40,12 +42,18 @@ The name must also obey the following constraints:
 * The ``country`` attribute is a valid `ISO 3166-1<https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>` two letter code in upper-case
 
 * The ``organisation`` field of the name obeys the following constraints:
+
     * Has at least two letters
-    * Does not include the following characters: ``,`` , ``"``, ``\``
+
+* All data fields adhere to the following constraints:
+
+    * Upper-case first letter
+    * Does not include the following characters: ``,``, ``=``, ``$``, ``"``, ``'``, ``\``
     * Is in NFKC normalization form
     * Does not contain the null character
     * Only the latin, common and inherited unicode scripts are supported
     * No double-spacing
+    * No leading or trailing whitespace
 
 This is to avoid right-to-left issues, debugging issues when we can't pronounce names over the phone, and
 character confusability attacks.

--- a/docs/source/shell.rst
+++ b/docs/source/shell.rst
@@ -91,6 +91,8 @@ The host key is loaded from the ``<node root directory>/sshkey/hostkey.pem`` fil
 generated automatically. In development mode, the seed may be specified to give the same results on the same computer
 in order to avoid host-checking errors.
 
+Only RSA key is currently supported as a host key. If ``hostkey.pem`` is not RSA, it will be replaced by the newly generated RSA key.
+
 Connecting to the shell
 ***********************
 


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/ENT-4915
https://r3-cev.atlassian.net/browse/ENT-4926

Correct docs for X500 name with:
- Constraints of the fields
- Maximum length of the whole string and individual fields (e.g. change <= 64 to < 64)

https://r3-cev.atlassian.net/browse/CORDA-3585

- Mention RSA as the only supported hostkey