### PR TITLE
NOTICK: Always use configured version of deterministic-rt.jar.

### DIFF
--- a/serialization-djvm/build.gradle
+++ b/serialization-djvm/build.gradle
@@ -12,10 +12,7 @@ description 'Serialization support for the DJVM'
 
 configurations {
     sandboxTesting
-    jdkRt.resolutionStrategy {
-        // Always check the repository for a newer SNAPSHOT.
-        cacheChangingModulesFor 0, 'seconds'
-    }
+    jdkRt
 }
 
 dependencies {
@@ -35,7 +32,7 @@ dependencies {
     // Test utilities
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
-    jdkRt "net.corda:deterministic-rt:latest.integration"
+    jdkRt "net.corda:deterministic-rt:$deterministic_rt_version"
 
     // The DJVM will need this classpath to run the unit tests.
     sandboxTesting files(sourceSets.getByName("test").output)


### PR DESCRIPTION
Use the configured version instead of the latest SNAPSHOT.