### PR TITLE
NOTICK: Fix potential infinite loop when a SecurityManager is installed.

### DIFF
--- a/testing/node-driver/src/main/java/net/corda/testing/driver/SharedMemoryIncremental.java
+++ b/testing/node-driver/src/main/java/net/corda/testing/driver/SharedMemoryIncremental.java
@@ -86,7 +86,10 @@ class SharedMemoryIncremental extends PortAllocation {
 
     private boolean isLocalPortAvailable(Long portToTest) {
         try (ServerSocket serverSocket = new ServerSocket(Math.toIntExact(portToTest))) {
-        } catch (Exception e) {
+        } catch (IOException e) {
+            // Don't catch anything other than IOException here in case we
+            // accidentally create an infinite loop. For example, installing
+            // a SecurityManager could throw AccessControlException.
             return false;
         }
         return true;


### PR DESCRIPTION
We can never create a ServerSocket if the SecurityManager forbids it, so avoid an infinite loop in that case.