### PR TITLE
ENT-4494 Harmonize CryptoService 

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
@@ -61,11 +61,6 @@ interface CryptoService : SignOnlyCryptoService {
      */
     fun generateKeyPair(alias: String, scheme: SignatureScheme): PublicKey
 
-    /**
-     * Returns the type of the service.
-     */
-    fun getType(): SupportedCryptoServices
-
 
     // ******************************************************
     // ENTERPRISE ONLY CODE FOR WRAPPING KEYS API STARTS HERE

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoService.kt
@@ -17,7 +17,6 @@ import net.corda.nodeapi.internal.crypto.save
 import net.corda.nodeapi.internal.cryptoservice.*
 import net.corda.nodeapi.internal.cryptoservice.CryptoService
 import net.corda.nodeapi.internal.cryptoservice.CryptoServiceException
-import net.corda.nodeapi.internal.cryptoservice.SupportedCryptoServices
 import org.bouncycastle.operator.ContentSigner
 import java.nio.file.Path
 import java.security.*
@@ -40,8 +39,6 @@ class BCCryptoService(private val legalName: X500Principal,
     private companion object {
         val detailedLogger = detailedLogger()
     }
-
-    override fun getType(): SupportedCryptoServices = SupportedCryptoServices.BC_SIMPLE
 
     // TODO check if keyStore exists.
     // TODO make it private when E2ETestKeyManagementService does not require direct access to the private key.

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -150,8 +150,8 @@ import net.corda.nodeapi.internal.crypto.X509Utilities.DEFAULT_VALIDITY_WINDOW
 import net.corda.nodeapi.internal.crypto.X509Utilities.DISTRIBUTED_NOTARY_COMPOSITE_KEY_ALIAS
 import net.corda.nodeapi.internal.crypto.X509Utilities.DISTRIBUTED_NOTARY_KEY_ALIAS
 import net.corda.nodeapi.internal.crypto.X509Utilities.NODE_IDENTITY_KEY_ALIAS
-import net.corda.nodeapi.internal.cryptoservice.CryptoServiceFactory
-import net.corda.nodeapi.internal.cryptoservice.SupportedCryptoServices
+import net.corda.node.utilities.cryptoservice.CryptoServiceFactory
+import net.corda.node.utilities.cryptoservice.SupportedCryptoServices
 import net.corda.nodeapi.internal.cryptoservice.bouncycastle.BCCryptoService
 import net.corda.nodeapi.internal.lifecycle.NodeLifecycleEvent
 import net.corda.nodeapi.internal.lifecycle.NodeLifecycleEventsDistributor

--- a/node/src/main/kotlin/net/corda/node/utilities/cryptoservice/CryptoServiceFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/cryptoservice/CryptoServiceFactory.kt
@@ -1,7 +1,8 @@
-package net.corda.nodeapi.internal.cryptoservice
+package net.corda.node.utilities.cryptoservice
 
 import net.corda.core.identity.CordaX500Name
 import net.corda.nodeapi.internal.config.FileBasedCertificateStoreSupplier
+import net.corda.nodeapi.internal.cryptoservice.CryptoService
 import net.corda.nodeapi.internal.cryptoservice.bouncycastle.BCCryptoService
 
 class CryptoServiceFactory {

--- a/node/src/main/kotlin/net/corda/node/utilities/cryptoservice/SupportedCryptoServices.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/cryptoservice/SupportedCryptoServices.kt
@@ -1,4 +1,4 @@
-package net.corda.nodeapi.internal.cryptoservice
+package net.corda.node.utilities.cryptoservice
 
 enum class SupportedCryptoServices(val userFriendlyName: String) {
     /** Identifier for [BCCryptoService]. */

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -18,8 +18,8 @@ import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_CLIENT_TLS
 import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_ROOT_CA
 import net.corda.nodeapi.internal.crypto.X509Utilities.DEFAULT_VALIDITY_WINDOW
 import net.corda.nodeapi.internal.cryptoservice.CryptoService
-import net.corda.nodeapi.internal.cryptoservice.CryptoServiceFactory
-import net.corda.nodeapi.internal.cryptoservice.SupportedCryptoServices
+import net.corda.node.utilities.cryptoservice.CryptoServiceFactory
+import net.corda.node.utilities.cryptoservice.SupportedCryptoServices
 import net.corda.nodeapi.internal.cryptoservice.bouncycastle.BCCryptoService
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockCryptoService.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockCryptoService.kt
@@ -10,7 +10,6 @@ import net.corda.nodeapi.internal.crypto.ContentSignerBuilder
 import net.corda.nodeapi.internal.cryptoservice.*
 import net.corda.nodeapi.internal.cryptoservice.CryptoService
 import net.corda.nodeapi.internal.cryptoservice.CryptoServiceException
-import net.corda.nodeapi.internal.cryptoservice.SupportedCryptoServices
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
 import java.security.PrivateKey
@@ -21,8 +20,6 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 
 class MockCryptoService(initialKeyPairs: Map<String, KeyPair>) : CryptoService {
-
-    override fun getType(): SupportedCryptoServices = SupportedCryptoServices.BC_SIMPLE
 
     private val aliasToKey: MutableMap<String, KeyPair> = mutableMapOf()
 


### PR DESCRIPTION
- Harmonize CryptoService interface/base class between OS and ENT
- move OS BC implementation to node project.
