### PR TITLE
[EG-69] fixed bug with picocli that was causing uncaught exception's stacktrace to always be printed on stderr

### DIFF
--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -70,9 +70,9 @@ fun CordaCliWrapper.start(args: Array<String>) {
         } else {
             Help.Ansi.AUTO
         }
+        @Suppress("SpreadOperator")
         val results = cmd.parseWithHandlers(RunLast().useOut(System.out).useAnsi(defaultAnsiMode),
-                DefaultExceptionHandler<List<Any>>().useErr(System.err).useAnsi(defaultAnsiMode).andExit(ExitCodes.FAILURE),
-                *args)
+                DefaultExceptionHandler<List<Any>>().useErr(System.err).useAnsi(defaultAnsiMode), *args)
         // If an error code has been returned, use this and exit
         results?.firstOrNull()?.let {
             if (it is Int) {


### PR DESCRIPTION
calling `picocli.CommandLine.AbstractHandler#andExit` causes the exception handler to forcefully terminate the program execution (calling `java.lang.System#exit`) at all costs, even in case of `ExecutionException` being throw by `picocli.CommandLine#parseWithHandlers(picocli.CommandLine.IParseResultHandler2<R>, picocli.CommandLine.IExceptionHandler2<R>, java.lang.String...)`, this was causing the program to always print the exception stack trace on the `stderr` and terminating even before entering the `catch` block from lines 85 to 93
