### PR TITLE
CORDA-3491 Remove the flow state when a flow finishes

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -18,7 +18,7 @@ interface CheckpointStorage {
     /**
      * Update an existing checkpoint. Will throw if there is not checkpoint for this id.
      */
-    fun updateCheckpoint(id: StateMachineRunId, checkpoint: Checkpoint, serializedFlowState: SerializedBytes<FlowState>)
+    fun updateCheckpoint(id: StateMachineRunId, checkpoint: Checkpoint, serializedFlowState: SerializedBytes<FlowState>?)
 
     /**
      * Remove existing checkpoint from the store.

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointPerformanceRecorder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointPerformanceRecorder.kt
@@ -45,7 +45,7 @@ class DBCheckpointPerformanceRecorder(metrics: MetricRegistry) : CheckpointPerfo
     }
 
     override fun record(serializedCheckpointState: SerializedBytes<CheckpointState>, serializedFlowState: SerializedBytes<FlowState>?) {
-        val flowStateSize = serializedFlowState?.size ?: 0 ;
+        val flowStateSize = serializedFlowState?.size ?: 0
         val totalSize = serializedCheckpointState.size.toLong() + flowStateSize.toLong()
         checkpointingMeter.mark()
         checkpointSizesThisSecond.update(totalSize)

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointPerformanceRecorder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointPerformanceRecorder.kt
@@ -17,7 +17,7 @@ interface CheckpointPerformanceRecorder {
     /**
      * Record performance metrics regarding the serialized size of [CheckpointState] and [FlowState]
      */
-    fun record(serializedCheckpointState: SerializedBytes<CheckpointState>, serializedFlowState: SerializedBytes<FlowState>)
+    fun record(serializedCheckpointState: SerializedBytes<CheckpointState>, serializedFlowState: SerializedBytes<FlowState>?)
 }
 
 class DBCheckpointPerformanceRecorder(metrics: MetricRegistry) : CheckpointPerformanceRecorder {
@@ -44,8 +44,9 @@ class DBCheckpointPerformanceRecorder(metrics: MetricRegistry) : CheckpointPerfo
         }
     }
 
-    override fun record(serializedCheckpointState: SerializedBytes<CheckpointState>, serializedFlowState: SerializedBytes<FlowState>) {
-        val totalSize = serializedCheckpointState.size.toLong() + serializedFlowState.size.toLong()
+    override fun record(serializedCheckpointState: SerializedBytes<CheckpointState>, serializedFlowState: SerializedBytes<FlowState>?) {
+        val flowStateSize = serializedFlowState?.size ?: 0 ;
+        val totalSize = serializedCheckpointState.size.toLong() + flowStateSize.toLong()
         checkpointingMeter.mark()
         checkpointSizesThisSecond.update(totalSize)
         var lastUpdateTime = lastBandwidthUpdate.get()

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -136,7 +136,7 @@ class DBCheckpointStorage(
 
         @Type(type = "corda-blob")
         @Column(name = "flow_state")
-        var flowStack: ByteArray? = EMPTY_BYTE_ARRAY,
+        var flowStack: ByteArray?,
 
         @Column(name = "hmac")
         var hmac: ByteArray,
@@ -506,11 +506,7 @@ class DBCheckpointStorage(
 
     private fun DBFlowCheckpoint.toSerializedCheckpoint(): Checkpoint.Serialized {
         val flowStack = blob.flowStack
-        val serialisedFlowState : SerializedBytes<FlowState>? = if (flowStack != null) {
-            SerializedBytes(flowStack)
-        } else {
-            null
-        }
+        val serialisedFlowState = flowStack?.let { SerializedBytes<FlowState>(it) } ?: null
         return Checkpoint.Serialized(
             serializedCheckpointState = SerializedBytes(blob.checkpoint),
             serializedFlowState = serialisedFlowState,

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -505,8 +505,7 @@ class DBCheckpointStorage(
     }
 
     private fun DBFlowCheckpoint.toSerializedCheckpoint(): Checkpoint.Serialized {
-        val flowStack = blob.flowStack
-        val serialisedFlowState = flowStack?.let { SerializedBytes<FlowState>(it) }
+        val serialisedFlowState = blob.flowStack?.let { SerializedBytes<FlowState>(it) }
         return Checkpoint.Serialized(
             serializedCheckpointState = SerializedBytes(blob.checkpoint),
             serializedFlowState = serialisedFlowState,

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -506,14 +506,14 @@ class DBCheckpointStorage(
 
     private fun DBFlowCheckpoint.toSerializedCheckpoint(): Checkpoint.Serialized {
         val flowStack = blob.flowStack
-        val flowState : SerializedBytes<FlowState>? = if (flowStack != null) {
+        val serialisedFlowState : SerializedBytes<FlowState>? = if (flowStack != null) {
             SerializedBytes(flowStack)
         } else {
             null
         }
         return Checkpoint.Serialized(
             serializedCheckpointState = SerializedBytes(blob.checkpoint),
-            serializedFlowState = flowState,
+            serializedFlowState = serialisedFlowState,
             // Always load as a [Clean] checkpoint to represent that the checkpoint is the last _good_ checkpoint
             errorState = ErrorState.Clean,
             // A checkpoint with a result should not normally be loaded (it should be [null] most of the time)

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -506,7 +506,7 @@ class DBCheckpointStorage(
 
     private fun DBFlowCheckpoint.toSerializedCheckpoint(): Checkpoint.Serialized {
         val flowStack = blob.flowStack
-        val serialisedFlowState = flowStack?.let { SerializedBytes<FlowState>(it) } ?: null
+        val serialisedFlowState = flowStack?.let { SerializedBytes<FlowState>(it) }
         return Checkpoint.Serialized(
             serializedCheckpointState = SerializedBytes(blob.checkpoint),
             serializedFlowState = serialisedFlowState,

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -152,7 +152,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
                                     val checkpoint = serialisedCheckpoint.deserialize(checkpointSerializationContext)
                                     val json = checkpoint.toJson(runId.uuid, now)
                                     val jsonBytes = writer.writeValueAsBytes(json)
-                                    jsonBytes to "${json.topLevelFlowClass.simpleName}-${runId.uuid}.json"
+                                    jsonBytes to "${json.topLevelFlowClass?.simpleName}-${runId.uuid}.json"
                                 } catch (e: Exception) {
                                     log.info("Failed to deserialise checkpoint with flowId: ${runId.uuid}", e)
                                     val errorBytes = checkpointDeserializationErrorMessage(runId, e).toByteArray()
@@ -204,6 +204,9 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
                 val fiber = flowState.frozenFiber.checkpointDeserialize(context = checkpointSerializationContext)
                 fiber to fiber.logic
             }
+            null -> {
+                null to null
+            }
         }
 
         val flowCallStack = if (fiber != null) {
@@ -217,7 +220,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
 
         return CheckpointJson(
                 flowId = id,
-                topLevelFlowClass = flowLogic.javaClass,
+                topLevelFlowClass = flowLogic?.javaClass,
                 topLevelFlowLogic = flowLogic,
                 flowCallStackSummary = flowCallStack.toSummary(),
                 flowCallStack = flowCallStack,
@@ -300,8 +303,8 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
     @Suppress("unused")
     private class CheckpointJson(
             val flowId: UUID,
-            val topLevelFlowClass: Class<FlowLogic<*>>,
-            val topLevelFlowLogic: FlowLogic<*>,
+            val topLevelFlowClass: Class<FlowLogic<*>>?,
+            val topLevelFlowLogic: FlowLogic<*>?,
             val flowCallStackSummary: List<FlowCallSummary>,
             val suspendedOn: SuspendedOn?,
             val flowCallStack: List<FlowCall>,

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -152,7 +152,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
                                     val checkpoint = serialisedCheckpoint.deserialize(checkpointSerializationContext)
                                     val json = checkpoint.toJson(runId.uuid, now)
                                     val jsonBytes = writer.writeValueAsBytes(json)
-                                    jsonBytes to "${json.topLevelFlowClass!!.simpleName}-${runId.uuid}.json"
+                                    jsonBytes to "${json.topLevelFlowClass.simpleName}-${runId.uuid}.json"
                                 } catch (e: Exception) {
                                     log.info("Failed to deserialise checkpoint with flowId: ${runId.uuid}", e)
                                     val errorBytes = checkpointDeserializationErrorMessage(runId, e).toByteArray()
@@ -204,7 +204,9 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
                 val fiber = flowState.frozenFiber.checkpointDeserialize(context = checkpointSerializationContext)
                 fiber to fiber.logic
             }
-            null -> throw IllegalStateException("Only runnable checkpoints with their flow stack are output by the checkpoint dumper")
+            is FlowState.Completed -> {
+                throw IllegalStateException("Only runnable checkpoints with their flow stack are output by the checkpoint dumper")
+            }
         }
 
         val flowCallStack = if (fiber != null) {
@@ -218,7 +220,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
 
         return CheckpointJson(
                 flowId = id,
-                topLevelFlowClass = flowLogic!!.javaClass,
+                topLevelFlowClass = flowLogic.javaClass,
                 topLevelFlowLogic = flowLogic,
                 flowCallStackSummary = flowCallStack.toSummary(),
                 flowCallStack = flowCallStack,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -95,7 +95,13 @@ class ActionExecutorImpl(
     @Suspendable
     private fun executePersistCheckpoint(action: Action.PersistCheckpoint) {
         val checkpoint = action.checkpoint
-        val serializedFlowState = checkpoint.flowState?.checkpointSerialize(checkpointSerializationContext)
+        val flowState = checkpoint.flowState
+        val serializedFlowState = when(flowState) {
+            FlowState.Completed -> null
+            else -> {
+                flowState.checkpointSerialize(checkpointSerializationContext)
+            }
+        }
         if (action.isCheckpointUpdate) {
             checkpointStorage.updateCheckpoint(action.id, checkpoint, serializedFlowState)
         } else {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -95,11 +95,14 @@ class ActionExecutorImpl(
     @Suspendable
     private fun executePersistCheckpoint(action: Action.PersistCheckpoint) {
         val checkpoint = action.checkpoint
-        val serializedFlowState = checkpoint.flowState.checkpointSerialize(checkpointSerializationContext)
+        val serializedFlowState = checkpoint.flowState?.checkpointSerialize(checkpointSerializationContext)
         if (action.isCheckpointUpdate) {
             checkpointStorage.updateCheckpoint(action.id, checkpoint, serializedFlowState)
         } else {
-            checkpointStorage.addCheckpoint(action.id, checkpoint, serializedFlowState)
+            val nonNullSerializedFlowState = requireNotNull(serializedFlowState) {
+                "Cannot create a new checkpoint with a null full state."
+            }
+            checkpointStorage.addCheckpoint(action.id, checkpoint, nonNullSerializedFlowState)
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -98,17 +98,15 @@ class ActionExecutorImpl(
         val flowState = checkpoint.flowState
         val serializedFlowState = when(flowState) {
             FlowState.Completed -> null
-            else -> {
-                flowState.checkpointSerialize(checkpointSerializationContext)
-            }
+            else -> flowState.checkpointSerialize(checkpointSerializationContext)
         }
         if (action.isCheckpointUpdate) {
             checkpointStorage.updateCheckpoint(action.id, checkpoint, serializedFlowState)
         } else {
-            val nonNullSerializedFlowState = requireNotNull(serializedFlowState) {
-                "Cannot create a new checkpoint with a null flow state."
+            if (flowState is FlowState.Completed) {
+                throw IllegalStateException("A new checkpoint cannot be created with a Completed FlowState.")
             }
-            checkpointStorage.addCheckpoint(action.id, checkpoint, nonNullSerializedFlowState)
+            checkpointStorage.addCheckpoint(action.id, checkpoint, serializedFlowState!!)
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -100,7 +100,7 @@ class ActionExecutorImpl(
             checkpointStorage.updateCheckpoint(action.id, checkpoint, serializedFlowState)
         } else {
             val nonNullSerializedFlowState = requireNotNull(serializedFlowState) {
-                "Cannot create a new checkpoint with a null full state."
+                "Cannot create a new checkpoint with a null flow state."
             }
             checkpointStorage.addCheckpoint(action.id, checkpoint, nonNullSerializedFlowState)
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -820,7 +820,7 @@ class SingleThreadedStateMachineManager(
                 fiber
             }
             is FlowState.Completed -> {
-                return null
+                return null // Places calling this function is rely on it to return null if the flow cannot be created from the checkpoint.
             }
         }
 
@@ -862,7 +862,7 @@ class SingleThreadedStateMachineManager(
             is FlowState.Started -> {
                 Fiber.unparkDeserialized(flow.fiber, scheduler)
             }
-            is FlowState.Completed -> throw IllegalArgumentException("Cannot resume on a finished flow state.")
+            is FlowState.Completed -> throw IllegalStateException("Cannot start (or resume) a completed flow.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -860,7 +860,7 @@ class SingleThreadedStateMachineManager(
             is FlowState.Started -> {
                 Fiber.unparkDeserialized(flow.fiber, scheduler)
             }
-            null -> { } //Cannot start a flow with a null flow state.
+            null -> throw IllegalArgumentException("Cannot resume on a finished flow state.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -49,6 +49,7 @@ import org.apache.activemq.artemis.utils.ReusableLatch
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.lang.Integer.min
+import java.lang.RuntimeException
 import java.security.SecureRandom
 import java.util.*
 import java.util.concurrent.*
@@ -820,6 +821,9 @@ class SingleThreadedStateMachineManager(
                 fiber.logic.stateMachine = fiber
                 fiber
             }
+            null -> {
+                return null
+            }
         }
 
         verifyFlowLogicIsSuspendable(fiber.logic)
@@ -853,6 +857,9 @@ class SingleThreadedStateMachineManager(
                     }
                     is FlowState.Started -> {
                         Fiber.unparkDeserialized(flow.fiber, scheduler)
+                    }
+                    null -> {
+                        //TODO: I should clean this up.
                     }
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -781,7 +781,7 @@ class SingleThreadedStateMachineManager(
             initialDeduplicationHandler: DeduplicationHandler?
     ): Flow? {
         val checkpoint = tryDeserializeCheckpoint(serializedCheckpoint, id)?.copy(status = Checkpoint.FlowStatus.RUNNABLE) ?: return null
-        val flowState = checkpoint.flowState
+        val flowState = checkpoint.flowState ?: return null
         val resultFuture = openFuture<Any?>()
         val fiber = when (flowState) {
             is FlowState.Unstarted -> {
@@ -821,9 +821,6 @@ class SingleThreadedStateMachineManager(
                 fiber.logic.stateMachine = fiber
                 fiber
             }
-            null -> {
-                return null
-            }
         }
 
         verifyFlowLogicIsSuspendable(fiber.logic)
@@ -859,7 +856,7 @@ class SingleThreadedStateMachineManager(
                         Fiber.unparkDeserialized(flow.fiber, scheduler)
                     }
                     null -> {
-                        //TODO: I should clean this up.
+                        //Cannot start a flow with a null flow state.
                     }
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -57,7 +57,7 @@ data class StateMachineState(
  */
 data class Checkpoint(
         val checkpointState: CheckpointState,
-        val flowState: FlowState,
+        val flowState: FlowState?,
         val errorState: ErrorState,
         val result: Any? = null,
         val status: FlowStatus = FlowStatus.RUNNABLE,
@@ -149,7 +149,7 @@ data class Checkpoint(
      */
     data class Serialized(
         val serializedCheckpointState: SerializedBytes<CheckpointState>,
-        val serializedFlowState: SerializedBytes<FlowState>,
+        val serializedFlowState: SerializedBytes<FlowState>?,
         val errorState: ErrorState,
         val result: SerializedBytes<Any>?,
         val status: FlowStatus,
@@ -165,7 +165,7 @@ data class Checkpoint(
         fun deserialize(checkpointSerializationContext: CheckpointSerializationContext): Checkpoint {
             return Checkpoint(
                 checkpointState = serializedCheckpointState.deserialize(context = SerializationDefaults.STORAGE_CONTEXT),
-                flowState = serializedFlowState.checkpointDeserialize(checkpointSerializationContext),
+                flowState = serializedFlowState?.checkpointDeserialize(checkpointSerializationContext),
                 errorState = errorState,
                 result = result?.deserialize(context = SerializationDefaults.STORAGE_CONTEXT),
                 status = status,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -57,7 +57,7 @@ data class StateMachineState(
  */
 data class Checkpoint(
         val checkpointState: CheckpointState,
-        val flowState: FlowState?,
+        val flowState: FlowState,
         val errorState: ErrorState,
         val result: Any? = null,
         val status: FlowStatus = FlowStatus.RUNNABLE,
@@ -165,7 +165,7 @@ data class Checkpoint(
         fun deserialize(checkpointSerializationContext: CheckpointSerializationContext): Checkpoint {
             return Checkpoint(
                 checkpointState = serializedCheckpointState.deserialize(context = SerializationDefaults.STORAGE_CONTEXT),
-                flowState = serializedFlowState?.checkpointDeserialize(checkpointSerializationContext),
+                flowState = serializedFlowState?.checkpointDeserialize(checkpointSerializationContext) ?: FlowState.Completed,
                 errorState = errorState,
                 result = result?.deserialize(context = SerializationDefaults.STORAGE_CONTEXT),
                 status = status,
@@ -299,6 +299,12 @@ sealed class FlowState {
     ) : FlowState() {
         override fun toString() = "Started(flowIORequest=$flowIORequest, frozenFiber=${frozenFiber.hash})"
     }
+
+    /**
+     * The flow has finished.
+     */
+    object Completed : FlowState()
+
 }
 
 /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -301,7 +301,7 @@ sealed class FlowState {
     }
 
     /**
-     * The flow has finished.
+     * The flow has completed. It does not have a running fiber that needs to be serialized and checkpointed.
      */
     object Completed : FlowState()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services.statemachine.transitions
 
 import net.corda.node.services.statemachine.*
+import java.lang.RuntimeException
 
 /**
  * This transition checks the current state of the flow and determines whether anything needs to be done.
@@ -28,6 +29,7 @@ class DoRemainingWorkTransition(
         return when (checkpoint.flowState) {
             is FlowState.Unstarted -> UnstartedFlowTransition(context, startingState, checkpoint.flowState).transition()
             is FlowState.Started -> StartedFlowTransition(context, startingState, checkpoint.flowState).transition()
+            null ->  throw RuntimeException("Tried to transition a deleted state.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -25,13 +25,11 @@ class DoRemainingWorkTransition(
 
     // If the flow is clean check the FlowState
     private fun cleanTransition(): TransitionResult {
-        val checkpoint = startingState.checkpoint
-        val flowState = requireNotNull(checkpoint.flowState) {
-            "Cannot transition a state with null flow state."
-        }
+        val flowState = startingState.checkpoint.flowState
         return when (flowState) {
             is FlowState.Unstarted -> UnstartedFlowTransition(context, startingState, flowState).transition()
             is FlowState.Started -> StartedFlowTransition(context, startingState, flowState).transition()
+            is FlowState.Completed -> throw IllegalArgumentException("Cannot transition a state with completed flow state.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -26,10 +26,12 @@ class DoRemainingWorkTransition(
     // If the flow is clean check the FlowState
     private fun cleanTransition(): TransitionResult {
         val checkpoint = startingState.checkpoint
-        return when (checkpoint.flowState) {
-            is FlowState.Unstarted -> UnstartedFlowTransition(context, startingState, checkpoint.flowState).transition()
-            is FlowState.Started -> StartedFlowTransition(context, startingState, checkpoint.flowState).transition()
-            null ->  throw RuntimeException("Tried to transition a deleted state.")
+        val flowState = requireNotNull(checkpoint.flowState) {
+            "Cannot transition a state with null flow state."
+        }
+        return when (flowState) {
+            is FlowState.Unstarted -> UnstartedFlowTransition(context, startingState, flowState).transition()
+            is FlowState.Started -> StartedFlowTransition(context, startingState, flowState).transition()
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services.statemachine.transitions
 
 import net.corda.node.services.statemachine.*
-import java.lang.RuntimeException
 
 /**
  * This transition checks the current state of the flow and determines whether anything needs to be done.
@@ -29,7 +28,7 @@ class DoRemainingWorkTransition(
         return when (flowState) {
             is FlowState.Unstarted -> UnstartedFlowTransition(context, startingState, flowState).transition()
             is FlowState.Started -> StartedFlowTransition(context, startingState, flowState).transition()
-            is FlowState.Completed -> throw IllegalArgumentException("Cannot transition a state with completed flow state.")
+            is FlowState.Completed -> throw IllegalStateException("Cannot transition a state with completed flow state.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -209,7 +209,7 @@ class TopLevelTransition(
                                 checkpointState = checkpoint.checkpointState.copy(
                                         numberOfSuspends = checkpoint.checkpointState.numberOfSuspends + 1
                                 ),
-                                flowState = null,
+                                flowState = FlowState.Completed,
                                 result = event.returnValue,
                                 status = Checkpoint.FlowStatus.COMPLETED
                             ),

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -209,6 +209,7 @@ class TopLevelTransition(
                                 checkpointState = checkpoint.checkpointState.copy(
                                         numberOfSuspends = checkpoint.checkpointState.numberOfSuspends + 1
                                 ),
+                                flowState = null,
                                 result = event.returnValue,
                                 status = Checkpoint.FlowStatus.COMPLETED
                             ),

--- a/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17-postgres.xml
@@ -47,7 +47,7 @@
                 <constraints nullable="false"/>
             </column>
             <column name="flow_state" type="varbinary(33554432)">
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
             </column>
             <column name="timestamp" type="java.sql.Types.TIMESTAMP">
                 <constraints nullable="false"/>

--- a/node/src/main/resources/migration/node-core.changelog-v17.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17.xml
@@ -47,7 +47,7 @@
                 <constraints nullable="false"/>
             </column>
             <column name="flow_state" type="blob">
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
             </column>
             <column name="timestamp" type="java.sql.Types.TIMESTAMP">
                 <constraints nullable="false"/>

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -469,15 +469,16 @@ class DBCheckpointStorageTests {
     fun `Checkpoint can be updated with flow io request information`() {
         val (id, checkpoint) = newCheckpoint(1)
         database.transaction {
-            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+            val serializedFlowState =
+                    checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState)
             val checkpointFromStorage = checkpointStorage.getCheckpoint(id)
             assertNull(checkpointFromStorage!!.flowIoRequest)
         }
         database.transaction {
             val newCheckpoint = checkpoint.copy(flowIoRequest = FlowIORequest.Sleep::class.java.simpleName)
-            val serializedFlowState = newCheckpoint.flowState.checkpointSerialize(
-                context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
+            val serializedFlowState = newCheckpoint.flowState?.checkpointSerialize(
+                    context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
             )
             checkpointStorage.updateCheckpoint(id, newCheckpoint, serializedFlowState)
         }
@@ -494,7 +495,8 @@ class DBCheckpointStorageTests {
         val maxProgressStepLength = 256
         val (id, checkpoint) = newCheckpoint(1)
         database.transaction {
-            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+            val serializedFlowState =
+                    checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState)
             val checkpointFromStorage = checkpointStorage.getCheckpoint(id)
             assertNull(checkpointFromStorage!!.progressStep)
@@ -505,7 +507,7 @@ class DBCheckpointStorageTests {
         """.trimIndent()
         database.transaction {
             val newCheckpoint = checkpoint.copy(progressStep = longString)
-            val serializedFlowState = newCheckpoint.flowState.checkpointSerialize(
+            val serializedFlowState = newCheckpoint.flowState?.checkpointSerialize(
                     context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
             )
             checkpointStorage.updateCheckpoint(id, newCheckpoint, serializedFlowState)
@@ -530,7 +532,8 @@ class DBCheckpointStorageTests {
         val paused = checkpoint.copy(status = Checkpoint.FlowStatus.PAUSED) // is considered runnable
 
         database.transaction {
-            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+            val serializedFlowState =
+                    checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
             checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), runnable, serializedFlowState)
             checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), hospitalized, serializedFlowState)
@@ -551,7 +554,7 @@ class DBCheckpointStorageTests {
                 object : CheckpointPerformanceRecorder {
                     override fun record(
                         serializedCheckpointState: SerializedBytes<CheckpointState>,
-                        serializedFlowState: SerializedBytes<FlowState>
+                        serializedFlowState: SerializedBytes<FlowState>?
                     ) {
                         // do nothing
                     }
@@ -581,7 +584,7 @@ class DBCheckpointStorageTests {
     }
 
     private fun Checkpoint.serializeFlowState(): SerializedBytes<FlowState> {
-        return flowState.checkpointSerialize(CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+        return flowState!!.checkpointSerialize(CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 
     private fun Checkpoint.Serialized.deserialize(): Checkpoint {

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -131,13 +131,23 @@ class DBCheckpointStorageTests {
                 checkpointStorage.checkpoints().single().deserialize()
             )
         }
-        val finalCheckpoint = updatedCheckpoint.copy(flowState = FlowState.Completed)
+    }
+
+    @Test(timeout = 300_000)
+    fun `update a checkpoint to completed`() {
+        val (id, checkpoint) = newCheckpoint()
+        val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.updateCheckpoint(id, finalCheckpoint, null)
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState)
+        }
+
+        val completedCheckpoint = checkpoint.copy(flowState = FlowState.Completed)
+        database.transaction {
+            checkpointStorage.updateCheckpoint(id, completedCheckpoint, null)
         }
         database.transaction {
             assertEquals(
-                    finalCheckpoint,
+                    completedCheckpoint,
                     checkpointStorage.checkpoints().single().deserialize()
             )
         }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -489,7 +489,7 @@ class DBCheckpointStorageTests {
         database.transaction {
             val newCheckpoint = checkpoint.copy(flowIoRequest = FlowIORequest.Sleep::class.java.simpleName)
             val serializedFlowState = newCheckpoint.flowState?.checkpointSerialize(
-                    context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
+                context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
             )
             checkpointStorage.updateCheckpoint(id, newCheckpoint, serializedFlowState)
         }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -131,6 +131,17 @@ class DBCheckpointStorageTests {
                 checkpointStorage.checkpoints().single().deserialize()
             )
         }
+        val finalCheckpoint = updatedCheckpoint.copy(flowState = null)
+        database.transaction {
+            checkpointStorage.updateCheckpoint(id, finalCheckpoint, updatedSerializedFlowState)
+
+        }
+        database.transaction {
+            assertEquals(
+                    updatedCheckpoint,
+                    checkpointStorage.checkpoints().single().deserialize()
+            )
+        }
     }
 
     @Test(timeout = 300_000)

--- a/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
@@ -15,6 +15,8 @@ import net.corda.core.internal.deleteIfExists
 import net.corda.core.internal.deleteRecursively
 import net.corda.core.internal.div
 import net.corda.core.internal.inputStream
+import net.corda.core.internal.isRegularFile
+import net.corda.core.internal.list
 import net.corda.core.internal.readFully
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SerializeAsToken
@@ -42,6 +44,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Clock
 import java.time.Instant
@@ -113,7 +116,7 @@ class CheckpointDumperImplTest {
         }
 
         dumper.dumpCheckpoints()
-	checkDumpFile()
+	    checkDumpFile(organisation)
     }
 
     @Test(timeout=300_000)
@@ -134,14 +137,15 @@ class CheckpointDumperImplTest {
         }
 
         dumper.dumpCheckpoints()
+        checkDumpFile("Only runnable checkpoints with their flow stack are output by the checkpoint dumper")
     }
 
-    private fun checkDumpFile() {
+    private fun checkDumpFile(match: String) {
         ZipInputStream(file.inputStream()).use { zip ->
             val entry = zip.nextEntry
             assertThat(entry.name, containsSubstring("json"))
             val content = zip.readFully()
-            assertThat(String(content), containsSubstring(organisation))
+            assertThat(String(content), containsSubstring(match))
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
@@ -147,7 +147,7 @@ class CheckpointDumperImplTest {
                 object : CheckpointPerformanceRecorder {
                     override fun record(
                         serializedCheckpointState: SerializedBytes<CheckpointState>,
-                        serializedFlowState: SerializedBytes<FlowState>
+                        serializedFlowState: SerializedBytes<FlowState>?
                     ) {
                         // do nothing
                     }
@@ -169,6 +169,6 @@ class CheckpointDumperImplTest {
     }
 
     private fun serializeFlowState(checkpoint: Checkpoint): SerializedBytes<FlowState> {
-        return checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+        return checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
@@ -117,7 +117,7 @@ class CheckpointDumperImplTest {
     }
 
     @Test(timeout=300_000)
-    fun testDumpCheckpointWithRemovedFlowState() {
+    fun `test checkpoint dumper with Completed FlowState`() {
         val dumper = CheckpointDumperImpl(checkpointStorage, database, services, baseDirectory)
         dumper.update(mockAfterStartEvent)
 
@@ -127,7 +127,7 @@ class CheckpointDumperImplTest {
             checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint))
         }
         val newCheckpoint = checkpoint.copy(
-            flowState = null
+            flowState = FlowState.Completed
         )
         database.transaction {
             checkpointStorage.updateCheckpoint(id, newCheckpoint, null)
@@ -191,6 +191,6 @@ class CheckpointDumperImplTest {
     }
 
     private fun serializeFlowState(checkpoint: Checkpoint): SerializedBytes<FlowState> {
-        return checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+        return checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -67,6 +67,7 @@ import org.assertj.core.api.Condition
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -342,13 +343,14 @@ class FlowFrameworkTests {
 
     //We should update this test when we do the work to persists the flow result.
     @Test(timeout = 300_000)
-    fun `Flow status is set to completed in database when the flow finishes`() {
+    fun `Flow status is set to completed in database when the flow finishes and serialised flow state is null`() {
         val terminationSignal = Semaphore(0)
         val flow = aliceNode.services.startFlow(NoOpFlow( terminateUponSignal = terminationSignal))
         mockNet.waitQuiescent() // current thread needs to wait fiber running on a different thread, has reached the blocking point
         aliceNode.database.transaction {
             val checkpoint = dbCheckpointStorage.getCheckpoint(flow.id)
             assertNull(checkpoint!!.result)
+            assertNotNull(checkpoint.serializedFlowState)
             assertNotEquals(Checkpoint.FlowStatus.COMPLETED, checkpoint.status)
         }
         terminationSignal.release()
@@ -356,6 +358,7 @@ class FlowFrameworkTests {
         aliceNode.database.transaction {
             val checkpoint = dbCheckpointStorage.getCheckpoint(flow.id)
             assertNull(checkpoint!!.result)
+            assertNull(checkpoint.serializedFlowState)
             assertEquals(Checkpoint.FlowStatus.COMPLETED, checkpoint.status)
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -103,7 +103,7 @@ class FlowFrameworkTests {
         object : CheckpointPerformanceRecorder {
             override fun record(
                 serializedCheckpointState: SerializedBytes<CheckpointState>,
-                serializedFlowState: SerializedBytes<FlowState>
+                serializedFlowState: SerializedBytes<FlowState>?
             ) {
                 // do nothing
             }


### PR DESCRIPTION
Updated Checkpoint Schema and in memory class so that the Flow state can be set to null. On successful flow completion the flow state is set to null. If the flow is hospitalised or is manually killed then the flow state is left in the DB to aid post mortem debugging. 