### PR TITLE
[ENT-4754] - Open access to members of FinalityFlow

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -40,11 +40,11 @@ import net.corda.core.utilities.debug
 // presence of @InitiatingFlow is checked). So the new API is inlined simply because that code path doesn't call initiateFlow.
 @InitiatingFlow
 class FinalityFlow private constructor(val transaction: SignedTransaction,
-                                       private val oldParticipants: Collection<Party>,
+                                       val oldParticipants: Collection<Party>,
                                        override val progressTracker: ProgressTracker,
-                                       private val sessions: Collection<FlowSession>,
-                                       private val newApi: Boolean,
-                                       private val statesToRecord: StatesToRecord = ONLY_RELEVANT) : FlowLogic<SignedTransaction>() {
+                                       val sessions: Collection<FlowSession>,
+                                       val newApi: Boolean,
+                                       val statesToRecord: StatesToRecord = ONLY_RELEVANT) : FlowLogic<SignedTransaction>() {
     @Deprecated(DEPRECATION_MSG)
     constructor(transaction: SignedTransaction, extraRecipients: Set<Party>, progressTracker: ProgressTracker) : this(
             transaction, extraRecipients, progressTracker, emptyList(), false

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -1,6 +1,7 @@
 package net.corda.core.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.CordaInternal
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.identity.Party
@@ -40,11 +41,18 @@ import net.corda.core.utilities.debug
 // presence of @InitiatingFlow is checked). So the new API is inlined simply because that code path doesn't call initiateFlow.
 @InitiatingFlow
 class FinalityFlow private constructor(val transaction: SignedTransaction,
-                                       val oldParticipants: Collection<Party>,
+                                       private val oldParticipants: Collection<Party>,
                                        override val progressTracker: ProgressTracker,
-                                       val sessions: Collection<FlowSession>,
-                                       val newApi: Boolean,
-                                       val statesToRecord: StatesToRecord = ONLY_RELEVANT) : FlowLogic<SignedTransaction>() {
+                                       private val sessions: Collection<FlowSession>,
+                                       private val newApi: Boolean,
+                                       private val statesToRecord: StatesToRecord = ONLY_RELEVANT) : FlowLogic<SignedTransaction>() {
+
+    @CordaInternal
+    data class ExtraConstructorArgs(val oldParticipants: Collection<Party>, val sessions: Collection<FlowSession>, val newApi: Boolean, val statesToRecord: StatesToRecord)
+
+    @CordaInternal
+    fun getExtraConstructorArgs() = ExtraConstructorArgs(oldParticipants, sessions, newApi, statesToRecord)
+
     @Deprecated(DEPRECATION_MSG)
     constructor(transaction: SignedTransaction, extraRecipients: Set<Party>, progressTracker: ProgressTracker) : this(
             transaction, extraRecipients, progressTracker, emptyList(), false


### PR DESCRIPTION
Open access to members of `FinalityFlow`. They are all `val`s and immutable collections, so should be safe from an immutability perspective.