### PR TITLE
ENT-4652: Tighten Groovy code for writing META-INF/Cordapp-Dependencies.

### DIFF
--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -63,10 +63,13 @@ dependencies {
 def cordappDependencies = file("${sourceSets['main'].output.resourcesDir}/META-INF/Cordapp-Dependencies")
 task generateDependencies {
     dependsOn project(':finance:contracts').tasks.jar
+    inputs.files(configurations.cordapp)
     outputs.files(cordappDependencies)
     doLast {
-        configurations.cordapp.forEach { cordapp ->
-            cordappDependencies << sha256(cordapp) << System.lineSeparator()
+        cordappDependencies.newWriter().withWriter { writer ->
+            configurations.cordapp.forEach { cordapp ->
+                writer << sha256(cordapp) << System.lineSeparator()
+            }
         }
     }
 }


### PR DESCRIPTION
Running the SIMM Valuation integration test, I noticed that it failed because it couldn't find a SHA256 for a certain attachment. It turned out that the `META-INF/Cordapp-Dependencies` file written into the `contract-states` CorDapp had somehow acquired an extra entry. However, there should only have been _one_ SHA256 in this file because `contract-states` only depends on _one_ CorDapp.

~I have only seen this issue once and have not been able to reproduce it, so I cannot determine its precise cause, I have rewritten the Groovy code which generates this `META-INF/Cordapp-Dependencies` file to ensure that its previous contents are _always_ overwritten and not accidentally appended to.~
I have been able to reproduce this problem by the following:
```
$ git checkout release/os/4.4
$ ./gradlew :samples:simm-valuation-demo:assemble
$ git checkout release/os/4.5
$ ./gradlew :samples:simm-valuation-demo:assemble
```
and then examining the contents of
```
samples/simm-valuation-demo/contracts-states/build/resources/main/META-INF/Cordapp-Dependencies
```

I have fixed it by ensuring that Groovy explicitly creates/truncates the file each time. It also helps to configure the files inside the `cordapp` configuration as inputs to the Gradle task to prevent the `Cordapp-Dependencies` file from becoming stale.