### PR TITLE
CORDA-3602 Set a Checkpoint as Incompatible if it Cannot be Deserialised

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineDeserializationTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineDeserializationTest.kt
@@ -1,0 +1,144 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.HospitalizeFlowException
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.messaging.startFlow
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.Permissions
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.OutOfProcess
+import net.corda.testing.driver.driver
+import net.corda.testing.node.User
+import org.junit.Ignore
+import org.junit.Test
+import java.lang.IllegalStateException
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class StatemachineDeserializationTest {
+
+    @Test(timeout = 300_000)
+    fun `Flows are marked as compatable = false if checkpoint deserialization fails`() {
+        testDeserialization(BlobMuddlingFlow.Column.CHECKPOINT)
+    }
+
+    @Test(timeout = 300_000)
+    fun `Flows are marked as compatable = false if flowSate deserialization fails`() {
+        testDeserialization(BlobMuddlingFlow.Column.FLOW_STATE)
+    }
+
+    fun testDeserialization(column: BlobMuddlingFlow.Column) {
+        driver(DriverParameters(inMemoryDB = false)) {
+            //We first start up a Node and run a flow which throws an exception causing the flow to end up in the hospital
+            //this causes the flow to persist a checkpoint.
+            val aliceUser = User("user", "foo", setOf(Permissions.all()))
+            val aliceNode = startNode(providedName = ALICE_NAME, rpcUsers = listOf(aliceUser)).getOrThrow()
+            val hospitalFlowId = aliceNode.rpc.startFlow(::HospitalizingFlow).id
+
+            //Next we run a flow which destroys the serialized flow data of the hospitalized flow in the database.
+            val muddlingFlow = aliceNode.rpc.startFlow(::BlobMuddlingFlow, hospitalFlowId, column)
+            muddlingFlow.returnValue.getOrThrow()
+            val timeStamp = aliceNode.rpc.startFlow(::GetTimeStampFlow, hospitalFlowId).returnValue.getOrThrow()
+
+            //We then stop the node and restart it.
+            aliceNode.stop()
+            val terminated = (aliceNode as OutOfProcess).process.waitFor(30, TimeUnit.SECONDS)
+            if (terminated) {
+                aliceNode.stop()
+            } else {
+                throw IllegalStateException("Out of process node is still up and running!")
+            }
+            val restartedAlice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(aliceUser)).getOrThrow()
+
+            //This causes the previously hospitalised flow to run again but it can no longer be deserailised.
+            //We check that the database has been updated marking the checkpoint as Compatable = False and re-timestamping.
+            val flow = restartedAlice.rpc.startFlow(::CheckCompatableFlow, hospitalFlowId)
+            assertEquals(false, flow.returnValue.getOrThrow())
+            val timeStampAfterRestart = restartedAlice.rpc.startFlow(::GetTimeStampFlow, hospitalFlowId).returnValue.getOrThrow()
+            assertNotEquals(timeStampAfterRestart, timeStamp)
+
+            //We then stop and restart the node for a second time.
+            restartedAlice.stop()
+            val terminatedAgain = (restartedAlice as OutOfProcess).process.waitFor(30, TimeUnit.SECONDS)
+            if (terminatedAgain) {
+                restartedAlice.stop()
+            } else {
+                throw IllegalStateException("Out of process node is still up and running!")
+            }
+            val restartedAgainAlice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(aliceUser)).getOrThrow()
+
+            //This time the checkpoint should not be updated as the StateMachine should not try and run a checkpoint with Compatable = False
+            val timeStampAfterSecondRestart = restartedAgainAlice.rpc.startFlow(::GetTimeStampFlow, hospitalFlowId).returnValue.getOrThrow()
+            assertEquals(timeStampAfterRestart, timeStampAfterSecondRestart)
+            restartedAgainAlice.stop()
+        }
+    }
+
+    @StartableByRPC
+    class HospitalizingFlow : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            throw HospitalizeFlowException("Flow went wrong!")
+        }
+    }
+
+    @StartableByRPC
+    class BlobMuddlingFlow(private val flowId: StateMachineRunId, private val column: Column) : FlowLogic<Unit>() {
+        // This flow messes up the FlowState. Such that the checkpoint cannot be deserialized anymore.
+        @CordaSerializable
+        enum class Column(val sqlName: String) {
+            CHECKPOINT("checkpoint_value"),
+            FLOW_STATE("flow_state")
+        }
+
+        @Suspendable
+        override fun call() {
+            val selectBlobSqlStatement = "select checkpoint_blob_id from node_checkpoints where flow_id = '${flowId.uuid}'"
+            logger.info(selectBlobSqlStatement)
+            val blobId = serviceHub.jdbcSession().prepareStatement(selectBlobSqlStatement).use {
+                it.executeQuery().use { query ->
+                    query.next()
+                    query.getLong(1)
+                }
+            }
+            val muddleBlobSqlStatement = "update node_checkpoint_blobs set ${column.sqlName} = 'DEADBEEF' where id = $blobId"
+            logger.info(muddleBlobSqlStatement)
+            serviceHub.jdbcSession().prepareStatement(muddleBlobSqlStatement).executeUpdate()
+        }
+    }
+
+    @StartableByRPC
+    class CheckCompatableFlow(private val flowId: StateMachineRunId) : FlowLogic<Boolean>() {
+        @Suspendable
+        override fun call() : Boolean {
+            val sqlStatement = "select compatible from node_checkpoints where flow_id = '${flowId.uuid}'"
+            return serviceHub.jdbcSession().prepareStatement(sqlStatement).use {
+                it.executeQuery().use {query ->
+                    query.next()
+                    query.getBoolean(1)
+                }
+            }
+        }
+    }
+
+    @StartableByRPC
+    class GetTimeStampFlow(private  val flowId: StateMachineRunId) : FlowLogic<String>() {
+        @Suspendable
+        override fun call() : String {
+            val sqlStatement = "select timestamp from node_checkpoints where flow_id = '${flowId.uuid}'"
+            return serviceHub.jdbcSession().prepareStatement(sqlStatement).use {
+                it.executeQuery().use {query ->
+                    query.next()
+                    query.getString(1)
+                }
+            }
+        }
+    }
+
+}

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -47,4 +47,9 @@ interface CheckpointStorage {
      * until the underlying database connection is closed, so any processing should happen before it is closed.
      */
     fun getRunnableCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
+
+    /**
+     * Set a checkpoint as compatible
+     */
+    fun updateCompatible(id: StateMachineRunId, compatible: Boolean)
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -311,7 +311,7 @@ class DBCheckpointStorage(
     override fun updateCompatible(id: StateMachineRunId, compatible: Boolean) {
         val checkpoint = getDBCheckpoint(id)
         checkpoint?.compatible = compatible
-        checkpoint?.checkpointInstant = Instant.now()
+        checkpoint?.checkpointInstant = clock.instant()
         currentDBSession().update(checkpoint)
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -311,6 +311,7 @@ class DBCheckpointStorage(
     override fun updateCompatible(id: StateMachineRunId, compatible: Boolean) {
         val checkpoint = getDBCheckpoint(id)
         checkpoint?.compatible = compatible
+        checkpoint?.checkpointInstant = Instant.now()
         currentDBSession().update(checkpoint)
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -308,6 +308,12 @@ class DBCheckpointStorage(
         }
     }
 
+    override fun updateCompatible(id: StateMachineRunId, compatible: Boolean) {
+        val checkpoint = getDBCheckpoint(id)
+        checkpoint?.compatible = compatible
+        currentDBSession().update(checkpoint)
+    }
+
     private fun getDBCheckpoint(id: StateMachineRunId): DBFlowCheckpoint? {
         return currentDBSession().find(DBFlowCheckpoint::class.java, id.uuid.toString())
     }


### PR DESCRIPTION
If the statemachine fails to deserialise a checkpoint then it updates the database to mark the checkpoint as 'compatible = false'. On Node startup checkpoints which are incompatible are not started. 

Added an expensive test (8 minutes on my MacBook in total) which checks that the checkpoint is updated correctly in the database. 