### PR TITLE
NOTICK Fix statemachine error handling tests

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineGeneralErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineGeneralErrorHandlingTest.kt
@@ -34,15 +34,15 @@ class StatemachineGeneralErrorHandlingTest : StatemachineErrorHandlingTest() {
             val rules = """
                 RULE Create Counter
                 CLASS ${ActionExecutorImpl::class.java.name}
-                METHOD executeSendInitial
+                METHOD executeSendMultiple
                 AT ENTRY
                 IF createCounter("counter", $counter)
                 DO traceln("Counter created")
                 ENDRULE
 
-                RULE Throw exception on executeSendInitial action
+                RULE Throw exception on executeSendMultiple action
                 CLASS ${ActionExecutorImpl::class.java.name}
-                METHOD executeSendInitial
+                METHOD executeSendMultiple
                 AT ENTRY
                 IF readCounter("counter") < 4
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("die dammit die")
@@ -114,15 +114,15 @@ class StatemachineGeneralErrorHandlingTest : StatemachineErrorHandlingTest() {
             val rules = """
                 RULE Create Counter
                 CLASS ${ActionExecutorImpl::class.java.name}
-                METHOD executeSendInitial
+                METHOD executeSendMultiple
                 AT ENTRY
                 IF createCounter("counter", $counter)
                 DO traceln("Counter created")
                 ENDRULE
 
-                RULE Throw exception on executeSendInitial action
+                RULE Throw exception on executeSendMultiple action
                 CLASS ${ActionExecutorImpl::class.java.name}
-                METHOD executeSendInitial
+                METHOD executeSendMultiple
                 AT ENTRY
                 IF readCounter("counter") < 3
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("die dammit die")

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineKillFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineKillFlowErrorHandlingTest.kt
@@ -208,15 +208,15 @@ class StatemachineKillFlowErrorHandlingTest : StatemachineErrorHandlingTest() {
             val rules = """
                 RULE Create Counter
                 CLASS ${ActionExecutorImpl::class.java.name}
-                METHOD executeSendInitial
+                METHOD executeSendMultiple
                 AT ENTRY
                 IF createCounter("counter", $counter)
                 DO traceln("Counter created")
                 ENDRULE
 
-                RULE Throw exception on executeSendInitial action
+                RULE Throw exception on executeSendMultiple action
                 CLASS ${ActionExecutorImpl::class.java.name}
-                METHOD executeSendInitial
+                METHOD executeSendMultiple
                 AT ENTRY
                 IF readCounter("counter") < 4
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("die dammit die")


### PR DESCRIPTION
Due to a change in how messaging works, `ActionExecutorImpl.executeSendInitial` was no longer being called. Changing the byteman script to throw an exception on hits to `ActionExecutorImpl.executeSendMultiple` allowed the tests to pass.