### PR TITLE
TM-226 - Publish API docs to Artifactory for new doc site

### DIFF
--- a/.ci/dev/publish-api-docs/Jenkinsfile
+++ b/.ci/dev/publish-api-docs/Jenkinsfile
@@ -1,0 +1,39 @@
+@Library('corda-shared-build-pipeline-steps')
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+pipeline {
+    agent { label 'local-k8s' }
+
+    options {
+        timestamps()
+        timeout(time: 3, unit: 'HOURS')
+    }
+
+    environment {
+        EXECUTOR_NUMBER = "${env.EXECUTOR_NUMBER}"
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+    }
+
+    stages {
+        stage('Build and publish API docs') {
+            steps {
+                script {
+                    stage('Build and publish API docs and publish .tar.gz to Artifactory') {
+                        sh "./gradlew :docs:artifactoryPublish " +
+                                "-PpublishApiDocs " +
+                                "-PartifactoryUsername=\"\${ARTIFACTORY_CREDENTIALS_USR}\" " +
+                                "-PartifactoryPassword=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" "
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        cleanup {
+            deleteDir() /* clean up our workspace */
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -215,6 +215,11 @@ if (ext.versionSuffix != ""){
     ext.corda_release_version = "${ext.baseVersion}".toString()
 }
 
+// Need to remove -SNAPSHOT suffix for publishing API docs to Artifactory
+if (findProperty("publishApiDocs") != null) {
+    ext.corda_release_version = "${ext.baseVersion}".toString()
+}
+
 // We need the following three lines even though they're inside an allprojects {} block below because otherwise
 // IntelliJ gets confused when importing the project and ends up erasing and recreating the .idea directory, along
 // with the run configurations. It also doesn't realise that the project is a Java 8 project and misconfigures
@@ -564,10 +569,23 @@ artifactory {
         defaults {
             // Root project applies the plugin (for this block) but does not need to be published
             if (project != rootProject) {
-                publications(project.extensions.publish.name())
+                if (project.name.toString() == 'docs') {
+                    publications('mavenZipApiDocs')
+                    publishPom = false
+                } else {
+                    publications(project.extensions.publish.name())
+                }
             }
         }
     }
+}
+
+artifactoryPublish {
+    clientConfig.publisher.repoKey = findProperty('publishApiDocs') != null ? 'corda-dependencies-dev' : 'corda-dev'
+    clientConfig.publisher.username = findProperty('publishApiDocs') != null ?
+            getProperty('artifactoryUsername') : System.getenv('CORDA_ARTIFACTORY_USERNAME')
+    clientConfig.publisher.password = findProperty('publishApiDocs') != null ?
+            getProperty('artifactoryPassword') : System.getenv('CORDA_ARTIFACTORY_PASSWORD')
 }
 
 task generateApi(type: net.corda.plugins.GenerateApi) {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -4,9 +4,15 @@ import java.nio.file.Files
 
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'kotlin'
+apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'maven-publish'
 
 dependencies {
     compile rootProject
+}
+
+ext {
+    baseFileName = "corda-docs"
 }
 
 def internalPackagePrefixes(sourceDirs) {
@@ -30,11 +36,12 @@ ext {
 }
 
 dokka {
+    outputFormat = findProperty("publishApiDocs") != null ? "gfm" : "html"
     outputDirectory = file("${rootProject.rootDir}/docs/build/html/api/kotlin")
 }
 
 task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    outputFormat = "javadoc"
+    outputFormat = findProperty("publishApiDocs") != null ? "gfm" : "javadoc"
     outputDirectory = file("${rootProject.rootDir}/docs/build/html/api/javadoc")
 }
 
@@ -78,3 +85,23 @@ task makeDocs(type: Exec) {
 }
 
 apidocs.shouldRunAfter makeDocs
+
+task zipApiDocs(type: Tar) {
+    dependsOn apidocs
+    from './build'
+    exclude '*publications'
+    destinationDir = file('.')
+    compression = Compression.GZIP
+    archiveName = baseFileName + ".tgz"
+}
+
+publishing {
+    publications {
+        mavenZipApiDocs(MavenPublication) {
+            artifact zipApiDocs {
+                artifactId baseFileName
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
WIP

This PR adds a Gradle task to zip the API docs and a Jenkinsfile for the job that will publish the zipped API docs to Artifactory. Similar PRs have been raised against Corda OS and ENT versions 4.1, 4.3, 4.4.

The published API docs will be consumed and processed to produce the new doc site, which exists in its own repository.