### PR TITLE
NOTICK: Prevent learning the location of a Class inside sandbox.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -4,6 +4,7 @@ package net.corda.core.internal
 
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
+import net.corda.core.StubOutForDJVM
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.SecureHash
@@ -417,6 +418,7 @@ fun <T, U : T> uncheckedCast(obj: T) = obj as U
 fun <K, V> Iterable<Pair<K, V>>.toMultiMap(): Map<K, List<V>> = this.groupBy({ it.first }) { it.second }
 
 /** Returns the location of this class. */
+@get:StubOutForDJVM
 val Class<*>.location: URL get() = protectionDomain.codeSource.location
 
 /** Convenience method to get the package name of a class literal. */


### PR DESCRIPTION
The `Class.location` function cannot be allowed inside a DJVM sandbox and will also be forbidden when `SecurityManager` locks down the flows. However, we cannot delete it from `core-deterministic` entirely because the Tokens SDK contracts need it (_outside_ the sandbox!) in order to lock down their `TokenType` attachment. So stub this function out instead so that invoking it throws an `UnsupportedOperationException`.