### PR TITLE
ENT-4921: Ensure that CorDapp classloader is not lost with graceful reconnect.

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -20,7 +20,6 @@ import net.corda.core.serialization.SerializationWhitelist
 import net.corda.core.serialization.internal.effectiveSerializationEnv
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.days
-import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.minutes
 import net.corda.core.utilities.seconds
 import net.corda.nodeapi.internal.ArtemisTcpTransport.Companion.rpcConnectorTcpTransport
@@ -614,7 +613,8 @@ class CordaRPCClient private constructor(
                     addresses,
                     configuration,
                     gracefulReconnect,
-                    sslConfiguration
+                    sslConfiguration,
+                    classLoader
             )
         } else {
             CordaRPCConnection(getRpcClient().start(


### PR DESCRIPTION
Remember our deserialization classloader when establishing a graceful RPC reconnection, because this classloader is full of custom serializers.