### PR TITLE
CORDA-3677 FlowExternalOperation serialising reference to FlowLogic

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalAsyncOperationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalAsyncOperationTest.kt
@@ -177,12 +177,14 @@ class FlowExternalAsyncOperationTest : AbstractFlowExternalOperationTest() {
         FlowWithExternalProcess(party) {
 
         @Suspendable
-        override fun testCode(): Any =
-            await(ExternalAsyncOperation(serviceHub) { _, _ ->
+        override fun testCode(): Any {
+            val e = createException()
+            return await(ExternalAsyncOperation(serviceHub) { _, _ ->
                 CompletableFuture<Any>().apply {
-                    completeExceptionally(createException())
+                    completeExceptionally(e)
                 }
             })
+        }
 
         private fun createException() = when (exceptionType) {
             HospitalizeFlowException::class.java -> HospitalizeFlowException("keep it around")

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
@@ -235,13 +235,9 @@ class FlowExternalOperationTest : AbstractFlowExternalOperationTest() {
         FlowWithExternalProcess(party) {
 
         @Suspendable
-        override fun testCode(): Any {
-            val e: Exception? = createException()
-            return await(ExternalOperation(serviceHub) { _, _ ->
-                if (e != null)
-                    throw e
-                return@ExternalOperation
-            })
+        override fun testCode() {
+            val e = createException()
+            await(ExternalOperation(serviceHub) { _, _ -> throw e })
         }
 
         private fun createException() = when (exceptionType) {

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
@@ -235,7 +235,10 @@ class FlowExternalOperationTest : AbstractFlowExternalOperationTest() {
         FlowWithExternalProcess(party) {
 
         @Suspendable
-        override fun testCode(): Any = await(ExternalOperation(serviceHub) { _, _ -> throw createException() })
+        override fun testCode(): Any {
+            val e = createException()
+            return await(ExternalOperation(serviceHub) { _, _ -> throw e })
+        }
 
         private fun createException() = when (exceptionType) {
             HospitalizeFlowException::class.java -> HospitalizeFlowException("keep it around")

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
@@ -236,8 +236,12 @@ class FlowExternalOperationTest : AbstractFlowExternalOperationTest() {
 
         @Suspendable
         override fun testCode(): Any {
-            val e = createException()
-            return await(ExternalOperation(serviceHub) { _, _ -> throw e })
+            val e: Exception? = createException()
+            return await(ExternalOperation(serviceHub) { _, _ ->
+                if (e != null)
+                    throw e
+                return@ExternalOperation
+            })
         }
 
         private fun createException() = when (exceptionType) {

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -579,12 +579,7 @@ abstract class FlowLogic<out T> {
     @Suspendable
     fun <R : Any> await(operation: FlowExternalAsyncOperation<R>): R {
         // Wraps the passed in [FlowExternalAsyncOperation] so its [CompletableFuture] can be converted into a [CordaFuture]
-        val flowAsyncOperation = object : FlowAsyncOperation<R>, WrappedFlowExternalAsyncOperation<R> {
-            override val operation = operation
-            override fun execute(deduplicationId: String): CordaFuture<R> {
-                return this.operation.execute(deduplicationId).asCordaFuture()
-            }
-        }
+        val flowAsyncOperation = WrappedFlowExternalAsyncOperation(operation)
         val request = FlowIORequest.ExecuteAsyncOperation(flowAsyncOperation)
         return stateMachine.suspend(request, false)
     }
@@ -598,18 +593,7 @@ abstract class FlowLogic<out T> {
      */
     @Suspendable
     fun <R : Any> await(operation: FlowExternalOperation<R>): R {
-        val flowAsyncOperation = object : FlowAsyncOperation<R>, WrappedFlowExternalOperation<R> {
-            override val serviceHub = this@FlowLogic.serviceHub as ServiceHubCoreInternal
-            override val operation = operation
-            override fun execute(deduplicationId: String): CordaFuture<R> {
-                // Using a [CompletableFuture] allows unhandled exceptions to be thrown inside the background operation
-                // the exceptions will be set on the future by [CompletableFuture.AsyncSupply.run]
-                return CompletableFuture.supplyAsync(
-                    Supplier { this.operation.execute(deduplicationId) },
-                    serviceHub.externalOperationExecutor
-                ).asCordaFuture()
-            }
-        }
+        val flowAsyncOperation = WrappedFlowExternalOperation(serviceHub as ServiceHubCoreInternal, operation)
         val request = FlowIORequest.ExecuteAsyncOperation(flowAsyncOperation)
         return stateMachine.suspend(request, false)
     }
@@ -619,21 +603,32 @@ abstract class FlowLogic<out T> {
  * [WrappedFlowExternalAsyncOperation] is added to allow jackson to properly reference the data stored within the wrapped
  * [FlowExternalAsyncOperation].
  */
-private interface WrappedFlowExternalAsyncOperation<R : Any> {
-    val operation: FlowExternalAsyncOperation<R>
+private class WrappedFlowExternalAsyncOperation<R : Any>(val operation: FlowExternalAsyncOperation<R>) : FlowAsyncOperation<R> {
+    override fun execute(deduplicationId: String): CordaFuture<R> {
+        return operation.execute(deduplicationId).asCordaFuture()
+    }
 }
 
 /**
  * [WrappedFlowExternalOperation] is added to allow jackson to properly reference the data stored within the wrapped
  * [FlowExternalOperation].
  *
- * The reference to [ServiceHub] is is also needed by Kryo to properly keep a reference to [ServiceHub] so that
+ * The reference to [ServiceHub] is also needed by Kryo to properly keep a reference to [ServiceHub] so that
  * [FlowExternalOperation] can be run from the [ServiceHubCoreInternal.externalOperationExecutor] without causing errors when retrying a
  * flow. A [NullPointerException] is thrown if [FlowLogic.serviceHub] is accessed from [FlowLogic.await] when retrying a flow.
  */
-private interface WrappedFlowExternalOperation<R : Any> {
-    val serviceHub: ServiceHub
+private class WrappedFlowExternalOperation<R : Any>(
+    val serviceHub: ServiceHubCoreInternal,
     val operation: FlowExternalOperation<R>
+) : FlowAsyncOperation<R> {
+    override fun execute(deduplicationId: String): CordaFuture<R> {
+        // Using a [CompletableFuture] allows unhandled exceptions to be thrown inside the background operation
+        // the exceptions will be set on the future by [CompletableFuture.AsyncSupply.run]
+        return CompletableFuture.supplyAsync(
+            Supplier { this.operation.execute(deduplicationId) },
+            serviceHub.externalOperationExecutor
+        ).asCordaFuture()
+    }
 }
 
 /**


### PR DESCRIPTION
In `FlowLogic.await` methods (FlowExternalOperation), objects that were created out of anonymous classes would get **implicit** references to `FlowLogic`. 

Changing anonymous classes to concrete classes prevents those objects getting those implicit references.