### PR TITLE
Fix build for simm-valuation-demo

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -74,6 +74,7 @@ see changes to this list.
 * David Lee (BCS)
 * Dinesh Rivankar (Persistent Systems Limited)
 * Dirk Hermans (KBC)
+* Dirkjan Ochtman (ING)
 * dmytrobr
 * Edward Greenwood (State Street)
 * Elendu Uche (APPZONE)

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     // The SIMM demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance:workflows')
     cordapp project(':finance:contracts')
-    cordapp project(path: ':samples:simm-valuation-demo:contracts-states', configuration: 'shrinkArtifacts')
+    cordapp project(path: ':samples:simm-valuation-demo:contracts-states')
 
     // Corda integration dependencies
     cordaCompile project(':core')


### PR DESCRIPTION
This was failing for me while building in IDEA with errors about
missing references to types defined in the demo's contracts-states.

I'm not sure why the `configuration: 'shrinkArtifacts'` parameter is there, but removing it seems to fix the build and seems unlikely to have any adverse effects.

# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/).