### PR TITLE
CORDA-3644: Add Corda-Test attribute to test artifacts' MANIFEST.MF

### DIFF
--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -29,7 +29,13 @@ dependencies {
 jar {
     baseName 'corda-mock'
     manifest {
-        attributes 'Automatic-Module-Name': 'net.corda.client.mock'
+        attributes(
+            'Automatic-Module-Name': 'net.corda.client.mock',
+
+            // This JAR is part of Corda's testing framework.
+            // Driver will not include it as part of an out-of-process node.
+            'Corda-Testing': true
+        )
     }
 }
 

--- a/testing/cordapps/dbfailure/dbfcontracts/build.gradle
+++ b/testing/cordapps/dbfailure/dbfcontracts/build.gradle
@@ -13,6 +13,11 @@ dependencies {
     compile project(":core")
 }
 
-jar{
+jar {
     baseName "testing-dbfailure-contracts"
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
 }

--- a/testing/cordapps/dbfailure/dbfworkflows/build.gradle
+++ b/testing/cordapps/dbfailure/dbfworkflows/build.gradle
@@ -7,6 +7,11 @@ dependencies {
     compile project(":testing:cordapps:dbfailure:dbfcontracts")
 }
 
-jar{
+jar {
     baseName "testing-dbfailure-workflows"
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
 }

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -66,6 +66,11 @@ task integrationTest(type: Test) {
 
 jar {
     baseName 'corda-node-driver'
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
 }
 
 publish {

--- a/testing/smoke-test-utils/build.gradle
+++ b/testing/smoke-test-utils/build.gradle
@@ -7,3 +7,11 @@ dependencies {
     compile project(':test-common')
     compile project(':client:rpc')
 }
+
+tasks.named('jar', Jar) {
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
+}

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -14,10 +14,12 @@ dependencies {
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-
 }
-compileKotlin {
-    kotlinOptions {
-        languageVersion = "1.2"
+
+tasks.named('jar', Jar) {
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
     }
 }

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -25,6 +25,11 @@ dependencies {
 
 jar {
     baseName 'corda-test-common'
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
 }
 
 publish {

--- a/testing/test-db/build.gradle
+++ b/testing/test-db/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 
 jar {
     baseName 'corda-test-db'
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
 }
 
 publish {

--- a/testing/test-utils/build.gradle
+++ b/testing/test-utils/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 
 jar {
     baseName 'corda-test-utils'
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
 }
 
 publish {


### PR DESCRIPTION
We should probably exclude node-driver itself from out-of-process nodes too, along with the rest of Corda's testing framework. Identify these jars by adding a new Corda-Testing attribute to their MANIFEST.MF so that the driver knows to exclude them from the node classpath.