### PR TITLE
[EG-140] Allow system property paths with multiple keys to be specified in node.conf

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -636,7 +636,7 @@ sshd
 
 systemProperties
   An optional map of additional system properties to be set when launching via ``corda.jar`` only.
-  Keys and values of the map should be strings. e.g. ``systemProperties = { visualvm.display.name = FooBar }``
+  Keys and values of the map should be strings. e.g. ``systemProperties = { "visualvm.display.name" = FooBar }``
 
   *Default:* not defined
 

--- a/node/capsule/src/main/java/CordaCaplet.java
+++ b/node/capsule/src/main/java/CordaCaplet.java
@@ -321,20 +321,25 @@ public class CordaCaplet extends Capsule {
      * Helper class so that we can parse the "systemProperties" element of node.conf.
      */
     private static class Property {
-        private final List<String> path;
+        private final String path;
         private final Object value;
 
-        Property(List<String> path, Object value) {
+        Property(String path, Object value) {
             this.path = path;
             this.value = value;
         }
 
         boolean isValid() {
-            return path.size() == 1;
+            try {
+                ConfigUtil.splitPath(path);
+                return true;
+            } catch (ConfigException e) {
+                return false;
+            }
         }
 
         String getKey() {
-            return path.get(0);
+            return path;
         }
 
         Object getValue() {
@@ -342,7 +347,7 @@ public class CordaCaplet extends Capsule {
         }
 
         static Property create(Map.Entry<String, ConfigValue> entry) {
-            return new Property(ConfigUtil.splitPath(entry.getKey()), entry.getValue().unwrapped());
+            return new Property(entry.getKey(), entry.getValue().unwrapped());
         }
     }
 }

--- a/node/capsule/src/main/java/CordaCaplet.java
+++ b/node/capsule/src/main/java/CordaCaplet.java
@@ -321,16 +321,16 @@ public class CordaCaplet extends Capsule {
      * Helper class so that we can parse the "systemProperties" element of node.conf.
      */
     private static class Property {
-        private final String path;
+        private final String key;
         private final Object value;
 
-        Property(String path, Object value) {
-            this.path = path;
+        Property(String key, Object value) {
+            this.key = key;
             this.value = value;
         }
 
         String getKey() {
-            return path;
+            return key;
         }
 
         Object getValue() {


### PR DESCRIPTION
A change in 4.4 prevents system properties with more than one key in the path from being read by the Corda Caplet on startup. This PR addresses the problem by internal `Property` helper class in the caplet.

Testing:
 - Verified that system properties are correctly parsed by looking in the logs for the command used by the caplet to start Corda.