### PR TITLE
TM-209: Dependx introduction for test running optimization

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,8 @@ pipeline {
                                 "-Dartifactory.password=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" " +
                                 "-Dgit.branch=\"\${GIT_BRANCH}\" " +
                                 "-Dgit.target.branch=\"\${CHANGE_TARGET}\" " +
+                                "-Ddependx.branch.origin=${env.GIT_COMMIT}" +
+                                "-Ddependx.branch.target=${CHANGE_TARGET}" +
                                 " allParallelIntegrationTest  --stacktrace"
                     }
                 }
@@ -58,6 +60,8 @@ pipeline {
                                 "-Dartifactory.password=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" " +
                                 "-Dgit.branch=\"\${GIT_BRANCH}\" " +
                                 "-Dgit.target.branch=\"\${CHANGE_TARGET}\" " +
+                                "-Ddependx.branch.origin=${env.GIT_COMMIT}" +
+                                "-Ddependx.branch.target=${CHANGE_TARGET}" +
                                 " allParallelUnitTest --stacktrace"
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,8 +45,8 @@ pipeline {
                                 "-Dartifactory.password=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" " +
                                 "-Dgit.branch=\"\${GIT_BRANCH}\" " +
                                 "-Dgit.target.branch=\"\${CHANGE_TARGET}\" " +
-                                "-Ddependx.branch.origin=${env.GIT_COMMIT}" +
-                                "-Ddependx.branch.target=${CHANGE_TARGET}" +
+                                "-Ddependx.branch.origin=${env.GIT_COMMIT} " +
+                                "-Ddependx.branch.target=${CHANGE_TARGET} " +
                                 " allParallelIntegrationTest  --stacktrace"
                     }
                 }
@@ -60,8 +60,8 @@ pipeline {
                                 "-Dartifactory.password=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" " +
                                 "-Dgit.branch=\"\${GIT_BRANCH}\" " +
                                 "-Dgit.target.branch=\"\${CHANGE_TARGET}\" " +
-                                "-Ddependx.branch.origin=${env.GIT_COMMIT}" +
-                                "-Ddependx.branch.target=${CHANGE_TARGET}" +
+                                "-Ddependx.branch.origin=${env.GIT_COMMIT} " +
+                                "-Ddependx.branch.target=${CHANGE_TARGET} " +
                                 " allParallelUnitTest --stacktrace"
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ buildscript {
         // See https://github.com/corda/gradle-capsule-plugin
         classpath "us.kirchmeier:gradle-capsule-plugin:1.0.4_r3"
         classpath group: "com.r3.testing", name: "gradle-distributed-testing-plugin", version: "1.2-LOCAL-K8S-SHARED-CACHE-SNAPSHOT", changing: true
-        classpath group: "com.r3.dependx", name: "gradle-dependx", version: "0.1.6", changing: true
+        classpath group: "com.r3.dependx", name: "gradle-dependx", version: "0.1.12", changing: true
         classpath "com.bmuschko:gradle-docker-plugin:5.0.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ buildscript {
         // See https://github.com/corda/gradle-capsule-plugin
         classpath "us.kirchmeier:gradle-capsule-plugin:1.0.4_r3"
         classpath group: "com.r3.testing", name: "gradle-distributed-testing-plugin", version: "1.2-LOCAL-K8S-SHARED-CACHE-SNAPSHOT", changing: true
-        classpath group: "com.r3.dependx", name: "gradle-dependx", version: "0.1.4", changing: true
+        classpath group: "com.r3.dependx", name: "gradle-dependx", version: "0.1.6", changing: true
         classpath "com.bmuschko:gradle-docker-plugin:5.0.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,7 @@ buildscript {
         // See https://github.com/corda/gradle-capsule-plugin
         classpath "us.kirchmeier:gradle-capsule-plugin:1.0.4_r3"
         classpath group: "com.r3.testing", name: "gradle-distributed-testing-plugin", version: "1.2-LOCAL-K8S-SHARED-CACHE-SNAPSHOT", changing: true
+        classpath group: "com.r3.dependx", name: "gradle-dependx", version: "0.1.4", changing: true
         classpath "com.bmuschko:gradle-docker-plugin:5.0.0"
     }
 }
@@ -204,6 +205,7 @@ apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: "com.bmuschko.docker-remote-api"
+apply plugin: "com.r3.dependx.dependxies"
 
 
 // If the command line project option -PversionFromGit is added to the gradle invocation, we'll resolve 
@@ -583,6 +585,11 @@ artifactory {
     }
 }
 
+dependxiesModule {
+    mode = "monitor"
+    skipTasks = "test,integrationTest,smokeTest,slowIntegrationTest"
+}
+
 task generateApi(type: net.corda.plugins.GenerateApi) {
     baseName = "api-corda"
 }
@@ -629,6 +636,7 @@ buildScan {
 }
 
 task allParallelIntegrationTest(type: ParallelTestGroup) {
+    dependsOn dependxiesModule
     podLogLevel PodLogLevel.INFO
     testGroups "integrationTest"
     numberOfShards 10
@@ -639,6 +647,7 @@ task allParallelIntegrationTest(type: ParallelTestGroup) {
     nodeTaints "big"
 }
 task allParallelUnitTest(type: ParallelTestGroup) {
+    dependsOn dependxiesModule
     podLogLevel PodLogLevel.INFO
     testGroups "test"
     numberOfShards 10
@@ -649,6 +658,7 @@ task allParallelUnitTest(type: ParallelTestGroup) {
     nodeTaints "small"
 }
 task allParallelUnitAndIntegrationTest(type: ParallelTestGroup) {
+    dependsOn dependxiesModule
     testGroups "test", "integrationTest"
     numberOfShards 15
     streamOutput false
@@ -659,6 +669,7 @@ task allParallelUnitAndIntegrationTest(type: ParallelTestGroup) {
 }
 task parallelRegressionTest(type: ParallelTestGroup) {
     testGroups "test", "integrationTest", "smokeTest"
+    dependsOn dependxiesModule
     numberOfShards 15
     streamOutput false
     coresPerFork 2
@@ -668,6 +679,7 @@ task parallelRegressionTest(type: ParallelTestGroup) {
 }
 task allParallelSmokeTest(type: ParallelTestGroup) {
     testGroups "smokeTest"
+    dependsOn dependxiesModule
     numberOfShards 4
     streamOutput false
     coresPerFork 6
@@ -677,6 +689,7 @@ task allParallelSmokeTest(type: ParallelTestGroup) {
 }
 task allParallelSlowIntegrationTest(type: ParallelTestGroup) {
     testGroups "slowIntegrationTest"
+    dependsOn dependxiesModule
     numberOfShards 4
     streamOutput false
     coresPerFork 6


### PR DESCRIPTION
This pr applies the newly created dependx gradle plugin in the test execution of corda.
This plugin, described in greater detail [here](https://github.com/corda/dependx-plugin) aims to skip unnecessary tests on pr builds by scanning the `git diff-tree` between origin and target branches, as well as the dependencies of any kind between modules, as they are described in the various build.gradle files.

As described in the plugin's readme, there are 2 modes, one that exposes a `skipExpr` task parameter to be appended on the gradle command executing the tests, and one that only monitors the modules that would be ignored and reports tasks that fail in these modules, and could highlights implicit dependencies across implementation changes and tests.

For now, the monitor mode is selected.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
