### PR TITLE
[CORDA-3628] - Implement sendAll API

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -25,6 +25,7 @@ import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationDefaults
+import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
@@ -316,6 +317,52 @@ abstract class FlowLogic<out T> {
         enforceNoDuplicates(sessions)
         return castMapValuesToKnownType(receiveAllMap(associateSessionsToReceiveType(receiveType, sessions)))
     }
+
+    /**
+     * Queues the given [payload] for sending to the provided [sessions] and continues without suspending.
+     *
+     * Note that the other parties may receive the message at some arbitrary later point or not at all: if one of the provided [sessions]
+     * is offline then message delivery will be retried until the corresponding node comes back or until the message is older than the
+     * network's event horizon time.
+     *
+     * @param payload the payload to send.
+     * @param sessions the sessions to send the provided payload to.
+     * @param maySkipCheckpoint whether checkpointing should be skipped.
+     */
+    @Suspendable
+    @JvmOverloads
+    fun sendAll(payload: Any, sessions: List<FlowSession>, maySkipCheckpoint: Boolean = false) {
+        val sessionToPayload = sessions.map { it to payload }.toMap()
+        return sendAll(sessionToPayload, maySkipCheckpoint)
+    }
+
+    /**
+     * Queues the given payloads for sending to the provided sessions and continues without suspending.
+     *
+     * Note that the other parties may receive the message at some arbitrary later point or not at all: if one of the provided [sessions]
+     * is offline then message delivery will be retried until the corresponding node comes back or until the message is older than the
+     * network's event horizon time.
+     *
+     * @param payloadsPerSession a mapping that contains the payload to be sent to each session.
+     * @param maySkipCheckpoint whether checkpointing should be skipped.
+     */
+    @Suspendable
+    @JvmOverloads
+    fun sendAll(payloadsPerSession: Map<FlowSession, Any>, maySkipCheckpoint: Boolean = false) {
+        val request = FlowIORequest.Send(
+                sessionToMessage = serializePayloads(payloadsPerSession)
+        )
+        stateMachine.suspend(request, maySkipCheckpoint)
+    }
+
+    private fun serializePayloads(payloadsPerSession: Map<FlowSession, Any>): Map<FlowSession, SerializedBytes<Any>> {
+        val cachedSerializedPayloads = mutableMapOf<Any, SerializedBytes<Any>>()
+
+        return payloadsPerSession.mapValues { (_, payload) ->
+            cachedSerializedPayloads[payload] ?: payload.serialize(context = SerializationDefaults.P2P_CONTEXT).also { cachedSerializedPayloads[payload] = it }
+        }
+    }
+
 
     /**
      * Invokes the given subflow. This function returns once the subflow completes successfully with the result

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -355,6 +355,7 @@ abstract class FlowLogic<out T> {
         stateMachine.suspend(request, maySkipCheckpoint)
     }
 
+    @Suspendable
     private fun serializePayloads(payloadsPerSession: Map<FlowSession, Any>): Map<FlowSession, SerializedBytes<Any>> {
         val cachedSerializedPayloads = mutableMapOf<Any, SerializedBytes<Any>>()
 

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -331,7 +331,7 @@ abstract class FlowLogic<out T> {
      */
     @Suspendable
     @JvmOverloads
-    fun sendAll(payload: Any, sessions: List<FlowSession>, maySkipCheckpoint: Boolean = false) {
+    fun sendAll(payload: Any, sessions: Set<FlowSession>, maySkipCheckpoint: Boolean = false) {
         val sessionToPayload = sessions.map { it to payload }.toMap()
         return sendAll(sessionToPayload, maySkipCheckpoint)
     }

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -270,7 +270,7 @@ In addition ``FlowLogic`` provides functions that can receive messages from mult
     * Receives from all ``FlowSession`` objects specified in the passed in map. The received types may differ.
 * ``receiveAll(receiveType: Class<R>, sessions: List<FlowSession>): List<UntrustworthyData<R>>``
     * Receives from all ``FlowSession`` objects specified in the passed in list. The received types must be the same.
-* ``sendAll(payload: Any, sessions: List<FlowSession>)``
+* ``sendAll(payload: Any, sessions: Set<FlowSession>)``
     * Sends the ``payload`` object to all the provided ``FlowSession``\s.
 * ``sendAll(payloadsPerSession: Map<FlowSession, Any>)``
     * Sends a potentially different payload to each ``FlowSession``, as specified by the provided ``payloadsPerSession``.

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -264,18 +264,18 @@ In order to create a communication session between your initiator flow and the r
 * ``sendAndReceive(receiveType: Class<R>, payload: Any): R``
     * Sends the ``payload`` object and receives an object of type ``receiveType`` back
 
-In addition ``FlowLogic`` provides functions that can receive messages from multiple sessions and send messages to multiple parties:
+In addition ``FlowLogic`` provides functions that can receive messages from multiple sessions and send messages to multiple sessions:
 
 * ``receiveAllMap(sessions: Map<FlowSession, Class<out Any>>): Map<FlowSession, UntrustworthyData<Any>>``
     * Receives from all ``FlowSession`` objects specified in the passed in map. The received types may differ.
 * ``receiveAll(receiveType: Class<R>, sessions: List<FlowSession>): List<UntrustworthyData<R>>``
     * Receives from all ``FlowSession`` objects specified in the passed in list. The received types must be the same.
 * ``sendAll(payload: Any, sessions: List<FlowSession>)``
-    * Sends the ``payload`` object to all the provided ``sessions``.
+    * Sends the ``payload`` object to all the provided ``FlowSession``\s.
 * ``sendAll(payloadsPerSession: Map<FlowSession, Any>)``
-    * Sends one payload to every session, as specified by the provided ``payloadsPerSession``.
+    * Sends a potentially different payload to each ``FlowSession``, as specified by the provided ``payloadsPerSession``.
 
-.. note:: It's more efficient to call ``sendAndReceive``, instead of calling ``send`` and then ``receive``. It's also more efficient to call ``sendAll``, instead of multiple ``send``\s.
+.. note:: It's more efficient to call ``sendAndReceive`` instead of calling ``send`` and then ``receive``. It's also more efficient to call ``sendAll``/``receiveAll`` instead of multiple ``send``/``receive`` respectively.
 
 InitiateFlow
 ~~~~~~~~~~~~

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -264,14 +264,18 @@ In order to create a communication session between your initiator flow and the r
 * ``sendAndReceive(receiveType: Class<R>, payload: Any): R``
     * Sends the ``payload`` object and receives an object of type ``receiveType`` back
 
-In addition ``FlowLogic`` provides functions that batch receives:
+In addition ``FlowLogic`` provides functions that can receive messages from multiple sessions and send messages to multiple parties:
 
 * ``receiveAllMap(sessions: Map<FlowSession, Class<out Any>>): Map<FlowSession, UntrustworthyData<Any>>``
-  Receives from all ``FlowSession`` objects specified in the passed in map. The received types may differ.
+    * Receives from all ``FlowSession`` objects specified in the passed in map. The received types may differ.
 * ``receiveAll(receiveType: Class<R>, sessions: List<FlowSession>): List<UntrustworthyData<R>>``
-  Receives from all ``FlowSession`` objects specified in the passed in list. The received types must be the same.
+    * Receives from all ``FlowSession`` objects specified in the passed in list. The received types must be the same.
+* ``sendAll(payload: Any, sessions: List<FlowSession>)``
+    * Sends the ``payload`` object to all the provided ``sessions``.
+* ``sendAll(payloadsPerSession: Map<FlowSession, Any>)``
+    * Sends one payload to every session, as specified by the provided ``payloadsPerSession``.
 
-The batched functions are implemented more efficiently by the flow framework.
+.. note:: It's more efficient to call ``sendAndReceive``, instead of calling ``send`` and then ``receive``. It's also more efficient to call ``sendAll``, instead of multiple ``send``\s.
 
 InitiateFlow
 ~~~~~~~~~~~~

--- a/docs/source/api-persistence.rst
+++ b/docs/source/api-persistence.rst
@@ -460,6 +460,7 @@ Please note that suspendable flow operations such as:
 * ``FlowSession.send``
 * ``FlowSession.receive``
 * ``FlowLogic.receiveAll``
+* ``FlowLogic.sendAll``
 * ``FlowLogic.sleep``
 * ``FlowLogic.subFlow``
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt
@@ -54,6 +54,11 @@ class MessagingExecutor(
     }
 
     @Synchronized
+    fun send(messages: Map<MessageRecipients, Message>) {
+        messages.forEach { recipients, message -> send(message, recipients) }
+    }
+
+    @Synchronized
     fun acknowledge(message: ClientMessage) {
         log.debug {
             val id = message.getStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_DUPLICATE_DETECTION_ID)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -38,6 +38,17 @@ sealed class Action {
     ) : Action()
 
     /**
+     * Send session messages to multiple destinations.
+     *
+     * @property sendInitial session messages to send in order to establish a session.
+     * @property sendExisting session messages to send to existing sessions.
+     */
+    data class SendMultiple(
+            val sendInitial: List<SendInitial>,
+            val sendExisting: List<SendExisting>
+    ): Action()
+
+    /**
      * Persist the specified [checkpoint].
      */
     data class PersistCheckpoint(val id: StateMachineRunId, val checkpoint: Checkpoint, val isCheckpointUpdate: Boolean) : Action()

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -194,9 +194,9 @@ class ActionExecutorImpl(
 
     @Suspendable
     private fun executeSendMultiple(action: Action.SendMultiple) {
-        val messageData = action.sendInitial.map { Triple(it.destination, it.initialise, it.deduplicationId) } +
-                action.sendExisting.map { Triple(it.peerParty, it.message, it.deduplicationId) }
-        flowMessaging.sendSessionMessages(messageData)
+        val messages = action.sendInitial.map { Message(it.destination, it.initialise, it.deduplicationId) } +
+                action.sendExisting.map { Message(it.peerParty, it.message, it.deduplicationId) }
+        flowMessaging.sendSessionMessages(messages)
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -68,6 +68,7 @@ class ActionExecutorImpl(
             is Action.RemoveCheckpoint -> executeRemoveCheckpoint(action)
             is Action.SendInitial -> executeSendInitial(action)
             is Action.SendExisting -> executeSendExisting(action)
+            is Action.SendMultiple -> executeSendMultiple(action)
             is Action.AddSessionBinding -> executeAddSessionBinding(action)
             is Action.RemoveSessionBindings -> executeRemoveSessionBindings(action)
             is Action.SignalFlowHasStarted -> executeSignalFlowHasStarted(action)
@@ -189,6 +190,13 @@ class ActionExecutorImpl(
     @Suspendable
     private fun executeSendExisting(action: Action.SendExisting) {
         flowMessaging.sendSessionMessage(action.peerParty, action.message, action.deduplicationId)
+    }
+
+    @Suspendable
+    private fun executeSendMultiple(action: Action.SendMultiple) {
+        val messageData = action.sendInitial.map { Triple(it.destination, it.initialise, it.deduplicationId) } +
+                action.sendExisting.map { Triple(it.peerParty, it.message, it.deduplicationId) }
+        flowMessaging.sendSessionMessages(messageData)
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
@@ -247,7 +247,7 @@ class StartedFlowTransition(
         val checkpoint = startingState.checkpoint
         val newSessions = LinkedHashMap(checkpoint.sessions)
         var index = 0
-        for ((sourceSessionId, message) in sourceSessionIdToMessage) {
+        for ((sourceSessionId, _) in sourceSessionIdToMessage) {
             val existingSessionState = checkpoint.sessions[sourceSessionId] ?: return freshErrorTransition(CannotFindSessionException(sourceSessionId))
             if (existingSessionState is SessionState.Initiated && existingSessionState.initiatedState is InitiatedSessionState.Ended) {
                 return freshErrorTransition(IllegalStateException("Tried to send to ended session $sourceSessionId"))
@@ -276,7 +276,7 @@ class StartedFlowTransition(
             val newBufferedMessages = initiatingSessionState.bufferedMessages + Pair(deduplicationId, sessionMessage)
             newSessions[sourceSessionId] = initiatingSessionState.copy(bufferedMessages = newBufferedMessages)
         }
-        val sendExistingActions = messagesByType[SessionState.Initiated::class]?.mapNotNull {(sourceSessionId, sessionState, message) ->
+        val sendExistingActions = messagesByType[SessionState.Initiated::class]?.mapNotNull {(_, sessionState, message) ->
             val initiatedSessionState = sessionState as SessionState.Initiated
             if (initiatedSessionState.initiatedState !is InitiatedSessionState.Live)
                 null

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
@@ -248,10 +248,7 @@ class StartedFlowTransition(
         val newSessions = LinkedHashMap(checkpoint.sessions)
         var index = 0
         for ((sourceSessionId, message) in sourceSessionIdToMessage) {
-            if (!checkpoint.sessions.containsKey(sourceSessionId))
-                return freshErrorTransition(CannotFindSessionException(sourceSessionId))
-
-            val existingSessionState = checkpoint.sessions[sourceSessionId]!!
+            val existingSessionState = checkpoint.sessions[sourceSessionId] ?: return freshErrorTransition(CannotFindSessionException(sourceSessionId))
             if (existingSessionState is SessionState.Initiated && existingSessionState.initiatedState is InitiatedSessionState.Ended) {
                 return freshErrorTransition(IllegalStateException("Tried to send to ended session $sourceSessionId"))
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
@@ -7,6 +7,7 @@ import net.corda.core.internal.FlowIORequest
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.utilities.toNonEmptySet
 import net.corda.node.services.statemachine.*
+import java.lang.IllegalStateException
 
 /**
  * This transition describes what should happen with a specific [FlowIORequest]. Note that at this time the request
@@ -247,45 +248,51 @@ class StartedFlowTransition(
         val newSessions = LinkedHashMap(checkpoint.sessions)
         var index = 0
         for ((sourceSessionId, message) in sourceSessionIdToMessage) {
-            val existingSessionState = checkpoint.sessions[sourceSessionId]
-            if (existingSessionState == null) {
+            if (!checkpoint.sessions.containsKey(sourceSessionId))
                 return freshErrorTransition(CannotFindSessionException(sourceSessionId))
-            } else {
-                val sessionMessage = DataSessionMessage(message)
-                val deduplicationId = DeduplicationId.createForNormal(checkpoint, index++, existingSessionState)
-                when (existingSessionState) {
-                    is SessionState.Uninitiated -> {
-                        val initialMessage = createInitialSessionMessage(existingSessionState.initiatingSubFlow, sourceSessionId, existingSessionState.additionalEntropy, message)
-                        actions.add(Action.SendInitial(existingSessionState.destination, initialMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID)))
-                        newSessions[sourceSessionId] = SessionState.Initiating(
-                                bufferedMessages = emptyList(),
-                                rejectionError = null,
-                                deduplicationSeed = existingSessionState.deduplicationSeed
-                        )
-                        Unit
-                    }
-                    is SessionState.Initiating -> {
-                        // We're initiating this session, buffer the message
-                        val newBufferedMessages = existingSessionState.bufferedMessages + Pair(deduplicationId, sessionMessage)
-                        newSessions[sourceSessionId] = existingSessionState.copy(bufferedMessages = newBufferedMessages)
-                    }
-                    is SessionState.Initiated -> {
-                        when (existingSessionState.initiatedState) {
-                            is InitiatedSessionState.Live -> {
-                                val sinkSessionId = existingSessionState.initiatedState.peerSinkSessionId
-                                val existingMessage = ExistingSessionMessage(sinkSessionId, sessionMessage)
-                                actions.add(Action.SendExisting(existingSessionState.peerParty, existingMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID)))
-                                Unit
-                            }
-                            InitiatedSessionState.Ended -> {
-                                return freshErrorTransition(IllegalStateException("Tried to send to ended session $sourceSessionId"))
-                            }
-                        }
-                    }
-                }
-            }
 
+            val existingSessionState = checkpoint.sessions[sourceSessionId]!!
+            if (existingSessionState is SessionState.Initiated && existingSessionState.initiatedState is InitiatedSessionState.Ended) {
+                return freshErrorTransition(IllegalStateException("Tried to send to ended session $sourceSessionId"))
+            }
         }
+
+        val messagesByType = sourceSessionIdToMessage.toList()
+                .map { (sourceSessionId, message) -> Triple(sourceSessionId, checkpoint.sessions[sourceSessionId]!!, message) }
+                .groupBy { it.second::class }
+
+        val sendInitialActions = messagesByType[SessionState.Uninitiated::class]?.map { (sourceSessionId, sessionState, message) ->
+            val uninitiatedSessionState = sessionState as SessionState.Uninitiated
+            val deduplicationId = DeduplicationId.createForNormal(checkpoint, index++, sessionState)
+            val initialMessage = createInitialSessionMessage(uninitiatedSessionState.initiatingSubFlow, sourceSessionId, uninitiatedSessionState.additionalEntropy, message)
+            newSessions[sourceSessionId] = SessionState.Initiating(
+                    bufferedMessages = emptyList(),
+                    rejectionError = null,
+                    deduplicationSeed = uninitiatedSessionState.deduplicationSeed
+            )
+            Action.SendInitial(uninitiatedSessionState.destination, initialMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID))
+        } ?: emptyList()
+        messagesByType[SessionState.Initiating::class]?.forEach { (sourceSessionId, sessionState, message) ->
+            val initiatingSessionState = sessionState as SessionState.Initiating
+            val sessionMessage = DataSessionMessage(message)
+            val deduplicationId = DeduplicationId.createForNormal(checkpoint, index++, initiatingSessionState)
+            val newBufferedMessages = initiatingSessionState.bufferedMessages + Pair(deduplicationId, sessionMessage)
+            newSessions[sourceSessionId] = initiatingSessionState.copy(bufferedMessages = newBufferedMessages)
+        }
+        val sendExistingActions = messagesByType[SessionState.Initiated::class]?.mapNotNull {(sourceSessionId, sessionState, message) ->
+            val initiatedSessionState = sessionState as SessionState.Initiated
+            if (initiatedSessionState.initiatedState !is InitiatedSessionState.Live)
+                null
+            else {
+                val sessionMessage = DataSessionMessage(message)
+                val deduplicationId = DeduplicationId.createForNormal(checkpoint, index++, initiatedSessionState)
+                val sinkSessionId = initiatedSessionState.initiatedState.peerSinkSessionId
+                val existingMessage = ExistingSessionMessage(sinkSessionId, sessionMessage)
+                Action.SendExisting(initiatedSessionState.peerParty, existingMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID))
+            }
+        } ?: emptyList()
+
+        actions.add(Action.SendMultiple(sendInitialActions, sendExistingActions))
         currentState = currentState.copy(checkpoint = checkpoint.copy(sessions = newSessions))
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -536,6 +536,16 @@ class FlowFrameworkTests {
         assertThat(result.getOrThrow()).isEqualTo("HelloHello")
     }
 
+    @Test(timeout=300_000)
+    fun `initiating flow with anonymous party at the same node`() {
+        val anonymousBob = bobNode.services.keyManagementService.freshKeyAndCert(bobNode.info.legalIdentitiesAndCerts.single(), false)
+        val bobResponderFlow = bobNode.registerCordappFlowFactory(SendAndReceiveFlow::class) { SingleInlinedSubFlow(it) }
+        val result = bobNode.services.startFlow(SendAndReceiveFlow(anonymousBob.party.anonymise(), "Hello")).resultFuture
+        mockNet.runNetwork()
+        bobResponderFlow.getOrThrow()
+        assertThat(result.getOrThrow()).isEqualTo("HelloHello")
+    }
+
     //region Helpers
 
     private val normalEnd = ExistingSessionMessage(SessionId(0), EndSessionMessage) // NormalSessionEnd(0)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
@@ -199,13 +199,13 @@ class FlowParallelMessagingTests {
                 throw IllegalArgumentException("at least two parties required for staged execution")
             }
 
-            val sessions = parties.map { initiateFlow(it) }
+            val sessions = parties.map { initiateFlow(it) }.toSet()
 
             sessions.first().send(StagedMessageType.INITIAL_RECIPIENT)
             sessions.first().receive<String>().unwrap{ payload -> assertEquals("pong", payload) }
 
             sendAll(StagedMessageType.REGULAR_RECIPIENT, sessions)
-            val messages = receiveAll(String::class.java, sessions)
+            val messages = receiveAll(String::class.java, sessions.toList())
 
             messages.map { it.unwrap { payload -> assertEquals("pong", payload) } }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
@@ -31,6 +31,7 @@ class FlowParallelMessagingTests {
 
     companion object {
 
+
         private lateinit var mockNet: InternalMockNetwork
         private lateinit var senderNode: TestStartedNode
         private lateinit var recipientNode1: TestStartedNode
@@ -65,7 +66,7 @@ class FlowParallelMessagingTests {
     }
 
 
-    @Test
+    @Test(timeout=300_000)
     fun `messages can be exchanged in parallel using sendAll & receiveAll between multiple parties successfully`() {
         val messages = mapOf(
                 recipientParty1 to MessageType.REPLY,
@@ -79,7 +80,7 @@ class FlowParallelMessagingTests {
         assertEquals("ok", result)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow exceptions from counterparties during receiveAll are handled properly`() {
         val messages = mapOf(
                 recipientParty1 to MessageType.REPLY,
@@ -93,7 +94,7 @@ class FlowParallelMessagingTests {
                 .hasMessage("graceful failure")
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `runtime exceptions from counterparties during receiveAll are handled properly`() {
         val messages = mapOf(
                 recipientParty1 to MessageType.REPLY,
@@ -106,7 +107,7 @@ class FlowParallelMessagingTests {
                 .isInstanceOf(UnexpectedFlowEndException::class.java)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `initial session messages and existing session messages can be sent together using sendAll`() {
         val flow = senderNode.services.startFlow(StagedSenderFlow(listOf(recipientParty1, recipientParty2)))
 
@@ -116,7 +117,7 @@ class FlowParallelMessagingTests {
         assertEquals("ok", result)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `messages can be exchanged successfully even between anonymous parties`() {
         val senderAnonymousParty = senderNode.createConfidentialIdentity(senderParty)
         val firstRecipientAnonymousParty = recipientNode1.createConfidentialIdentity(recipientParty1)
@@ -163,6 +164,7 @@ class FlowParallelMessagingTests {
         }
     }
 
+    @Suppress("TooGenericExceptionThrown")
     @InitiatedBy(SenderFlow::class)
     class RecipientFlow(private val otherPartySession: FlowSession): FlowLogic<String>() {
         @Suspendable

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
@@ -1,0 +1,235 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.Destination
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.UnexpectedFlowEndException
+import net.corda.core.identity.Party
+import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.unwrap
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.node.internal.InternalMockNetwork
+import net.corda.testing.node.internal.InternalMockNodeParameters
+import net.corda.testing.node.internal.TestStartedNode
+import net.corda.testing.node.internal.enclosedCordapp
+import net.corda.testing.node.internal.startFlow
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class FlowParallelMessagingTests {
+
+    companion object {
+
+        private lateinit var mockNet: InternalMockNetwork
+        private lateinit var senderNode: TestStartedNode
+        private lateinit var recipientNode1: TestStartedNode
+        private lateinit var recipientNode2: TestStartedNode
+        private lateinit var notaryIdentity: Party
+        private lateinit var senderParty: Party
+        private lateinit var recipientParty1: Party
+        private lateinit var recipientParty2: Party
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            mockNet = InternalMockNetwork(
+                    cordappsForAllNodes = listOf(enclosedCordapp())
+            )
+
+            senderNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME.copy(organisation = "SenderNode")))
+            recipientNode1 = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME.copy(organisation = "RecipientNode1")))
+            recipientNode2 = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME.copy(organisation = "RecipientNode2")))
+
+            notaryIdentity = mockNet.defaultNotaryIdentity
+            senderParty = senderNode.info.singleIdentity()
+            recipientParty1 = recipientNode1.info.singleIdentity()
+            recipientParty2 = recipientNode2.info.singleIdentity()
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun cleanUp() {
+            mockNet.stopNodes()
+        }
+    }
+
+
+    @Test
+    fun `messages can be exchanged in parallel using sendAll & receiveAll between multiple parties successfully`() {
+        val messages = mapOf(
+                recipientParty1 to MessageType.REPLY,
+                recipientParty2 to MessageType.REPLY
+        )
+        val flow = senderNode.services.startFlow(SenderFlow(messages))
+
+        mockNet.runNetwork()
+        val result = flow.resultFuture.getOrThrow()
+
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun `flow exceptions from counterparties during receiveAll are handled properly`() {
+        val messages = mapOf(
+                recipientParty1 to MessageType.REPLY,
+                recipientParty2 to MessageType.GRACEFUL_FAILURE
+        )
+        val flow = senderNode.services.startFlow(SenderFlow(messages))
+
+        mockNet.runNetwork()
+        assertThatThrownBy{ flow.resultFuture.getOrThrow() }
+                .isInstanceOf(FlowException::class.java)
+                .hasMessage("graceful failure")
+    }
+
+    @Test
+    fun `runtime exceptions from counterparties during receiveAll are handled properly`() {
+        val messages = mapOf(
+                recipientParty1 to MessageType.REPLY,
+                recipientParty2 to MessageType.CRASH
+        )
+        val flow = senderNode.services.startFlow(SenderFlow(messages))
+
+        mockNet.runNetwork()
+        assertThatThrownBy{ flow.resultFuture.getOrThrow() }
+                .isInstanceOf(UnexpectedFlowEndException::class.java)
+    }
+
+    @Test
+    fun `initial session messages and existing session messages can be sent together using sendAll`() {
+        val flow = senderNode.services.startFlow(StagedSenderFlow(listOf(recipientParty1, recipientParty2)))
+
+        mockNet.runNetwork()
+        val result = flow.resultFuture.getOrThrow()
+
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun `messages can be exchanged successfully even between anonymous parties`() {
+        val senderAnonymousParty = senderNode.createConfidentialIdentity(senderParty)
+        val firstRecipientAnonymousParty = recipientNode1.createConfidentialIdentity(recipientParty1)
+        senderNode.verifyAndRegister(firstRecipientAnonymousParty)
+        val secondRecipientAnonymousParty = recipientNode2.createConfidentialIdentity(recipientParty2)
+        senderNode.verifyAndRegister(secondRecipientAnonymousParty)
+
+        val messages = mapOf(
+                senderAnonymousParty.party.anonymise() to MessageType.REPLY,
+                firstRecipientAnonymousParty.party.anonymise() to MessageType.REPLY,
+                secondRecipientAnonymousParty.party.anonymise() to MessageType.REPLY
+        )
+
+        val flow = senderNode.services.startFlow(SenderFlow(messages))
+
+        mockNet.runNetwork()
+        val result = flow.resultFuture.getOrThrow()
+
+        assertEquals("ok", result)
+    }
+
+    fun TestStartedNode.createConfidentialIdentity(party: Party) =
+            services.keyManagementService.freshKeyAndCert(services.myInfo.legalIdentitiesAndCerts.single { it.name == party.name }, false)
+
+    fun TestStartedNode.verifyAndRegister(identity: PartyAndCertificate) =
+            services.identityService.verifyAndRegisterIdentity(identity)
+
+    @StartableByRPC
+    @InitiatingFlow
+    class SenderFlow(private val parties: Map<out Destination, MessageType>): FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String {
+            val messagesPerSession = parties.toList().map { (party, messageType) ->
+                val session = initiateFlow(party)
+                Pair(session, messageType)
+            }.toMap()
+
+            sendAll(messagesPerSession)
+            val messages = receiveAll(String::class.java, messagesPerSession.keys.toList())
+
+            messages.map { it.unwrap { payload -> assertEquals("pong", payload) } }
+
+            return "ok"
+        }
+    }
+
+    @InitiatedBy(SenderFlow::class)
+    class RecipientFlow(private val otherPartySession: FlowSession): FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String {
+            val msg = otherPartySession.receive<MessageType>().unwrap { it }
+            when (msg) {
+                MessageType.REPLY -> otherPartySession.send("pong")
+                MessageType.GRACEFUL_FAILURE -> throw FlowException("graceful failure")
+                MessageType.CRASH -> throw RuntimeException("crash")
+            }
+
+            return "ok"
+        }
+    }
+
+    @StartableByRPC
+    @InitiatingFlow
+    class StagedSenderFlow(private val parties: List<out Destination>): FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String {
+            if (parties.size < 2) {
+                throw IllegalArgumentException("at least two parties required for staged execution")
+            }
+
+            val sessions = parties.map { initiateFlow(it) }
+
+            sessions.first().send(StagedMessageType.INITIAL_RECIPIENT)
+            sessions.first().receive<String>().unwrap{ payload -> assertEquals("pong", payload) }
+
+            sendAll(StagedMessageType.REGULAR_RECIPIENT, sessions)
+            val messages = receiveAll(String::class.java, sessions)
+
+            messages.map { it.unwrap { payload -> assertEquals("pong", payload) } }
+
+            return "ok"
+        }
+    }
+
+    @InitiatedBy(StagedSenderFlow::class)
+    class StagedRecipientFlow(private val otherPartySession: FlowSession): FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String {
+            val msg = otherPartySession.receive<StagedMessageType>().unwrap { it }
+            when (msg) {
+                StagedMessageType.INITIAL_RECIPIENT -> {
+                    otherPartySession.send("pong")
+                    otherPartySession.receive<StagedMessageType>().unwrap { payload -> assertEquals(StagedMessageType.REGULAR_RECIPIENT, payload) }
+                    otherPartySession.send("pong")
+                }
+                StagedMessageType.REGULAR_RECIPIENT -> otherPartySession.send("pong")
+            }
+
+            return "ok"
+        }
+    }
+
+    @CordaSerializable
+    enum class MessageType {
+        REPLY,
+        GRACEFUL_FAILURE,
+        CRASH
+    }
+
+    @CordaSerializable
+    enum class StagedMessageType {
+        INITIAL_RECIPIENT,
+        REGULAR_RECIPIENT
+    }
+
+}

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
@@ -31,7 +31,6 @@ class FlowParallelMessagingTests {
 
     companion object {
 
-
         private lateinit var mockNet: InternalMockNetwork
         private lateinit var senderNode: TestStartedNode
         private lateinit var recipientNode1: TestStartedNode

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
@@ -181,7 +181,7 @@ class FlowParallelMessagingTests {
 
     @StartableByRPC
     @InitiatingFlow
-    class StagedSenderFlow(private val parties: List<out Destination>): FlowLogic<String>() {
+    class StagedSenderFlow(private val parties: List<Destination>): FlowLogic<String>() {
         @Suspendable
         override fun call(): String {
             if (parties.size < 2) {


### PR DESCRIPTION
Implementation of `sendAll` API to allow sending messages to multiple destinations with a single checkpoint.