### PR TITLE
NOTICK: Add timeouts to serialization-djvm tests too.

### DIFF
--- a/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/DeserializeOffsetTimeTest.kt
+++ b/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/DeserializeOffsetTimeTest.kt
@@ -13,7 +13,7 @@ import java.util.function.Function
 @ExtendWith(LocalSerialization::class)
 class DeserializeOffsetTimeTest : TestBase(KOTLIN) {
     @Test
-	fun `test deserializing instant`() {
+	fun `test deserializing offset time`() {
         val time = OffsetTime.now()
         val data = time.serialize()
 

--- a/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/TestBase.kt
+++ b/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/TestBase.kt
@@ -13,16 +13,19 @@ import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.UserPathSource
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.fail
 import java.io.File
 import java.nio.file.Files.exists
 import java.nio.file.Files.isDirectory
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit.MINUTES
 import java.util.function.Consumer
 import kotlin.concurrent.thread
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
+@Timeout(5, unit = MINUTES)
 abstract class TestBase(type: SandboxType) {
     companion object {
         const val SANDBOX_STRING = "sandbox.java.lang.String"


### PR DESCRIPTION
The serialization-djvm module uses JUnit 5 and so falls outside the rest of Corda's "test timeout" initiative. However, that shouldn't imply that this module is exempt . Set each test's test timeout to 5 minutes, like everything else. (Which is overkill, but anyway...)

Also rename a test with a copy-'n-paste error name, because it annoys me.