### PR TITLE
CORDA-3685: Prevent ServiceHub.signInitialTransaction from throwing undeclared checked exceptions.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -77,7 +77,12 @@ fun <T : Any> deserialiseComponentGroup(componentGroups: List<ComponentGroup>,
         try {
             factory.deserialize(component, clazz.java, context)
         } catch (e: MissingAttachmentsException) {
-            throw e
+            /**
+             * [ServiceHub.signInitialTransaction] forgets to declare that
+             * it may throw any checked exceptions. Wrap this one inside
+             * an unchecked version to avoid breaking Java CorDapps.
+             */
+            throw MissingAttachmentsRuntimeException(e.ids, e.message, e)
         } catch (e: Exception) {
             throw TransactionDeserialisationException(groupEnum, internalIndex, e)
         }
@@ -88,7 +93,7 @@ fun <T : Any> deserialiseComponentGroup(componentGroups: List<ComponentGroup>,
  * Exception raised if an error was encountered while attempting to deserialise a component group in a transaction.
  */
 class TransactionDeserialisationException(groupEnum: ComponentGroupEnum, index: Int, cause: Exception):
-        Exception("Failed to deserialise group $groupEnum at index $index in transaction: ${cause.message}", cause)
+        RuntimeException("Failed to deserialise group $groupEnum at index $index in transaction: ${cause.message}", cause)
 
 /**
  * Method to deserialise Commands from its two groups:

--- a/core/src/main/kotlin/net/corda/core/serialization/MissingAttachmentsRuntimeException.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/MissingAttachmentsRuntimeException.kt
@@ -1,0 +1,17 @@
+package net.corda.core.serialization
+
+import net.corda.core.CordaRuntimeException
+import net.corda.core.KeepForDJVM
+import net.corda.core.node.services.AttachmentId
+
+@KeepForDJVM
+@CordaSerializable
+class MissingAttachmentsRuntimeException(val ids: List<AttachmentId>, message: String?, cause: Throwable?)
+    : CordaRuntimeException(message, cause) {
+
+    @Suppress("unused")
+    constructor(ids: List<AttachmentId>, message: String?) : this(ids, message, null)
+
+    @Suppress("unused")
+    constructor(ids: List<AttachmentId>) : this(ids, null, null)
+}


### PR DESCRIPTION
Both `TransactionDeserialisationException` and `MissingAttachmentsException` may be thrown by `ServiceHub.signInitialTransaction()`. These are checked exceptions, but `ServiceHub` does not declare them as thrown via a `@Throws` annotation. Kotlin may not care about this, but Java does!

Fix this for Java by ensuring that `ServiceHub.signInitialTransaction()` only throws unchecked exceptions.