### PR TITLE
CORDA-3394: Move the unit test to the correct location

### DIFF
--- a/core/src/test/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtilsBuilderTest.kt
+++ b/core/src/test/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtilsBuilderTest.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.vault
+package net.corda.core.node.services.vault
 
 import net.corda.core.node.services.vault.BinaryComparisonOperator
 import net.corda.core.node.services.vault.Builder.`in`


### PR DESCRIPTION
Move the unit test to the correct location.