### PR TITLE
CORDA-3644: Scan the CorDapp classloader directly for SerializationWhitelist.

### DIFF
--- a/docs/source/example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/TutorialFlowAsyncOperationTest.java
+++ b/docs/source/example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/TutorialFlowAsyncOperationTest.java
@@ -1,6 +1,5 @@
 package net.corda.docs.java.tutorial.test;
 
-import kotlin.Unit;
 import net.corda.client.rpc.CordaRPCClient;
 import net.corda.core.messaging.CordaRPCOps;
 import net.corda.core.utilities.KotlinUtilsKt;
@@ -10,24 +9,24 @@ import net.corda.testing.driver.*;
 import net.corda.testing.node.User;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.concurrent.Future;
 
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static net.corda.testing.core.TestConstants.ALICE_NAME;
+import static net.corda.testing.driver.Driver.driver;
+import static net.corda.testing.node.internal.InternalTestUtilsKt.cordappWithPackages;
 import static org.junit.Assert.assertEquals;
 
-public final class TutorialFlowAsyncOperationTest {
+public class TutorialFlowAsyncOperationTest {
     // DOCSTART summingWorks
     @Test
-    public final void summingWorks() {
-        Driver.driver(new DriverParameters(), (DriverDSL dsl) -> {
-            User aliceUser = new User("aliceUser", "testPassword1",
-                    new HashSet<>(Collections.singletonList(Permissions.all()))
-            );
+    public void summingWorks() {
+        driver(new DriverParameters(singletonList(cordappWithPackages("net.corda.docs.java.tutorial.flowstatemachines"))), (DriverDSL dsl) -> {
+            User aliceUser = new User("aliceUser", "testPassword1", singleton(Permissions.all()));
             Future<NodeHandle> aliceFuture = dsl.startNode(new NodeParameters()
                     .withProvidedName(ALICE_NAME)
-                    .withRpcUsers(Collections.singletonList(aliceUser))
+                    .withRpcUsers(singletonList(aliceUser))
             );
             NodeHandle alice = KotlinUtilsKt.getOrThrow(aliceFuture, null);
             CordaRPCClient aliceClient = new CordaRPCClient(alice.getRpcAddress());
@@ -35,7 +34,7 @@ public final class TutorialFlowAsyncOperationTest {
             Future<Integer> answerFuture = aliceProxy.startFlowDynamic(ExampleSummingFlow.class).getReturnValue();
             int answer = KotlinUtilsKt.getOrThrow(answerFuture, null);
             assertEquals(3, answer);
-            return Unit.INSTANCE;
+            return null;
         });
     }
     // DOCEND summingWorks

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/TutorialFlowAsyncOperationTest.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/TutorialFlowAsyncOperationTest.kt
@@ -10,7 +10,6 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.cordappWithPackages
-import net.corda.testing.node.internal.findCordapp
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/node/src/integration-test/kotlin/net/corda/node/logging/ErrorCodeLoggingTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/logging/ErrorCodeLoggingTests.kt
@@ -1,6 +1,5 @@
 package net.corda.node.logging
 
-import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
@@ -23,7 +22,13 @@ class ErrorCodeLoggingTests {
             node.rpc.startFlow(::MyFlow).waitForCompletion()
             val logFile = node.logFile()
 
-            val linesWithErrorCode = logFile.useLines { lines -> lines.filter { line -> line.contains("[errorCode=") }.filter { line -> line.contains("moreInformationAt=https://errors.corda.net/") }.toList() }
+            val linesWithErrorCode = logFile.useLines { lines ->
+                lines.filter { line ->
+                    line.contains("[errorCode=")
+                }.filter { line ->
+                    line.contains("moreInformationAt=https://errors.corda.net/")
+                }.toList()
+            }
 
             assertThat(linesWithErrorCode).isNotEmpty
         }
@@ -35,10 +40,11 @@ class ErrorCodeLoggingTests {
 	fun `When logging is set to error level, there are no other levels logged after node startup`() {
         driver(DriverParameters(notarySpecs = emptyList())) {
             val node = startNode(startInSameProcess = false, logLevelOverride = "ERROR").getOrThrow()
-            node.rpc.startFlow(::MyFlow).waitForCompletion()
             val logFile = node.logFile()
+            val lengthAfterStart = logFile.length()
+            node.rpc.startFlow(::MyFlow).waitForCompletion()
             // An exception thrown in a flow will log at the "INFO" level.
-            assertThat(logFile.length()).isEqualTo(0)
+            assertThat(logFile.length()).isEqualTo(lengthAfterStart)
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -22,7 +22,6 @@ import net.corda.node.VersionInfo
 import net.corda.nodeapi.internal.cordapp.CordappLoader
 import net.corda.nodeapi.internal.coreContractClasses
 import net.corda.serialization.internal.DefaultWhitelist
-import org.apache.commons.collections4.map.LRUMap
 import java.lang.reflect.Modifier
 import java.math.BigInteger
 import java.net.URL
@@ -293,9 +292,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
     }
 
     private fun findWhitelists(cordappJarPath: RestrictedURL): List<SerializationWhitelist> {
-        val whitelists = URLClassLoader(arrayOf(cordappJarPath.url)).use {
-            ServiceLoader.load(SerializationWhitelist::class.java, it).toList()
-        }
+        val whitelists = ServiceLoader.load(SerializationWhitelist::class.java, appClassLoader).toList()
         return whitelists.filter {
             it.javaClass.location == cordappJarPath.url && it.javaClass.name.startsWith(cordappJarPath.qualifiedNamePrefix)
         } + DefaultWhitelist // Always add the DefaultWhitelist to the whitelist for an app.
@@ -309,14 +306,16 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
         return scanResult.getClassesWithSuperclass(MappedSchema::class).instances().toSet()
     }
 
-    private val cachedScanResult = LRUMap<RestrictedURL, RestrictedScanResult>(1000)
-
     private fun scanCordapp(cordappJarPath: RestrictedURL): RestrictedScanResult {
-        logger.info("Scanning CorDapp in ${cordappJarPath.url}")
-        return cachedScanResult.computeIfAbsent(cordappJarPath) {
-            val scanResult = ClassGraph().addClassLoader(appClassLoader).overrideClasspath(cordappJarPath.url).enableAllInfo().pooledScan()
-            RestrictedScanResult(scanResult, cordappJarPath.qualifiedNamePrefix)
-        }
+        val cordappElement = cordappJarPath.url.toString()
+        logger.info("Scanning CorDapp in $cordappElement")
+        val scanResult = ClassGraph()
+            .filterClasspathElements { elt -> elt == cordappElement }
+            .overrideClassLoaders(appClassLoader)
+            .ignoreParentClassLoaders()
+            .enableAllInfo()
+            .pooledScan()
+        return RestrictedScanResult(scanResult, cordappJarPath.qualifiedNamePrefix)
     }
 
     private fun <T : Any> loadClass(className: String, type: KClass<T>): Class<out T>? {

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -320,7 +320,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
 
     private fun <T : Any> loadClass(className: String, type: KClass<T>): Class<out T>? {
         return try {
-            appClassLoader.loadClass(className).asSubclass(type.java)
+            Class.forName(className, false, appClassLoader).asSubclass(type.java)
         } catch (e: ClassCastException) {
             logger.warn("As $className must be a sub-type of ${type.java.name}")
             null

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -56,7 +56,7 @@ jar {
 }
 
 task testJar(type: Jar) {
-    classifier "test"
+    classifier "tests"
     from sourceSets.main.output
     from sourceSets.test.output
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -973,6 +973,7 @@ class DriverDSLImpl(
         // belong inside a Corda Node.
         private fun isTestArtifact(name: String): Boolean {
             return name.endsWith("-tests.jar")
+                    || name.endsWith("-test.jar")
                     || name.startsWith("corda-mock")
                     || name.startsWith("junit")
                     || name.startsWith("testng")


### PR DESCRIPTION
- Configure `ClassGraph` so that it only scans each CorDapp's URL within `appClassLoader`, and does not descend into any of the parent classloaders.
- Pass `appClassLoader` _directly_ to `ServiceLoader` and **do not** create an ephemeral `URLClassLoader`. Otherwise we get seemingly inexplicable `ClassNotFoundException` errors when trying to read `SerializationWhitelist.whitelists` because the classloader providing the `SerializationWhitelist` instance has been closed already,
- Throw the `LRUMap` away because the `ScanResult` objects inside it are used once and then closed, putting them all beyond re-use.
- Filter directories, CorDapps and _blatant_ test JARs from the out-of-process node's classpath. CorDapps are identified by their attributes in `MANIFEST.MF`.