### PR TITLE
CORDA-3680: Add CorDapp custom serialisers to Driver's in-process nodes.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/rpc/client/AMQPClientSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/rpc/client/AMQPClientSerializationScheme.kt
@@ -66,7 +66,7 @@ class AMQPClientSerializationScheme(
         }
     }
 
-    override fun canDeserializeVersion(magic: CordaSerializationMagic, target: SerializationContext.UseCase): Boolean {
+    override fun canDeserializeVersion(magic: CordaSerializationMagic, target: UseCase): Boolean {
         return magic == amqpMagic && (target == UseCase.RPCClient || target == UseCase.P2P)
     }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPServerSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPServerSerializationScheme.kt
@@ -18,10 +18,16 @@ class AMQPServerSerializationScheme(
         cordappSerializationWhitelists: Set<SerializationWhitelist>,
         serializerFactoriesForContexts: MutableMap<SerializationFactoryCacheKey, SerializerFactory>
 ) : AbstractAMQPSerializationScheme(cordappCustomSerializers, cordappSerializationWhitelists, serializerFactoriesForContexts) {
-    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers, cordapps.serializationWhitelists, AccessOrderLinkedHashMap<SerializationFactoryCacheKey, SerializerFactory>(128).toSynchronised())
-    constructor(cordapps: List<Cordapp>, serializerFactoriesForContexts: MutableMap<SerializationFactoryCacheKey, SerializerFactory>) : this(cordapps.customSerializers, cordapps.serializationWhitelists, serializerFactoriesForContexts)
+    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers, cordapps.serializationWhitelists)
+    constructor(cordapps: List<Cordapp>, serializerFactoriesForContexts: MutableMap<SerializationFactoryCacheKey, SerializerFactory>)
+        : this(cordapps.customSerializers, cordapps.serializationWhitelists, serializerFactoriesForContexts)
+    constructor(
+        cordappCustomSerializers: Set<SerializationCustomSerializer<*,*>>,
+        cordappSerializationWhitelists: Set<SerializationWhitelist>
+    ) : this(cordappCustomSerializers, cordappSerializationWhitelists, AccessOrderLinkedHashMap<SerializationFactoryCacheKey, SerializerFactory>(128).toSynchronised())
 
-    constructor() : this(emptySet(), emptySet(), AccessOrderLinkedHashMap<SerializationFactoryCacheKey, SerializerFactory>(128).toSynchronised() )
+    @Suppress("UNUSED")
+    constructor() : this(emptySet(), emptySet())
 
     override fun rpcClientSerializerFactory(context: SerializationContext): SerializerFactory {
         throw UnsupportedOperationException()

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithCustomSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithCustomSerializerTest.kt
@@ -18,12 +18,20 @@ import net.corda.testing.node.internal.cordappWithPackages
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.BeforeClass
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
 import kotlin.test.assertFailsWith
 
+@RunWith(Parameterized::class)
 @Suppress("FunctionName")
-class ContractWithCustomSerializerTest {
+class ContractWithCustomSerializerTest(private val runInProcess: Boolean) {
     companion object {
         const val CURRANTS = 5000L
+
+        @Parameters
+        @JvmStatic
+        fun modes(): List<Array<Boolean>> = listOf(Array(1) { true }, Array(1) { false })
 
         @BeforeClass
         @JvmStatic
@@ -37,7 +45,7 @@ class ContractWithCustomSerializerTest {
         val user = User("u", "p", setOf(Permissions.all()))
         driver(DriverParameters(
             portAllocation = incrementalPortAllocation(),
-            startNodesInProcess = false,
+            startNodesInProcess = runInProcess,
             notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
             cordappsForAllNodes = listOf(
                 cordappWithPackages("net.corda.flows.serialization.custom").signed(),


### PR DESCRIPTION
Add the CorDapp custom serializers and whitelists to the `AMQPServerSerializationScheme` belonging to `DriverSerializationEnvironment`. Modify the basic driver-based serialization integration tests to run with both in-process and out-of-process nodes.