### PR TITLE
CORDA-3596 Record flow metadata

### DIFF
--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -18,21 +18,41 @@ import java.security.Principal
  * @property impersonatedActor Optional impersonated actor, used for logging but not for authorisation.
  */
 @CordaSerializable
-data class InvocationContext(val origin: InvocationOrigin, val trace: Trace, val actor: Actor?, val externalTrace: Trace? = null, val impersonatedActor: Actor? = null) {
+data class InvocationContext(
+    val origin: InvocationOrigin,
+    val trace: Trace,
+    val actor: Actor?,
+    val externalTrace: Trace? = null,
+    val impersonatedActor: Actor? = null,
+    val arguments: List<Any?> = emptyList()
+) {
     companion object {
         /**
          * Creates an [InvocationContext] with a [Trace] that defaults to a [java.util.UUID] as value and [java.time.Instant.now] timestamp.
          */
         @DeleteForDJVM
         @JvmStatic
-        fun newInstance(origin: InvocationOrigin, trace: Trace = Trace.newInstance(), actor: Actor? = null, externalTrace: Trace? = null, impersonatedActor: Actor? = null) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor)
+        fun newInstance(
+            origin: InvocationOrigin,
+            trace: Trace = Trace.newInstance(),
+            actor: Actor? = null,
+            externalTrace: Trace? = null,
+            impersonatedActor: Actor? = null,
+            arguments: List<Any?> = emptyList()
+        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, arguments)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.RPC] origin.
          */
         @DeleteForDJVM
         @JvmStatic
-        fun rpc(actor: Actor, trace: Trace = Trace.newInstance(), externalTrace: Trace? = null, impersonatedActor: Actor? = null): InvocationContext = newInstance(InvocationOrigin.RPC(actor), trace, actor, externalTrace, impersonatedActor)
+        fun rpc(
+            actor: Actor,
+            trace: Trace = Trace.newInstance(),
+            externalTrace: Trace? = null,
+            impersonatedActor: Actor? = null,
+            arguments: List<Any?> = emptyList()
+        ): InvocationContext = newInstance(InvocationOrigin.RPC(actor), trace, actor, externalTrace, impersonatedActor, arguments)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.Peer] origin.

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -26,12 +26,22 @@ data class InvocationContext(
     val impersonatedActor: Actor? = null,
     val arguments: List<Any?> = emptyList()
 ) {
+
+    constructor(
+        origin: InvocationOrigin,
+        trace: Trace,
+        actor: Actor?,
+        externalTrace: Trace? = null,
+        impersonatedActor: Actor? = null
+    ) : this(origin, trace, actor, externalTrace, impersonatedActor, emptyList())
+
     companion object {
         /**
          * Creates an [InvocationContext] with a [Trace] that defaults to a [java.util.UUID] as value and [java.time.Instant.now] timestamp.
          */
         @DeleteForDJVM
         @JvmStatic
+        @JvmOverloads
         @Suppress("LongParameterList")
         fun newInstance(
             origin: InvocationOrigin,
@@ -47,6 +57,7 @@ data class InvocationContext(
          */
         @DeleteForDJVM
         @JvmStatic
+        @JvmOverloads
         fun rpc(
             actor: Actor,
             trace: Trace = Trace.newInstance(),
@@ -88,6 +99,23 @@ data class InvocationContext(
      * Associated security principal.
      */
     fun principal(): Principal = origin.principal()
+
+    fun copy(
+        origin: InvocationOrigin = this.origin,
+        trace: Trace = this.trace,
+        actor: Actor? = this.actor,
+        externalTrace: Trace? = this.externalTrace,
+        impersonatedActor: Actor? = this.impersonatedActor
+    ): InvocationContext {
+        return copy(
+            origin = origin,
+            trace = trace,
+            actor = actor,
+            externalTrace = externalTrace,
+            impersonatedActor = impersonatedActor,
+            arguments = arguments
+        )
+    }
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -32,6 +32,7 @@ data class InvocationContext(
          */
         @DeleteForDJVM
         @JvmStatic
+        @Suppress("LongParameterList")
         fun newInstance(
             origin: InvocationOrigin,
             trace: Trace = Trace.newInstance(),

--- a/node/src/integration-test/kotlin/net/corda/node/services/persistence/CordaPersistenceServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/persistence/CordaPersistenceServiceTests.kt
@@ -78,7 +78,7 @@ class CordaPersistenceServiceTests {
                             compatible = false,
                             progressStep = "",
                             ioRequestType = FlowIORequest.ForceCheckpoint::class.java.simpleName,
-                            checkpointInstant = Instant.now(),
+                            checkpointInstant = now,
                             flowMetadata = createMetadataRecord(flowId, now)
                         )
                     )
@@ -98,8 +98,7 @@ class CordaPersistenceServiceTests {
                 launchingCordapp = "this cordapp",
                 platformVersion = PLATFORM_VERSION,
                 rpcUsername = "Batman",
-                invocationInstant = Instant.now(),
-                receivedInstant = Instant.now(),
+                invocationInstant = timestamp,
                 startInstant = timestamp,
                 finishInstant = null
             )

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -220,6 +220,7 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         @Column(name = "finish_time", nullable = true)
         var finishInstant: Instant?
     ) {
+        @Suppress("ComplexMethod")
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -4,6 +4,7 @@ import net.corda.core.context.InvocationContext
 import net.corda.core.context.InvocationOrigin
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.PLATFORM_VERSION
+import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
@@ -275,7 +276,6 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
     ): DBFlowCheckpoint {
         val flowId = id.uuid.toString()
         val now = Instant.now()
-        val invocationId = checkpoint.checkpointState.invocationContext.trace.invocationId.value
 
         val serializedCheckpointState = checkpoint.checkpointState.storageSerialize()
         checkpointPerformanceRecorder.record(serializedCheckpointState, serializedFlowState)
@@ -448,7 +448,7 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
     private fun InvocationContext.getFlowParameters(): List<Any?> {
         // Only RPC flows have parameters which are found in index 1
         return if(arguments.isNotEmpty()) {
-            (arguments[1] as Array<Any?>).toList()
+            uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()
         } else {
             emptyList()
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -213,11 +213,8 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         @Column(name = "invocation_time", nullable = false)
         var invocationInstant: Instant,
 
-        @Column(name = "received_time", nullable = false)
-        var receivedInstant: Instant,
-
         @Column(name = "start_time", nullable = true)
-        var startInstant: Instant?,
+        var startInstant: Instant,
 
         @Column(name = "finish_time", nullable = true)
         var finishInstant: Instant?
@@ -317,8 +314,6 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
             platformVersion = PLATFORM_VERSION,
             rpcUsername = context.principal().name,
             invocationInstant = context.trace.invocationId.timestamp,
-            // [receivedInstant] makes no sense anymore as we have _started_ the flow
-            receivedInstant = Instant.now(),
             startInstant = Instant.now(),
             finishInstant = null
         ).apply {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -286,8 +286,6 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         val blob = createDBCheckpointBlob(serializedCheckpointState, serializedFlowState, now)
 
         val metadata = createMetadata(flowId, checkpoint)
-        metadata.flowId = flowId
-        currentDBSession().update(metadata)
         // Most fields are null as they cannot have been set when creating the initial checkpoint
         return DBFlowCheckpoint(
             id = flowId,

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -75,7 +75,7 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
     }
 
     enum class StartReason {
-        RPC, FLOW, SERVICE, SCHEDULED, INITIATED
+        RPC, SERVICE, SCHEDULED, INITIATED
     }
 
     @Entity

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -97,7 +97,7 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         var exceptionDetails: DBFlowException?,
 
         @OneToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name = "invocation_id", referencedColumnName = "invocation_id")
+        @JoinColumn(name = "flow_id", referencedColumnName = "flow_id")
         var flowMetadata: DBFlowMetadata,
 
         @Column(name = "status", nullable = false)
@@ -183,11 +183,11 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
     class DBFlowMetadata(
 
         @Id
+        @Column(name = "flow_id", nullable = false)
+        var flowId: String,
+
         @Column(name = "invocation_id", nullable = false)
         var invocationId: String,
-
-        @Column(name = "flow_id", nullable = true)
-        var flowId: String?,
 
         @Column(name = "flow_name", nullable = false)
         var flowName: String,
@@ -306,9 +306,8 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         val context = checkpoint.checkpointState.invocationContext
         val flowInfo = checkpoint.checkpointState.subFlowStack.first()
         return DBFlowMetadata(
-            // will be no point having a PK of invocation id anymore
-            invocationId = context.trace.invocationId.value,
             flowId = flowId,
+            invocationId = context.trace.invocationId.value,
             flowName = flowInfo.flowClass.name,
             // will come from the context
             userSuppliedIdentifier = null,

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -219,8 +219,45 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
 
         @Column(name = "finish_time", nullable = true)
         var finishInstant: Instant?
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
 
-    )
+            other as DBFlowMetadata
+
+            if (flowId != other.flowId) return false
+            if (invocationId != other.invocationId) return false
+            if (flowName != other.flowName) return false
+            if (userSuppliedIdentifier != other.userSuppliedIdentifier) return false
+            if (startType != other.startType) return false
+            if (!initialParameters.contentEquals(other.initialParameters)) return false
+            if (launchingCordapp != other.launchingCordapp) return false
+            if (platformVersion != other.platformVersion) return false
+            if (rpcUsername != other.rpcUsername) return false
+            if (invocationInstant != other.invocationInstant) return false
+            if (startInstant != other.startInstant) return false
+            if (finishInstant != other.finishInstant) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = flowId.hashCode()
+            result = 31 * result + invocationId.hashCode()
+            result = 31 * result + flowName.hashCode()
+            result = 31 * result + (userSuppliedIdentifier?.hashCode() ?: 0)
+            result = 31 * result + startType.hashCode()
+            result = 31 * result + initialParameters.contentHashCode()
+            result = 31 * result + launchingCordapp.hashCode()
+            result = 31 * result + platformVersion
+            result = 31 * result + rpcUsername.hashCode()
+            result = 31 * result + invocationInstant.hashCode()
+            result = 31 * result + startInstant.hashCode()
+            result = 31 * result + (finishInstant?.hashCode() ?: 0)
+            return result
+        }
+    }
 
     override fun addCheckpoint(id: StateMachineRunId, checkpoint: Checkpoint, serializedFlowState: SerializedBytes<FlowState>) {
         currentDBSession().save(createDBCheckpoint(id, checkpoint, serializedFlowState))

--- a/node/src/main/resources/migration/node-core.changelog-v17-keys.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17-keys.xml
@@ -9,7 +9,7 @@
         <addPrimaryKey columnNames="id" constraintName="node_checkpoint_blobs_pk" tableName="node_checkpoint_blobs"/>
         <addPrimaryKey columnNames="id" constraintName="node_checkpoint_exceptions_pk" tableName="node_flow_exceptions"/>
         <addPrimaryKey columnNames="id" constraintName="node_checkpoint_results_pk" tableName="node_flow_results"/>
-        <addPrimaryKey columnNames="invocation_id" constraintName="node_flow_metadata_pk" tableName="node_flow_metadata"/>
+        <addPrimaryKey columnNames="flow_id" constraintName="node_flow_metadata_pk" tableName="node_flow_metadata"/>
     </changeSet>
 
 
@@ -26,9 +26,9 @@
                              constraintName="node_checkpoint_to_result_fk"
                              referencedColumnNames="id" referencedTableName="node_flow_results"/>
 
-    <addForeignKeyConstraint baseColumnNames="invocation_id" baseTableName="node_checkpoints"
+    <addForeignKeyConstraint baseColumnNames="flow_id" baseTableName="node_checkpoints"
                              constraintName="node_metadata_to_checkpoints_fk"
-                             referencedColumnNames="invocation_id" referencedTableName="node_flow_metadata"/>
+                             referencedColumnNames="flow_id" referencedTableName="node_flow_metadata"/>
 </changeSet>
 
 

--- a/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
@@ -19,9 +19,6 @@
             <column name="error_id" type="BIGINT">
                 <constraints nullable="true"/>
             </column>
-            <column name="invocation_id" type="NVARCHAR(128)">
-                <constraints nullable="false"/>
-            </column>
             <column name="status" type="TINYINT">
                 <constraints nullable="false"/>
             </column>
@@ -98,11 +95,11 @@
 
     <changeSet author="R3.Corda" id="add_new_flow_metadata_table-pg" dbms="postgresql">
         <createTable tableName="node_flow_metadata">
-            <column name="invocation_id" type="NVARCHAR(128)">
+            <column name="flow_id" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
-            <column name="flow_id" type="NVARCHAR(64)">
-                <constraints nullable="true"/>
+            <column name="invocation_id" type="NVARCHAR(128)">
+                <constraints nullable="false"/>
             </column>
             <column name="flow_name" type="NVARCHAR(128)">
                 <constraints nullable="false"/>

--- a/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
@@ -122,7 +122,7 @@
             <column name="platform_version" type="TINYINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="rpc_user" type="NVARCHAR(64)">
+            <column name="rpc_user" type="NVARCHAR(128)">
                 <constraints nullable="false"/>
             </column>
             <column name="invocation_time" type="java.sql.Types.TIMESTAMP">

--- a/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
@@ -125,11 +125,8 @@
             <column name="invocation_time" type="java.sql.Types.TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="received_time" type="java.sql.Types.TIMESTAMP">
-                <constraints nullable="false"/>
-            </column>
             <column name="start_time" type="java.sql.Types.TIMESTAMP">
-                <constraints nullable="true"/>
+                <constraints nullable="false"/>
             </column>
             <column name="finish_time" type="java.sql.Types.TIMESTAMP">
                 <constraints nullable="true"/>

--- a/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
@@ -116,7 +116,7 @@
             <column name="flow_parameters" type="varbinary(33554432)">
                 <constraints nullable="false"/>
             </column>
-            <column name="cordapp_name" type="NVARCHAR(64)">
+            <column name="cordapp_name" type="NVARCHAR(128)">
                 <constraints nullable="false"/>
             </column>
             <column name="platform_version" type="TINYINT">

--- a/node/src/main/resources/migration/node-core.changelog-v17.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17.xml
@@ -19,9 +19,6 @@
             <column name="error_id" type="BIGINT">
                 <constraints nullable="true"/>
             </column>
-            <column name="invocation_id" type="NVARCHAR(128)">
-                <constraints nullable="false"/>
-            </column>
             <column name="status" type="TINYINT">
                 <constraints nullable="false"/>
             </column>
@@ -98,11 +95,11 @@
 
     <changeSet author="R3.Corda" id="add_new_flow_metadata_table" dbms="!postgresql">
         <createTable tableName="node_flow_metadata">
-            <column name="invocation_id" type="NVARCHAR(128)">
+            <column name="flow_id" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
-            <column name="flow_id" type="NVARCHAR(64)">
-                <constraints nullable="true"/>
+            <column name="invocation_id" type="NVARCHAR(128)">
+                <constraints nullable="false"/>
             </column>
             <column name="flow_name" type="NVARCHAR(128)">
                 <constraints nullable="false"/>

--- a/node/src/main/resources/migration/node-core.changelog-v17.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17.xml
@@ -122,7 +122,7 @@
             <column name="platform_version" type="TINYINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="rpc_user" type="NVARCHAR(64)">
+            <column name="rpc_user" type="NVARCHAR(128)">
                 <constraints nullable="false"/>
             </column>
             <column name="invocation_time" type="java.sql.Types.TIMESTAMP">

--- a/node/src/main/resources/migration/node-core.changelog-v17.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17.xml
@@ -125,11 +125,8 @@
             <column name="invocation_time" type="java.sql.Types.TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="received_time" type="java.sql.Types.TIMESTAMP">
-                <constraints nullable="false"/>
-            </column>
             <column name="start_time" type="java.sql.Types.TIMESTAMP">
-                <constraints nullable="true"/>
+                <constraints nullable="false"/>
             </column>
             <column name="finish_time" type="java.sql.Types.TIMESTAMP">
                 <constraints nullable="true"/>

--- a/node/src/main/resources/migration/node-core.changelog-v17.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17.xml
@@ -116,7 +116,7 @@
             <column name="flow_parameters" type="blob">
                 <constraints nullable="false"/>
             </column>
-            <column name="cordapp_name" type="NVARCHAR(64)">
+            <column name="cordapp_name" type="NVARCHAR(128)">
                 <constraints nullable="false"/>
             </column>
             <column name="platform_version" type="TINYINT">

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecorderTest.kt
@@ -1,0 +1,454 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.context.InvocationContext
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.SchedulableState
+import net.corda.core.contracts.ScheduledActivity
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.flows.FlowExternalAsyncOperation
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowLogicRefFactory
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.SchedulableFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.StartableByService
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.identity.Party
+import net.corda.core.internal.PLATFORM_VERSION
+import net.corda.core.messaging.startFlow
+import net.corda.core.node.AppServiceHub
+import net.corda.core.node.services.CordaService
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.SerializationDefaults
+import net.corda.core.serialization.SingletonSerializeAsToken
+import net.corda.core.serialization.deserialize
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.Permissions
+import net.corda.node.services.persistence.DBCheckpointStorage
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.function.Supplier
+import kotlin.reflect.jvm.jvmName
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FlowMetadataRecorderTest {
+
+    private val user = User("mark", "dadada", setOf(Permissions.all()))
+    private val string = "I must be delivered for 4.5"
+    private val someObject = SomeObject("Store me in the database please", 1234)
+
+    @Before
+    fun before() {
+        MyFlow.hook = null
+        MyResponder.hook = null
+        MyFlowWithoutParameters.hook
+    }
+
+    @Test(timeout = 300_000)
+    fun `rpc started flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyFlow.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                }
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyFlow::class.java.name, it.flowName)
+                // Should be changed when [userSuppliedIdentifier] gets filled in future changes
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.RPC, it.startType)
+                assertEquals(
+                    listOf(nodeBHandle.nodeInfo.singleIdentity(), string, someObject),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
+                assertEquals(PLATFORM_VERSION, it.platformVersion)
+                assertEquals(user.username, it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNotNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `rpc started flows have metadata recorded - no parameters`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyFlowWithoutParameters.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                }
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(::MyFlowWithoutParameters).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyFlowWithoutParameters::class.java.name, it.flowName)
+                // Should be changed when [userSuppliedIdentifier] gets filled in future changes
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.RPC, it.startType)
+                assertEquals(
+                    emptyList<Any?>(),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
+                assertEquals(PLATFORM_VERSION, it.platformVersion)
+                assertEquals(user.username, it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNotNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `initiated flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyResponder.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                }
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyResponder::class.java.name, it.flowName)
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.INITIATED, it.startType)
+                assertEquals(
+                    emptyList<Any?>(),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
+                assertEquals(6, it.platformVersion)
+                assertEquals(nodeAHandle.nodeInfo.singleIdentity().name.toString(), it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNotNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `service started flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyFlow.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                }
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyServiceStartingFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyFlow::class.java.name, it.flowName)
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.SERVICE, it.startType)
+                assertEquals(
+                    emptyList<Any?>(),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
+                assertEquals(PLATFORM_VERSION, it.platformVersion)
+                assertEquals(MyService::class.java.name, it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNotNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `scheduled flows have metadata recorded`() {
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            val lock = Semaphore(1)
+
+            var flowId: StateMachineRunId? = null
+            var context: InvocationContext? = null
+            var metadata: DBCheckpointStorage.DBFlowMetadata? = null
+            MyFlow.hook =
+                { flowIdFromHook: StateMachineRunId, contextFromHook: InvocationContext, metadataFromHook: DBCheckpointStorage.DBFlowMetadata ->
+                    flowId = flowIdFromHook
+                    context = contextFromHook
+                    metadata = metadataFromHook
+                    // Release the lock so the asserts can be processed
+                    lock.release()
+                }
+
+            // Acquire the lock to prevent the asserts from being processed too early
+            lock.acquire()
+
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::MyStartedScheduledFlow,
+                    nodeBHandle.nodeInfo.singleIdentity(),
+                    string,
+                    someObject
+                ).returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+            }
+
+            // Block here until released in the hook
+            lock.acquire()
+
+            metadata!!.let {
+                assertEquals(context!!.trace.invocationId.value, it.invocationId)
+                assertEquals(flowId!!.uuid.toString(), it.flowId)
+                assertEquals(MyFlow::class.java.name, it.flowName)
+                assertNull(it.userSuppliedIdentifier)
+                assertEquals(DBCheckpointStorage.StartReason.SCHEDULED, it.startType)
+                assertEquals(
+                    emptyList<Any?>(),
+                    it.initialParameters.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                )
+                assertThat(it.launchingCordapp).contains("custom-cordapp")
+                assertEquals(PLATFORM_VERSION, it.platformVersion)
+                assertEquals("Scheduler", it.rpcUsername)
+                assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
+                assertTrue(it.receivedInstant >= it.invocationInstant)
+                assertNotNull(it.startInstant)
+                assertNull(it.finishInstant)
+            }
+        }
+    }
+
+    @InitiatingFlow
+    @StartableByRPC
+    @StartableByService
+    @SchedulableFlow
+    class MyFlow(private val party: Party, string: String, someObject: SomeObject) :
+        FlowLogic<Unit>() {
+
+        companion object {
+            var hook: ((
+                flowId: StateMachineRunId,
+                context: InvocationContext,
+                metadata: DBCheckpointStorage.DBFlowMetadata
+            ) -> Unit)? = null
+        }
+
+        @Suspendable
+        override fun call() {
+            hook?.let {
+                it(
+                    stateMachine.id,
+                    stateMachine.context,
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                )
+            }
+            initiateFlow(party).sendAndReceive<String>("Hello there")
+        }
+    }
+
+    @InitiatedBy(MyFlow::class)
+    class MyResponder(private val session: FlowSession) : FlowLogic<Unit>() {
+
+        companion object {
+            var hook: ((
+                flowId: StateMachineRunId,
+                context: InvocationContext,
+                metadata: DBCheckpointStorage.DBFlowMetadata
+            ) -> Unit)? = null
+        }
+
+        @Suspendable
+        override fun call() {
+            session.receive<String>()
+            hook?.let {
+                it(
+                    stateMachine.id,
+                    stateMachine.context,
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                )
+            }
+            session.send("Hello there")
+        }
+    }
+
+    @StartableByRPC
+    class MyFlowWithoutParameters : FlowLogic<Unit>() {
+
+        companion object {
+            var hook: ((
+                flowId: StateMachineRunId,
+                context: InvocationContext,
+                metadata: DBCheckpointStorage.DBFlowMetadata
+            ) -> Unit)? = null
+        }
+
+        @Suspendable
+        override fun call() {
+            hook?.let {
+                it(
+                    stateMachine.id,
+                    stateMachine.context,
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                )
+            }
+        }
+    }
+
+    @StartableByRPC
+    class MyServiceStartingFlow(private val party: Party, private val string: String, private val someObject: SomeObject) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            await(object : FlowExternalAsyncOperation<Unit> {
+                override fun execute(deduplicationId: String): CompletableFuture<Unit> {
+                    return serviceHub.cordaService(MyService::class.java).startFlow(party, string, someObject)
+                }
+            })
+        }
+    }
+
+    @StartableByRPC
+    class MyStartedScheduledFlow(private val party: Party, private val string: String, private val someObject: SomeObject) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            val tx = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
+                addOutputState(ScheduledState(party, string, someObject, listOf(ourIdentity)))
+                addCommand(DummyContract.Commands.Create(), ourIdentity.owningKey)
+            }
+            val stx = serviceHub.signInitialTransaction(tx)
+            serviceHub.recordTransactions(stx)
+        }
+    }
+
+    @CordaService
+    class MyService(private val services: AppServiceHub) : SingletonSerializeAsToken() {
+
+        private val executorService = Executors.newFixedThreadPool(1)
+
+        fun findMetadata(context: InvocationContext): DBCheckpointStorage.DBFlowMetadata {
+            return services.database.transaction {
+                session.find(DBCheckpointStorage.DBFlowMetadata::class.java, context.trace.invocationId.value)
+            }
+        }
+
+        fun startFlow(party: Party, string: String, someObject: SomeObject): CompletableFuture<Unit> {
+            return CompletableFuture.supplyAsync(
+                Supplier<Unit> { services.startFlow(MyFlow(party, string, someObject)).returnValue.getOrThrow() },
+                executorService
+            )
+        }
+    }
+
+    @CordaSerializable
+    data class SomeObject(private val string: String, private val number: Int)
+
+    @BelongsToContract(DummyContract::class)
+    data class ScheduledState(
+        val party: Party,
+        val string: String,
+        val someObject: SomeObject,
+        override val participants: List<Party>,
+        override val linearId: UniqueIdentifier = UniqueIdentifier()
+    ) : SchedulableState, LinearState {
+
+        override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
+            val logicRef = flowLogicRefFactory.create(MyFlow::class.jvmName, party, string, someObject)
+            return ScheduledActivity(logicRef, Instant.now())
+        }
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -55,7 +55,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class FlowMetadataRecorderTest {
+class FlowMetadataRecordingTest {
 
     private val user = User("mark", "dadada", setOf(Permissions.all()))
     private val string = "I must be delivered for 4.5"

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -110,8 +110,7 @@ class FlowMetadataRecordingTest {
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
                 assertEquals(user.username, it.rpcUsername)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
-                assertTrue(it.receivedInstant >= it.invocationInstant)
-                assertNotNull(it.startInstant)
+                assertTrue(it.startInstant >= it.invocationInstant)
                 assertNull(it.finishInstant)
             }
         }
@@ -153,8 +152,7 @@ class FlowMetadataRecordingTest {
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
                 assertEquals(user.username, it.rpcUsername)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
-                assertTrue(it.receivedInstant >= it.invocationInstant)
-                assertNotNull(it.startInstant)
+                assertTrue(it.startInstant >= it.invocationInstant)
                 assertNull(it.finishInstant)
             }
         }
@@ -254,8 +252,7 @@ class FlowMetadataRecordingTest {
                 assertEquals(6, it.platformVersion)
                 assertEquals(nodeAHandle.nodeInfo.singleIdentity().name.toString(), it.rpcUsername)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
-                assertTrue(it.receivedInstant >= it.invocationInstant)
-                assertNotNull(it.startInstant)
+                assertTrue(it.startInstant >= it.invocationInstant)
                 assertNull(it.finishInstant)
             }
         }
@@ -301,8 +298,7 @@ class FlowMetadataRecordingTest {
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
                 assertEquals(MyService::class.java.name, it.rpcUsername)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
-                assertTrue(it.receivedInstant >= it.invocationInstant)
-                assertNotNull(it.startInstant)
+                assertTrue(it.startInstant >= it.invocationInstant)
                 assertNull(it.finishInstant)
             }
         }
@@ -358,8 +354,7 @@ class FlowMetadataRecordingTest {
                 assertEquals(PLATFORM_VERSION, it.platformVersion)
                 assertEquals("Scheduler", it.rpcUsername)
                 assertEquals(context!!.trace.invocationId.timestamp, it.invocationInstant)
-                assertTrue(it.receivedInstant >= it.invocationInstant)
-                assertNotNull(it.startInstant)
+                assertTrue(it.startInstant >= it.invocationInstant)
                 assertNull(it.finishInstant)
             }
         }
@@ -390,14 +385,14 @@ class FlowMetadataRecordingTest {
                 it(
                     stateMachine.id,
                     stateMachine.context,
-                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.id)
                 )
             }
             initiateFlow(party).sendAndReceive<String>("Hello there")
             hookAfterSuspend?.let {
                 it(
                     stateMachine.context,
-                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.id)
                 )
             }
         }
@@ -421,7 +416,7 @@ class FlowMetadataRecordingTest {
                 it(
                     stateMachine.id,
                     stateMachine.context,
-                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.id)
                 )
             }
             session.send("Hello there")
@@ -445,7 +440,7 @@ class FlowMetadataRecordingTest {
                 it(
                     stateMachine.id,
                     stateMachine.context,
-                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.context)
+                    serviceHub.cordaService(MyService::class.java).findMetadata(stateMachine.id)
                 )
             }
         }
@@ -485,9 +480,9 @@ class FlowMetadataRecordingTest {
 
         private val executorService = Executors.newFixedThreadPool(1)
 
-        fun findMetadata(context: InvocationContext): DBCheckpointStorage.DBFlowMetadata {
+        fun findMetadata(flowId: StateMachineRunId): DBCheckpointStorage.DBFlowMetadata {
             return services.database.transaction {
-                session.find(DBCheckpointStorage.DBFlowMetadata::class.java, context.trace.invocationId.value)
+                session.find(DBCheckpointStorage.DBFlowMetadata::class.java, flowId.uuid.toString())
             }
         }
 


### PR DESCRIPTION
Record flow metadata during the zero'th checkpoint that occurs before
calling the flow's `call` function.

This required adding an RPC call's arguments to the `InvocationContext`
that gets created. These arguments are then accessible within the
statemachine and from the `Checkpoint` class. The arguments are then
extracted when recording a flow's metadata inside of
`DBCheckpointStorage`.

Updated the size of the started by column to 128 since it was not long
enough to hold the fully qualified class of a service that started a
flow.