### PR TITLE
[CORDA-3628] - Avoid sending actions to the state machine if no messages are to be sent

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -46,7 +46,11 @@ sealed class Action {
     data class SendMultiple(
             val sendInitial: List<SendInitial>,
             val sendExisting: List<SendExisting>
-    ): Action()
+    ): Action() {
+        init {
+            check(sendInitial.isNotEmpty() || sendExisting.isNotEmpty()) { "At least one of the lists with initial or existing session messages should contain items." }
+        }
+    }
 
     /**
      * Persist the specified [checkpoint].

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
@@ -289,7 +289,9 @@ class StartedFlowTransition(
             }
         } ?: emptyList()
 
-        actions.add(Action.SendMultiple(sendInitialActions, sendExistingActions))
+        if (sendInitialActions.isNotEmpty() || sendExistingActions.isNotEmpty()) {
+            actions.add(Action.SendMultiple(sendInitialActions, sendExistingActions))
+        }
         currentState = currentState.copy(checkpoint = checkpoint.copy(sessions = newSessions))
     }
 


### PR DESCRIPTION
A follow-up on https://github.com/corda/corda/pull/5990 to avoid sending actions to the state machine, which will not trigger sending of any messages.