### PR TITLE
ENT-4918: Support symbolic link for certificates directory during node registration

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -86,7 +86,7 @@ open class NetworkRegistrationHelper(
      * @throws CertificateRequestException if the certificate retrieved by doorman is invalid.
      */
     fun generateKeysAndRegister() {
-        certificatesDirectory.createDirectories()
+        certificatesDirectory.safeSymbolicRead().createDirectories()
         // We need this in case cryptoService and certificateStore share the same KeyStore (for backwards compatibility purposes).
         // If we didn't, then an update to cryptoService wouldn't be reflected to certificateStore that is already loaded in memory.
         val certStore: CertificateStore = if (cryptoService is BCCryptoService) cryptoService.certificateStore else certificateStore


### PR DESCRIPTION
Problem: node initial registration fails if ``certificates`` directory exists as a symbolic link to another directory on Unix.

Added unit test to verify this behavior.