### PR TITLE
[NOTICK] - Enable check in detekt for unused imports

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt
@@ -1,7 +1,6 @@
 package net.corda.client.rpc
 
 import co.paralleluniverse.fibers.Suspendable
-import com.esotericsoftware.kryo.KryoException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.messaging.startFlow

--- a/common/configuration-parsing/src/test/kotlin/net/corda/common/configuration/parsing/internal/SpecificationTest.kt
+++ b/common/configuration-parsing/src/test/kotlin/net/corda/common/configuration/parsing/internal/SpecificationTest.kt
@@ -1,7 +1,6 @@
 package net.corda.common.configuration.parsing.internal
 
 import com.typesafe.config.Config
-import net.corda.common.validation.internal.Validated
 import net.corda.common.validation.internal.Validated.Companion.invalid
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
@@ -5,13 +5,11 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.HospitalizeFlowException
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
-import net.corda.core.internal.packageName
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.queryBy
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.minutes
-import net.corda.node.services.statemachine.StaffedFlowHospital
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyState
 import net.corda.testing.core.ALICE_NAME
@@ -22,7 +20,6 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.cordappsForPackages
 import org.junit.Test
 import java.sql.SQLTransientConnectionException
-import java.util.concurrent.Semaphore
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
@@ -5,6 +5,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.HospitalizeFlowException
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
+import net.corda.core.internal.packageName
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.queryBy
 import net.corda.core.transactions.TransactionBuilder

--- a/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt
@@ -49,7 +49,7 @@ interface Attachment : NamedByHash {
 
     /**
      * Finds the named file case insensitively and copies it to the output stream.
-     * @throws FileNotFoundException if the given path doesn't exist in the attachment.
+     * @throws [FileNotFoundException] if the given path doesn't exist in the attachment.
      */
     @JvmDefault
     fun extractFile(path: String, outputTo: OutputStream) = openAsJAR().use { it.extractFile(path, outputTo) }

--- a/core/src/main/kotlin/net/corda/core/crypto/NullKeys.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/NullKeys.kt
@@ -2,7 +2,6 @@ package net.corda.core.crypto
 
 import net.corda.core.KeepForDJVM
 import net.corda.core.identity.AnonymousParty
-import net.corda.core.serialization.CordaSerializable
 import java.security.PublicKey
 
 @KeepForDJVM

--- a/core/src/main/kotlin/net/corda/core/flows/FlowExternalOperations.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowExternalOperations.kt
@@ -1,7 +1,5 @@
 package net.corda.core.flows
 
-import net.corda.core.internal.ServiceHubCoreInternal
-import net.corda.core.node.ServiceHub
 import java.util.concurrent.CompletableFuture
 
 /**

--- a/core/src/main/kotlin/net/corda/core/internal/X500Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/X500Utils.kt
@@ -4,7 +4,6 @@ package net.corda.core.internal
 
 import net.corda.core.KeepForDJVM
 import net.corda.core.identity.CordaX500Name
-import org.bouncycastle.asn1.ASN1Encodable
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import org.bouncycastle.asn1.x500.AttributeTypeAndValue
 import org.bouncycastle.asn1.x500.X500Name

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -252,7 +252,7 @@ interface CordaRPCOps : RPCOps {
      * Note: This operation may be restricted only to node administrators.
      * @param parametersHash hash of network parameters to accept
      * @throws IllegalArgumentException if network map advertises update with different parameters hash then the one accepted by node's operator.
-     * @throws IOException if failed to send the approval to network map
+     * @throws [IOException] if failed to send the approval to network map
      */
     // TODO This operation should be restricted to just node admins.
     fun acceptNewNetworkParameters(parametersHash: SecureHash)

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -8,7 +8,6 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.Party
 import net.corda.core.node.services.Vault
 import net.corda.core.schemas.StatePersistable
 import net.corda.core.serialization.CordaSerializable

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/CheckpointSerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/CheckpointSerializationAPI.kt
@@ -3,7 +3,6 @@ package net.corda.core.serialization.internal
 import net.corda.core.DeleteForDJVM
 import net.corda.core.DoNotImplement
 import net.corda.core.KeepForDJVM
-import net.corda.core.crypto.SecureHash
 import net.corda.core.serialization.*
 import net.corda.core.utilities.ByteSequence
 import net.corda.core.utilities.sequence

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -134,7 +134,7 @@ open class TransactionBuilder(
      *
      * @returns A new [WireTransaction] that will be unaffected by further changes to this [TransactionBuilder].
      *
-     * @throws ZoneVersionTooLowException if there are reference states and the zone minimum platform version is less than 4.
+     * @throws [ZoneVersionTooLowException] if there are reference states and the zone minimum platform version is less than 4.
      */
     @Throws(MissingContractAttachments::class)
     fun toWireTransaction(services: ServicesForResolution): WireTransaction = toWireTransactionWithContext(services, null)

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -317,7 +317,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
     /**
      * Checks that the given signature matches one of the commands and that it is a correct signature over the tx.
      *
-     * @throws SignatureException if the signature didn't match the transaction contents.
+     * @throws [SignatureException] if the signature didn't match the transaction contents.
      * @throws IllegalArgumentException if the signature key doesn't appear in any command.
      */
     fun checkSignature(sig: TransactionSignature) {

--- a/core/src/test/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtilsBuilderTest.kt
+++ b/core/src/test/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtilsBuilderTest.kt
@@ -1,6 +1,5 @@
 package net.corda.core.node.services.vault
 
-import net.corda.core.node.services.vault.BinaryComparisonOperator
 import net.corda.core.node.services.vault.Builder.`in`
 import net.corda.core.node.services.vault.Builder.equal
 import net.corda.core.node.services.vault.Builder.greaterThan
@@ -13,8 +12,6 @@ import net.corda.core.node.services.vault.Builder.notEqual
 import net.corda.core.node.services.vault.Builder.notIn
 import net.corda.core.node.services.vault.Builder.notLike
 import net.corda.core.node.services.vault.Builder.notNull
-import net.corda.core.node.services.vault.CollectionOperator
-import net.corda.core.node.services.vault.ColumnPredicate
 import net.corda.core.node.services.vault.ColumnPredicate.AggregateFunction
 import net.corda.core.node.services.vault.ColumnPredicate.Between
 import net.corda.core.node.services.vault.ColumnPredicate.BinaryComparison
@@ -23,12 +20,6 @@ import net.corda.core.node.services.vault.ColumnPredicate.EqualityComparison
 import net.corda.core.node.services.vault.ColumnPredicate.Likeness
 import net.corda.core.node.services.vault.ColumnPredicate.NullExpression
 import net.corda.core.node.services.vault.CriteriaExpression.ColumnPredicateExpression
-import net.corda.core.node.services.vault.EqualityComparisonOperator
-import net.corda.core.node.services.vault.FieldInfo
-import net.corda.core.node.services.vault.LikenessOperator
-import net.corda.core.node.services.vault.NullOperator
-import net.corda.core.node.services.vault.Operator
-import net.corda.core.node.services.vault.getField
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.ObjectAssert
 import org.junit.Test

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -87,7 +87,6 @@
     <ID>ComplexCondition:InternalUtils.kt$it.type == this &amp;&amp; it.isPublic &amp;&amp; it.isStatic &amp;&amp; it.isFinal</ID>
     <ID>ComplexCondition:Main.kt$Main$(hostname != null) &amp;&amp; (port != null) &amp;&amp; (username != null) &amp;&amp; (password != null)</ID>
     <ID>ComplexCondition:Schema.kt$obj == null || obj is DescribedType || obj is Binary || forGenericType(type).run { isPrimitive(this) || this == TopType }</ID>
-    <ID>ComplexCondition:TopLevelTransition.kt$TopLevelTransition$currentState.isTransactionTracked &amp;&amp; checkpoint.flowState is FlowState.Started &amp;&amp; checkpoint.flowState.flowIORequest is FlowIORequest.WaitForLedgerCommit &amp;&amp; checkpoint.flowState.flowIORequest.hash == event.transaction.id</ID>
     <ID>ComplexCondition:WireTransaction.kt$WireTransaction$notary != null &amp;&amp; (inputs.isNotEmpty() || references.isNotEmpty() || timeWindow != null)</ID>
     <ID>ComplexMethod:AMQPBridgeManager.kt$AMQPBridgeManager.AMQPBridge$private fun clientArtemisMessageHandler(artemisMessage: ClientMessage)</ID>
     <ID>ComplexMethod:AMQPBridgeTest.kt$AMQPBridgeTest$@Test(timeout=300_000) fun `test acked and nacked messages`()</ID>
@@ -160,7 +159,6 @@
     <ID>ComplexMethod:MerkleTransaction.kt$FilteredTransaction.Companion$ private fun filterWithFun(wtx: WireTransaction, filtering: Predicate&lt;Any&gt;): List&lt;FilteredComponentGroup&gt;</ID>
     <ID>ComplexMethod:NetworkBootstrapper.kt$NetworkBootstrapper$private fun bootstrap( directory: Path, cordappJars: List&lt;Path&gt;, copyCordapps: CopyCordapps, fromCordform: Boolean, networkParametersOverrides: NetworkParametersOverrides = NetworkParametersOverrides() )</ID>
     <ID>ComplexMethod:NetworkBootstrapper.kt$NetworkBootstrapper$private fun createNodeDirectoriesIfNeeded(directory: Path, fromCordform: Boolean): Boolean</ID>
-    <ID>ComplexMethod:NetworkMapUpdater.kt$NetworkMapUpdater$fun updateNetworkMapCache(): Duration</ID>
     <ID>ComplexMethod:NetworkParametersReader.kt$NetworkParametersReader$fun read(): NetworkParametersAndSigned</ID>
     <ID>ComplexMethod:NetworkRegistrationHelper.kt$NetworkRegistrationHelper$ private fun pollServerForCertificates(requestId: String): List&lt;X509Certificate&gt;</ID>
     <ID>ComplexMethod:NewTransaction.kt$NewTransaction$fun show(window: Window)</ID>
@@ -321,7 +319,6 @@
     <ID>ForbiddenComment:CustomSerializer.kt$CustomSerializer.SubClass$// TODO: should this be a custom serializer at all, or should it just be a plain AMQPSerializer?</ID>
     <ID>ForbiddenComment:CustomSerializer.kt$CustomSerializer.SubClass$// TODO: should this be empty or contain the schema of the super?</ID>
     <ID>ForbiddenComment:DbTransactionsResolver.kt$DbTransactionsResolver$// TODO: This approach has two problems. Analyze and resolve them:</ID>
-    <ID>ForbiddenComment:DefaultKryoCustomizer.kt$DefaultKryoCustomizer$// TODO: re-organise registrations into logical groups before v1.0</ID>
     <ID>ForbiddenComment:DigitalSignatureWithCert.kt$// TODO: Rename this to DigitalSignature.WithCert once we're happy for it to be public API. The methods will need documentation</ID>
     <ID>ForbiddenComment:DriverDSLImpl.kt$DriverDSLImpl$// TODO: Derive name from the full picked name, don't just wrap the common name</ID>
     <ID>ForbiddenComment:DriverDSLImpl.kt$DriverDSLImpl$//TODO: remove this once we can bundle quasar properly.</ID>
@@ -1740,6 +1737,18 @@
     <ID>TopLevelPropertyNaming:SerializationEnvironment.kt$val _inheritableContextSerializationEnv = InheritableThreadLocalToggleField&lt;SerializationEnvironment&gt;("inheritableContextSerializationEnv") { stack -&gt; stack.fold(false) { isAGlobalThreadBeingCreated, e -&gt; isAGlobalThreadBeingCreated || (e.className == "io.netty.util.concurrent.GlobalEventExecutor" &amp;&amp; e.methodName == "startThread") || (e.className == "java.util.concurrent.ForkJoinPool\$DefaultForkJoinWorkerThreadFactory" &amp;&amp; e.methodName == "newThread") } }</ID>
     <ID>TopLevelPropertyNaming:SerializationEnvironment.kt$val _rpcClientSerializationEnv = SimpleToggleField&lt;SerializationEnvironment&gt;("rpcClientSerializationEnv")</ID>
     <ID>TopLevelPropertyNaming:SerializationFormat.kt$const val encodingNotPermittedFormat = "Encoding not permitted: %s"</ID>
+    <ID>UnusedImports:Amount.kt$import net.corda.core.crypto.CompositeKey</ID>
+    <ID>UnusedImports:Amount.kt$import net.corda.core.identity.Party</ID>
+    <ID>UnusedImports:DummyLinearStateSchemaV1.kt$import net.corda.core.contracts.ContractState</ID>
+    <ID>UnusedImports:FlowsExecutionModeRpcTest.kt$import net.corda.core.internal.packageName</ID>
+    <ID>UnusedImports:FlowsExecutionModeRpcTest.kt$import net.corda.finance.schemas.CashSchemaV1</ID>
+    <ID>UnusedImports:InternalTestUtils.kt$import java.nio.file.Files</ID>
+    <ID>UnusedImports:InternalTestUtils.kt$import net.corda.nodeapi.internal.loadDevCaTrustStore</ID>
+    <ID>UnusedImports:NetworkMap.kt$import net.corda.core.node.NodeInfo</ID>
+    <ID>UnusedImports:NodeParameters.kt$import net.corda.core.identity.Party</ID>
+    <ID>UnusedImports:SerializerFactory.kt$import java.io.NotSerializableException</ID>
+    <ID>UnusedImports:TransformTypes.kt$import net.corda.core.serialization.CordaSerializationTransformEnumDefaults</ID>
+    <ID>UnusedImports:VaultSchema.kt$import net.corda.core.contracts.ContractState</ID>
     <ID>VariableNaming:AttachmentsClassLoaderSerializationTests.kt$AttachmentsClassLoaderSerializationTests$val DUMMY_NOTARY = TestIdentity(DUMMY_NOTARY_NAME, 20).party</ID>
     <ID>VariableNaming:AttachmentsClassLoaderSerializationTests.kt$AttachmentsClassLoaderSerializationTests$val MEGA_CORP = TestIdentity(CordaX500Name("MegaCorp", "London", "GB")).party</ID>
     <ID>VariableNaming:BootstrapperView.kt$BootstrapperView$val YAML_MAPPER = Constants.getContextMapper()</ID>
@@ -2030,8 +2039,6 @@
     <ID>WildcardImport:DBTransactionStorage.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:DBTransactionStorage.kt$import net.corda.nodeapi.internal.persistence.*</ID>
     <ID>WildcardImport:DBTransactionStorageTests.kt$import net.corda.testing.core.*</ID>
-    <ID>WildcardImport:DefaultKryoCustomizer.kt$import de.javakaffee.kryoserializers.guava.*</ID>
-    <ID>WildcardImport:DefaultKryoCustomizer.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:DeleteForDJVM.kt$import kotlin.annotation.AnnotationTarget.*</ID>
     <ID>WildcardImport:DemoBench.kt$import tornadofx.*</ID>
     <ID>WildcardImport:DemoBenchNodeInfoFilesCopier.kt$import tornadofx.*</ID>
@@ -2163,8 +2170,6 @@
     <ID>WildcardImport:KotlinIntegrationTestingTutorial.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:Kryo.kt$import com.esotericsoftware.kryo.*</ID>
     <ID>WildcardImport:Kryo.kt$import net.corda.core.transactions.*</ID>
-    <ID>WildcardImport:KryoCheckpointSerializer.kt$import net.corda.core.serialization.*</ID>
-    <ID>WildcardImport:KryoCheckpointSerializer.kt$import net.corda.serialization.internal.*</ID>
     <ID>WildcardImport:KryoStreamsTest.kt$import java.io.*</ID>
     <ID>WildcardImport:KryoTests.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:KryoTests.kt$import net.corda.core.crypto.*</ID>
@@ -2224,12 +2229,6 @@
     <ID>WildcardImport:NetworkMapTest.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NetworkMapTest.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:NetworkMapTest.kt$import net.corda.testing.node.internal.*</ID>
-    <ID>WildcardImport:NetworkMapUpdater.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:NetworkMapUpdater.kt$import net.corda.nodeapi.internal.network.*</ID>
-    <ID>WildcardImport:NetworkMapUpdaterTest.kt$import com.nhaarman.mockito_kotlin.*</ID>
-    <ID>WildcardImport:NetworkMapUpdaterTest.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:NetworkMapUpdaterTest.kt$import net.corda.testing.core.*</ID>
-    <ID>WildcardImport:NetworkMapUpdaterTest.kt$import org.junit.*</ID>
     <ID>WildcardImport:NetworkParametersReader.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NetworkParametersReaderTest.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NetworkParametersReaderTest.kt$import net.corda.nodeapi.internal.network.*</ID>

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -194,3 +194,5 @@ style:
     active: true
     excludes: "**/buildSrc/**"
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+  UnusedImports:
+    active: true

--- a/docker/src/main/kotlin/net.corda.core/ConfigExporter.kt
+++ b/docker/src/main/kotlin/net.corda.core/ConfigExporter.kt
@@ -11,7 +11,6 @@ import net.corda.common.validation.internal.Validated
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.parseAsNodeConfiguration
 import net.corda.nodeapi.internal.config.toConfig
-import net.corda.nodeapi.internal.config.toConfigValue
 import java.io.File
 
 class ConfigExporter {

--- a/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/Utils.kt
+++ b/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/Utils.kt
@@ -1,17 +1,13 @@
 package io.cryptoblk.core
 
-import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 
 inline fun <reified T : ContractState> ServiceHub.queryStateByRef(ref: StateRef): StateAndRef<T> {

--- a/finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt
+++ b/finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt
@@ -8,11 +8,8 @@ import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.FungibleAsset
-import net.corda.core.contracts.InsufficientBalanceException
 import net.corda.core.contracts.Issued
 import net.corda.core.contracts.MoveCommand
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.TransactionState
 import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.contracts.requireThat
 import net.corda.core.contracts.select
@@ -20,12 +17,10 @@ import net.corda.core.contracts.verifyMoveCommand
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
-import net.corda.core.identity.Party
 import net.corda.core.internal.Emoji
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.LedgerTransaction
-import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.NonEmptySet
 import net.corda.core.utilities.seconds
 import net.corda.finance.contracts.NetCommand

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/serialization/kryo/KryoAttachmentTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/serialization/kryo/KryoAttachmentTest.kt
@@ -12,8 +12,6 @@ import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.CheckpointSerializationContextImpl
 import net.corda.serialization.internal.CordaSerializationEncoding
-import net.corda.testing.core.ALICE_NAME
-import net.corda.testing.core.TestIdentity
 import net.corda.testing.core.internal.CheckpointSerializationEnvironmentRule
 import org.junit.Assert
 import org.junit.Before

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
@@ -1,6 +1,5 @@
 package net.corda.nodeapi.internal
 
-import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.Party
 import net.corda.core.messaging.MessageRecipientGroup

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
@@ -18,9 +18,7 @@ import net.corda.core.serialization.SerializeAsTokenContext
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.transactions.*
 import net.corda.core.utilities.OpaqueBytes
-import net.corda.serialization.internal.checkUseCase
 import net.corda.core.utilities.SgxSupport
-import net.corda.serialization.internal.serializationContextKey
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.InputStream

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
@@ -19,6 +19,7 @@ import net.corda.core.serialization.SerializedBytes
 import net.corda.core.transactions.*
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.SgxSupport
+import net.corda.serialization.internal.serializationContextKey
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.InputStream

--- a/node/src/integration-test/kotlin/net/corda/node/NodeRPCTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeRPCTests.kt
@@ -5,7 +5,6 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.FINANCE_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.FINANCE_WORKFLOWS_CORDAPP
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -29,7 +29,6 @@ import net.corda.coretesting.internal.DEV_INTERMEDIATE_CA
 import net.corda.coretesting.internal.DEV_ROOT_CA
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.coretesting.internal.stubs.CertificateStoreStubs
-import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
 import net.corda.nodeapi.internal.protonwrapper.netty.toRevocationConfig
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.bouncycastle.asn1.x500.X500Name

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
@@ -4,13 +4,9 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.client.rpc.CordaRPCClientConfiguration
 import net.corda.core.CordaRuntimeException
-import net.corda.core.concurrent.CordaFuture
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.internal.FlowAsyncOperation
 import net.corda.core.internal.IdempotentFlow
-import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.executeAsync
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.ProgressTracker

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
@@ -16,7 +16,6 @@ import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startNode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
-import org.hibernate.exception.GenericJDBCException
 import org.junit.Test
 import java.sql.SQLException
 import kotlin.test.assertEquals

--- a/node/src/main/kotlin/net/corda/node/internal/SwapIdentitiesHandler.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/SwapIdentitiesHandler.kt
@@ -4,7 +4,6 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.confidential.SwapIdentitiesFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
 import net.corda.core.internal.warnOnce
 
 /**

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -4,7 +4,6 @@ import net.corda.cliutils.CliWrapperBase
 import net.corda.core.internal.createFile
 import net.corda.core.internal.div
 import net.corda.core.internal.exists
-import net.corda.core.utilities.Try
 import net.corda.node.InitialRegistrationCmdLineOptions
 import net.corda.node.NodeRegistrationOption
 import net.corda.node.internal.*

--- a/node/src/main/kotlin/net/corda/node/migration/PersistentIdentityMigrationNewTable.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/PersistentIdentityMigrationNewTable.kt
@@ -10,7 +10,6 @@ import net.corda.core.schemas.MappedSchema
 import net.corda.core.utilities.contextLogger
 import net.corda.node.internal.DBNetworkParametersStorage
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.keys.BasicHSMKeyManagementService
 import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.nodeapi.internal.crypto.X509CertificateFactory

--- a/node/src/main/kotlin/net/corda/node/services/diagnostics/NodeDiagnosticsService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/diagnostics/NodeDiagnosticsService.kt
@@ -1,13 +1,9 @@
 package net.corda.node.services.diagnostics
 
 import net.corda.common.logging.CordaVersion
-import net.corda.core.cordapp.Cordapp
-import net.corda.core.cordapp.CordappInfo
-import net.corda.core.node.NodeDiagnosticInfo
 import net.corda.core.node.services.diagnostics.DiagnosticsService
 import net.corda.core.node.services.diagnostics.NodeVersionInfo
 import net.corda.core.serialization.SingletonSerializeAsToken
-import net.corda.node.internal.cordapp.CordappProviderInternal
 
 class NodeDiagnosticsService : DiagnosticsService, SingletonSerializeAsToken() {
 

--- a/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
@@ -7,9 +7,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.MAX_HASH_HEX_SIZE
 import net.corda.node.services.identity.PersistentIdentityService
-import net.corda.node.services.persistence.WritablePublicKeyToOwningIdentityCache
 import net.corda.node.utilities.AppendOnlyPersistentMap
-import net.corda.nodeapi.internal.KeyOwningIdentity
 import net.corda.nodeapi.internal.cryptoservice.SignOnlyCryptoService
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX

--- a/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services.messaging
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.newSecureRandom
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.messaging.MessageRecipients

--- a/node/src/main/kotlin/net/corda/node/services/persistence/PublicKeyToOwningIdentityCacheImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/PublicKeyToOwningIdentityCacheImpl.kt
@@ -3,7 +3,6 @@ package net.corda.node.services.persistence
 import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.core.crypto.toStringShort
 import net.corda.core.internal.NamedCacheFactory
-import net.corda.core.internal.hash
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
 import net.corda.node.services.identity.PersistentIdentityService

--- a/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt
@@ -15,7 +15,6 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager
 import java.io.IOException
-import java.lang.RuntimeException
 import java.nio.file.Path
 import java.security.KeyStoreException
 import javax.security.auth.login.AppConfigurationEntry

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -10,7 +10,6 @@ import net.corda.core.utilities.Try
 import net.corda.node.services.messaging.DeduplicationHandler
 import net.corda.node.services.messaging.ReceivedMessage
 import rx.Observable
-import java.util.concurrent.Future
 
 /**
  * A StateMachineManager is responsible for coordination and persistence of multiple [FlowStateMachine] objects.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt
@@ -3,7 +3,6 @@ package net.corda.node.services.statemachine.interceptors
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.utilities.contextLogger
-import net.corda.core.utilities.debug
 import net.corda.node.services.statemachine.ActionExecutor
 import net.corda.node.services.statemachine.ErrorState
 import net.corda.node.services.statemachine.Event

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
@@ -4,7 +4,6 @@ import net.corda.core.flows.FlowException
 import net.corda.core.flows.UnexpectedFlowEndException
 import net.corda.core.identity.Party
 import net.corda.core.internal.DeclaredField
-import net.corda.core.internal.declaredField
 import net.corda.node.services.statemachine.Action
 import net.corda.node.services.statemachine.ConfirmSessionMessage
 import net.corda.node.services.statemachine.DataSessionMessage

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationService.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationService.kt
@@ -1,7 +1,6 @@
 package net.corda.node.utilities.registration
 
 import net.corda.core.CordaException
-import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import java.security.cert.X509Certificate
 import java.time.Duration

--- a/node/src/test/kotlin/net/corda/node/services/diagnostics/NodeDiagnosticsServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/diagnostics/NodeDiagnosticsServiceTest.kt
@@ -1,14 +1,6 @@
 package net.corda.node.services.diagnostics
 
 import net.corda.common.logging.CordaVersion
-import net.corda.core.contracts.ContractClassName
-import net.corda.core.cordapp.Cordapp
-import net.corda.core.cordapp.CordappContext
-import net.corda.core.cordapp.CordappInfo
-import net.corda.core.flows.FlowLogic
-import net.corda.core.internal.cordapp.CordappImpl
-import net.corda.core.node.services.AttachmentId
-import net.corda.node.internal.cordapp.CordappProviderInternal
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/ExternalIdMappingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/ExternalIdMappingTest.kt
@@ -19,7 +19,6 @@ import org.junit.Rule
 import org.junit.Test
 import java.util.*
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 class ExternalIdMappingTest {

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -46,9 +46,6 @@ import org.mockito.Mockito.doReturn
 import rx.observers.TestSubscriber
 import java.math.BigDecimal
 import java.security.PublicKey
-import java.security.cert.CertStore
-import java.security.cert.TrustAnchor
-import java.security.cert.X509Certificate
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors

--- a/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt
@@ -1,7 +1,6 @@
 package net.corda.node.utilities
 
 import org.junit.Test
-import java.net.InetAddress
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTSmartConfigTests.kt
+++ b/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTSmartConfigTests.kt
@@ -1,11 +1,7 @@
 package net.corda.notary.experimental.bftsmart
 
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.notary.experimental.bftsmart.BFTSmartConfigInternal
 import net.corda.notary.experimental.bftsmart.BFTSmartConfigInternal.Companion.portIsClaimedFormat
-import net.corda.notary.experimental.bftsmart.maxFaultyReplicas
-import net.corda.notary.experimental.bftsmart.minClusterSize
-import net.corda.notary.experimental.bftsmart.minCorrectReplicas
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import kotlin.test.assertEquals

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/CheckpointSerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/CheckpointSerializationScheme.kt
@@ -1,12 +1,10 @@
 package net.corda.serialization.internal
 
 import net.corda.core.KeepForDJVM
-import net.corda.core.crypto.SecureHash
 import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.EncodingWhitelist
 import net.corda.core.serialization.SerializationEncoding
 import net.corda.core.serialization.internal.CheckpointSerializationContext
-import java.lang.UnsupportedOperationException
 
 @KeepForDJVM
 data class CheckpointSerializationContextImpl @JvmOverloads constructor(

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumEvolutionSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumEvolutionSerializer.kt
@@ -1,14 +1,9 @@
 package net.corda.serialization.internal.amqp
 
-import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.SerializationContext
-import net.corda.serialization.internal.model.LocalTypeInformation
-import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
-import java.io.NotSerializableException
 import java.lang.UnsupportedOperationException
 import java.lang.reflect.Type
-import java.util.*
 
 /**
  * Used whenever a deserialized enums fingerprint doesn't match the fingerprint of the generated

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Envelope.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Envelope.kt
@@ -5,8 +5,6 @@ import org.apache.qpid.proton.amqp.DescribedType
 import org.apache.qpid.proton.codec.Data
 import org.apache.qpid.proton.codec.DescribedTypeConstructor
 
-import java.io.NotSerializableException
-
 /**
  * This class wraps all serialized data, so that the schema can be carried along with it.  We will provide various
  * internal utilities to decompose and recompose with/without schema etc so that e.g. we can store objects with a

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SingletonSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SingletonSerializer.kt
@@ -2,7 +2,6 @@ package net.corda.serialization.internal.amqp
 
 import net.corda.core.serialization.SerializationContext
 import net.corda.serialization.internal.model.LocalTypeInformation
-import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationPropertyOrdering.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationPropertyOrdering.kt
@@ -4,10 +4,6 @@ import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.serialization.internal.amqp.testutils.*
 import org.junit.Test
 import kotlin.test.assertEquals
-import org.apache.qpid.proton.amqp.Symbol
-import java.lang.reflect.Method
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class SerializationPropertyOrdering {
     companion object {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationSchemaTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationSchemaTests.kt
@@ -1,14 +1,9 @@
 package net.corda.serialization.internal.amqp
 
 import net.corda.core.serialization.*
-import net.corda.core.utilities.ByteSequence
 import net.corda.serialization.internal.BuiltInExceptionsWhitelist
-import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.GlobalTransientClassWhiteList
 import net.corda.serialization.internal.SerializationContextImpl
-import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
-import org.junit.Test
-import kotlin.test.assertEquals
 
 // Make sure all serialization calls in this test don't get stomped on by anything else
 val TESTING_CONTEXT = SerializationContextImpl(amqpMagic,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockKeyManagementService.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockKeyManagementService.kt
@@ -5,10 +5,7 @@ import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.node.services.identity.InMemoryIdentityService
-import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.keys.KeyManagementServiceInternal
-import net.corda.node.services.persistence.WritablePublicKeyToOwningIdentityCache
-import net.corda.nodeapi.internal.KeyOwningIdentity
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
 import java.security.PrivateKey

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -1,6 +1,5 @@
 package net.corda.cliutils
 
-import net.corda.cliutils.ExitCodes
 import net.corda.core.internal.rootMessage
 import net.corda.core.utilities.contextLogger
 import org.fusesource.jansi.AnsiConsole

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -19,8 +19,6 @@ import org.fusesource.jansi.AnsiOutputStream
 import rx.Observable.combineLatest
 import rx.Subscription
 import java.util.*
-import java.util.stream.IntStream
-import kotlin.streams.toList
 
 abstract class ANSIProgressRenderer {
 


### PR DESCRIPTION
This change enables the `UnusedImports` rule in detekt. I also removed any unused imports reported by the new rule. There were a few false positives, since it seems to be unable to detect some uses, such as extension functions and mentions in kdocs but not in the beginning. I added those in the baseline.