### PR TITLE
CORDA-3651: addManifest now uses separate files for reading and writing.

### DIFF
--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
@@ -12,6 +12,7 @@ import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.security.PublicKey
 import java.util.jar.Attributes
 import java.util.jar.JarInputStream
@@ -88,12 +89,13 @@ object JarSignatureTestUtils {
             JarInputStream(FileInputStream((this / fileName).toFile())).use(JarSignatureCollector::collectSigners)
 
     fun Path.addManifest(fileName: String, vararg entries: Pair<Attributes.Name, String>) {
+        val outputFile = this / (fileName + "Output")
         JarInputStream(FileInputStream((this / fileName).toFile())).use { input ->
             val manifest = input.manifest ?: Manifest()
             entries.forEach { (attributeName, value) ->
                 manifest.mainAttributes[attributeName] = value
             }
-            val output = JarOutputStream(FileOutputStream((this / fileName).toFile()), manifest)
+            val output = JarOutputStream(FileOutputStream(outputFile.toFile()), manifest)
             var entry = input.nextEntry
             val buffer = ByteArray(1 shl 14)
             while (true) {
@@ -108,5 +110,6 @@ object JarSignatureTestUtils {
             }
             output.close()
         }
+        Files.copy(outputFile, this / fileName, REPLACE_EXISTING)
     }
 }


### PR DESCRIPTION
Was seeing an intermittent test failure on Windows when creating Jars - see CORDA-3651 for the stack trace.
The test Jar creation calls the addManifest function which was reading and writing to the same file, this has been fixed now is OS. I am suspecting this may have been a cause for the failure in Windows.