### PR TITLE
CORDA-3576: Use the connectionMaxRetryInterval configuration 

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -4,7 +4,12 @@ package net.corda.core.internal
 
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
-import net.corda.core.crypto.*
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SignedData
+import net.corda.core.crypto.sha256
+import net.corda.core.crypto.sign
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
@@ -40,11 +45,23 @@ import java.security.KeyPair
 import java.security.MessageDigest
 import java.security.PrivateKey
 import java.security.PublicKey
-import java.security.cert.*
+import java.security.cert.CertPath
+import java.security.cert.CertPathValidator
+import java.security.cert.CertPathValidatorException
+import java.security.cert.PKIXCertPathValidatorResult
+import java.security.cert.PKIXParameters
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
 import java.time.Duration
 import java.time.temporal.Temporal
 import java.util.*
-import java.util.Spliterator.*
+import java.util.Spliterator.DISTINCT
+import java.util.Spliterator.IMMUTABLE
+import java.util.Spliterator.NONNULL
+import java.util.Spliterator.ORDERED
+import java.util.Spliterator.SIZED
+import java.util.Spliterator.SORTED
+import java.util.Spliterator.SUBSIZED
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
@@ -78,6 +95,8 @@ infix fun Temporal.until(endExclusive: Temporal): Duration = Duration.between(th
 operator fun Duration.div(divider: Long): Duration = dividedBy(divider)
 operator fun Duration.times(multiplicand: Long): Duration = multipliedBy(multiplicand)
 operator fun Duration.times(multiplicand: Double): Duration = Duration.ofNanos((toNanos() * multiplicand).roundToLong())
+fun min(d1: Duration, d2: Duration): Duration = if (d1 <= d2) d1 else d2
+
 
 /**
  * Returns the single element matching the given [predicate], or `null` if the collection is empty, or throws exception


### PR DESCRIPTION
When reconnecting the RPC client we weren't using the config option `connectionMaxRetryInterval`.  So pop that into the logic.

I've also added a log line so that it's a bot more clear (both for testing and for users) what's going on with the back-off/retry.

#### Testing Evidence
This isn't something easily testable so I've captured the output of the RPC client directly.  The config used for this test was:

```
            val config = CordaRPCClientConfiguration.DEFAULT.copy(
                    connectionRetryInterval = Duration.ofSeconds(1),
                    connectionRetryIntervalMultiplier = 2.0,
                    connectionMaxRetryInterval = Duration.ofMinutes(1)
            )
```

So starting at one second, doubling the interval each attempt, and with a maximum of 1 minute intervals (unlimited attempts).

Here's the result:

```
[ERROR] 08:30:33,776 [Thread-0 (ActiveMQ-client-factory-threads-190439151)] internal.RPCClientProxyHandler. - Could not reconnect to the RPC server.
[INFO] 08:30:33,882 [Thread-8] internal.RPCClient. - Failed Startup took 2045 msec
[INFO] 08:30:34,887 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT2S
[INFO] 08:30:34,887 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:30:36,928 [Thread-8] internal.RPCClient. - Failed Startup took 2039 msec
[INFO] 08:30:38,936 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT4S
[INFO] 08:30:38,936 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:30:40,978 [Thread-8] internal.RPCClient. - Failed Startup took 2042 msec
[INFO] 08:30:44,982 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT8S
[INFO] 08:30:44,982 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:30:47,023 [Thread-8] internal.RPCClient. - Failed Startup took 2040 msec
[INFO] 08:30:55,029 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT16S
[INFO] 08:30:55,029 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:30:57,060 [Thread-8] internal.RPCClient. - Failed Startup took 2030 msec
[INFO] 08:31:13,072 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT32S
[INFO] 08:31:13,073 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:31:15,132 [Thread-8] internal.RPCClient. - Failed Startup took 2059 msec
[INFO] 08:31:47,140 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT1M
[INFO] 08:31:47,140 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:31:49,172 [Thread-8] internal.RPCClient. - Failed Startup took 2031 msec
[INFO] 08:32:49,179 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT1M
[INFO] 08:32:49,179 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:32:51,202 [Thread-8] internal.RPCClient. - Failed Startup took 2022 msec
[INFO] 08:33:51,207 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT1M
[INFO] 08:33:51,208 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
[INFO] 08:33:53,241 [Thread-8] internal.RPCClient. - Failed Startup took 2032 msec
[INFO] 08:34:53,253 [Thread-8] internal.ReconnectingCordaRPCOps. - Could not establish connection.  Next retry interval PT1M
[INFO] 08:34:53,253 [Thread-8] internal.ReconnectingCordaRPCOps. - Connecting to: localhost:17116
```

At that point the unit test I was using to emulate this system timed out.  But you can clearly see the retries doubling up to 1 minute and staying there.