### PR TITLE
CORDA-3604 Store failed and hospitalised errors along with corresponding statuses

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.api
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.serialization.SerializedBytes
 import net.corda.node.services.statemachine.Checkpoint
+import net.corda.node.services.statemachine.CheckpointContext
 import net.corda.node.services.statemachine.FlowState
 import java.util.stream.Stream
 
@@ -19,6 +20,11 @@ interface CheckpointStorage {
      * Update an existing checkpoint. Will throw if there is not checkpoint for this id.
      */
     fun updateCheckpoint(id: StateMachineRunId, checkpoint: Checkpoint, serializedFlowState: SerializedBytes<FlowState>)
+
+    /**
+     * Update existing checkpoint's context. Will throw if there is not checkpoint for this id.
+     */
+    fun updateCheckpointContext(id: StateMachineRunId, checkpointContext: CheckpointContext)
 
     /**
      * Remove existing checkpoint from the store.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -42,6 +42,8 @@ sealed class Action {
      */
     data class PersistCheckpoint(val id: StateMachineRunId, val checkpoint: Checkpoint, val isCheckpointUpdate: Boolean) : Action()
 
+    data class UpdateCheckpointContext(val id: StateMachineRunId, val checkpointContext: CheckpointContext) : Action()
+
     /**
      * Remove the checkpoint corresponding to [id].
      */

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -53,6 +53,7 @@ class ActionExecutorImpl(
         return when (action) {
             is Action.TrackTransaction -> executeTrackTransaction(fiber, action)
             is Action.PersistCheckpoint -> executePersistCheckpoint(action)
+            is Action.UpdateCheckpointContext -> executeUpdateCheckpointContext(action)
             is Action.PersistDeduplicationFacts -> executePersistDeduplicationIds(action)
             is Action.AcknowledgeMessages -> executeAcknowledgeMessages(action)
             is Action.PropagateErrors -> executePropagateErrors(action)
@@ -100,6 +101,13 @@ class ActionExecutorImpl(
         } else {
             checkpointStorage.addCheckpoint(action.id, checkpoint, serializedFlowState)
         }
+    }
+
+    @Suspendable
+    private fun executeUpdateCheckpointContext(action: Action.UpdateCheckpointContext) {
+        // checkpoint context:
+        val checkpointContext = action.checkpointContext
+        checkpointStorage.updateCheckpointContext(action.id, checkpointContext)
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -51,20 +51,42 @@ data class StateMachineState(
 )
 
 /**
+ * Needs to be in sync when a flow retries from previous checkpoint
+ */
+interface CheckpointActual {
+    val checkpointState: CheckpointState
+    val flowState: FlowState
+    val errorState: ErrorState
+}
+
+/**
+ * Can be out of sync when a flow retries from previous checkpoint
+ */
+interface CheckpointContext {
+    val result: Any?
+    val status: Checkpoint.FlowStatus
+    val progressStep: String?
+    val flowIoRequest: Class<out FlowIORequest<*>>?
+    val compatible: Boolean
+}
+
+/**
  * @param checkpointState the state of the checkpoint
  * @param flowState the state of the flow itself, including the frozen fiber/FlowLogic.
  * @param errorState the "dirtiness" state including the involved errors and their propagation status.
  */
 data class Checkpoint(
-        val checkpointState: CheckpointState,
-        val flowState: FlowState,
-        val errorState: ErrorState,
-        val result: Any? = null,
-        val status: FlowStatus = FlowStatus.RUNNABLE,
-        val progressStep: String? = null,
-        val flowIoRequest: Class<out FlowIORequest<*>>? = null,
-        val compatible: Boolean = true
-) {
+        // Actual
+        override val checkpointState: CheckpointState,
+        override val flowState: FlowState,
+        override val errorState: ErrorState,
+        // Context
+        override val result: Any? = null,
+        override val status: FlowStatus = FlowStatus.RUNNABLE,
+        override val progressStep: String? = null,
+        override val flowIoRequest: Class<out FlowIORequest<*>>? = null,
+        override val compatible: Boolean = true
+): CheckpointActual, CheckpointContext {
     @CordaSerializable
     enum class FlowStatus {
         RUNNABLE,

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -744,6 +744,12 @@ internal fun sessionData(payload: Any) = ExistingSessionMessage(SessionId(0), Da
 
 @InitiatingFlow
 internal open class SendFlow(private val payload: Any, private vararg val otherParties: Party) : FlowLogic<FlowInfo>() {
+
+    companion object {
+        var hookBeforeCheckpoint: () -> Unit = {}
+        var hookAfterCheckpoint: () -> Unit = {}
+    }
+
     init {
         require(otherParties.isNotEmpty())
     }
@@ -752,7 +758,9 @@ internal open class SendFlow(private val payload: Any, private vararg val otherP
     override fun call(): FlowInfo {
         val flowInfos = otherParties.map {
             val session = initiateFlow(it)
+            hookBeforeCheckpoint()
             session.send(payload)
+            hookAfterCheckpoint()
             session.getCounterpartyFlowInfo()
         }.toList()
         return flowInfos.first()


### PR DESCRIPTION
With this PR we set the `Checkpoint.status` to 'FAILED' every time a flow is failing, and to 'HOSPITALIZED' whenever a flow gets kept in Hospital for observation along with their errors.

This PR triggered some draft thinking of categorizing the `Checkpoint`'s old and new fields. 
Since we introduced new fields to the checkpoint/ extracted some out of the checkpoint blob, we now have the fields that are the actual checkpoint as we used to know it, which, have to get persisted in the database whenever we actually persist a checkpoint. And then, there are the rest ones, that can get persisted even when we don't really  persist a checkpoint.