### PR TITLE
CORDA-3593: exit the InteractiveShell on shutdown command

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -634,6 +634,10 @@ object InteractiveShell {
             InputStreamSerializer.invokeContext = null
             InputStreamDeserializer.closeAll()
         }
+        if (cmd == "shutdown") {
+            out.println("Called 'shutdown' on the node.\nQuitting the shell now.").also { out.flush() }
+            onExit.invoke()
+        }
         return result
     }
 


### PR DESCRIPTION
Before we'd hang get a disconnect message and the shell would remain open with no connection to a dead node.

Now:

![image](https://user-images.githubusercontent.com/8395358/74657956-3896d580-5189-11ea-9d19-4710b0b22e64.png)

There's still some log syncing issue at the end.  I can possibly raise a separate issue against that.
