### PR TITLE
EG-71: Changed the default file limit in the log4j2 configuration 

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -66,8 +66,8 @@
             <PatternLayout pattern="%msg%n%throwable{0}" />
         </Console>
 
-        <!-- Will generate up to 100 log files for a given day. During every rollover it will delete
-             those that are older than 60 days, but keep the most recent 10 GB -->
+        <!-- Will generate up to 500 log files for a given day. Adjust this number according to the available storage.
+             During every rollover it will delete those that are older than 60 days, but keep the most recent 10 GB -->
         <RollingRandomAccessFile name="RollingFile-Appender"
                      fileName="${log-path}/${log-name}.log"
                      filePattern="${archive}/${log-name}.%date{yyyy-MM-dd}-%i.log.gz">

--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -93,7 +93,7 @@
                 <SizeBasedTriggeringPolicy size="100MB"/>
             </Policies>
 
-            <DefaultRolloverStrategy min="1" max="100">
+            <DefaultRolloverStrategy min="1" max="500">
                 <Delete basePath="${archive}" maxDepth="1">
                     <IfFileName glob="${log-name}*.log.gz"/>
                     <IfLastModified age="60d">


### PR DESCRIPTION
Changed the default file limit from 100 to 500 in the log4j2 configuration file to address the roll over issue as described in EG-71.  This is different from the proposed 1000. 

The previous quota of 100 log files per day is insufficient for nodes that use TRACE log level. This quota is reached in approximately in less than two hours. The existing log files get overridden, and important log information is lost. To deal with this issue, the quota was increased to 500 log files per day. This should allow for enough information to be captured to diagnose problems at runtime. To decide this number, the storage size was taken into consideration. As files older than 60 days get deleted, for a single node, the maximum accumulated log size using the previous configuration was 10 MB * 100 file/day * 60 days = 60000 MB (60 GB). With this new configuration, the maximum expected storage is 300 GB.
