### PR TITLE
NOTICK: Update Gradle files for DeteKt plugins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -465,18 +465,20 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
     }
 }
 
-task detekt(type: JavaExec, dependsOn: ":detekt-plugins:jar") {
-    main = "io.gitlab.arturbosch.detekt.cli.Main"
-    classpath = configurations.detekt
+tasks.register('detekt', JavaExec) {
     def input = "$projectDir"
     def config = "$projectDir/detekt-config.yml"
     def baseline = "$projectDir/detekt-baseline.xml"
-    def plugins = "$projectDir/detekt-plugins/build/libs/detekt-plugins-${version}.jar"
+    def detektPluginsJar = project(':detekt-plugins').tasks.jar
+    def plugins = detektPluginsJar.outputs.files.singleFile
     def params = ['-i', input, '-c', config, '-b', baseline, '--plugins', plugins]
+    inputs.files(detektPluginsJar, config, baseline)
+    main = "io.gitlab.arturbosch.detekt.cli.Main"
+    classpath = configurations.detekt
     args(params)
 }
 
-task detektBaseline(type: JavaExec) {
+tasks.register('detektBaseline', JavaExec) {
     main = "io.gitlab.arturbosch.detekt.cli.Main"
     classpath = configurations.detekt
     def input = "$projectDir"

--- a/detekt-plugins/build.gradle
+++ b/detekt-plugins/build.gradle
@@ -1,23 +1,11 @@
 plugins {
-    id 'java'
     id 'kotlin'
-    id 'kotlin-jpa'
-}
-
-sourceCompatibility = 1.8
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation "io.gitlab.arturbosch.detekt:detekt-api:$detekt_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "io.gitlab.arturbosch.detekt:detekt-test:$detekt_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "io.gitlab.arturbosch.detekt:detekt-api:$detekt_version"
-}
-
-publish {
-    name "corda-detekt-plugins"
 }


### PR DESCRIPTION
Small rework of Gradle for `detekt-plugins`:
- Use Gradle "lazy" task registration to avoid configuring DeteKt tasks unnecessarily.
- Configure inputs for `detekt` task, which also provides implicit dependency on plugins jar task.
- Remove `java` plugin from `detekt-plugins` as this is implicitly applied by `kotlin` plugin.
- Remove `kotlin-jpa` compiler plugin because we are not generating JPA entities.
- Remove `sourceCompatibility` and `repositories` because these are applied by `allprojects` in root.
- Configure JUnit version using `$junit_version`.
- Move `implementation` above`testImplementation`.
- Remove unused `publish` block because we are not publishing the Detekt plugins.