### PR TITLE
Bump dependx to 0.1.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ buildscript {
         // See https://github.com/corda/gradle-capsule-plugin
         classpath "us.kirchmeier:gradle-capsule-plugin:1.0.4_r3"
         classpath group: "com.r3.testing", name: "gradle-distributed-testing-plugin", version: "1.2-LOCAL-K8S-SHARED-CACHE-SNAPSHOT", changing: true
-        classpath group: "com.r3.dependx", name: "gradle-dependx", version: "0.1.12", changing: true
+        classpath group: "com.r3.dependx", name: "gradle-dependx", version: "0.1.13", changing: true
         classpath "com.bmuschko:gradle-docker-plugin:5.0.0"
     }
 }


### PR DESCRIPTION
Bump dependx to 0.1.13, which warns instead of throwing when a dependency is discovered but doesn't refer to a known project (could happen i.e. due to outdated commented out lines)

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
