### PR TITLE
CORDA-3596 Record flow metadata

### DIFF
--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -9,7 +9,7 @@ import net.corda.finance.flows.AbstractCashFlow;
 import net.corda.finance.flows.CashIssueFlow;
 import net.corda.finance.flows.CashPaymentFlow;
 import net.corda.finance.schemas.CashSchemaV1;
-import net.corda.node.internal.NodeWithInfo;
+import net.corda.testing.node.internal.NodeWithInfo;
 import net.corda.testing.internal.InternalTestUtilsKt;
 import net.corda.testing.node.User;
 import net.corda.testing.node.internal.NodeBasedTest;

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -20,7 +20,7 @@ import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
 import net.corda.finance.workflows.getCashBalance
 import net.corda.finance.workflows.getCashBalances
-import net.corda.node.internal.NodeWithInfo
+import net.corda.testing.node.internal.NodeWithInfo
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.testing.common.internal.checkNotOnClasspath
 import net.corda.testing.core.*

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
@@ -2,10 +2,8 @@ package net.corda.client.rpc
 
 import net.corda.core.context.Actor
 import net.corda.core.context.Trace
-import net.corda.core.internal.packageName
 import net.corda.core.messaging.CordaRPCOps
-import net.corda.finance.schemas.CashSchemaV1
-import net.corda.node.internal.NodeWithInfo
+import net.corda.testing.node.internal.NodeWithInfo
 import net.corda.node.services.Permissions
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.node.User

--- a/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
@@ -10,7 +10,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.node.internal.DataSourceFactory
-import net.corda.node.internal.NodeWithInfo
+import net.corda.testing.node.internal.NodeWithInfo
 import net.corda.node.services.Permissions
 import net.corda.node.services.config.PasswordEncryption
 import net.corda.testing.core.ALICE_NAME

--- a/node/src/integration-test/kotlin/net/corda/node/services/persistence/CordaPersistenceServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/persistence/CordaPersistenceServiceTests.kt
@@ -94,7 +94,7 @@ class CordaPersistenceServiceTests {
                 startType = DBCheckpointStorage.StartReason.RPC,
                 launchingCordapp = "this cordapp",
                 platformVersion = PLATFORM_VERSION,
-                rpcUsername = "Batman",
+                startedBy = "Batman",
                 invocationInstant = Instant.now(),
                 receivedInstant = Instant.now(),
                 startInstant = timestamp,

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -14,7 +14,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
-import net.corda.node.internal.NodeWithInfo
+import net.corda.testing.node.internal.NodeWithInfo
 import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.INTERNAL_PREFIX
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NOTIFICATIONS_ADDRESS

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -320,7 +320,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     protected val network: MessagingService = makeMessagingService().tokenize()
     val services = ServiceHubInternalImpl().tokenize()
     val checkpointStorage = DBCheckpointStorage(DBCheckpointPerformanceRecorder(services.monitoringService.metrics))
-    val flowMetadataRecorder = FlowMetadataRecorder(checkpointStorage, database, platformClock)
+    val flowMetadataRecorder = FlowMetadataRecorder(checkpointStorage, cordappProvider, database, platformClock)
     @Suppress("LeakingThis")
     val smm = makeStateMachineManager()
     val flowStarter = FlowStarterImpl(smm, flowLogicRefFactory)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -320,7 +320,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     protected val network: MessagingService = makeMessagingService().tokenize()
     val services = ServiceHubInternalImpl().tokenize()
     val checkpointStorage = DBCheckpointStorage(DBCheckpointPerformanceRecorder(services.monitoringService.metrics))
-    val flowMetadataRecorder = FlowMetadataRecorder(checkpointStorage, platformClock, database)
+    val flowMetadataRecorder = FlowMetadataRecorder(checkpointStorage, database, platformClock)
     @Suppress("LeakingThis")
     val smm = makeStateMachineManager()
     val flowStarter = FlowStarterImpl(smm, flowLogicRefFactory)

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -117,7 +117,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(
             startedType = DBCheckpointStorage.StartReason.SERVICE,
             // the name of the service starting the flow (qualified name is too long)
             // make the field longer or limit the name (the service name could be long as well)
-            rpcUser = serviceInstance::class.simpleName!!
+            startedBy = serviceInstance::class.simpleName!!
         )
         return flowStarter.startFlow(flow, context).getOrThrow()
     }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -264,7 +264,7 @@ internal class CordaRPCOpsImpl(
             flow = logicType,
             invocationContext = context,
             startedType = DBCheckpointStorage.StartReason.RPC,
-            rpcUser = context.actor?.id?.value ?: UNKNOWN_RPC_USER,
+            startedBy = context.actor?.id?.value ?: UNKNOWN_RPC_USER,
             parameters = args.toList(),
             // This is will need to be filled in by the actual userSuppliedIdentifier in future changes
             userSuppliedIdentifier = null

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -48,9 +48,6 @@ import net.corda.node.serialization.amqp.AMQPServerSerializationScheme
 import net.corda.node.serialization.kryo.KRYO_CHECKPOINT_CONTEXT
 import net.corda.node.serialization.kryo.KryoCheckpointSerializer
 import net.corda.node.services.Permissions
-import net.corda.node.services.api.FlowStarter
-import net.corda.node.services.api.ServiceHubInternal
-import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.config.JmxReporterType
 import net.corda.node.services.config.MB
 import net.corda.node.services.config.NodeConfiguration
@@ -104,12 +101,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.management.ObjectName
 import kotlin.system.exitProcess
-
-class NodeWithInfo(val node: Node, val info: NodeInfo) {
-    val services: StartedNodeServices = object : StartedNodeServices, ServiceHubInternal by node.services, FlowStarter by node.flowStarter {}
-    fun dispose() = node.stop()
-    fun <T : FlowLogic<*>> registerInitiatedFlow(initiatedFlowClass: Class<T>) = node.registerInitiatedFlow(node.smm, initiatedFlowClass)
-}
 
 /**
  * A Node manages a standalone server that takes part in the P2P network. It creates the services found in [ServiceHub],

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
@@ -217,4 +217,6 @@ open class CordappProviderImpl(val cordappLoader: CordappLoader,
     fun getCordappForClass(className: String): Cordapp? = cordapps.find { it.cordappClasses.contains(className) }
 
     override fun getCordappForFlow(flowLogic: FlowLogic<*>) = cordappLoader.flowCordappMap[flowLogic.javaClass]
+
+    override fun getCordappForFlow(flowLogicClass: Class<out FlowLogic<*>>) = cordappLoader.flowCordappMap[flowLogicClass]
 }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderInternal.kt
@@ -10,5 +10,6 @@ import net.corda.core.internal.cordapp.CordappImpl
 interface CordappProviderInternal : CordappProvider, CordappFixupInternal {
     val cordapps: List<CordappImpl>
     fun getCordappForFlow(flowLogic: FlowLogic<*>): Cordapp?
+    fun getCordappForFlow(flowLogicClass: Class<out FlowLogic<*>>): Cordapp?
     fun fixupAttachments(attachments: Collection<Attachment>): Collection<Attachment>
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -60,7 +60,7 @@ interface CheckpointStorage {
         val parameters: List<Any?>,
         val launchingCordapp: String,
         val platformVersion: Int,
-        val rpcUser: String,
+        val startedBy: String,
         val invocationInstant: Instant,
         val receivedInstant: Instant
     )

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -3,8 +3,10 @@ package net.corda.node.services.api
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.FlowIORequest
 import net.corda.core.serialization.SerializedBytes
+import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.node.services.statemachine.Checkpoint
 import net.corda.node.services.statemachine.FlowState
+import java.time.Instant
 import java.util.stream.Stream
 
 /**
@@ -42,4 +44,24 @@ interface CheckpointStorage {
      * underlying database connection is closed, so any processing should happen before it is closed.
      */
     fun getAllCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
+
+    fun addMetadata(metadata: FlowMetadata)
+
+    // should use the still serialized parameters to save extra serialization
+    // passing in serialized arguments means that the flow name will be included
+    // as that is one of the arguments to start flow
+    // this is correctness vs performance
+    // the flow name could always be removed on the client side
+    data class FlowMetadata(
+        val invocationId: String,
+        val flowName: String,
+        val userSuppliedIdentifier: String?,
+        val startedType: DBCheckpointStorage.StartReason,
+        val parameters: List<Any?>,
+        val launchingCordapp: String,
+        val platformVersion: Int,
+        val rpcUser: String,
+        val invocationInstant: Instant,
+        val receivedInstant: Instant
+    )
 }

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -290,7 +290,7 @@ class NodeSchedulerService(
                         invocationContext = context,
                         startedType = DBCheckpointStorage.StartReason.SCHEDULED,
                         // Would be great to have the name of the state that triggered this scheduled operation
-                        rpcUser = serviceHub.myInfo.legalIdentities[0].name.toString()
+                        startedBy = serviceHub.myInfo.legalIdentities[0].name.toString()
                     )
                     flowStarter.startFlow(startFlowEvent)
                 }

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -290,7 +290,7 @@ class NodeSchedulerService(
                         invocationContext = context,
                         startedType = DBCheckpointStorage.StartReason.SCHEDULED,
                         // Would be great to have the name of the state that triggered this scheduled operation
-                        startedBy = serviceHub.myInfo.legalIdentities[0].name.toString()
+                        startedBy = serviceHub.myInfo.legalIdentities[0].toString()
                     )
                     flowStarter.startFlow(startFlowEvent)
                 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services.persistence
 
 import net.corda.core.flows.StateMachineRunId
-import net.corda.core.internal.PLATFORM_VERSION
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
@@ -200,8 +199,8 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         @Column(name = "platform_version", nullable = false)
         var platformVersion: Int,
 
-        @Column(name = "rpc_user", nullable = false)
-        var rpcUsername: String,
+        @Column(name = "started_by", nullable = false)
+        var startedBy: String,
 
         @Column(name = "invocation_time", nullable = false)
         var invocationInstant: Instant,
@@ -259,7 +258,7 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
                 initialParameters = metadata.parameters.storageSerialize().bytes,
                 launchingCordapp = launchingCordapp,
                 platformVersion = platformVersion,
-                rpcUsername = rpcUser,
+                startedBy = startedBy,
                 invocationInstant = invocationInstant,
                 receivedInstant = receivedInstant,
                 startInstant = null,
@@ -287,7 +286,6 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
 
         val blob = createDBCheckpointBlob(serializedCheckpointState, serializedFlowState, now)
         // Need to update the metadata record to join it to the main checkpoint record
-
         val metadata = requireNotNull(
             currentDBSession().find(
                 DBFlowMetadata::class.java,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
@@ -10,8 +10,8 @@ import java.time.Clock
 
 class FlowMetadataRecorder(
     private val checkpointStorage: CheckpointStorage,
-    private val clock: Clock,
-    private val database: CordaPersistence? = null
+    private val database: CordaPersistence,
+    private val clock: Clock
 ) {
 
     fun record(
@@ -22,7 +22,7 @@ class FlowMetadataRecorder(
         parameters: List<Any?> = emptyList(),
         userSuppliedIdentifier: String? = null
     ) {
-        database?.transaction {
+        database.transaction {
             checkpointStorage.addMetadata(
                 CheckpointStorage.FlowMetadata(
                     invocationId = invocationContext.trace.invocationId.value,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
@@ -26,7 +26,7 @@ class FlowMetadataRecorder(
             checkpointStorage.addMetadata(
                 CheckpointStorage.FlowMetadata(
                     invocationId = invocationContext.trace.invocationId.value,
-                    flowName = flow.canonicalName,
+                    flowName = flow.canonicalName ?: flow.name,
                     // Is this the right value to pass in?
                     userSuppliedIdentifier = userSuppliedIdentifier,
                     startedType = startedType,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
@@ -18,7 +18,7 @@ class FlowMetadataRecorder(
         flow: Class<out FlowLogic<*>>,
         invocationContext: InvocationContext,
         startedType: DBCheckpointStorage.StartReason,
-        rpcUser: String,
+        startedBy: String,
         parameters: List<Any?> = emptyList(),
         userSuppliedIdentifier: String? = null
     ) {
@@ -39,7 +39,7 @@ class FlowMetadataRecorder(
                     launchingCordapp = "where do I get this info?",
                     platformVersion = PLATFORM_VERSION,
                     // might be able to keep the code above depends on what the context contains in it
-                    rpcUser = rpcUser,
+                    startedBy = startedBy,
                     invocationInstant = invocationContext.trace.invocationId.timestamp,
                     // Just take now's time or record it earlier and pass it to here?
                     receivedInstant = clock.instant()

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorder.kt
@@ -1,0 +1,50 @@
+package net.corda.node.services.statemachine
+
+import net.corda.core.context.InvocationContext
+import net.corda.core.flows.FlowLogic
+import net.corda.core.internal.PLATFORM_VERSION
+import net.corda.node.services.api.CheckpointStorage
+import net.corda.node.services.persistence.DBCheckpointStorage
+import net.corda.nodeapi.internal.persistence.CordaPersistence
+import java.time.Clock
+
+class FlowMetadataRecorder(
+    private val checkpointStorage: CheckpointStorage,
+    private val clock: Clock,
+    private val database: CordaPersistence? = null
+) {
+
+    fun record(
+        flow: Class<out FlowLogic<*>>,
+        invocationContext: InvocationContext,
+        startedType: DBCheckpointStorage.StartReason,
+        rpcUser: String,
+        parameters: List<Any?> = emptyList(),
+        userSuppliedIdentifier: String? = null
+    ) {
+        database?.transaction {
+            checkpointStorage.addMetadata(
+                CheckpointStorage.FlowMetadata(
+                    invocationId = invocationContext.trace.invocationId.value,
+                    flowName = flow.canonicalName,
+                    // Is this the right value to pass in?
+                    userSuppliedIdentifier = userSuppliedIdentifier,
+                    startedType = startedType,
+                    // Do not include the flow name in the parameters list
+                    parameters = parameters,
+                    // Probably going to be filled in on flow start
+                    // CordappProvider.getCordappForFlow
+                    // Either DI the class or it can be filled in on flow start since the information is held
+                    // within the first checkpoint (inside the [SubFlow] class
+                    launchingCordapp = "where do I get this info?",
+                    platformVersion = PLATFORM_VERSION,
+                    // might be able to keep the code above depends on what the context contains in it
+                    rpcUser = rpcUser,
+                    invocationInstant = invocationContext.trace.invocationId.timestamp,
+                    // Just take now's time or record it earlier and pass it to here?
+                    receivedInstant = clock.instant()
+                )
+            )
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -557,7 +557,7 @@ class SingleThreadedStateMachineManager(
             flow = flowLogic::class.java,
             invocationContext = invocationContext,
             startedType = DBCheckpointStorage.StartReason.INITIATED,
-            rpcUser = peerSession.counterparty.name.toString()
+            startedBy = peerSession.counterparty.name.toString()
         )
         val ourIdentity = ourFirstIdentity
         startFlowInternal(

--- a/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
@@ -122,7 +122,7 @@
             <column name="platform_version" type="TINYINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="rpc_user" type="NVARCHAR(64)">
+            <column name="started_by" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
             <column name="invocation_time" type="java.sql.Types.TIMESTAMP">

--- a/node/src/main/resources/migration/node-core.changelog-v17.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17.xml
@@ -122,7 +122,7 @@
             <column name="platform_version" type="TINYINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="rpc_user" type="NVARCHAR(64)">
+            <column name="started_by" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
             <column name="invocation_time" type="java.sql.Types.TIMESTAMP">

--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -150,8 +150,8 @@ class NodeSchedulerServiceTest : NodeSchedulerServiceTestBase() {
                 // do nothing
             }
         }),
-        testClock,
-        database
+        database,
+        testClock
     )
 
     private val scheduler = NodeSchedulerService(
@@ -287,8 +287,8 @@ class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
                     // do nothing
                 }
             }),
-            testClock,
-            db
+            db,
+            testClock
         )
         return NodeSchedulerService(
             testClock,

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -525,7 +525,7 @@ class DBCheckpointStorageTests {
             startType = DBCheckpointStorage.StartReason.RPC,
             launchingCordapp = "this cordapp",
             platformVersion = PLATFORM_VERSION,
-            rpcUsername = "Batman",
+            startedBy = "Batman",
             invocationInstant = checkpoint.checkpointState.invocationContext.trace.invocationId.timestamp,
             receivedInstant = Instant.now(),
             startInstant = null,

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
@@ -105,7 +105,7 @@ class FlowMetadataRecorderTest {
                 // Needs to be filled in
                 assertEquals("where do I get this info?", it.launchingCordapp)
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
-                assertEquals(user.username, it.rpcUsername)
+                assertEquals(user.username, it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
                 assertTrue(it.receivedInstant >= it.invocationInstant)
                 assertNull(it.startInstant)
@@ -153,7 +153,7 @@ class FlowMetadataRecorderTest {
                 // needs to be filled in
                 assertEquals("where do I get this info?", it.launchingCordapp)
                 assertEquals(6, it.platformVersion)
-                assertEquals(nodeAHandle.nodeInfo.singleIdentity().name.toString(), it.rpcUsername)
+                assertEquals(nodeAHandle.nodeInfo.singleIdentity().name.toString(), it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
                 assertTrue(it.receivedInstant >= it.invocationInstant)
                 assertNull(it.startInstant)
@@ -201,7 +201,7 @@ class FlowMetadataRecorderTest {
                 // needs to be filled in
                 assertEquals("where do I get this info?", it.launchingCordapp)
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
-                assertEquals(MyService::class.simpleName, it.rpcUsername)
+                assertEquals(MyService::class.simpleName, it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
                 assertTrue(it.receivedInstant >= it.invocationInstant)
                 assertNull(it.startInstant)
@@ -259,7 +259,7 @@ class FlowMetadataRecorderTest {
                 // needs to be filled in
                 assertEquals("where do I get this info?", it.launchingCordapp)
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
-                assertEquals(nodeAHandle.nodeInfo.singleIdentity().toString(), it.rpcUsername)
+                assertEquals(nodeAHandle.nodeInfo.singleIdentity().toString(), it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
                 assertTrue(it.receivedInstant >= it.invocationInstant)
                 assertNull(it.startInstant)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
@@ -1,0 +1,389 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.context.InvocationContext
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.SchedulableState
+import net.corda.core.contracts.ScheduledActivity
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.flows.FlowExternalAsyncOperation
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowLogicRefFactory
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.SchedulableFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.StartableByService
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.identity.Party
+import net.corda.core.internal.PLATFORM_VERSION
+import net.corda.core.messaging.startFlow
+import net.corda.core.node.AppServiceHub
+import net.corda.core.node.services.CordaService
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.SerializationDefaults
+import net.corda.core.serialization.SingletonSerializeAsToken
+import net.corda.core.serialization.deserialize
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.Permissions
+import net.corda.node.services.persistence.DBCheckpointStorage
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.User
+import org.junit.Before
+import org.junit.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.function.Supplier
+import kotlin.reflect.jvm.jvmName
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FlowMetadataRecorderTest {
+
+    private val user = User("mark", "dadada", setOf(Permissions.all()))
+    private val string = "I must be delivered for 4.5"
+    private val someObject = SomeObject("Store me in the database please", 1234)
+
+    @Before
+    fun before() {
+        MyFlow.hook = null
+        MyResponder.hook = null
+    }
+
+    @Test(timeout = 300_000)
+    fun `rpc started flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyFlow.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                }
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyFlow::class.qualifiedName, it.flowName)
+                // Should be changed when [userSuppliedIdentifier] gets filled in future changes
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.RPC, it.startType)
+                assertEquals(
+                    listOf(nodeBHandle.nodeInfo.singleIdentity(), string, someObject),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                // Needs to be filled in
+                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertEquals(PLATFORM_VERSION, it.platformVersion)
+                assertEquals(user.username, it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `initiated flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyResponder.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                }
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyResponder::class.qualifiedName, it.flowName)
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.INITIATED, it.startType)
+                assertEquals(
+                    emptyList<Any?>(),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                // needs to be filled in
+                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertEquals(6, it.platformVersion)
+                assertEquals(nodeAHandle.nodeInfo.singleIdentity().name.toString(), it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `service started flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyFlow.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                }
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyServiceStartingFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyFlow::class.qualifiedName, it.flowName)
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.SERVICE, it.startType)
+                assertEquals(
+                    emptyList<Any?>(),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                // needs to be filled in
+                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertEquals(PLATFORM_VERSION, it.platformVersion)
+                assertEquals(MyService::class.simpleName, it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `scheduled flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            val lock = Semaphore(1)
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyFlow.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                    // Release the lock so the asserts can be processed
+                    lock.release()
+                }
+
+            // Acquire the lock to prevent the asserts from being processed too early
+            lock.acquire()
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyStartedScheduledFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                    ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            // Block here until released in the hook
+            lock.acquire()
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyFlow::class.qualifiedName, it.flowName)
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.SCHEDULED, it.startType)
+                assertEquals(
+                    emptyList<Any?>(),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                // needs to be filled in
+                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertEquals(PLATFORM_VERSION, it.platformVersion)
+                assertEquals(nodeAHandle.nodeInfo.singleIdentity().toString(), it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @InitiatingFlow
+    @StartableByRPC
+    @StartableByService
+    @SchedulableFlow
+    class MyFlow(private val party: Party, string: String, someObject: SomeObject) :
+        FlowLogic<Unit>() {
+
+        companion object {
+            var hook: ((
+                flowId: StateMachineRunId,
+                context: InvocationContext,
+                metadata: DBCheckpointStorage.DBFlowMetadata
+            ) -> Unit)? = null
+        }
+
+        @Suspendable
+        override fun call() {
+            initiateFlow(party).sendAndReceive<String>("Hello there")
+            hook?.let {
+                it(
+                    stateMachine.id,
+                    stateMachine.context,
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                )
+            }
+        }
+    }
+
+    @InitiatedBy(MyFlow::class)
+    class MyResponder(private val session: FlowSession) : FlowLogic<Unit>() {
+
+        companion object {
+            var hook: ((
+                flowId: StateMachineRunId,
+                context: InvocationContext,
+                metadata: DBCheckpointStorage.DBFlowMetadata
+            ) -> Unit)? = null
+        }
+
+        @Suspendable
+        override fun call() {
+            session.receive<String>()
+            hook?.let {
+                it(
+                    stateMachine.id,
+                    stateMachine.context,
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                )
+            }
+            session.send("Hello there")
+        }
+    }
+
+    @StartableByRPC
+    class MyServiceStartingFlow(private val party: Party, private val string: String, private val someObject: SomeObject) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            await(object : FlowExternalAsyncOperation<Unit> {
+                override fun execute(deduplicationId: String): CompletableFuture<Unit> {
+                    return serviceHub.cordaService(MyService::class.java).startFlow(party, string, someObject)
+                }
+            })
+        }
+    }
+
+    @StartableByRPC
+    class MyStartedScheduledFlow(private val party: Party, private val string: String, private val someObject: SomeObject) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            val tx = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
+                addOutputState(ScheduledState(party, string, someObject, listOf(ourIdentity)))
+                addCommand(DummyContract.Commands.Create(), ourIdentity.owningKey)
+            }
+            val stx = serviceHub.signInitialTransaction(tx)
+            serviceHub.recordTransactions(stx)
+        }
+    }
+
+    @CordaService
+    class MyService(private val services: AppServiceHub) : SingletonSerializeAsToken() {
+
+        private val executorService = Executors.newFixedThreadPool(1)
+
+        fun findMetadata(context: InvocationContext): DBCheckpointStorage.DBFlowMetadata {
+            return services.database.transaction {
+                session.find(DBCheckpointStorage.DBFlowMetadata::class.java, context.trace.invocationId.value)
+            }
+        }
+
+        fun startFlow(party: Party, string: String, someObject: SomeObject): CompletableFuture<Unit> {
+            return CompletableFuture.supplyAsync(
+                Supplier<Unit> { services.startFlow(MyFlow(party, string, someObject)).returnValue.getOrThrow() },
+                executorService
+            )
+        }
+    }
+
+    @CordaSerializable
+    data class SomeObject(private val string: String, private val number: Int)
+
+    @BelongsToContract(DummyContract::class)
+    data class ScheduledState(
+        val party: Party,
+        val string: String,
+        val someObject: SomeObject,
+        override val participants: List<Party>,
+        override val linearId: UniqueIdentifier = UniqueIdentifier()
+    ) : SchedulableState, LinearState {
+
+        override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
+            val logicRef = flowLogicRefFactory.create(MyFlow::class.jvmName, party, string, someObject)
+            return ScheduledActivity(logicRef, Instant.now())
+        }
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
@@ -39,6 +39,7 @@ import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import java.time.Duration
@@ -102,8 +103,7 @@ class FlowMetadataRecorderTest {
                     listOf(nodeBHandle.nodeInfo.singleIdentity(), string, someObject),
                     it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
                 )
-                // Needs to be filled in
-                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
                 assertEquals(user.username, it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
@@ -150,8 +150,7 @@ class FlowMetadataRecorderTest {
                     emptyList<Any?>(),
                     it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
                 )
-                // needs to be filled in
-                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
                 assertEquals(6, it.platformVersion)
                 assertEquals(nodeAHandle.nodeInfo.singleIdentity().name.toString(), it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
@@ -198,8 +197,7 @@ class FlowMetadataRecorderTest {
                     emptyList<Any?>(),
                     it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
                 )
-                // needs to be filled in
-                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
                 assertEquals(MyService::class.simpleName, it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
@@ -256,8 +254,7 @@ class FlowMetadataRecorderTest {
                     emptyList<Any?>(),
                     it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
                 )
-                // needs to be filled in
-                assertEquals("where do I get this info?", it.launchingCordapp)
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
                 assertEquals(nodeAHandle.nodeInfo.singleIdentity().toString(), it.startedBy)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt
@@ -4,7 +4,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.node.internal.NodeWithInfo
+import net.corda.testing.node.internal.NodeWithInfo
 import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.nodeapi.internal.persistence.CordaPersistence

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -41,7 +41,6 @@ import net.corda.core.utilities.millis
 import net.corda.node.NodeRegistrationOption
 import net.corda.node.VersionInfo
 import net.corda.node.internal.Node
-import net.corda.node.internal.NodeWithInfo
 import net.corda.node.internal.clientSslOptionsCompatibleWith
 import net.corda.node.services.Permissions
 import net.corda.node.services.config.ConfigHelper

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -4,6 +4,8 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.common.configuration.parsing.internal.ConfigurationWithOptions
 import net.corda.core.DoNotImplement
+import net.corda.core.concurrent.CordaFuture
+import net.corda.core.context.InvocationContext
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.random63BitValue
@@ -12,8 +14,15 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.*
+import net.corda.core.internal.FlowIORequest
+import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.NetworkParametersStorage
+import net.corda.core.internal.PLATFORM_VERSION
+import net.corda.core.internal.VisibleForTesting
+import net.corda.core.internal.createDirectories
+import net.corda.core.internal.div
 import net.corda.core.internal.notary.NotaryService
+import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.RPCOps
@@ -33,13 +42,19 @@ import net.corda.node.internal.NodeFlowManager
 import net.corda.node.services.api.FlowStarter
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.api.StartedNodeServices
-import net.corda.node.services.config.*
+import net.corda.node.services.config.FlowTimeoutConfiguration
+import net.corda.node.services.config.NetworkParameterAcceptanceSettings
+import net.corda.node.services.config.NodeConfiguration
+import net.corda.node.services.config.NotaryConfig
+import net.corda.node.services.config.VerifierType
 import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.keys.BasicHSMKeyManagementService
 import net.corda.node.services.keys.KeyManagementServiceInternal
 import net.corda.node.services.messaging.Message
 import net.corda.node.services.messaging.MessagingService
+import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.node.services.persistence.NodeAttachmentService
+import net.corda.node.services.statemachine.ExternalEvent
 import net.corda.node.services.statemachine.FlowState
 import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.node.utilities.AffinityExecutor.ServiceAffinityExecutor
@@ -54,8 +69,12 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.internal.stubs.CertificateStoreStubs
 import net.corda.testing.internal.testThreadFactory
-import net.corda.testing.node.*
+import net.corda.testing.node.InMemoryMessagingNetwork
+import net.corda.testing.node.MockNetworkNotarySpec
+import net.corda.testing.node.MockNetworkParameters
+import net.corda.testing.node.MockNodeParameters
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
+import net.corda.testing.node.TestClock
 import org.apache.activemq.artemis.utils.ReusableLatch
 import org.apache.sshd.common.util.security.SecurityUtils
 import rx.Observable
@@ -278,6 +297,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
     ) {
         companion object {
             private val staticLog = contextLogger()
+            private val UNKNOWN_RPC_USER = "Unknown RPC user"
         }
 
         /** The actual [TestStartedNode] implementation created by this node */
@@ -330,15 +350,49 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
 
         override fun createStartedNode(nodeInfo: NodeInfo, rpcOps: CordaRPCOps, notaryService: NotaryService?): TestStartedNode {
             return TestStartedNodeImpl(
-                    this,
-                    attachments,
-                    network as MockNodeMessagingService,
-                    object : StartedNodeServices, ServiceHubInternal by services, FlowStarter by flowStarter {},
-                    nodeInfo,
-                    smm,
-                    database,
-                    rpcOps,
-                    notaryService
+                this,
+                attachments,
+                network as MockNodeMessagingService,
+                object : StartedNodeServices, ServiceHubInternal by services, FlowStarter by flowStarter {
+                    override fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<FlowStateMachine<T>> {
+                        flowMetadataRecorder.record(
+                            flow = event.flowLogic::class.java,
+                            invocationContext = event.context,
+                            startedType = DBCheckpointStorage.StartReason.RPC,
+                            startedBy = event.context.actor?.id?.value ?: UNKNOWN_RPC_USER
+                        )
+                        return flowStarter.startFlow(event)
+                    }
+
+                    override fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+                        flowMetadataRecorder.record(
+                            flow = logic::class.java,
+                            invocationContext = context,
+                            startedType = DBCheckpointStorage.StartReason.RPC,
+                            startedBy = context.actor?.id?.value ?: UNKNOWN_RPC_USER
+                        )
+                        return flowStarter.startFlow(logic, context)
+                    }
+
+                    override fun <T> invokeFlowAsync(
+                        logicType: Class<out FlowLogic<T>>,
+                        context: InvocationContext,
+                        vararg args: Any?
+                    ): CordaFuture<FlowStateMachine<T>> {
+                        flowMetadataRecorder.record(
+                            flow = logicType,
+                            invocationContext = context,
+                            startedType = DBCheckpointStorage.StartReason.RPC,
+                            startedBy = context.actor?.id?.value ?: UNKNOWN_RPC_USER
+                        )
+                        return flowStarter.invokeFlowAsync(logicType, context)
+                    }
+                },
+                nodeInfo,
+                smm,
+                database,
+                rpcOps,
+                notaryService
             )
         }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
@@ -14,7 +14,6 @@ import net.corda.node.VersionInfo
 import net.corda.node.internal.FlowManager
 import net.corda.node.internal.Node
 import net.corda.node.internal.NodeFlowManager
-import net.corda.node.internal.NodeWithInfo
 import net.corda.node.services.config.*
 import net.corda.nodeapi.internal.DevIdentityGenerator
 import net.corda.nodeapi.internal.config.toConfig

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeWithInfo.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeWithInfo.kt
@@ -1,0 +1,61 @@
+package net.corda.testing.node.internal
+
+import net.corda.core.concurrent.CordaFuture
+import net.corda.core.context.InvocationContext
+import net.corda.core.flows.FlowLogic
+import net.corda.core.internal.FlowStateMachine
+import net.corda.core.node.NodeInfo
+import net.corda.node.internal.FlowStarterImpl
+import net.corda.node.internal.Node
+import net.corda.node.services.api.FlowStarter
+import net.corda.node.services.api.ServiceHubInternal
+import net.corda.node.services.api.StartedNodeServices
+import net.corda.node.services.persistence.DBCheckpointStorage
+import net.corda.node.services.statemachine.ExternalEvent
+
+class NodeWithInfo(val node: Node, val info: NodeInfo) {
+
+    private companion object {
+        val UNKNOWN_RPC_USER = "Unknown RPC user"
+    }
+
+    val services: StartedNodeServices = object : StartedNodeServices, ServiceHubInternal by node.services, FlowStarter by node.flowStarter {
+
+        override fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<FlowStateMachine<T>> {
+            node.flowMetadataRecorder.record(
+                flow = event.flowLogic::class.java,
+                invocationContext = event.context,
+                startedType = DBCheckpointStorage.StartReason.RPC,
+                startedBy = event.context.actor?.id?.value ?: UNKNOWN_RPC_USER
+            )
+            return node.flowStarter.startFlow(event)
+        }
+
+        override fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+            node.flowMetadataRecorder.record(
+                flow = logic::class.java,
+                invocationContext = context,
+                startedType = DBCheckpointStorage.StartReason.RPC,
+                startedBy = context.actor?.id?.value ?: UNKNOWN_RPC_USER
+            )
+            return node.flowStarter.startFlow(logic, context)
+        }
+
+        override fun <T> invokeFlowAsync(
+            logicType: Class<out FlowLogic<T>>,
+            context: InvocationContext,
+            vararg args: Any?
+        ): CordaFuture<FlowStateMachine<T>> {
+            node.flowMetadataRecorder.record(
+                flow = logicType,
+                invocationContext = context,
+                startedType = DBCheckpointStorage.StartReason.RPC,
+                startedBy = context.actor?.id?.value ?: UNKNOWN_RPC_USER
+            )
+            return node.flowStarter.invokeFlowAsync(logicType, context)
+        }
+    }
+
+    fun dispose() = node.stop()
+    fun <T : FlowLogic<*>> registerInitiatedFlow(initiatedFlowClass: Class<T>) = node.registerInitiatedFlow(node.smm, initiatedFlowClass)
+}


### PR DESCRIPTION
For all types of flow starts, flow metadata is recorded. The type of
flow start determines what data can be recorded.

* `FlowMetadataRecorder` delegates to `CheckpointStorage` to record the
metadata of a flow. This class is called from all points where a new
flow is started. A new database transaction is opened to save the
metadata as this function is called outside the context of a flow and
therefore an existing database transaction.

* `RpcCallRecorder` provides a way to record RPC calls. For flows this
triggers the recording of a flow metadata record. For all other calls,
nothing current happens. This pathway will be filled in when merged with
 the RPC audit data work that is being done.

* `CheckpointStorage` has a new function, `addMetadata` and is
implemented in `DBCheckpointStorage`. For now, a new class has been
added inside of the internal (`FlowMetadata`) as a wrapper object that
can be passed to `addMetadata`. This stops the entity from leaking out
of `DBCheckpointStorage`.

* Various classes have had their constructors changed to allow the
recording classes to be passed into them.