### PR TITLE
CORDA-3668: Prevent AttachmentURLConnection from assigning ALL_PERMISSIONS.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -383,8 +383,9 @@ object AttachmentURLStreamHandlerFactory : URLStreamHandlerFactory {
          * Define the permissions that [AttachmentsClassLoader] will need to
          * use this [URL]. The attachment is stored in memory, and so we
          * don't need any extra permissions here. But if we don't override
-         * [getPermission] then we will get the default ALL_PERMISSIONS
-         * in the classes' [java.security.ProtectionDomain].
+         * [getPermission] then [AttachmentsClassLoader] will assign the
+         * default permission of ALL_PERMISSION to these classes'
+         * [java.security.ProtectionDomain]. This would be a security hole!
          */
         override fun getPermission(): Permission? = null
         override fun connect() {

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.net.*
+import java.security.Permission
 import java.util.*
 
 /**
@@ -378,6 +379,14 @@ object AttachmentURLStreamHandlerFactory : URLStreamHandlerFactory {
     private class AttachmentURLConnection(url: URL, private val attachment: Attachment) : URLConnection(url) {
         override fun getContentLengthLong(): Long = attachment.size.toLong()
         override fun getInputStream(): InputStream = attachment.open()
+        /**
+         * Define the permissions that [AttachmentsClassLoader] will need to
+         * use this [URL]. The attachment is stored in memory, and so we
+         * don't need any extra permissions here. But if we don't override
+         * [getPermission] then we will get the default ALL_PERMISSIONS
+         * in the classes' [java.security.ProtectionDomain].
+         */
+        override fun getPermission(): Permission? = null
         override fun connect() {
             connected = true
         }


### PR DESCRIPTION
Configure `AttachmentURLConnection` to assign _no_ extra permissions to any `ProtectionDomain` sourced from its URL. An attachment is stored in memory, and we require no extra permissions to read it anyway. But otherwise, its classes inside an `AttachmentsClassLoader` would be assigned the default of `ALL_PERMISSIONS` instead.

While I'm in the area, ensure that all `AttachmentClassLoader` instances in the test cases are closed afterwards.