### PR TITLE
Prevent Quasar from instrumenting classes that belong to AttachmentsClassLoader.

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -270,7 +270,8 @@ task slowIntegrationTest(type: Test) {
 // quasar exclusions upon agent code instrumentation at run-time
 quasar {
     excludeClassLoaders.addAll(
-            'net.corda.djvm.**'
+            'net.corda.djvm.**',
+            'net.corda.core.serialization.internal.**'
     )
     excludePackages.addAll(
             "antlr**",

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -92,7 +92,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: [
         applicationId = "net.corda.node.Corda"
         // See experimental/quasar-hook/README.md for how to generate.
         def quasarExcludeExpression = "x(antlr**;bftsmart**;co.paralleluniverse**;com.codahale**;com.esotericsoftware**;com.fasterxml**;com.google**;com.ibm**;com.intellij**;com.jcabi**;com.nhaarman**;com.opengamma**;com.typesafe**;com.zaxxer**;de.javakaffee**;groovy**;groovyjarjarantlr**;groovyjarjarasm**;io.atomix**;io.github**;io.netty**;jdk**;kotlin**;net.corda.djvm**;djvm**;net.bytebuddy**;net.i2p**;org.apache**;org.bouncycastle**;org.codehaus**;org.crsh**;org.dom4j**;org.fusesource**;org.h2**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.objectweb**;org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**;org.jolokia**;com.lmax**;picocli**;liquibase**;com.github.benmanes**;org.json**;org.postgresql**;nonapi.io.github.classgraph**)"
-        def quasarClassLoaderExclusion = "l(net.corda.djvm.**)"
+        def quasarClassLoaderExclusion = "l(net.corda.djvm.**;net.corda.core.serialization.internal.**)"
         javaAgents = quasar_classifier == null ? ["quasar-core-${quasar_version}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"] : ["quasar-core-${quasar_version}-${quasar_classifier}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"]
         systemProperties['visualvm.display.name'] = 'Corda'
         if (JavaVersion.current() == JavaVersion.VERSION_1_8) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -918,7 +918,7 @@ class DriverDSLImpl(
                     "org.hamcrest**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.junit**;org.mockito**;org.objectweb**;" +
                     "org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**;org.jolokia**;" +
                     "com.lmax**;picocli**;liquibase**;com.github.benmanes**;org.json**;org.postgresql**;nonapi.io.github.classgraph**;)"
-            val excludeClassloaderPattern = "l(net.corda.djvm.**)"
+            val excludeClassloaderPattern = "l(net.corda.djvm.**;net.corda.core.serialization.internal.**)"
             val extraJvmArguments = systemProperties.removeResolvedClasspath().map { "-D${it.key}=${it.value}" } +
                     "-javaagent:$quasarJarPath=$excludePackagePattern$excludeClassloaderPattern"
 


### PR DESCRIPTION
The `AttachmentsClassLoader` contains contract classes and custom serializers and is used by contract verification. Its classes should not need to be instrumented by Quasar any more than the DJVM's sandbox classes do, and so configure Quasar _to leave `AttachmentsClassLoader` instances alone!_