### PR TITLE
CORDA-3644: Add Corda-Testing tag to core-test-utils manifest.

### DIFF
--- a/testing/core-test-utils/build.gradle
+++ b/testing/core-test-utils/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 
 jar {
     baseName 'corda-core-test-utils'
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
 }
 
 publish {


### PR DESCRIPTION
Add `Corda-Testing` tag to ensure Driver doesn't deploy this artifact into an "out-of-process" node.