### PR TITLE
Updating Artifactory URLs for Corda OS 4.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ buildscript {
     ext.artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')
     ext.hikari_version = '3.3.1'
     ext.liquibase_version = '3.6.3'
-    ext.artifactory_contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
+    ext.artifactory_contextUrl = 'https://software.r3.com/artifactory'
     ext.snake_yaml_version = constants.getProperty('snakeYamlVersion')
     ext.docker_compose_rule_version = '0.35.0'
     ext.selenium_version = '3.141.59'
@@ -157,7 +157,7 @@ buildscript {
             url 'https://kotlin.bintray.com/kotlinx'
         }
         maven {
-            url "https://ci-artifactory.corda.r3cev.com/artifactory/corda-dependencies-dev"
+            url "$artifactory_contextUrl/corda-dependencies-dev"
         }
         maven {
             url "$artifactory_contextUrl/corda-releases"

--- a/docker/src/bash/example-mini-network.sh
+++ b/docker/src/bash/example-mini-network.sh
@@ -7,9 +7,9 @@ DOCKER_IMAGE_VERSION="corda-zulu-4.4-snapshot"
 mkdir cordapps
 rm -f cordapps/*
 
-wget -O cordapps/finance-contracts.jar          https://ci-artifactory.corda.r3cev.com/artifactory/list/corda-dev/net/corda/corda-finance-contracts/${CORDAPP_VERSION}/corda-finance-contracts-${CORDAPP_VERSION}.jar
-wget -O cordapps/finance-workflows.jar          https://ci-artifactory.corda.r3cev.com/artifactory/list/corda-dev/net/corda/corda-finance-workflows/${CORDAPP_VERSION}/corda-finance-workflows-${CORDAPP_VERSION}.jar
-wget -O cordapps/confidential-identities.jar    https://ci-artifactory.corda.r3cev.com/artifactory/list/corda-dev/net/corda/corda-confidential-identities/${CORDAPP_VERSION}/corda-confidential-identities-${CORDAPP_VERSION}.jar
+wget -O cordapps/finance-contracts.jar          https://software.r3.com/artifactory/list/corda-dev/net/corda/corda-finance-contracts/${CORDAPP_VERSION}/corda-finance-contracts-${CORDAPP_VERSION}.jar
+wget -O cordapps/finance-workflows.jar          https://software.r3.com/artifactory/list/corda-dev/net/corda/corda-finance-workflows/${CORDAPP_VERSION}/corda-finance-workflows-${CORDAPP_VERSION}.jar
+wget -O cordapps/confidential-identities.jar    https://software.r3.com/artifactory/list/corda-dev/net/corda/corda-confidential-identities/${CORDAPP_VERSION}/corda-confidential-identities-${CORDAPP_VERSION}.jar
 
 rm keystore
 

--- a/docs/source/network-builder.rst
+++ b/docs/source/network-builder.rst
@@ -16,7 +16,7 @@ Unlike the official image, a `node.conf` file and CorDapps are embedded into the
 More backends may be added in future. The tool is open source, so contributions to add more
 destinations for the containers are welcome!
 
-`Download the Corda Network Builder <https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-tools-network-builder/|corda_version|/corda-tools-network-builder-|corda_version|.jar>`_.
+`Download the Corda Network Builder <https://software.r3.com/artifactory/corda-releases/net/corda/corda-tools-network-builder/|corda_version|/corda-tools-network-builder-|corda_version|.jar>`_.
 
 .. _pre-requisites:
 

--- a/docs/source/node-upgrade-notes.rst
+++ b/docs/source/node-upgrade-notes.rst
@@ -50,7 +50,7 @@ for further information.
 Step 4. Replace ``corda.jar`` with the new version
 --------------------------------------------------
 
-Download the latest version of Corda from `our Artifactory site <https://ci-artifactory.corda.r3cev.com/artifactory/webapp/#/artifacts/browse/simple/General/corda/net/corda/corda-node>`_.
+Download the latest version of Corda from `our Artifactory site <https://software.r3.com/artifactory/webapp/#/artifacts/browse/simple/General/corda/net/corda/corda-node>`_.
 Make sure it's available on your path, and that you've read the :doc:`release-notes`, in particular to discover what version of Java this
 node requires.
 

--- a/docs/source/testnet-explorer-corda.rst
+++ b/docs/source/testnet-explorer-corda.rst
@@ -34,8 +34,8 @@ couple of resources.
 
    .. code-block:: bash
 
-       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-contracts/|corda_version|/corda-finance-contracts-|corda_version|.jar
-       wget https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-finance-workflows/|corda_version|/corda-finance-workflows-|corda_version|.jar
+       wget https://software.r3.com/artifactory/corda-releases/net/corda/corda-finance-contracts/|corda_version|/corda-finance-contracts-|corda_version|.jar
+       wget https://software.r3.com/artifactory/corda-releases/net/corda/corda-finance-workflows/|corda_version|/corda-finance-workflows-|corda_version|.jar
 
    This is required to run some flows to check your connections, and to issue/transfer cash to counterparties. Copy it to
    the Corda installation location:
@@ -70,7 +70,7 @@ couple of resources.
 
    .. code:: bash
 
-       http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases/net/corda/corda-tools-explorer/|corda_version|-corda/corda-tools-explorer-|corda_version|-corda.jar
+       https://software.r3.com/artifactory/corda-releases/net/corda/corda-tools-explorer/|corda_version|-corda/corda-tools-explorer-|corda_version|-corda.jar
 
    .. warning:: This Node Explorer is incompatible with the Corda Enterprise distribution and vice versa as they currently
       use different serialisation schemes (Kryo vs AMQP).


### PR DESCRIPTION
* Switching Artifactory URLs from obsolete ci-artifactory to software.r3.com