### PR TITLE
EG-466 'shutdown' command is repeated twice in the list of available shell commands.

### DIFF
--- a/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
@@ -1,6 +1,5 @@
 package net.corda.tools.shell;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.corda.client.jackson.StringToMethodCallParser;
 import net.corda.core.messaging.CordaRPCOps;
@@ -13,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +56,9 @@ public class RunShellCommand extends InteractiveShellCommand {
         // Each element we emit is a map of column -> content.
         Set<Map.Entry<String, String>> entries = cordaRpcOpsParser.getAvailableCommands().entrySet();
         List<Map.Entry<String, String>> entryList = new ArrayList<>(entries);
+
+        entryList.add(new AbstractMap.SimpleEntry<>("gracefulShutdown", ""));//Shell only command
+
         entryList.sort(comparing(Map.Entry::getKey));
         for (Map.Entry<String, String> entry : entryList) {
             // Skip these entries as they aren't really interesting for the user.
@@ -68,17 +71,6 @@ public class RunShellCommand extends InteractiveShellCommand {
                 throw new RuntimeException(e);
             }
         }
-
-        Lists.newArrayList(
-                commandAndDesc("shutdown", "Shuts node down (immediately)"),
-                commandAndDesc("gracefulShutdown", "Shuts node down gracefully, waiting for all flows to complete first.")
-        ).forEach(stringStringMap -> {
-            try {
-                context.provide(stringStringMap);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
     }
 
     @NotNull


### PR DESCRIPTION
EG-466

'shutdown' command is repeated twice in the list of available shell commands.
--
Shutdown used to be a shell-only command, this bug seems to have been introduced when it was moved to RPC. See https://github.com/corda/corda/commit/7a077e76f0cdf457cd40033fb0da594805a5951e 

The second shutdown is removed from the list.

After that we will only have gracefulShutdown as a shell command.
--
Also fixing inconsistencies related to gracefulShutdown:

- It was always at the end of the command list rather than being ordered alphabetically
- It contained a description in the ‘Parameter types’ column, it should be empty as it does not take any parameters

