### PR TITLE
ENT-4334 - Don't stop the node inside the unit test

### DIFF
--- a/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/QuasarExcludePackagesTest.kt
@@ -47,8 +47,7 @@ class QuasarExcludePackagesTest {
         val nodeConfiguration :NodeConfiguration = V1NodeConfigurationSpec.parse(config).value()
 
         // Act
-        val node = Node(nodeConfiguration, VersionInfo.UNKNOWN)
-        node.stop()
+        Node(nodeConfiguration, VersionInfo.UNKNOWN)
 
         // Assert
         Assert.assertTrue(Retransform.getInstrumentor().isExcluded("net.corda.node.internal.QuasarExcludePackagesTest.Test"))


### PR DESCRIPTION
The test node had not been started and is causing tests to fail.