### PR TITLE
CORDA-3655 Do not run COMPLETED, FAILED or KILLED flows on node startup

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
@@ -5,7 +5,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.internal.CheckpointSerializationDefaults
-import net.corda.core.serialization.internal.checkpointDeserialize
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.statemachine.SubFlow
 import net.corda.node.services.statemachine.SubFlowVersion
@@ -36,7 +35,7 @@ object CheckpointVerifier {
 
         val cordappsByHash = currentCordapps.associateBy { it.jarHash }
 
-        checkpointStorage.getAllCheckpoints().use {
+        checkpointStorage.getAllRunnableCheckpoints().use {
             it.forEach { (_, serializedCheckpoint) ->
                 val checkpoint = try {
                     serializedCheckpoint.deserialize(checkpointSerializationContext)

--- a/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
@@ -35,7 +35,7 @@ object CheckpointVerifier {
 
         val cordappsByHash = currentCordapps.associateBy { it.jarHash }
 
-        checkpointStorage.getAllRunnableCheckpoints().use {
+        checkpointStorage.getRunnableCheckpoints().use {
             it.forEach { (_, serializedCheckpoint) ->
                 val checkpoint = try {
                     serializedCheckpoint.deserialize(checkpointSerializationContext)

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -37,7 +37,7 @@ interface CheckpointStorage {
     fun getCheckpoint(id: StateMachineRunId): Checkpoint.Serialized?
 
     /**
-     * Stream all runnable checkpoints from the store. If this is backed by a database the stream will be valid
+     * Stream runnable checkpoints from the store. If this is backed by a database the stream will be valid
      * until the underlying database connection is closed, so any processing should happen before it is closed.
      */
     fun getRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -37,6 +37,12 @@ interface CheckpointStorage {
     fun getCheckpoint(id: StateMachineRunId): Checkpoint.Serialized?
 
     /**
+     * Stream all checkpoints from the store. If this is backed by a database the stream will be valid until the
+     * underlying database connection is closed, so any processing should happen before it is closed.
+     */
+    fun getAllCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
+
+    /**
      * Stream runnable checkpoints from the store. If this is backed by a database the stream will be valid
      * until the underlying database connection is closed, so any processing should happen before it is closed.
      */

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services.api
 
 import net.corda.core.flows.StateMachineRunId
-import net.corda.core.internal.FlowIORequest
 import net.corda.core.serialization.SerializedBytes
 import net.corda.node.services.statemachine.Checkpoint
 import net.corda.node.services.statemachine.FlowState
@@ -40,6 +39,8 @@ interface CheckpointStorage {
     /**
      * Stream all checkpoints from the store. If this is backed by a database the stream will be valid until the
      * underlying database connection is closed, so any processing should happen before it is closed.
+     *
+     * To fetch every checkpoint from the database (not runnable and runnable ones) [runnableCheckpoints] must be set to false.
      */
-    fun getAllCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
+    fun getAllCheckpoints(runnableCheckpoints: Boolean = true): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -37,10 +37,8 @@ interface CheckpointStorage {
     fun getCheckpoint(id: StateMachineRunId): Checkpoint.Serialized?
 
     /**
-     * Stream all checkpoints from the store. If this is backed by a database the stream will be valid until the
-     * underlying database connection is closed, so any processing should happen before it is closed.
-     *
-     * To fetch every checkpoint from the database (not runnable and runnable ones) [runnableCheckpoints] must be set to false.
+     * Stream all runnable checkpoints from the store. If this is backed by a database the stream will be valid
+     * until the underlying database connection is closed, so any processing should happen before it is closed.
      */
-    fun getAllCheckpoints(runnableCheckpoints: Boolean = true): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
+    fun getAllRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -40,5 +40,5 @@ interface CheckpointStorage {
      * Stream all runnable checkpoints from the store. If this is backed by a database the stream will be valid
      * until the underlying database connection is closed, so any processing should happen before it is closed.
      */
-    fun getAllRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
+    fun getRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -2,7 +2,6 @@ package net.corda.node.services.persistence
 
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.PLATFORM_VERSION
-import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
@@ -44,6 +43,8 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         private const val HMAC_SIZE_BYTES = 16
 
         private const val MAX_PROGRESS_STEP_LENGTH = 256
+
+        private val NOT_RUNNABLE_CHECKPOINTS = listOf(FlowStatus.COMPLETED, FlowStatus.FAILED, FlowStatus.KILLED)
 
         /**
          * This needs to run before Hibernate is initialised.
@@ -241,11 +242,15 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         return getDBCheckpoint(id)?.toSerializedCheckpoint()
     }
 
-    override fun getAllCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>> {
+    override fun getAllCheckpoints(runnableCheckpoints: Boolean): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>> {
         val session = currentDBSession()
-        val criteriaQuery = session.criteriaBuilder.createQuery(DBFlowCheckpoint::class.java)
+        val criteriaBuilder = session.criteriaBuilder
+        val criteriaQuery = criteriaBuilder.createQuery(DBFlowCheckpoint::class.java)
         val root = criteriaQuery.from(DBFlowCheckpoint::class.java)
         criteriaQuery.select(root)
+        if (runnableCheckpoints) {
+            criteriaQuery.where(criteriaBuilder.not(root.get<FlowStatus>(DBFlowCheckpoint::status.name).`in`(NOT_RUNNABLE_CHECKPOINTS)))
+        }
         return session.createQuery(criteriaQuery).stream().map {
             StateMachineRunId(UUID.fromString(it.id)) to it.toSerializedCheckpoint()
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -242,6 +242,16 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         return getDBCheckpoint(id)?.toSerializedCheckpoint()
     }
 
+    override fun getAllCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>> {
+        val session = currentDBSession()
+        val criteriaQuery = session.criteriaBuilder.createQuery(DBFlowCheckpoint::class.java)
+        val root = criteriaQuery.from(DBFlowCheckpoint::class.java)
+        criteriaQuery.select(root)
+        return session.createQuery(criteriaQuery).stream().map {
+            StateMachineRunId(UUID.fromString(it.id)) to it.toSerializedCheckpoint()
+        }
+    }
+
     override fun getRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>> {
         val session = currentDBSession()
         val criteriaBuilder = session.criteriaBuilder

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -242,7 +242,7 @@ class DBCheckpointStorage(private val checkpointPerformanceRecorder: CheckpointP
         return getDBCheckpoint(id)?.toSerializedCheckpoint()
     }
 
-    override fun getAllRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>> {
+    override fun getRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>> {
         val session = currentDBSession()
         val criteriaBuilder = session.criteriaBuilder
         val criteriaQuery = criteriaBuilder.createQuery(DBFlowCheckpoint::class.java)

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -141,7 +141,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
         try {
             if (lock.getAndIncrement() == 0 && !file.exists()) {
                 database.transaction {
-                    checkpointStorage.getAllRunnableCheckpoints().use { stream ->
+                    checkpointStorage.getRunnableCheckpoints().use { stream ->
                         ZipOutputStream(file.outputStream()).use { zip ->
                             stream.forEach { (runId, serialisedCheckpoint) ->
 

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -141,7 +141,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
         try {
             if (lock.getAndIncrement() == 0 && !file.exists()) {
                 database.transaction {
-                    checkpointStorage.getAllCheckpoints().use { stream ->
+                    checkpointStorage.getAllRunnableCheckpoints().use { stream ->
                         ZipOutputStream(file.outputStream()).use { zip ->
                             stream.forEach { (runId, serialisedCheckpoint) ->
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -329,7 +329,7 @@ class SingleThreadedStateMachineManager(
     }
 
     private fun restoreFlowsFromCheckpoints(): List<Flow> {
-        return checkpointStorage.getAllCheckpoints().use {
+        return checkpointStorage.getAllRunnableCheckpoints().use {
             it.mapNotNull { (id, serializedCheckpoint) ->
                 // If a flow is added before start() then don't attempt to restore it
                 mutex.locked { if (id in flows) return@mapNotNull null }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -329,7 +329,7 @@ class SingleThreadedStateMachineManager(
     }
 
     private fun restoreFlowsFromCheckpoints(): List<Flow> {
-        return checkpointStorage.getAllRunnableCheckpoints().use {
+        return checkpointStorage.getRunnableCheckpoints().use {
             it.mapNotNull { (id, serializedCheckpoint) ->
                 // If a flow is added before start() then don't attempt to restore it
                 mutex.locked { if (id in flows) return@mapNotNull null }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -63,7 +63,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 internal fun CheckpointStorage.getAllIncompleteCheckpoints(): List<Checkpoint.Serialized> {
-    return getAllCheckpoints().use {
+    return getAllRunnableCheckpoints().use {
         it.map { it.second }.toList()
     }.filter { it.status !=  Checkpoint.FlowStatus.COMPLETED }
 }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -63,7 +63,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 internal fun CheckpointStorage.getAllIncompleteCheckpoints(): List<Checkpoint.Serialized> {
-    return getAllRunnableCheckpoints().use {
+    return getRunnableCheckpoints().use {
         it.map { it.second }.toList()
     }.filter { it.status !=  Checkpoint.FlowStatus.COMPLETED }
 }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -44,7 +44,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 internal fun CheckpointStorage.checkpoints(): List<Checkpoint.Serialized> {
-    return getAllCheckpoints().use {
+    return getAllRunnableCheckpoints().use {
         it.map { it.second }.toList()
     }
 }
@@ -494,7 +494,7 @@ class DBCheckpointStorageTests {
     }
 
     @Test(timeout = 300_000)
-    fun `fetch -runnable checkpoints only- and -all checkpoints in the database-`() {
+    fun `fetch runnable checkpoints`() {
         val (id, checkpoint) = newCheckpoint(1)
         // runnables
         val runnable = checkpoint.copy(status = Checkpoint.FlowStatus.RUNNABLE)
@@ -518,8 +518,7 @@ class DBCheckpointStorageTests {
         }
 
         database.transaction {
-            assertEquals(3, checkpointStorage.getAllCheckpoints().count())
-            assertEquals(6, checkpointStorage.getAllCheckpoints(runnableCheckpoints = false).count())
+            assertEquals(3, checkpointStorage.getAllRunnableCheckpoints().count())
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -44,7 +44,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 internal fun CheckpointStorage.checkpoints(): List<Checkpoint.Serialized> {
-    return getAllRunnableCheckpoints().use {
+    return getRunnableCheckpoints().use {
         it.map { it.second }.toList()
     }
 }
@@ -518,7 +518,7 @@ class DBCheckpointStorageTests {
         }
 
         database.transaction {
-            assertEquals(3, checkpointStorage.getAllRunnableCheckpoints().count())
+            assertEquals(3, checkpointStorage.getRunnableCheckpoints().count())
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -495,7 +495,7 @@ class DBCheckpointStorageTests {
 
     @Test(timeout = 300_000)
     fun `fetch runnable checkpoints`() {
-        val (id, checkpoint) = newCheckpoint(1)
+        val (_, checkpoint) = newCheckpoint(1)
         // runnables
         val runnable = checkpoint.copy(status = Checkpoint.FlowStatus.RUNNABLE)
         val hospitalized = checkpoint.copy(status = Checkpoint.FlowStatus.HOSPITALIZED)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -493,6 +493,36 @@ class DBCheckpointStorageTests {
         }
     }
 
+    @Test(timeout = 300_000)
+    fun `fetch -runnable checkpoints only- and -all checkpoints in the database-`() {
+        val (id, checkpoint) = newCheckpoint(1)
+        // runnables
+        val runnable = checkpoint.copy(status = Checkpoint.FlowStatus.RUNNABLE)
+        val hospitalized = checkpoint.copy(status = Checkpoint.FlowStatus.HOSPITALIZED)
+        // not runnables
+        val completed = checkpoint.copy(status = Checkpoint.FlowStatus.COMPLETED)
+        val failed = checkpoint.copy(status = Checkpoint.FlowStatus.FAILED)
+        val killed = checkpoint.copy(status = Checkpoint.FlowStatus.KILLED)
+        // tentative
+        val paused = checkpoint.copy(status = Checkpoint.FlowStatus.PAUSED) // is considered runnable
+
+        database.transaction {
+            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+
+            checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), runnable, serializedFlowState)
+            checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), hospitalized, serializedFlowState)
+            checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), completed, serializedFlowState)
+            checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), failed, serializedFlowState)
+            checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), killed, serializedFlowState)
+            checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), paused, serializedFlowState)
+        }
+
+        database.transaction {
+            assertEquals(3, checkpointStorage.getAllCheckpoints().count())
+            assertEquals(6, checkpointStorage.getAllCheckpoints(runnableCheckpoints = false).count())
+        }
+    }
+
     private fun newCheckpointStorage() {
         database.transaction {
             checkpointStorage = DBCheckpointStorage(object : CheckpointPerformanceRecorder {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -640,13 +640,13 @@ class FlowFrameworkTests {
                 throw SQLException("deadlock") // will cause flow to retry
             } else {
                 // The persisted Checkpoint should be still failed here -> it should change to RUNNABLE after suspension
-                checkpointStatusInDBBeforeSuspension = aliceNode.internals.checkpointStorage.getAllCheckpoints().toList().single().second.status
+                checkpointStatusInDBBeforeSuspension = aliceNode.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single().second.status
                 checkpointStatusInMemoryBeforeSuspension = flowFiber.transientState!!.value.checkpoint.status
             }
         }
 
         SuspendingFlow.hookAfterCheckpoint = {
-            checkpointStatusInDBAfterSuspension = aliceNode.internals.checkpointStorage.getAllCheckpoints().toList().single().second.status
+            checkpointStatusInDBAfterSuspension = aliceNode.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single().second.status
         }
 
         aliceNode.services.startFlow(SuspendingFlow()).resultFuture.getOrThrow()
@@ -676,7 +676,7 @@ class FlowFrameworkTests {
                 firstExecution = false
                 throw SQLException("deadlock") // will cause flow to retry
             } else {
-                checkpointStatusInDB = aliceNode.internals.checkpointStorage.getAllCheckpoints().toList().single().second.status
+                checkpointStatusInDB = aliceNode.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single().second.status
                 checkpointStatusInMemory = flowFiber.transientState!!.value.checkpoint.status
             }
         }
@@ -691,7 +691,7 @@ class FlowFrameworkTests {
 
     // the following method should be removed when implementing CORDA-3604.
     private fun manuallyFailCheckpointInDB(node: TestStartedNode) {
-        val idCheckpoint = node.internals.checkpointStorage.getAllCheckpoints().toList().single()
+        val idCheckpoint = node.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single()
         val checkpoint = idCheckpoint.second
         val updatedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.FAILED)
         node.internals.checkpointStorage.updateCheckpoint(idCheckpoint.first,

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -640,7 +640,7 @@ class FlowFrameworkTests {
                 throw SQLException("deadlock") // will cause flow to retry
             } else {
                 // The persisted Checkpoint should be still failed here -> it should change to RUNNABLE after suspension
-                checkpointStatusInDBBeforeSuspension = aliceNode.internals.checkpointStorage.getRunnableCheckpoints().toList().single().second.status
+                checkpointStatusInDBBeforeSuspension = aliceNode.internals.checkpointStorage.getAllCheckpoints().toList().single().second.status
                 checkpointStatusInMemoryBeforeSuspension = flowFiber.transientState!!.value.checkpoint.status
             }
         }
@@ -676,7 +676,7 @@ class FlowFrameworkTests {
                 firstExecution = false
                 throw SQLException("deadlock") // will cause flow to retry
             } else {
-                checkpointStatusInDB = aliceNode.internals.checkpointStorage.getRunnableCheckpoints().toList().single().second.status
+                checkpointStatusInDB = aliceNode.internals.checkpointStorage.getAllCheckpoints().toList().single().second.status
                 checkpointStatusInMemory = flowFiber.transientState!!.value.checkpoint.status
             }
         }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -640,13 +640,13 @@ class FlowFrameworkTests {
                 throw SQLException("deadlock") // will cause flow to retry
             } else {
                 // The persisted Checkpoint should be still failed here -> it should change to RUNNABLE after suspension
-                checkpointStatusInDBBeforeSuspension = aliceNode.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single().second.status
+                checkpointStatusInDBBeforeSuspension = aliceNode.internals.checkpointStorage.getRunnableCheckpoints().toList().single().second.status
                 checkpointStatusInMemoryBeforeSuspension = flowFiber.transientState!!.value.checkpoint.status
             }
         }
 
         SuspendingFlow.hookAfterCheckpoint = {
-            checkpointStatusInDBAfterSuspension = aliceNode.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single().second.status
+            checkpointStatusInDBAfterSuspension = aliceNode.internals.checkpointStorage.getRunnableCheckpoints().toList().single().second.status
         }
 
         aliceNode.services.startFlow(SuspendingFlow()).resultFuture.getOrThrow()
@@ -676,7 +676,7 @@ class FlowFrameworkTests {
                 firstExecution = false
                 throw SQLException("deadlock") // will cause flow to retry
             } else {
-                checkpointStatusInDB = aliceNode.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single().second.status
+                checkpointStatusInDB = aliceNode.internals.checkpointStorage.getRunnableCheckpoints().toList().single().second.status
                 checkpointStatusInMemory = flowFiber.transientState!!.value.checkpoint.status
             }
         }
@@ -691,7 +691,7 @@ class FlowFrameworkTests {
 
     // the following method should be removed when implementing CORDA-3604.
     private fun manuallyFailCheckpointInDB(node: TestStartedNode) {
-        val idCheckpoint = node.internals.checkpointStorage.getAllRunnableCheckpoints().toList().single()
+        val idCheckpoint = node.internals.checkpointStorage.getRunnableCheckpoints().toList().single()
         val checkpoint = idCheckpoint.second
         val updatedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.FAILED)
         node.internals.checkpointStorage.updateCheckpoint(idCheckpoint.first,


### PR DESCRIPTION
COMPLETED, FAILED or KILLED flows will not be loaded on node startup (`StateMachineManager.start`).