### PR TITLE
CORDA-3617: Remove Schedulable states from core-deterministic.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -134,8 +134,7 @@ interface LinearState : ContractState {
     val linearId: UniqueIdentifier
 }
 // DOCEND 2
-
-@KeepForDJVM
+@DeleteForDJVM
 interface SchedulableState : ContractState {
     /**
      * Indicate whether there is some activity to be performed at some future point in time with respect to this
@@ -146,7 +145,6 @@ interface SchedulableState : ContractState {
      *
      * @return null if there is no activity to schedule.
      */
-    @DeleteForDJVM
     fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity?
 }
 
@@ -176,6 +174,7 @@ data class StateAndRef<out T : ContractState>(val state: TransactionState<T>, va
 // DOCEND 7
 
 /** A wrapper for a [StateAndRef] indicating that it should be added to a transaction as a reference input state. */
+@KeepForDJVM
 data class ReferencedStateAndRef<out T : ContractState>(val stateAndRef: StateAndRef<T>)
 
 /** Filters a list of [StateAndRef] objects according to the type of the states */


### PR DESCRIPTION
We cannot implement `SchedulableState` inside a deterministic contract CorDapp because `FlowLogicRefFactory` does not exist inside `core-deterministic.`

Conversely, it's a Good Idea to ensure that ProGuard preserves _every_ method of `ReferencedStateAndRef` when it shrinks the `core` jar.

Note that this PR has _zero_ impact on `core` itself.