### PR TITLE
EG-62: Consistent Error Handling of Node Post Network Parameters Update

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -29,8 +29,8 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
                         "parameters advertised by network map. Please update node to use correct network parameters file."
         )
         class OldParams(previousParametersHash: SecureHash, advertisedParametersHash: SecureHash) : Error(
-                "Node uses parameters with hash: $previousParametersHash but network map is advertising: " +
-                        "$advertisedParametersHash. Please update node to use correct network parameters file."
+                """Node is using network parameters with hash $previousParametersHash but the network map is advertising $advertisedParametersHash.
+                To resolve this mismatch, and move to the current parameters, delete the $NETWORK_PARAMS_FILE_NAME file from the node's directory and restart."""
         )
     }
 


### PR DESCRIPTION
When running a node in UAT post Flag Day, the error message that is returned should be enhanced to allow new users to quickly debug the issue. The previous format of this error message was:

`Node uses parameters with hash: $previousParametersHash but network map is advertising: $advertisedParametersHash. Please update node to use correct network parameters file.`

This message has been changed to:

`Node is using network parameters with hash $previousParametersHash but the network map is advertising $advertisedParametersHash. To resolve this mismatch, and move to the current parameters, delete the $NETWORK_PARAMS_FILE_NAME file from the node's directory and restart.`

This change provides error handling consistency with the NetworkMapUpdater class. 