### PR TITLE
CORDA-3599 Add progress tracker information to checkpoint

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -43,6 +43,8 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
 
         private const val HMAC_SIZE_BYTES = 16
 
+        private const val MAX_PROGRESS_STEP_LENGTH = 256
+
         /**
          * This needs to run before Hibernate is initialised.
          *
@@ -333,6 +335,9 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         //val result = updateDBFlowResult(entity, checkpoint, now)
         val exceptionDetails = updateDBFlowException(entity, checkpoint, now)
 
+        println("PROGRESS STEP = ${checkpoint.progressStep}")
+        println("PROGRESS STEP = ${checkpoint.progressStep?.take(MAX_PROGRESS_STEP_LENGTH)}")
+
         return entity.apply {
             this.blob = blob
             //Set the result to null for now.
@@ -342,7 +347,7 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
             this.flowMetadata = entity.flowMetadata
             this.status = checkpoint.status
             this.compatible = checkpoint.compatible
-            this.progressStep = checkpoint.progressStep
+            this.progressStep = checkpoint.progressStep?.take(MAX_PROGRESS_STEP_LENGTH)
             this.ioRequestType = checkpoint.flowIoRequest
             this.checkpointInstant = now
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -335,9 +335,6 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         //val result = updateDBFlowResult(entity, checkpoint, now)
         val exceptionDetails = updateDBFlowException(entity, checkpoint, now)
 
-        println("PROGRESS STEP = ${checkpoint.progressStep}")
-        println("PROGRESS STEP = ${checkpoint.progressStep?.take(MAX_PROGRESS_STEP_LENGTH)}")
-
         return entity.apply {
             this.blob = blob
             //Set the result to null for now.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
@@ -102,20 +102,20 @@ sealed class Event {
      * @param ioRequest the request triggering the suspension.
      * @param maySkipCheckpoint indicates whether the persistence may be skipped.
      * @param fiber the serialised stack of the flow.
-     * @param currentStep the current progress tracker step.
+     * @param progressStep the current progress tracker step.
      */
     data class Suspend(
             val ioRequest: FlowIORequest<*>,
             val maySkipCheckpoint: Boolean,
             val fiber: SerializedBytes<FlowStateMachineImpl<*>>,
-            var currentStep: ProgressTracker.Step?
+            var progressStep: ProgressTracker.Step?
     ) : Event() {
         override fun toString() =
                 "Suspend(" +
                         "ioRequest=$ioRequest, " +
                         "maySkipCheckpoint=$maySkipCheckpoint, " +
                         "fiber=${fiber.hash}, " +
-                        "currentStep=${currentStep?.label}" +
+                        "currentStep=${progressStep?.label}" +
                         ")"
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
@@ -6,6 +6,7 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.FlowIORequest
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ProgressTracker
 import net.corda.node.services.messaging.DeduplicationHandler
 import java.util.*
 
@@ -101,17 +102,20 @@ sealed class Event {
      * @param ioRequest the request triggering the suspension.
      * @param maySkipCheckpoint indicates whether the persistence may be skipped.
      * @param fiber the serialised stack of the flow.
+     * @param currentStep the current progress tracker step.
      */
     data class Suspend(
             val ioRequest: FlowIORequest<*>,
             val maySkipCheckpoint: Boolean,
-            val fiber: SerializedBytes<FlowStateMachineImpl<*>>
+            val fiber: SerializedBytes<FlowStateMachineImpl<*>>,
+            var currentStep: ProgressTracker.Step?
     ) : Event() {
         override fun toString() =
                 "Suspend(" +
                         "ioRequest=$ioRequest, " +
                         "maySkipCheckpoint=$maySkipCheckpoint, " +
                         "fiber=${fiber.hash}, " +
+                        "currentStep=${currentStep?.label}" +
                         ")"
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -430,7 +430,8 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                 Event.Suspend(
                         ioRequest = ioRequest,
                         maySkipCheckpoint = skipPersistingCheckpoint,
-                        fiber = this.checkpointSerialize(context = serializationContext.value)
+                        fiber = this.checkpointSerialize(context = serializationContext.value),
+                        currentStep = logic.progressTracker?.currentStep
                 )
             } catch (exception: Exception) {
                 Event.Error(exception)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -431,7 +431,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                         ioRequest = ioRequest,
                         maySkipCheckpoint = skipPersistingCheckpoint,
                         fiber = this.checkpointSerialize(context = serializationContext.value),
-                        currentStep = logic.progressTracker?.currentStep
+                        progressStep = logic.progressTracker?.currentStep
                 )
             } catch (exception: Exception) {
                 Event.Error(exception)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -160,7 +160,7 @@ class TopLevelTransition(
                             numberOfSuspends = currentState.checkpoint.checkpointState.numberOfSuspends + 1
                     ),
                     flowIoRequest = event.ioRequest::class.java.simpleName,
-                    progressStep = event.currentStep?.label
+                    progressStep = event.progressStep?.label
             )
             if (event.maySkipCheckpoint) {
                 actions.addAll(arrayOf(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -159,7 +159,8 @@ class TopLevelTransition(
                     checkpointState = currentState.checkpoint.checkpointState.copy(
                             numberOfSuspends = currentState.checkpoint.checkpointState.numberOfSuspends + 1
                     ),
-                    flowIoRequest = event.ioRequest::class.java.simpleName
+                    flowIoRequest = event.ioRequest::class.java.simpleName,
+                    progressStep = event.currentStep?.label
             )
             if (event.maySkipCheckpoint) {
                 actions.addAll(arrayOf(


### PR DESCRIPTION
The checkpoint Database is updated when the state machine suspends with the progress trackers current step name. This is truncated if it is longer than the Database column.