### PR TITLE
CORDA-3587: hashLookup command help misspelling

### DIFF
--- a/tools/shell/src/main/java/net/corda/tools/shell/HashLookupShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/HashLookupShellCommand.java
@@ -22,13 +22,13 @@ public class HashLookupShellCommand extends InteractiveShellCommand {
     @Man("Checks if a transaction matching a specified Id hash value is recorded on this node.\n\n" +
             "This is mainly intended to be used for troubleshooting notarisation issues when a\n" +
             "state is claimed to be already consumed by another transaction.\n\n" +
-            "Example usage: hash-lookup E470FD8A6350A74217B0A99EA5FB71F091C84C64AD0DE0E72ECC10421D03AAC9"
+            "Example usage: hashLookup E470FD8A6350A74217B0A99EA5FB71F091C84C64AD0DE0E72ECC10421D03AAC9"
     )
     public void main(@Usage("A hexadecimal SHA-256 hash value representing the hashed transaction Id") @Argument(unquote = false) String txIdHash) {
-        logger.info("Executing command \"hash-lookup\".");
+        logger.info("Executing command \"hashLookup\".");
 
         if (txIdHash == null) {
-            out.println("Please provide a hexadecimal transaction Id hash value, see 'man hash-lookup'", Decoration.bold, Color.red);
+            out.println("Please provide a hexadecimal transaction Id hash value, see 'man hashLookup'", Decoration.bold, Color.red);
             return;
         }
 


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-3587

Misspelling of the hashLookup command name in help.