### PR TITLE
ENT-4334 Configuration option to exclude packages from Quasar instrumentation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -109,6 +109,8 @@ Unreleased
   options, as well as ``extensions.sshd`` configuration entry, have been removed from the standalone shell.
   Available alternatives are either to use the standalone shell directly, or connect to the node embedded shell via SSH.
 
+* Added new node configuration option to exclude packages from Quasar instrumentation.
+
 .. _changelog_v4.1:
 
 Version 4.1

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -558,11 +558,21 @@ p2pAddress
   
 
   *Default:* not defined
-  
-quasarExcludePackages
-  A list of packages to exclude from Quasar instrumentation. Wildcards are allowed, for example ``org.xml**``.
 
-  *Default:* empty list
+quasar
+  Options for controlling Quasar instrumentation.
+
+  excludePackages
+    A list of packages to exclude from Quasar instrumentation. Wildcards are allowed, for example ``org.xml**``.
+
+    *Default:* empty list
+
+  Example configuration:
+
+  .. parsed-literal::
+    quasar {
+      excludePackages=["org.xml**", "org.yaml**"]
+    }
 
 rpcAddress (deprecated)
   The address of the RPC system on which RPC requests can be made to the node.

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -559,6 +559,11 @@ p2pAddress
 
   *Default:* not defined
   
+quasarExcludePackages
+  A list of packages to exclude from Quasar instrumentation. Wildcards are allowed, for example ``org.xml**``.
+
+  *Default:* empty list
+
 rpcAddress (deprecated)
   The address of the RPC system on which RPC requests can be made to the node.
   If not provided then the node will run without RPC.

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -559,20 +559,17 @@ p2pAddress
 
   *Default:* not defined
 
-quasar
-  Options for controlling Quasar instrumentation.
+quasarExcludePackages
+  A list of packages to exclude from Quasar instrumentation. Wildcards are allowed, for example ``org.xml**``.
 
-  excludePackages
-    A list of packages to exclude from Quasar instrumentation. Wildcards are allowed, for example ``org.xml**``.
+  **Important: Do not change unless requested by support.**
 
-    *Default:* empty list
+  *Default:* empty list
 
   Example configuration:
 
   .. parsed-literal::
-    quasar {
-      excludePackages=["org.xml**", "org.yaml**"]
-    }
+    quasarExcludePackages=["org.xml**", "org.yaml**"]
 
 rpcAddress (deprecated)
   The address of the RPC system on which RPC requests can be made to the node.

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -426,7 +426,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     private fun quasarExcludePackages(nodeConfiguration: NodeConfiguration) {
         val quasarInstrumentor = Retransform.getInstrumentor()
 
-        nodeConfiguration.quasar.excludePackages.forEach { packageExclude ->
+        nodeConfiguration.quasarExcludePackages.forEach { packageExclude ->
             quasarInstrumentor.addExcludedPackage(packageExclude)
         }
     }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1,5 +1,6 @@
 package net.corda.node.internal
 
+import co.paralleluniverse.fibers.instrument.Retransform
 import com.codahale.metrics.MetricRegistry
 import com.google.common.collect.MutableClassToInstanceMap
 import com.google.common.util.concurrent.MoreExecutors
@@ -227,6 +228,8 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 MoreExecutors.shutdownAndAwaitTermination(it, 50, SECONDS)
             }
         }
+
+        quasarExcludePackages(configuration)
     }
 
     private val notaryLoader = configuration.notary?.let {
@@ -418,6 +421,14 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             }
         }
         return validateKeyStores()
+    }
+
+    private fun quasarExcludePackages(nodeConfiguration: NodeConfiguration) {
+        val quasarInstrumentor = Retransform.getInstrumentor()
+
+        for (packageExclude in nodeConfiguration.quasarExcludePackages) {
+            quasarInstrumentor.addExcludedPackage(packageExclude)
+        }
     }
 
     open fun generateAndSaveNodeInfo(): NodeInfo {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -426,7 +426,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     private fun quasarExcludePackages(nodeConfiguration: NodeConfiguration) {
         val quasarInstrumentor = Retransform.getInstrumentor()
 
-        for (packageExclude in nodeConfiguration.quasar.excludePackages) {
+        nodeConfiguration.quasar.excludePackages.forEach { packageExclude ->
             quasarInstrumentor.addExcludedPackage(packageExclude)
         }
     }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -426,7 +426,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     private fun quasarExcludePackages(nodeConfiguration: NodeConfiguration) {
         val quasarInstrumentor = Retransform.getInstrumentor()
 
-        for (packageExclude in nodeConfiguration.quasarExcludePackages) {
+        for (packageExclude in nodeConfiguration.quasar.excludePackages) {
             quasarInstrumentor.addExcludedPackage(packageExclude)
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -90,7 +90,7 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
 
     val flowExternalOperationThreadPoolSize: Int
 
-    val quasar: QuasarConfiguration
+    val quasarExcludePackages: List<String>
 
     companion object {
         // default to at least 8MB and a bit extra for larger heap sizes
@@ -213,15 +213,6 @@ data class FlowTimeoutConfiguration(
         val timeout: Duration,
         val maxRestartCount: Int,
         val backoffBase: Double
-)
-
-/**
- * Options for controlling Quasar instrumentation.
- *
- * @property excludePackages A list of packages to exclude from Quasar instrumentation. Wildcards are allowed (org.xml**).
- */
-data class QuasarConfiguration(
-        val excludePackages: List<String> = emptyList()
 )
 
 internal typealias Valid<TARGET> = Validated<TARGET, Configuration.Validation.Error>

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -215,6 +215,11 @@ data class FlowTimeoutConfiguration(
         val backoffBase: Double
 )
 
+/**
+ * Options for controlling Quasar instrumentation.
+ *
+ * @property excludePackages A list of packages to exclude from Quasar instrumentation. Wildcards are allowed (org.xml**).
+ */
 data class QuasarConfiguration(
         val excludePackages: List<String> = emptyList()
 )

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -90,7 +90,7 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
 
     val flowExternalOperationThreadPoolSize: Int
 
-    val quasarExcludePackages: List<String>
+    val quasar: QuasarConfiguration
 
     companion object {
         // default to at least 8MB and a bit extra for larger heap sizes
@@ -213,6 +213,10 @@ data class FlowTimeoutConfiguration(
         val timeout: Duration,
         val maxRestartCount: Int,
         val backoffBase: Double
+)
+
+data class QuasarConfiguration(
+        val excludePackages: List<String> = emptyList()
 )
 
 internal typealias Valid<TARGET> = Validated<TARGET, Configuration.Validation.Error>

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -90,6 +90,8 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
 
     val flowExternalOperationThreadPoolSize: Int
 
+    val quasarExcludePackages: List<String>
+
     companion object {
         // default to at least 8MB and a bit extra for larger heap sizes
         val defaultTransactionCacheSize: Long = 8.MB + getAdditionalCacheMemory()

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -83,7 +83,7 @@ data class NodeConfigurationImpl(
         override val blacklistedAttachmentSigningKeys: List<String> = Defaults.blacklistedAttachmentSigningKeys,
         override val configurationWithOptions: ConfigurationWithOptions,
         override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize,
-        override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages
+        override val quasar: QuasarConfiguration = Defaults.quasar
 ) : NodeConfiguration {
     internal object Defaults {
         val jmxMonitoringHttpPort: Int? = null
@@ -121,6 +121,7 @@ data class NodeConfigurationImpl(
         val blacklistedAttachmentSigningKeys: List<String> = emptyList()
         const val flowExternalOperationThreadPoolSize: Int = 1
         val quasarExcludePackages: List<String> = emptyList()
+        val quasar: QuasarConfiguration = QuasarConfiguration(quasarExcludePackages)
 
         fun cordappsDirectories(baseDirectory: Path) = listOf(baseDirectory / CORDAPPS_DIR_NAME_DEFAULT)
 

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -82,7 +82,8 @@ data class NodeConfigurationImpl(
                 Defaults.networkParameterAcceptanceSettings,
         override val blacklistedAttachmentSigningKeys: List<String> = Defaults.blacklistedAttachmentSigningKeys,
         override val configurationWithOptions: ConfigurationWithOptions,
-        override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize
+        override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize,
+        override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages
 ) : NodeConfiguration {
     internal object Defaults {
         val jmxMonitoringHttpPort: Int? = null
@@ -119,6 +120,7 @@ data class NodeConfigurationImpl(
         val networkParameterAcceptanceSettings: NetworkParameterAcceptanceSettings = NetworkParameterAcceptanceSettings()
         val blacklistedAttachmentSigningKeys: List<String> = emptyList()
         const val flowExternalOperationThreadPoolSize: Int = 1
+        val quasarExcludePackages: List<String> = emptyList()
 
         fun cordappsDirectories(baseDirectory: Path) = listOf(baseDirectory / CORDAPPS_DIR_NAME_DEFAULT)
 

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -83,7 +83,7 @@ data class NodeConfigurationImpl(
         override val blacklistedAttachmentSigningKeys: List<String> = Defaults.blacklistedAttachmentSigningKeys,
         override val configurationWithOptions: ConfigurationWithOptions,
         override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize,
-        override val quasar: QuasarConfiguration = Defaults.quasar
+        override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages
 ) : NodeConfiguration {
     internal object Defaults {
         val jmxMonitoringHttpPort: Int? = null
@@ -121,7 +121,6 @@ data class NodeConfigurationImpl(
         val blacklistedAttachmentSigningKeys: List<String> = emptyList()
         const val flowExternalOperationThreadPoolSize: Int = 1
         val quasarExcludePackages: List<String> = emptyList()
-        val quasar: QuasarConfiguration = QuasarConfiguration(quasarExcludePackages)
 
         fun cordappsDirectories(baseDirectory: Path) = listOf(baseDirectory / CORDAPPS_DIR_NAME_DEFAULT)
 

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
@@ -24,12 +24,10 @@ import net.corda.node.services.config.FlowOverrideConfig
 import net.corda.node.services.config.FlowTimeoutConfiguration
 import net.corda.node.services.config.NetworkParameterAcceptanceSettings
 import net.corda.node.services.config.NetworkServicesConfig
-import net.corda.node.services.config.NodeConfigurationImpl
 import net.corda.node.services.config.NodeH2Settings
 import net.corda.node.services.config.NodeRpcSettings
 import net.corda.node.services.config.NotaryConfig
 import net.corda.node.services.config.PasswordEncryption
-import net.corda.node.services.config.QuasarConfiguration
 import net.corda.node.services.config.SecurityConfiguration
 import net.corda.node.services.config.SecurityConfiguration.AuthService.Companion.defaultAuthServiceId
 import net.corda.node.services.config.Valid
@@ -188,14 +186,6 @@ internal object FlowTimeoutConfigurationSpec : Configuration.Specification<FlowT
 
     override fun parseValid(configuration: Config): Valid<FlowTimeoutConfiguration> {
         return valid(FlowTimeoutConfiguration(configuration[timeout], configuration[maxRestartCount], configuration[backoffBase]))
-    }
-}
-
-internal object QuasarConfigurationSpec : Configuration.Specification<QuasarConfiguration>("QuasarConfiguration"){
-    private val excludePackages by string().list().optional().withDefaultValue(NodeConfigurationImpl.Defaults.quasarExcludePackages)
-
-    override fun parseValid(configuration: Config): Valid<QuasarConfiguration> {
-        return valid(QuasarConfiguration(configuration[excludePackages]))
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
@@ -24,10 +24,12 @@ import net.corda.node.services.config.FlowOverrideConfig
 import net.corda.node.services.config.FlowTimeoutConfiguration
 import net.corda.node.services.config.NetworkParameterAcceptanceSettings
 import net.corda.node.services.config.NetworkServicesConfig
+import net.corda.node.services.config.NodeConfigurationImpl
 import net.corda.node.services.config.NodeH2Settings
 import net.corda.node.services.config.NodeRpcSettings
 import net.corda.node.services.config.NotaryConfig
 import net.corda.node.services.config.PasswordEncryption
+import net.corda.node.services.config.QuasarConfiguration
 import net.corda.node.services.config.SecurityConfiguration
 import net.corda.node.services.config.SecurityConfiguration.AuthService.Companion.defaultAuthServiceId
 import net.corda.node.services.config.Valid
@@ -186,6 +188,14 @@ internal object FlowTimeoutConfigurationSpec : Configuration.Specification<FlowT
 
     override fun parseValid(configuration: Config): Valid<FlowTimeoutConfiguration> {
         return valid(FlowTimeoutConfiguration(configuration[timeout], configuration[maxRestartCount], configuration[backoffBase]))
+    }
+}
+
+internal object QuasarConfigurationSpec : Configuration.Specification<QuasarConfiguration>("QuasarConfiguration"){
+    private val excludePackages by string().list().optional().withDefaultValue(NodeConfigurationImpl.Defaults.quasarExcludePackages)
+
+    override fun parseValid(configuration: Config): Valid<QuasarConfiguration> {
+        return valid(QuasarConfiguration(configuration[excludePackages]))
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -64,6 +64,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
             .optional()
             .withDefaultValue(Defaults.networkParameterAcceptanceSettings)
     private val flowExternalOperationThreadPoolSize by int().optional().withDefaultValue(Defaults.flowExternalOperationThreadPoolSize)
+    private val quasarExcludePackages by string().list().optional().withDefaultValue(Defaults.quasarExcludePackages)
     @Suppress("unused")
     private val custom by nestedObject().optional()
     @Suppress("unused")
@@ -128,7 +129,8 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     blacklistedAttachmentSigningKeys = configuration[blacklistedAttachmentSigningKeys],
                     networkParameterAcceptanceSettings = configuration[networkParameterAcceptanceSettings],
                     configurationWithOptions = ConfigurationWithOptions(configuration, Configuration.Validation.Options.defaults),
-                    flowExternalOperationThreadPoolSize = configuration[flowExternalOperationThreadPoolSize]
+                    flowExternalOperationThreadPoolSize = configuration[flowExternalOperationThreadPoolSize],
+                    quasarExcludePackages = configuration[quasarExcludePackages]
             ))
         } catch (e: Exception) {
             return when (e) {

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -64,7 +64,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
             .optional()
             .withDefaultValue(Defaults.networkParameterAcceptanceSettings)
     private val flowExternalOperationThreadPoolSize by int().optional().withDefaultValue(Defaults.flowExternalOperationThreadPoolSize)
-    private val quasar by nested(QuasarConfigurationSpec).optional().withDefaultValue(Defaults.quasar)
+    private val quasarExcludePackages by string().list().optional().withDefaultValue(Defaults.quasarExcludePackages)
     @Suppress("unused")
     private val custom by nestedObject().optional()
     @Suppress("unused")
@@ -130,7 +130,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     networkParameterAcceptanceSettings = configuration[networkParameterAcceptanceSettings],
                     configurationWithOptions = ConfigurationWithOptions(configuration, Configuration.Validation.Options.defaults),
                     flowExternalOperationThreadPoolSize = configuration[flowExternalOperationThreadPoolSize],
-                    quasar = configuration[quasar]
+                    quasarExcludePackages = configuration[quasarExcludePackages]
             ))
         } catch (e: Exception) {
             return when (e) {

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -64,7 +64,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
             .optional()
             .withDefaultValue(Defaults.networkParameterAcceptanceSettings)
     private val flowExternalOperationThreadPoolSize by int().optional().withDefaultValue(Defaults.flowExternalOperationThreadPoolSize)
-    private val quasarExcludePackages by string().list().optional().withDefaultValue(Defaults.quasarExcludePackages)
+    private val quasar by nested(QuasarConfigurationSpec).optional().withDefaultValue(Defaults.quasar)
     @Suppress("unused")
     private val custom by nestedObject().optional()
     @Suppress("unused")
@@ -130,7 +130,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     networkParameterAcceptanceSettings = configuration[networkParameterAcceptanceSettings],
                     configurationWithOptions = ConfigurationWithOptions(configuration, Configuration.Validation.Options.defaults),
                     flowExternalOperationThreadPoolSize = configuration[flowExternalOperationThreadPoolSize],
-                    quasarExcludePackages = configuration[quasarExcludePackages]
+                    quasar = configuration[quasar]
             ))
         } catch (e: Exception) {
             return when (e) {

--- a/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
@@ -2,7 +2,6 @@ package net.corda.node.internal
 
 import co.paralleluniverse.fibers.instrument.Retransform
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 import net.corda.core.internal.toPath
 import net.corda.node.VersionInfo
 import net.corda.node.services.config.ConfigHelper
@@ -14,11 +13,37 @@ import org.junit.Test
 class QuasarExcludePackagesTest {
 
     @Test(timeout=300_000)
-    fun `quasarExcludePackages is passed through to QuasarInstrumentor`() {
+    fun `quasarexcludePackages default is empty list`() {
 
         // Arrange
-        val overrides = ConfigFactory.parseMap(mapOf("quasarExcludePackages" to listOf("net.corda.node.internal.QuasarExcludePackagesTest**")))
-        val config = getConfig("working-config.conf", overrides)
+        val config = getConfig("working-config.conf")
+
+        // Act
+        val nodeConfiguration :NodeConfiguration = V1NodeConfigurationSpec.parse(config).value()
+
+        // Assert
+        Assert.assertEquals(emptyList<String>(), nodeConfiguration.quasar.excludePackages)
+    }
+
+
+    @Test(timeout=300_000)
+    fun `quasarexcludePackages is read from configuration`() {
+
+        // Arrange
+        val config = getConfig("test-config-quasarexcludepackages.conf")
+
+        // Act
+        val nodeConfiguration :NodeConfiguration = V1NodeConfigurationSpec.parse(config).value()
+
+        // Assert
+        Assert.assertEquals(listOf("net.corda.node.internal.QuasarExcludePackagesTest**"), nodeConfiguration.quasar.excludePackages)
+    }
+
+    @Test(timeout=300_000)
+    fun `quasarexcludePackages is passed through to QuasarInstrumentor`() {
+
+        // Arrange
+        val config = getConfig("test-config-quasarexcludepackages.conf")
         val nodeConfiguration :NodeConfiguration = V1NodeConfigurationSpec.parse(config).value()
 
         // Act
@@ -29,12 +54,9 @@ class QuasarExcludePackagesTest {
         Assert.assertTrue(Retransform.getInstrumentor().isExcluded("net.corda.node.internal.QuasarExcludePackagesTest.Test"))
     }
 
-    private fun getConfig(cfgName: String, overrides: Config = ConfigFactory.empty()): Config {
-        val path = this::class.java.classLoader.getResource(cfgName).toPath()
-        return ConfigHelper.loadConfig(
-                baseDirectory = path.parent,
-                configFile = path,
-                configOverrides = overrides
-        )
+    private fun getConfig(cfgName: String): Config {
+        val resource = this::class.java.classLoader.getResource(cfgName) ?: throw Exception("Resource not found")
+        val path = resource.toPath()
+        return ConfigHelper.loadConfig(path.parent, path)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 class QuasarExcludePackagesTest {
 
     @Test(timeout=300_000)
-    fun `quasarexcludePackages default is empty list`() {
+    fun `quasarExcludePackages default is empty list`() {
 
         // Arrange
         val config = getConfig("working-config.conf")
@@ -22,12 +22,12 @@ class QuasarExcludePackagesTest {
         val nodeConfiguration :NodeConfiguration = V1NodeConfigurationSpec.parse(config).value()
 
         // Assert
-        Assert.assertEquals(emptyList<String>(), nodeConfiguration.quasar.excludePackages)
+        Assert.assertEquals(emptyList<String>(), nodeConfiguration.quasarExcludePackages)
     }
 
 
     @Test(timeout=300_000)
-    fun `quasarexcludePackages is read from configuration`() {
+    fun `quasarExcludePackages is read from configuration`() {
 
         // Arrange
         val config = getConfig("test-config-quasarexcludepackages.conf")
@@ -36,11 +36,11 @@ class QuasarExcludePackagesTest {
         val nodeConfiguration :NodeConfiguration = V1NodeConfigurationSpec.parse(config).value()
 
         // Assert
-        Assert.assertEquals(listOf("net.corda.node.internal.QuasarExcludePackagesTest**"), nodeConfiguration.quasar.excludePackages)
+        Assert.assertEquals(listOf("net.corda.node.internal.QuasarExcludePackagesTest**"), nodeConfiguration.quasarExcludePackages)
     }
 
     @Test(timeout=300_000)
-    fun `quasarexcludePackages is passed through to QuasarInstrumentor`() {
+    fun `quasarExcludePackages is passed through to QuasarInstrumentor`() {
 
         // Arrange
         val config = getConfig("test-config-quasarexcludepackages.conf")

--- a/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
@@ -54,8 +54,10 @@ class QuasarExcludePackagesTest {
         Assert.assertTrue(Retransform.getInstrumentor().isExcluded("net.corda.node.internal.QuasarExcludePackagesTest.Test"))
     }
 
+    class ResourceMissingException(message: String) : Exception(message)
+
     private fun getConfig(cfgName: String): Config {
-        val resource = this::class.java.classLoader.getResource(cfgName) ?: throw Exception("Resource not found")
+        val resource = this::class.java.classLoader.getResource(cfgName) ?: throw ResourceMissingException("Resource not found")
         val path = resource.toPath()
         return ConfigHelper.loadConfig(path.parent, path)
     }

--- a/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
@@ -1,0 +1,40 @@
+package net.corda.node.internal
+
+import co.paralleluniverse.fibers.instrument.Retransform
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import net.corda.core.internal.toPath
+import net.corda.node.VersionInfo
+import net.corda.node.services.config.ConfigHelper
+import net.corda.node.services.config.NodeConfiguration
+import net.corda.node.services.config.schema.v1.V1NodeConfigurationSpec
+import org.junit.Assert
+import org.junit.Test
+
+class QuasarExcludePackagesTest {
+
+    @Test(timeout=300_000)
+    fun `quasarExcludePackages is passed through to QuasarInstrumentor`() {
+
+        // Arrange
+        val overrides = ConfigFactory.parseMap(mapOf("quasarExcludePackages" to listOf("net.corda.node.internal.QuasarExcludePackagesTest**")))
+        val config = getConfig("working-config.conf", overrides)
+        val nodeConfiguration :NodeConfiguration = V1NodeConfigurationSpec.parse(config).value()
+
+        // Act
+        val node = Node(nodeConfiguration, VersionInfo.UNKNOWN)
+        node.stop()
+
+        // Assert
+        Assert.assertTrue(Retransform.getInstrumentor().isExcluded("net.corda.node.internal.QuasarExcludePackagesTest.Test"))
+    }
+
+    private fun getConfig(cfgName: String, overrides: Config = ConfigFactory.empty()): Config {
+        val path = this::class.java.classLoader.getResource(cfgName).toPath()
+        return ConfigHelper.loadConfig(
+                baseDirectory = path.parent,
+                configFile = path,
+                configOverrides = overrides
+        )
+    }
+}

--- a/node/src/test/resources/test-config-quasarexcludepackages.conf
+++ b/node/src/test/resources/test-config-quasarexcludepackages.conf
@@ -1,0 +1,35 @@
+myLegalName = "O=Alice Corp, L=Madrid, C=ES"
+emailAddress = "admin@company.com"
+keyStorePassword = "cordacadevpass"
+trustStorePassword = "trustpass"
+crlCheckSoftFail = true
+baseDirectory = "/opt/corda"
+cordappDirectories = ["./myCorDapps1", "./myCorDapps2"]
+dataSourceProperties = {
+    dataSourceClassName = org.h2.jdbcx.JdbcDataSource
+    dataSource.url = "jdbc:h2:file:blah"
+    dataSource.user = "sa"
+    dataSource.password = ""
+}
+database = {
+    transactionIsolationLevel = "REPEATABLE_READ"
+    exportHibernateJMXStatistics = "false"
+}
+p2pAddress = "localhost:2233"
+h2port = 0
+useTestClock = false
+verifierType = InMemory
+rpcSettings = {
+    address = "locahost:3418"
+    adminAddress = "localhost:3419"
+    useSsl = false
+    standAloneBroker = false
+}
+flowTimeout {
+    timeout = 30 seconds
+    maxRestartCount = 3
+    backoffBase = 2.0
+}
+quasar {
+    excludePackages = [ "net.corda.node.internal.QuasarExcludePackagesTest**" ]
+}

--- a/node/src/test/resources/test-config-quasarexcludepackages.conf
+++ b/node/src/test/resources/test-config-quasarexcludepackages.conf
@@ -30,6 +30,4 @@ flowTimeout {
     maxRestartCount = 3
     backoffBase = 2.0
 }
-quasar {
-    excludePackages = [ "net.corda.node.internal.QuasarExcludePackagesTest**" ]
-}
+quasarExcludePackages = [ "net.corda.node.internal.QuasarExcludePackagesTest**" ]

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -461,6 +461,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
             doReturn(makeTestDataSourceProperties("node_${id}_net_$networkId")).whenever(it).dataSourceProperties
             doReturn(emptyList<SecureHash>()).whenever(it).extraNetworkMapKeys
             doReturn(listOf(baseDirectory / "cordapps")).whenever(it).cordappDirectories
+            doReturn(emptyList<String>()).whenever(it).quasarExcludePackages
             parameters.configOverrides(it)
         }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -461,7 +461,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
             doReturn(makeTestDataSourceProperties("node_${id}_net_$networkId")).whenever(it).dataSourceProperties
             doReturn(emptyList<SecureHash>()).whenever(it).extraNetworkMapKeys
             doReturn(listOf(baseDirectory / "cordapps")).whenever(it).cordappDirectories
-            doReturn(emptyList<String>()).whenever(it).quasarExcludePackages
+            doReturn(QuasarConfiguration()).whenever(it).quasar
             parameters.configOverrides(it)
         }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -461,7 +461,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
             doReturn(makeTestDataSourceProperties("node_${id}_net_$networkId")).whenever(it).dataSourceProperties
             doReturn(emptyList<SecureHash>()).whenever(it).extraNetworkMapKeys
             doReturn(listOf(baseDirectory / "cordapps")).whenever(it).cordappDirectories
-            doReturn(QuasarConfiguration()).whenever(it).quasar
+            doReturn(emptyList<String>()).whenever(it).quasarExcludePackages
             parameters.configOverrides(it)
         }
 


### PR DESCRIPTION
Add a new `node.conf` option to exclude packages from Quasar instrumentation.

```
quasarExcludePackages = ["org.xml**", "org.yaml**"]
```
