### PR TITLE
[CORDA-3628] - Remove overloads for sendAll

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -333,7 +333,7 @@ abstract class FlowLogic<out T> {
     @JvmOverloads
     fun sendAll(payload: Any, sessions: Set<FlowSession>, maySkipCheckpoint: Boolean = false) {
         val sessionToPayload = sessions.map { it to payload }.toMap()
-        return sendAll(sessionToPayload, maySkipCheckpoint)
+        return sendAllMap(sessionToPayload, maySkipCheckpoint)
     }
 
     /**
@@ -348,7 +348,7 @@ abstract class FlowLogic<out T> {
      */
     @Suspendable
     @JvmOverloads
-    fun sendAll(payloadsPerSession: Map<FlowSession, Any>, maySkipCheckpoint: Boolean = false) {
+    fun sendAllMap(payloadsPerSession: Map<FlowSession, Any>, maySkipCheckpoint: Boolean = false) {
         val request = FlowIORequest.Send(
                 sessionToMessage = serializePayloads(payloadsPerSession)
         )

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -272,7 +272,7 @@ In addition ``FlowLogic`` provides functions that can receive messages from mult
     * Receives from all ``FlowSession`` objects specified in the passed in list. The received types must be the same.
 * ``sendAll(payload: Any, sessions: Set<FlowSession>)``
     * Sends the ``payload`` object to all the provided ``FlowSession``\s.
-* ``sendAll(payloadsPerSession: Map<FlowSession, Any>)``
+* ``sendAllMap(payloadsPerSession: Map<FlowSession, Any>)``
     * Sends a potentially different payload to each ``FlowSession``, as specified by the provided ``payloadsPerSession``.
 
 .. note:: It's more efficient to call ``sendAndReceive`` instead of calling ``send`` and then ``receive``. It's also more efficient to call ``sendAll``/``receiveAll`` instead of multiple ``send``/``receive`` respectively.

--- a/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
@@ -91,7 +91,7 @@ interface MessagingService : ServiceLifecycleSupport {
      * @param addressedMessages The list of messages together with the recipients, retry ids and sequence keys.
      */
     @Suspendable
-    fun send(addressedMessages: List<AddressedMessage>)
+    fun sendAll(addressedMessages: List<AddressedMessage>)
 
     /**
      * Returns an initialised [Message] with the current time, etc, already filled in.

--- a/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt
@@ -54,7 +54,7 @@ class MessagingExecutor(
     }
 
     @Synchronized
-    fun send(messages: Map<MessageRecipients, Message>) {
+    fun sendAll(messages: Map<MessageRecipients, Message>) {
         messages.forEach { recipients, message -> send(message, recipients) }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
@@ -511,7 +511,7 @@ class P2PMessagingClient(val config: NodeConfiguration,
     }
 
     @Suspendable
-    override fun send(addressedMessages: List<MessagingService.AddressedMessage>) {
+    override fun sendAll(addressedMessages: List<MessagingService.AddressedMessage>) {
         for ((message, target, sequenceKey) in addressedMessages) {
             send(message, target, sequenceKey)
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMessaging.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMessaging.kt
@@ -64,7 +64,7 @@ class FlowMessagingImpl(val serviceHub: ServiceHubInternal): FlowMessaging {
     @Suspendable
     override fun sendSessionMessages(messageData: List<Message>) {
         val addressedMessages = messageData.map { createMessage(it.destination, it.sessionMessage, it.dedupId) }
-        serviceHub.networkService.send(addressedMessages)
+        serviceHub.networkService.sendAll(addressedMessages)
     }
 
     private fun createMessage(destination: Destination, message: SessionMessage, deduplicationId: SenderDeduplicationId): MessagingService.AddressedMessage {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowParallelMessagingTests.kt
@@ -165,7 +165,7 @@ class FlowParallelMessagingTests {
                 Pair(session, messageType)
             }.toMap()
 
-            sendAll(messagesPerSession)
+            sendAllMap(messagesPerSession)
             val messages = receiveAll(String::class.java, messagesPerSession.keys.toList())
 
             messages.map { it.unwrap { payload -> assertEquals("pong", payload) } }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNodeMessagingService.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNodeMessagingService.kt
@@ -161,7 +161,7 @@ class MockNodeMessagingService(private val configuration: NodeConfiguration,
         }
     }
 
-    override fun send(addressedMessages: List<MessagingService.AddressedMessage>) {
+    override fun sendAll(addressedMessages: List<MessagingService.AddressedMessage>) {
         for ((message, target, sequenceKey) in addressedMessages) {
             send(message, target, sequenceKey)
         }


### PR DESCRIPTION
Follow-up on https://github.com/corda/corda/pull/5990.
Renaming the methods related to `sendAll` in order to remove overloads, as necessitated by the following quasar bug: https://github.com/puniverse/quasar/issues/294