### PR TITLE
ENT-4982 Database transaction handling with entity managers

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -196,7 +196,7 @@ class CordaPersistence(
         _contextDatabase.set(this)
         val transaction = contextTransaction
         try {
-            transaction.session.flush()
+//            transaction.session.flush()
             return transaction.connection
         } catch (e: Exception) {
             if (e is SQLException || e is PersistenceException) {
@@ -211,14 +211,15 @@ class CordaPersistence(
      * @param isolationLevel isolation level for the transaction.
      * @param statement to be executed in the scope of this transaction.
      */
-    fun <T> transaction(isolationLevel: TransactionIsolationLevel, statement: DatabaseTransaction.() -> T): T =
-            transaction(isolationLevel, 2, false, statement)
+    fun <T> transaction(isolationLevel: TransactionIsolationLevel, withErrorHandler: Boolean, statement: DatabaseTransaction.() -> T): T =
+            transaction(isolationLevel, 2, false, withErrorHandler, statement)
 
     /**
      * Executes given statement in the scope of transaction with the transaction level specified at the creation time.
      * @param statement to be executed in the scope of this transaction.
      */
-    fun <T> transaction(statement: DatabaseTransaction.() -> T): T = transaction(defaultIsolationLevel, statement)
+    @JvmOverloads
+    fun <T> transaction(useErrorHandler: Boolean = true, statement: DatabaseTransaction.() -> T): T = transaction(defaultIsolationLevel, useErrorHandler, statement)
 
     /**
      * Executes given statement in the scope of transaction, with the given isolation level.
@@ -228,7 +229,7 @@ class CordaPersistence(
      * @param statement to be executed in the scope of this transaction.
      */
     fun <T> transaction(isolationLevel: TransactionIsolationLevel, recoverableFailureTolerance: Int,
-                        recoverAnyNestedSQLException: Boolean, statement: DatabaseTransaction.() -> T): T {
+                        recoverAnyNestedSQLException: Boolean, useErrorHandler: Boolean, statement: DatabaseTransaction.() -> T): T {
         _contextDatabase.set(this)
         val outer = contextTransactionOrNull
         return if (outer != null) {
@@ -237,16 +238,24 @@ class CordaPersistence(
             // previously been created by the flow state machine in ActionExecutorImpl#executeCreateTransaction
             // b. exceptions coming out from top level transactions are already being handled in CordaPersistence#inTopLevelTransaction
             // i.e. roll back and close the transaction
-            try {
+            if(useErrorHandler) {
+                outer.withErrorHandler(statement)
+            } else {
                 outer.statement()
-            } catch (e: Exception) {
-                if (e is SQLException || e is PersistenceException || e is HospitalizeFlowException) {
-                    outer.errorHandler(e)
-                }
-                throw e
             }
         } else {
             inTopLevelTransaction(isolationLevel, recoverableFailureTolerance, recoverAnyNestedSQLException, statement)
+        }
+    }
+
+    private fun <T> DatabaseTransaction.withErrorHandler(statement: DatabaseTransaction.() -> T): T {
+        return try {
+            statement()
+        } catch (e: Exception) {
+            if ((e is SQLException || e is PersistenceException || e is HospitalizeFlowException)) {
+                errorHandler(e)
+            }
+            throw e
         }
     }
 
@@ -256,7 +265,7 @@ class CordaPersistence(
      * @param recoverableFailureTolerance number of transaction commit retries for SQL while SQL exception is encountered.
      */
     fun <T> transaction(recoverableFailureTolerance: Int, statement: DatabaseTransaction.() -> T): T {
-        return transaction(defaultIsolationLevel, recoverableFailureTolerance, false, statement)
+        return transaction(defaultIsolationLevel, recoverableFailureTolerance, false, false, statement)
     }
 
     private fun <T> inTopLevelTransaction(isolationLevel: TransactionIsolationLevel, recoverableFailureTolerance: Int,

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -211,8 +211,8 @@ class CordaPersistence(
      * @param isolationLevel isolation level for the transaction.
      * @param statement to be executed in the scope of this transaction.
      */
-    fun <T> transaction(isolationLevel: TransactionIsolationLevel, withErrorHandler: Boolean, statement: DatabaseTransaction.() -> T): T =
-            transaction(isolationLevel, 2, false, withErrorHandler, statement)
+    fun <T> transaction(isolationLevel: TransactionIsolationLevel, useErrorHandler: Boolean, statement: DatabaseTransaction.() -> T): T =
+            transaction(isolationLevel, 2, false, useErrorHandler, statement)
 
     /**
      * Executes given statement in the scope of transaction with the transaction level specified at the creation time.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -196,7 +196,7 @@ class CordaPersistence(
         _contextDatabase.set(this)
         val transaction = contextTransaction
         try {
-//            transaction.session.flush()
+            transaction.session.flush()
             return transaction.connection
         } catch (e: Exception) {
             if (e is SQLException || e is PersistenceException) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt
@@ -137,5 +137,5 @@ class DatabaseTransactionException(override val cause: Throwable): CordaRuntimeE
 
 // should this just be an `IllegalStateException`?
 class RolledBackDatabaseSessionException : CordaRuntimeException(
-    "Further operations are being executed on a rolled back database session"
+    "Attempted to commit database transaction marked for rollback"
 )

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
@@ -75,31 +75,6 @@ class RestrictedEntityManager(private val delegate: EntityManager) : EntityManag
         delegate.refresh(entity)
     }
 
-    override fun <T : Any?> find(entityClass: Class<T>?, primaryKey: Any?, properties: MutableMap<String, Any>?): T {
-        checkSessionIsNotRolledBack()
-        return delegate.find(entityClass, primaryKey, properties)
-    }
-
-    override fun <T : Any?> find(entityClass: Class<T>?, primaryKey: Any?, lockMode: LockModeType?): T {
-        checkSessionIsNotRolledBack()
-        return delegate.find(entityClass, primaryKey, lockMode)
-    }
-
-    override fun <T : Any?> find(entityClass: Class<T>?, primaryKey: Any?): T {
-        checkSessionIsNotRolledBack()
-        return delegate.find(entityClass, primaryKey)
-    }
-
-    override fun <T : Any?> find(
-        entityClass: Class<T>?,
-        primaryKey: Any?,
-        lockMode: LockModeType?,
-        properties: MutableMap<String, Any>?
-    ): T {
-        checkSessionIsNotRolledBack()
-        return delegate.find(entityClass, primaryKey, lockMode, properties)
-    }
-
     private fun checkSessionIsNotRolledBack() {
         if (delegate.transaction.rollbackOnly) {
             throw RolledBackDatabaseSessionException()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
@@ -1,6 +1,7 @@
 package net.corda.nodeapi.internal.persistence
 
 import javax.persistence.EntityManager
+import javax.persistence.EntityTransaction
 
 /**
  * A delegate of [EntityManager] which disallows some operations.
@@ -13,6 +14,31 @@ class RestrictedEntityManager(private val delegate: EntityManager) : EntityManag
 
     override fun clear() {
         throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
+    }
+
+    override fun persist(entity: Any?) {
+        checkSessionIsNotRolledBack()
+        delegate.persist(entity)
+    }
+
+    override fun <T : Any?> merge(entity: T): T {
+        checkSessionIsNotRolledBack()
+        return delegate.merge(entity)
+    }
+
+    override fun remove(entity: Any?) {
+        checkSessionIsNotRolledBack()
+        delegate.remove(entity)
+    }
+
+    override fun getTransaction(): EntityTransaction {
+        throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
+    }
+
+    private fun checkSessionIsNotRolledBack() {
+        if (delegate.transaction.rollbackOnly) {
+            throw RolledBackDatabaseSessionException()
+        }
     }
 
     // TODO: Figure out which other methods on EntityManager need to be blocked?

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
@@ -7,6 +7,7 @@ import javax.persistence.LockModeType
 /**
  * A delegate of [EntityManager] which disallows some operations.
  */
+@Suppress("TooManyFunctions")
 class RestrictedEntityManager(private val delegate: EntityManager) : EntityManager by delegate {
 
     override fun close() {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManager.kt
@@ -2,6 +2,7 @@ package net.corda.nodeapi.internal.persistence
 
 import javax.persistence.EntityManager
 import javax.persistence.EntityTransaction
+import javax.persistence.LockModeType
 
 /**
  * A delegate of [EntityManager] which disallows some operations.
@@ -12,7 +13,19 @@ class RestrictedEntityManager(private val delegate: EntityManager) : EntityManag
         throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
     }
 
-    override fun clear() {
+    override fun getTransaction(): EntityTransaction {
+        throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
+    }
+
+    override fun <T : Any?> unwrap(cls: Class<T>?): T {
+        throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
+    }
+
+    override fun getDelegate(): Any {
+        throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
+    }
+
+    override fun setProperty(propertyName: String?, value: Any?) {
         throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
     }
 
@@ -31,8 +44,59 @@ class RestrictedEntityManager(private val delegate: EntityManager) : EntityManag
         delegate.remove(entity)
     }
 
-    override fun getTransaction(): EntityTransaction {
-        throw UnsupportedOperationException("This method cannot be called via ServiceHub.withEntityManager.")
+    override fun lock(entity: Any?, lockMode: LockModeType?) {
+        checkSessionIsNotRolledBack()
+        delegate.lock(entity, lockMode)
+    }
+
+    override fun lock(entity: Any?, lockMode: LockModeType?, properties: MutableMap<String, Any>?) {
+        checkSessionIsNotRolledBack()
+        delegate.lock(entity, lockMode, properties)
+    }
+
+    override fun refresh(entity: Any?, properties: MutableMap<String, Any>?) {
+        checkSessionIsNotRolledBack()
+        delegate.refresh(entity, properties)
+    }
+
+    override fun refresh(entity: Any?, lockMode: LockModeType?) {
+        checkSessionIsNotRolledBack()
+        delegate.refresh(entity, lockMode)
+    }
+
+    override fun refresh(entity: Any?, lockMode: LockModeType?, properties: MutableMap<String, Any>?) {
+        checkSessionIsNotRolledBack()
+        delegate.refresh(entity, lockMode, properties)
+    }
+
+    override fun refresh(entity: Any?) {
+        checkSessionIsNotRolledBack()
+        delegate.refresh(entity)
+    }
+
+    override fun <T : Any?> find(entityClass: Class<T>?, primaryKey: Any?, properties: MutableMap<String, Any>?): T {
+        checkSessionIsNotRolledBack()
+        return delegate.find(entityClass, primaryKey, properties)
+    }
+
+    override fun <T : Any?> find(entityClass: Class<T>?, primaryKey: Any?, lockMode: LockModeType?): T {
+        checkSessionIsNotRolledBack()
+        return delegate.find(entityClass, primaryKey, lockMode)
+    }
+
+    override fun <T : Any?> find(entityClass: Class<T>?, primaryKey: Any?): T {
+        checkSessionIsNotRolledBack()
+        return delegate.find(entityClass, primaryKey)
+    }
+
+    override fun <T : Any?> find(
+        entityClass: Class<T>?,
+        primaryKey: Any?,
+        lockMode: LockModeType?,
+        properties: MutableMap<String, Any>?
+    ): T {
+        checkSessionIsNotRolledBack()
+        return delegate.find(entityClass, primaryKey, lockMode, properties)
     }
 
     private fun checkSessionIsNotRolledBack() {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManagerTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManagerTest.kt
@@ -1,0 +1,192 @@
+package net.corda.nodeapi.internal.persistence
+
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.serialization.CordaSerializable
+import net.corda.node.services.schema.NodeSchemaService
+import net.corda.testing.internal.configureDatabase
+import net.corda.testing.node.MockServices
+import org.hibernate.Session
+import org.junit.Test
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.LockModeType
+import javax.persistence.Table
+import kotlin.test.assertFailsWith
+
+class RestrictedEntityManagerTest {
+    private val database = configureDatabase(
+        hikariProperties = MockServices.makeTestDataSourceProperties(),
+        databaseConfig = DatabaseConfig(),
+        wellKnownPartyFromX500Name = { null },
+        wellKnownPartyFromAnonymous = { null },
+        schemaService = NodeSchemaService(setOf(CustomMappedSchema))
+    )
+
+    private val entity = CustomTableEntity(1, "Boris Johnson", "Here is a picture of my zoom meeting id")
+    private lateinit var restrictedEntityManager: RestrictedEntityManager
+
+    @Test(timeout = 300_000)
+    fun `can call clear`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            restrictedEntityManager.clear()
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `can call detatch`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            restrictedEntityManager.persist(entity)
+            restrictedEntityManager.detach(entity)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call close`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            assertFailsWith<UnsupportedOperationException> {
+                restrictedEntityManager.close()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call getTransaction`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            assertFailsWith<UnsupportedOperationException> {
+                restrictedEntityManager.transaction
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call unwrap`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            assertFailsWith<UnsupportedOperationException> {
+                restrictedEntityManager.unwrap(Session::class.java)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call getDelete`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            assertFailsWith<UnsupportedOperationException> {
+                restrictedEntityManager.delegate
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call setProperty`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            assertFailsWith<UnsupportedOperationException> {
+                restrictedEntityManager.setProperty("key", "value")
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `can call persist on a normal session`() {
+        database.transaction {
+            restrictedEntityManager = RestrictedEntityManager(entityManager)
+            restrictedEntityManager.persist(entity)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call persist on a session marked for rolled back`() {
+        database.transaction {
+            val manager = entityManager
+            restrictedEntityManager = RestrictedEntityManager(manager)
+            assertFailsWith<RolledBackDatabaseSessionException> {
+                manager.transaction.setRollbackOnly()
+                restrictedEntityManager.persist(entity)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call merge on a session marked for rolled back`() {
+        database.transaction {
+            val manager = entityManager
+            restrictedEntityManager = RestrictedEntityManager(manager)
+            assertFailsWith<RolledBackDatabaseSessionException> {
+                manager.transaction.setRollbackOnly()
+                restrictedEntityManager.merge(entity)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call remove on asession marked for rolled back`() {
+        database.transaction {
+            val manager = entityManager
+            restrictedEntityManager = RestrictedEntityManager(manager)
+            assertFailsWith<RolledBackDatabaseSessionException> {
+                manager.transaction.setRollbackOnly()
+                restrictedEntityManager.remove(entity)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call find on a session marked for rollback`() {
+        database.transaction {
+            val manager = entityManager
+            restrictedEntityManager = RestrictedEntityManager(manager)
+            assertFailsWith<RolledBackDatabaseSessionException> {
+                manager.transaction.setRollbackOnly()
+                restrictedEntityManager.find(entity::class.java, entity.id)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call refresh on a session marked for rollback`() {
+        database.transaction {
+            val manager = entityManager
+            restrictedEntityManager = RestrictedEntityManager(manager)
+            assertFailsWith<RolledBackDatabaseSessionException> {
+                manager.transaction.setRollbackOnly()
+                restrictedEntityManager.refresh(entity)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `cannot call lock on a session marked for rollback`() {
+        database.transaction {
+            val manager = entityManager
+            restrictedEntityManager = RestrictedEntityManager(manager)
+            assertFailsWith<RolledBackDatabaseSessionException> {
+                manager.transaction.setRollbackOnly()
+                restrictedEntityManager.lock(entity, LockModeType.OPTIMISTIC)
+            }
+        }
+    }
+
+    @Entity
+    @Table(name = "custom_table")
+    @CordaSerializable
+    data class CustomTableEntity constructor(
+        @Id
+        @Column(name = "id", nullable = false)
+        var id: Int,
+        @Column(name = "name", nullable = false)
+        var name: String,
+        @Column(name = "quote", nullable = false)
+        var quote: String
+    )
+
+    object CustomSchema
+
+    object CustomMappedSchema : MappedSchema(CustomSchema::class.java, 1, listOf(CustomTableEntity::class.java))
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/AbstractFlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/AbstractFlowEntityManagerTest.kt
@@ -1,0 +1,134 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.messaging.startFlow
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.node.services.statemachine.StaffedFlowHospital
+import org.junit.Before
+import java.util.concurrent.Semaphore
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+import kotlin.test.assertEquals
+
+abstract class AbstractFlowEntityManagerTest {
+
+    protected companion object {
+
+        const val TABLE_NAME = "entity_manager_custom_table"
+
+        val entityWithIdOne = CustomTableEntity(1, "Dan", "This won't work")
+        val anotherEntityWithIdOne = CustomTableEntity(1, "Rick", "I'm pretty sure this will work")
+        val entityWithIdTwo = CustomTableEntity(2, "Ivan", "This will break existing CorDapps")
+        val entityWithIdThree = CustomTableEntity(3, "Some other guy", "What am I doing here?")
+    }
+
+    @CordaSerializable
+    enum class CommitStatus { INTERMEDIATE_COMMIT, NO_INTERMEDIATE_COMMIT }
+
+    @Before
+    open fun before() {
+        StaffedFlowHospital.onFlowDischarged.clear()
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.clear()
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.clear()
+    }
+
+    protected inline fun <reified R : FlowLogic<Any>> CordaRPCOps.expectFlowFailureAndAssertCreatedEntities(
+        crossinline flow: (CommitStatus) -> R,
+        commitStatus: CommitStatus,
+        numberOfDischarges: Int,
+        numberOfExpectedEntities: Int
+    ): Int {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val lock = Semaphore(0)
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ -> lock.release() }
+        startFlow(flow, commitStatus)
+        lock.acquire()
+        assertEquals(
+            numberOfDischarges,
+            counter,
+            "[$commitStatus] expected the flow to be discharged from hospital $numberOfDischarges time(s)"
+        )
+        val numberOfEntities = startFlow(::GetCustomEntities).returnValue.getOrThrow().size
+        assertEquals(
+            numberOfExpectedEntities,
+            numberOfEntities,
+            "[$commitStatus] expected $numberOfExpectedEntities to be saved"
+        )
+        startFlow(::DeleteCustomEntities).returnValue.getOrThrow(30.seconds)
+        return numberOfEntities
+    }
+
+    protected inline fun <reified R : FlowLogic<Any>> CordaRPCOps.expectFlowSuccessAndAssertCreatedEntities(
+        crossinline flow: (CommitStatus) -> R,
+        commitStatus: CommitStatus,
+        numberOfDischarges: Int,
+        numberOfExpectedEntities: Int
+    ): Int {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        startFlow(flow, commitStatus).returnValue.getOrThrow(30.seconds)
+        assertEquals(
+            numberOfDischarges,
+            counter,
+            "[$commitStatus] expected the flow to be discharged from hospital $numberOfDischarges time(s)"
+        )
+        val numberOfEntities = startFlow(::GetCustomEntities).returnValue.getOrThrow().size
+        assertEquals(
+            numberOfExpectedEntities,
+            numberOfEntities,
+            "[$commitStatus] expected $numberOfExpectedEntities to be saved"
+        )
+        startFlow(::DeleteCustomEntities).returnValue.getOrThrow(30.seconds)
+        return numberOfEntities
+    }
+
+    @StartableByRPC
+    class GetCustomEntities : FlowLogic<List<CustomTableEntity>>() {
+        @Suspendable
+        override fun call(): List<CustomTableEntity> {
+            return serviceHub.withEntityManager {
+                val criteria = criteriaBuilder.createQuery(CustomTableEntity::class.java)
+                criteria.select(criteria.from(CustomTableEntity::class.java))
+                createQuery(criteria).resultList
+            }
+        }
+    }
+
+    @StartableByRPC
+    class DeleteCustomEntities : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                val delete = criteriaBuilder.createCriteriaDelete(CustomTableEntity::class.java)
+                delete.from(CustomTableEntity::class.java)
+                createQuery(delete).executeUpdate()
+            }
+        }
+    }
+
+    @Entity
+    @Table(name = TABLE_NAME)
+    @CordaSerializable
+    data class CustomTableEntity constructor(
+        @Id
+        @Column(name = "id", nullable = false)
+        var id: Int,
+        @Column(name = "name", nullable = false)
+        var name: String,
+        @Column(name = "quote", nullable = false)
+        var quote: String
+    )
+
+    object CustomSchema
+
+    object CustomMappedSchema : MappedSchema(CustomSchema::class.java, 1, listOf(CustomTableEntity::class.java))
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerNestedTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerNestedTest.kt
@@ -1,0 +1,374 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.millis
+import net.corda.core.utilities.seconds
+import net.corda.node.services.statemachine.StaffedFlowHospital
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import org.junit.Test
+import javax.persistence.PersistenceException
+import kotlin.test.assertEquals
+
+class FlowEntityManagerNestedTest : AbstractFlowEntityManagerTest() {
+
+    @Test(timeout = 300_000)
+    fun `entity manager inside an entity manager saves all data`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+
+            alice.rpc.startFlow(::EntityManagerInsideAnEntityManagerFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(0, counter)
+            val entities = alice.rpc.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+            assertEquals(2, entities.size)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `entity manager inside an entity manager that throws an error does not save any data`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerInsideAnEntityManagerThatThrowsAnExceptionFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 0
+            )
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerInsideAnEntityManagerThatThrowsAnExceptionFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `entity manager that saves an entity with an entity manager inside it that throws an error after saving the entity does not save any data`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAfterSavingFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 0
+            )
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAfterSavingFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `entity manager that saves an entity with an entity manager inside it that throws an error and catching it around the entity manager after saving the entity saves the data from the external entity manager`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `entity manager that saves an entity with an entity manager inside it that throws an error and catching it inside the entity manager after saving the entity saves the data from the external entity manager`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesInsideTheEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesInsideTheEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `entity manager that saves an entity with an entity manager inside it that throws an error and catching it around the entity manager before saving the entity saves the data from the external entity manager`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerBeforeSavingFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerBeforeSavingFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `entity manager with an entity manager inside it saves an entity, outer throws and catches the error outside itself after saving the entity does not save the data from the internal entity manager`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesAroundOuterEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesAroundOuterEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `entity manager with an entity manager inside it saves an entity, outer throws and catches the error inside itself after saving the entity does not save the data from the internal entity manager`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesInsideOuterEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesInsideOuterEntityManagerAfterSavingFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerInsideAnEntityManagerFlow : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+                serviceHub.withEntityManager {
+                    persist(entityWithIdTwo)
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerInsideAnEntityManagerThatThrowsAnExceptionFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                serviceHub.withEntityManager {
+                    persist(anotherEntityWithIdOne)
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAfterSavingFlow(private val commitStatus: CommitStatus) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(entityWithIdTwo)
+                serviceHub.withEntityManager {
+                    persist(anotherEntityWithIdOne)
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerAfterSavingFlow(
+        private val commitStatus: CommitStatus
+    ) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(entityWithIdTwo)
+                try {
+                    serviceHub.withEntityManager {
+                        persist(anotherEntityWithIdOne)
+                    }
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesInsideTheEntityManagerAfterSavingFlow(
+        private val commitStatus: CommitStatus
+    ) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(entityWithIdTwo)
+                serviceHub.withEntityManager {
+                    try {
+                        persist(anotherEntityWithIdOne)
+                        flush()
+                    } catch (e: PersistenceException) {
+                        logger.info("Caught the exception!")
+                    }
+                }
+
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerBeforeSavingFlow(
+        private val commitStatus: CommitStatus
+    ) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                try {
+                    serviceHub.withEntityManager {
+                        persist(anotherEntityWithIdOne)
+                    }
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+                persist(entityWithIdTwo)
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesAroundOuterEntityManagerAfterSavingFlow(
+        private val commitStatus: CommitStatus
+    ) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            try {
+                serviceHub.withEntityManager {
+                    serviceHub.withEntityManager {
+                        persist(entityWithIdTwo)
+                    }
+                    persist(anotherEntityWithIdOne)
+                }
+            } catch (e: PersistenceException) {
+                logger.info("Caught the exception!")
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesInsideOuterEntityManagerAfterSavingFlow(
+        private val commitStatus: CommitStatus
+    ) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                serviceHub.withEntityManager {
+                    persist(entityWithIdTwo)
+                }
+                try {
+                    persist(anotherEntityWithIdOne)
+                    flush()
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerStatementTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerStatementTest.kt
@@ -1,0 +1,309 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.millis
+import net.corda.core.utilities.seconds
+import net.corda.node.services.statemachine.StaffedFlowHospital
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import org.hibernate.exception.ConstraintViolationException
+import org.junit.Test
+import javax.persistence.PersistenceException
+import kotlin.test.assertEquals
+
+class FlowEntityManagerStatementTest : AbstractFlowEntityManagerTest() {
+
+    @Test(timeout = 300_000)
+    fun `data can be saved by a sql statement using entity manager`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+
+            alice.rpc.startFlow(::EntityManagerSqlFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(0, counter)
+            val entities = alice.rpc.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+            assertEquals(1, entities.size)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation caused by a sql statement should save no data`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerErrorFromSqlFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 0
+            )
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerErrorFromSqlFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation caused by a sql statement that is caught inside an entity manager block saves none of the data inside of it`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            // 1 entity saved from the first entity manager block that does not get rolled back
+            // even if there is no intermediate commit to the database
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlInsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlInsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation caused by a sql statement that is caught outside an entity manager block saves none of the data inside of it`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            // 1 entity saved from the first entity manager block that does not get rolled back
+            // even if there is no intermediate commit to the database
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlOutsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlOutsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation caused by a sql statement that is caught inside an entity manager and more data is saved afterwards inside the same entity manager should not save the extra data`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInTheSameEntityManagerFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInTheSameEntityManagerFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation caused by a sql statement that is caught inside an entity manager and more data is saved afterwards inside a new entity manager should save the extra data`() {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInNewEntityManagerFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInNewEntityManagerFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 2
+            )
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerSqlFlow : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                    .setParameter("id", anotherEntityWithIdOne.id)
+                    .setParameter("name", anotherEntityWithIdOne.name)
+                    .setParameter("quote", anotherEntityWithIdOne.name)
+                    .executeUpdate()
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerErrorFromSqlFlow(private val commitStatus: CommitStatus) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                    .setParameter("id", anotherEntityWithIdOne.id)
+                    .setParameter("name", anotherEntityWithIdOne.name)
+                    .setParameter("quote", anotherEntityWithIdOne.name)
+                    .executeUpdate()
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerCatchErrorFromSqlInsideTheEntityManagerFlow(private val commitStatus: CommitStatus) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                try {
+                    createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                        .setParameter("id", anotherEntityWithIdOne.id)
+                        .setParameter("name", anotherEntityWithIdOne.name)
+                        .setParameter("quote", anotherEntityWithIdOne.name)
+                        .executeUpdate()
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerCatchErrorFromSqlOutsideTheEntityManagerFlow(private val commitStatus: CommitStatus) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            try {
+                serviceHub.withEntityManager {
+                    createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                        .setParameter("id", anotherEntityWithIdOne.id)
+                        .setParameter("name", anotherEntityWithIdOne.name)
+                        .setParameter("quote", anotherEntityWithIdOne.name)
+                        .executeUpdate()
+                }
+            } catch (e: PersistenceException) {
+                logger.info("Caught the exception!")
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInTheSameEntityManagerFlow(private val commitStatus: CommitStatus) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                try {
+                    createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                        .setParameter("id", anotherEntityWithIdOne.id)
+                        .setParameter("name", anotherEntityWithIdOne.name)
+                        .setParameter("quote", anotherEntityWithIdOne.name)
+                        .executeUpdate()
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+                // These entities are not saved since the transaction is marked for rollback
+                try {
+                    createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                        .setParameter("id", entityWithIdTwo.id)
+                        .setParameter("name", entityWithIdTwo.name)
+                        .setParameter("quote", entityWithIdTwo.name)
+                        .executeUpdate()
+                } catch (e: PersistenceException) {
+                    if (e.cause is ConstraintViolationException) {
+                        throw e
+                    } else {
+                        logger.info(
+                            """
+                            Caught exception from second sql statement inside the same broken entity manager
+                            This happens if the database has thrown an exception due to rolling back the db transaction
+                        """.trimIndent(), e
+                        )
+                    }
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInNewEntityManagerFlow(private val commitStatus: CommitStatus) :
+        FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            try {
+                serviceHub.withEntityManager {
+                    createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                        .setParameter("id", anotherEntityWithIdOne.id)
+                        .setParameter("name", anotherEntityWithIdOne.name)
+                        .setParameter("quote", anotherEntityWithIdOne.name)
+                        .executeUpdate()
+
+                }
+            } catch (e: PersistenceException) {
+                logger.info("Caught the exception!")
+            }
+            serviceHub.withEntityManager {
+                val query = createNativeQuery("INSERT INTO $TABLE_NAME VALUES (:id, :name, :quote)")
+                    .setParameter("id", entityWithIdTwo.id)
+                    .setParameter("name", entityWithIdTwo.name)
+                    .setParameter("quote", entityWithIdTwo.name)
+                query.executeUpdate()
+            }
+            sleep(1.millis)
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
@@ -111,7 +111,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(::EntityManagerSaveEntitiesWithoutAFlushFlow)
                     .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
@@ -131,7 +130,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(::EntityManagerSaveEntitiesWithAFlushFlow)
                     .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
@@ -150,7 +148,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 assertFailsWith<TimeoutException> {
                     it.proxy.startFlow(::EntityManagerErrorWithoutAFlushFlow, commitStatus)
@@ -172,7 +169,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 assertFailsWith<TimeoutException> {
                     it.proxy.startFlow(::EntityManagerErrorWithAFlushFlow, commitStatus)
@@ -193,7 +189,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(::EntityManagerWithAFlushCatchErrorInsideTheEntityManagerFlow, commitStatus)
                     .returnValue.getOrThrow(20.seconds)
@@ -213,7 +208,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(::EntityManagerWithAFlushCatchErrorOutsideTheEntityManagerFlow, commitStatus)
                     .returnValue.getOrThrow(20.seconds)
@@ -233,7 +227,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 assertFailsWith<TimeoutException> {
                     it.proxy.startFlow(::EntityManagerSavingMultipleEntitiesWithASingleErrorFlow, commitStatus)
@@ -255,7 +248,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(
                     ::EntityManagerSavingMultipleEntitiesWithASingleCaughtErrorFlow,
@@ -277,7 +269,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(
                     ::EntityManagerCatchErrorAndSaveMoreEntitiesInANewEntityManager,
@@ -300,7 +291,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 assertFailsWith<RolledBackDatabaseSessionException> {
                     it.proxy.startFlow(
@@ -327,7 +317,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         driver(DriverParameters(startNodesInProcess = true)) {
 
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(
                     ::EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager,
@@ -667,7 +656,8 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
     }
 
     @StartableByRPC
-    class EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+    class EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager(private val commitStatus: CommitStatus) :
+        FlowLogic<Unit>() {
 
         @Suspendable
         override fun call() {

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
@@ -1,0 +1,984 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.CollectSignaturesFlow
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveFinalityFlow
+import net.corda.core.flows.SignTransactionFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.messaging.startFlow
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.millis
+import net.corda.core.utilities.seconds
+import net.corda.core.utilities.unwrap
+import net.corda.node.services.Permissions
+import net.corda.node.services.statemachine.StaffedFlowHospital
+import net.corda.nodeapi.internal.persistence.RolledBackDatabaseSessionException
+import net.corda.testing.contracts.DummyState
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.DummyCommandData
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.User
+import org.hibernate.exception.ConstraintViolationException
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.sql.Savepoint
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeoutException
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.PersistenceException
+import javax.persistence.Table
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Tests that I need
+ *
+ * 1)   No database error works (data saved) ✅
+ * 2)   Constraint violation without a flush breaks (no data saved and savepoint released) ✅
+ * 3)   Constraint violation with a flush breaks (no data saved and savepoint released) ✅
+ * 4)   Constraint violation with a flush that is caught works (no data saved) ✅
+ * 5)   Constraint violation with a flush that is caught outside of the entity manager block works (no data saved) ✅
+ * 6)   Constraint violation on a single entity when saving multiple entities breaks ✅
+ *      (no data saved / test transactionality within an entity manager block)
+ * 7)   Constraint violation on a single entity when saving multiple entities breaks works ✅
+ *      (no data saved / test transactionality within an entity manager block)
+ * 8)   Constraint violation with a flush that is caught inside an entity manager and more data is saved afterwards in a new entity manager (the extra data should be saved) ✅
+ * 9)   Constraint violation with a flush that is caught inside an entity manager and more data is saved afterwards in the same entity manager (throws exception) ✅
+ * 10)  Constraint violation with a flush that is caught outside an entity manager and more data is saved afterwards in a new entity manager (the extra data should be saved) ✅
+ * 11)  All data is saved when a suspension point is reached
+ * 12)  Hibernate session is cleared when rolling back a session/save-point (calling find/merge/persist should not hit evicted entity)
+ * 13)  Other types of hibernate ([PersistenceException]s) can be caught
+ * 14)
+ *
+ * I should take into account having a commit in between the entity managers or not
+ * Basically the tests above can be repeated with a commit between each entity manager (use parameterized tests that determine whether to
+ * trigger the commit?)
+ *
+ * I should also test constraint violations within a single entity manager
+ *
+ * entity manager inside an entity manager?
+ */
+@RunWith(Parameterized::class)
+class FlowEntityManagerTest(var commitStatus: CommitStatus) {
+
+    private companion object {
+        val entityWithIdOne = CustomTableEntity(1, "Dan", "This won't work")
+        val anotherEntityWithIdOne = CustomTableEntity(1, "Rick", "I'm pretty sure this will work")
+        val entityWithIdTwo = CustomTableEntity(2, "Ivan", "This will break existing CorDapps")
+        val entityWithIdThree = CustomTableEntity(3, "Some other guy", "What am I doing here?")
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() = listOf(CommitStatus.INTERMEDIATE_COMMIT, CommitStatus.NO_INTERMEDIATE_COMMIT)
+    }
+
+    @CordaSerializable
+    enum class CommitStatus { INTERMEDIATE_COMMIT, NO_INTERMEDIATE_COMMIT }
+
+    @Before
+    fun before() {
+        StaffedFlowHospital.onFlowDischarged.clear()
+    }
+
+    // This doesn't need to be parameterized...
+    @Test(timeout = 300_000)
+    fun `entities can be saved using entity manager without a flush`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(::EntityManagerSaveEntitiesWithoutAFlushFlow)
+                    .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+                assertEquals(0, counter)
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(3, entities.size)
+            }
+        }
+    }
+
+    // This doesn't need to be parameterized...
+    @Test(timeout = 300_000)
+    fun `entities can be saved using entity manager with a flush`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(::EntityManagerSaveEntitiesWithAFlushFlow)
+                    .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+                assertEquals(0, counter)
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(3, entities.size)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation without a flush breaks`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                assertFailsWith<TimeoutException> {
+                    it.proxy.startFlow(::EntityManagerErrorWithoutAFlushFlow, commitStatus)
+                        .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+                }
+                assertEquals(3, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(1, entities.size)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation with a flush breaks`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                assertFailsWith<TimeoutException> {
+                    it.proxy.startFlow(::EntityManagerErrorWithAFlushFlow, commitStatus)
+                        .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
+                }
+                assertEquals(3, counter)
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(1, entities.size)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation with a flush that is caught inside an entity manager block saves no data`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(::EntityManagerWithAFlushCatchErrorInsideTheEntityManagerFlow, commitStatus)
+                    .returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(1, entities.size)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation with a flush that is caught outside the entity manager block saves no data`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(::EntityManagerWithAFlushCatchErrorOutsideTheEntityManagerFlow, commitStatus)
+                    .returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(1, entities.size)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation on a single entity when saving multiple entities does not save any entities`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                assertFailsWith<TimeoutException> {
+                    it.proxy.startFlow(::EntityManagerSavingMultipleEntitiesWithASingleErrorFlow, commitStatus)
+                        .returnValue.getOrThrow(20.seconds)
+                }
+                assertEquals(3, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(1, entities.size)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation on a single entity when saving multiple entities and catching the error does not save any entities`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::EntityManagerSavingMultipleEntitiesWithASingleCaughtErrorFlow,
+                    commitStatus
+                ).returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(1, entities.size)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation that is caught inside an entity manager and more data is saved afterwards inside a new entity manager should save the extra data`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::EntityManagerCatchErrorAndSaveMoreEntitiesInANewEntityManager,
+                    commitStatus
+                ).returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(3, entities.size)
+            }
+        }
+    }
+
+    // maybe we should throw an error if a session is broken but the flow tries to insert more entities
+    @Test(timeout = 300_000)
+    fun `constraint violation that is caught inside an entity manager and more data is saved afterwards inside the same entity manager should throw an exception`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                assertFailsWith<RolledBackDatabaseSessionException> {
+                    it.proxy.startFlow(
+                        ::EntityManagerCatchErrorAndSaveMoreEntitiesInTheSameEntityManager,
+                        commitStatus
+                    ).returnValue.getOrThrow(20.seconds)
+                }
+                assertEquals(0, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                when (commitStatus) {
+                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
+                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(0, entities.size)
+                }
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `constraint violation that is caught outside an entity manager and more data is saved afterwards inside a new entity manager should save the extra data`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(
+                    ::EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager,
+                    commitStatus
+                ).returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                // 1 entity exists to trigger constraint violation
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(3, entities.size)
+            }
+        }
+    }
+
+    /*
+    Once a flush is made and caught, it is not possible to do anything using [withEntityManager] again (even inside a new call to it).
+
+    The question is, why is the flow able to progress as normal after catching a [flush] error but calling [withEntityManager] again
+    fails due to the caught error resurfacing due to a [flush]. It does not matter whether the [flush] comes from a user [flush] or the
+    [flush] that occurs when opening a [withEntityManager] block.
+     */
+    @Test(timeout = 300_000)
+    @Ignore
+    fun `constraint violation inside entity manager *with multiple flushes that insert extra data* and *catching the exception* will allow the flow to finish`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                val txId = it.proxy.startFlow(::EntityManagerWithFlushCatchAndNewDataFlow, nodeBHandle.nodeInfo.singleIdentity())
+                    .returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                val txFromVault = it.proxy.stateMachineRecordedTransactionMappingSnapshot().firstOrNull()?.transactionId
+                assertEquals(txId, txFromVault)
+                val entity = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow().single()
+                assertEquals(entityWithIdOne, entity)
+            }
+        }
+        assertEquals(0, counter)
+    }
+
+    @Test(timeout = 300_000)
+    @Ignore
+    fun `constraint violation inside entity manager *with multiple flushes that insert extra data* and *catching the exception* will allow the flow to finish 123123`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                val txId = it.proxy.startFlow(::EntityManagerWithFlushCatchAndNewDataFlow2, nodeBHandle.nodeInfo.singleIdentity())
+                    .returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                val txFromVault = it.proxy.stateMachineRecordedTransactionMappingSnapshot().firstOrNull()?.transactionId
+                assertEquals(txId, txFromVault)
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(3, entities.size)
+//                assertEquals(entityOne, entity)
+            }
+        }
+        assertEquals(0, counter)
+    }
+
+    @Test(timeout = 300_000)
+    @Ignore
+    fun `constraint violation inside entity manager *with multiple flushes that insert extra data* and *catching the exception* will allow the flow to finish SAVE POINTS`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                val txId = it.proxy.startFlow(::EntityManagerWithFlushCatchAndNewDataFlow3, nodeBHandle.nodeInfo.singleIdentity())
+                    .returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                val txFromVault = it.proxy.stateMachineRecordedTransactionMappingSnapshot().firstOrNull()?.transactionId
+                assertEquals(txId, txFromVault)
+                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+                assertEquals(2, entities.size)
+//                assertEquals(entityOne, entity)
+            }
+        }
+        assertEquals(0, counter)
+    }
+
+    /*
+    Calling rollback inside a flow blows it up when it reaches the next suspend/commit
+
+    Caused by: java.lang.IllegalStateException: Transaction not successfully started
+	at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:98) ~[hibernate-core-5.4.3.Final.jar:5.4.3.Final]
+	at net.corda.nodeapi.internal.persistence.DatabaseTransaction.commit(DatabaseTransaction.kt:76) ~[corda-node-api-4.4-SNAPSHOT.jar:?]
+	at net.corda.node.services.statemachine.ActionExecutorImpl.executeCommitTransaction(ActionExecutorImpl.kt:230) ~[corda-node-4.4-SNAPSHOT.jar:?]
+	at net.corda.node.services.statemachine.ActionExecutorImpl.executeAction(ActionExecutorImpl.kt:77) ~[corda-node-4.4-SNAPSHOT.jar:?]
+	at net.corda.node.services.statemachine.TransitionExecutorImpl.executeTransition(TransitionExecutorImpl.kt:44) ~[corda-node-4.4-SNAPSHOT.jar:?]
+	... 18 more
+
+     */
+    @Test(timeout = 300_000)
+    @Ignore
+    fun `constraint violation inside entity manager *with flush* error that is caught, transaction is rolled back and new data is inserted, flow finishes`() {
+        var counter = 0
+        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
+        val user = User("mark", "dadada", setOf(Permissions.all()))
+        driver(DriverParameters(startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+                val txId = it.proxy.startFlow(::EntityManagerWithFlushCatchRollbackAndNewDataFlow, nodeBHandle.nodeInfo.singleIdentity())
+                    .returnValue.getOrThrow(20.seconds)
+                assertEquals(0, counter)
+                val txFromVault = it.proxy.stateMachineRecordedTransactionMappingSnapshot().firstOrNull()?.transactionId
+                assertEquals(txId, txFromVault)
+                val entity = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow().single()
+                assertEquals(entityWithIdOne, entity)
+            }
+        }
+        assertEquals(0, counter)
+    }
+
+    @StartableByRPC
+    class EntityManagerSaveEntitiesWithoutAFlushFlow : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+                persist(entityWithIdTwo)
+                persist(entityWithIdThree)
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerSaveEntitiesWithAFlushFlow : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+                persist(entityWithIdTwo)
+                persist(entityWithIdThree)
+                flush()
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerErrorWithoutAFlushFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(anotherEntityWithIdOne)
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerErrorWithAFlushFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(anotherEntityWithIdOne)
+                flush()
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerWithAFlushCatchErrorInsideTheEntityManagerFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(anotherEntityWithIdOne)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerWithAFlushCatchErrorOutsideTheEntityManagerFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            try {
+                serviceHub.withEntityManager {
+                    persist(anotherEntityWithIdOne)
+                    flush()
+                }
+            } catch (e: PersistenceException) {
+                logger.info("Caught the exception!")
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerSavingMultipleEntitiesWithASingleErrorFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(anotherEntityWithIdOne)
+                persist(entityWithIdTwo)
+                persist(entityWithIdThree)
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerSavingMultipleEntitiesWithASingleCaughtErrorFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(anotherEntityWithIdOne)
+                persist(entityWithIdTwo)
+                persist(entityWithIdThree)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerCatchErrorAndSaveMoreEntitiesInANewEntityManager(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(anotherEntityWithIdOne)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(entityWithIdTwo)
+                persist(entityWithIdThree)
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerCatchErrorAndSaveMoreEntitiesInTheSameEntityManager(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(anotherEntityWithIdOne)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    logger.info("Caught the exception!")
+                }
+                persist(entityWithIdTwo)
+                persist(entityWithIdThree)
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            try {
+                serviceHub.withEntityManager {
+                    persist(anotherEntityWithIdOne)
+                    flush()
+                }
+            } catch (e: PersistenceException) {
+                logger.info("Caught the exception!")
+            }
+            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
+                sleep(1.millis)
+            }
+            serviceHub.withEntityManager {
+                persist(entityWithIdTwo)
+                persist(entityWithIdThree)
+            }
+            sleep(1.millis)
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerWithFlushCatchAndNewDataFlow(private val party: Party) : FlowLogic<SecureHash>() {
+        companion object {
+            val log = contextLogger()
+        }
+
+        @Suspendable
+        override fun call(): SecureHash {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+                log.info("After the first insert")
+            }
+            sleep(1.millis)
+            serviceHub.withEntityManager {
+                // the exception is not triggered until the second commit
+                // it does not happen inline by hibernate
+                persist(anotherEntityWithIdOne)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    // it does not make it to here as a constraint violation exception
+                    if (e.cause is ConstraintViolationException) {
+                        log.info("Caught the exception!")
+                        clear()
+                        detach(anotherEntityWithIdOne)
+                    }
+                }
+            }
+            serviceHub.withEntityManager {
+                persist(entityWithIdTwo)
+//                flush()
+                log.info("After the second flush")
+            }
+            return subFlow(CreateATransactionFlow(party)).also {
+                log.info("Reached the end of the flow")
+            }
+        }
+    }
+
+    @StartableByRPC
+    class EntityManagerWithFlushCatchAndNewDataFlow2(private val party: Party) : FlowLogic<SecureHash>() {
+        companion object {
+            val log = contextLogger()
+        }
+
+        @Suspendable
+        override fun call(): SecureHash {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+//                flush()
+                log.info("After the first insert")
+            }
+            sleep(1.millis)
+            doStuff()
+            sleep(1.millis)
+//            serviceHub.jdbcSession().setSavepoint()
+            serviceHub.withEntityManager {
+                val entity = find(CustomTableEntity::class.java, 1)
+                log.info("I found the entity : $entity")
+                val entity2 = find(CustomTableEntity::class.java, 2)
+                log.info("I found the entity2 : $entity2")
+                persist(entityWithIdThree)
+                val entity3 = find(CustomTableEntity::class.java, 3)
+                log.info("I found the entity3 : $entity3")
+//                flush()
+                log.info("After the second flush")
+            }
+            return subFlow(CreateATransactionFlow(party)).also {
+                log.info("Reached the end of the flow")
+            }
+        }
+
+        private fun doStuff() {
+//            val savePoint = createSavepoint()
+            serviceHub.withEntityManager {
+                // the exception is not triggered until the second commit
+                // it does not happen inline by hibernate
+                persist(entityWithIdTwo)
+                persist(anotherEntityWithIdOne)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    // it does not make it to here as a constraint violation exception
+                    if (e.cause is ConstraintViolationException) {
+                        log.info("Caught the exception!")
+//                        savePoint.rollback()
+//                        clear()
+//                        detach(entityTwo)
+                    }
+                }
+            }
+//            savePoint.release()
+        }
+
+        private fun createSavepoint(): Savepoint {
+            val connection = serviceHub.jdbcSession()
+            return connection.setSavepoint()
+        }
+
+        private fun Savepoint.rollback() = serviceHub.jdbcSession().rollback(this)
+
+        private fun Savepoint.release() = serviceHub.jdbcSession().releaseSavepoint(this)
+    }
+
+    @StartableByRPC
+    class EntityManagerWithFlushCatchAndNewDataFlow3(private val party: Party) : FlowLogic<SecureHash>() {
+        companion object {
+            val log = contextLogger()
+        }
+
+        @Suspendable
+        override fun call(): SecureHash {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+//                flush()
+                log.info("After the first insert")
+            }
+            sleep(1.millis)
+            doStuff()
+//            sleep(1.millis)
+//            serviceHub.jdbcSession().setSavepoint()
+            serviceHub.withEntityManager {
+                val entity = find(CustomTableEntity::class.java, 1)
+                log.info("I found the entity : $entity")
+                val entity2 = find(CustomTableEntity::class.java, 2)
+                log.info("I found the entity2 : $entity2")
+                persist(entityWithIdThree)
+                val entity3 = find(CustomTableEntity::class.java, 3)
+                log.info("I found the entity3 : $entity3")
+//                flush()
+                log.info("After the second flush")
+            }
+            return subFlow(CreateATransactionFlow(party)).also {
+                log.info("Reached the end of the flow")
+            }
+        }
+
+        private fun doStuff() {
+            val savePoint = createSavepoint()
+            serviceHub.withEntityManager {
+                // the exception is not triggered until the second commit
+                // it does not happen inline by hibernate
+                persist(entityWithIdTwo)
+                persist(anotherEntityWithIdOne)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    // it does not make it to here as a constraint violation exception
+                    if (e.cause is ConstraintViolationException) {
+                        log.info("Caught the exception!")
+                        savePoint.rollback()
+//                        clear()
+//                        detach(entityTwo)
+                    }
+                }
+            }
+            savePoint.release()
+        }
+
+        private fun createSavepoint(): Savepoint {
+            val connection = serviceHub.jdbcSession()
+            return connection.setSavepoint()
+        }
+
+        private fun Savepoint.rollback() = serviceHub.jdbcSession().rollback(this)
+
+        private fun Savepoint.release() = serviceHub.jdbcSession().releaseSavepoint(this)
+    }
+
+    @StartableByRPC
+    class EntityManagerWithFlushCatchRollbackAndNewDataFlow(private val party: Party) : FlowLogic<SecureHash>() {
+        companion object {
+            val log = contextLogger()
+        }
+
+        @Suspendable
+        override fun call(): SecureHash {
+            serviceHub.withEntityManager {
+                persist(entityWithIdOne)
+                log.info("After the first insert")
+            }
+            sleep(1.millis)
+            serviceHub.withEntityManager {
+                // the exception is not triggered until the second commit
+                // it does not happen inline by hibernate
+                persist(anotherEntityWithIdOne)
+                try {
+                    flush()
+                } catch (e: PersistenceException) {
+                    // it does not make it to here as a constraint violation exception
+                    if (e.cause is ConstraintViolationException) {
+                        log.info("Caught the exception!")
+                        transaction.rollback()
+                        transaction.begin()
+                    }
+                }
+            }
+            serviceHub.withEntityManager {
+                persist(entityWithIdTwo)
+                flush()
+                log.info("After the second flush")
+            }
+            return subFlow(CreateATransactionFlow(party)).also {
+                log.info("Reached the end of the flow")
+            }
+        }
+    }
+
+    @InitiatingFlow
+    class CreateATransactionFlow(val party: Party) : FlowLogic<SecureHash>() {
+        @Suspendable
+        override fun call(): SecureHash {
+            val session = initiateFlow(party)
+            val tx = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
+                addOutputState(DummyState(participants = listOf(ourIdentity, party)))
+                addCommand(DummyCommandData, ourIdentity.owningKey, party.owningKey)
+            }
+            val stx = serviceHub.signInitialTransaction(tx)
+            val ftx = subFlow(CollectSignaturesFlow(stx, listOf(session)))
+            return subFlow(FinalityFlow(ftx, session)).id
+        }
+    }
+
+    @InitiatedBy(CreateATransactionFlow::class)
+    class CreateATransactionResponder(val session: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val stx = subFlow(object : SignTransactionFlow(session) {
+                override fun checkTransaction(stx: SignedTransaction) {
+                }
+            })
+            subFlow(ReceiveFinalityFlow(session, stx.id))
+        }
+    }
+
+    @StartableByRPC
+    class GetCustomEntities : FlowLogic<List<CustomTableEntity>>() {
+        @Suspendable
+        override fun call(): List<CustomTableEntity> {
+            return serviceHub.withEntityManager {
+                val criteria = criteriaBuilder.createQuery(CustomTableEntity::class.java)
+                criteria.select(criteria.from(CustomTableEntity::class.java))
+                createQuery(criteria).resultList.also {
+                    logger.info("results = $it")
+                }
+            }
+        }
+    }
+
+    @InitiatingFlow
+    class PingPongFlow(val party: Party) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val session = initiateFlow(party)
+            session.sendAndReceive<String>("ping pong").unwrap { it }
+            logger.info("Finished the ping pong flow")
+        }
+    }
+
+    @InitiatedBy(PingPongFlow::class)
+    class PingPongResponder(val session: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            session.receive<String>().unwrap { it }
+            session.send("I got you bro")
+            logger.info("Finished the ping pong responder")
+        }
+    }
+
+    @Entity
+    @Table(name = "custom_table")
+    @CordaSerializable
+    data class CustomTableEntity constructor(
+        @Id
+        @Column(name = "id", nullable = false)
+        var id: Int,
+        @Column(name = "name", nullable = false)
+        var name: String,
+        @Column(name = "quote", nullable = false)
+        var quote: String
+    )
+
+    object CustomSchema
+
+    object CustomMappedSchema : MappedSchema(CustomSchema::class.java, 1, listOf(CustomTableEntity::class.java))
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
@@ -1,7 +1,6 @@
 package net.corda.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.CollectSignaturesFlow
 import net.corda.core.flows.FinalityFlow
@@ -16,16 +15,12 @@ import net.corda.core.identity.Party
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
-import net.corda.core.schemas.MappedSchema
-import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
 import net.corda.core.utilities.seconds
-import net.corda.node.services.Permissions
 import net.corda.node.services.statemachine.StaffedFlowHospital
 import net.corda.testing.contracts.DummyState
 import net.corda.testing.core.ALICE_NAME
@@ -34,698 +29,339 @@ import net.corda.testing.core.DummyCommandData
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
-import net.corda.testing.node.User
-import org.apache.logging.log4j.Level
-import org.apache.logging.log4j.core.config.Configurator
+import org.hibernate.exception.ConstraintViolationException
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import java.sql.Connection
-import java.time.Duration
-import java.time.temporal.ChronoUnit
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import java.util.concurrent.TimeoutException
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.Id
+import java.util.concurrent.Semaphore
 import javax.persistence.PersistenceException
-import javax.persistence.Table
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
-/**
- * Tests that I need
- *
- * 1)   No database error works (data saved) ✅
- * 2)   Constraint violation without a flush breaks (no data saved and savepoint released) ✅
- * 3)   Constraint violation with a flush breaks (no data saved and savepoint released) ✅
- * 4)   Constraint violation with a flush that is caught works (no data saved) ✅
- * 5)   Constraint violation with a flush that is caught outside of the entity manager block works (no data saved) ✅
- * 6)   Constraint violation inside a single entity manager breaks (no data saved) ✅
- * 7)   Constraint violation on a single entity when saving multiple entities breaks ✅
- *      (no data saved / test transactionality within an entity manager block)
- * 8)   Constraint violation on a single entity when saving multiple entities breaks works ✅
- *      (no data saved / test transactionality within an entity manager block)
- * 9)   Constraint violation with a flush that is caught inside an entity manager and more data is saved afterwards in a new entity manager (the extra data should be saved) ✅
- * 10)  Constraint violation with a flush that is caught inside an entity manager and more data is saved afterwards in the same entity manager (throws exception) ✅
- * 11)  Constraint violation with a flush that is caught outside an entity manager and more data is saved afterwards in a new entity manager (the extra data should be saved) ✅
- * 12)  Data is only saved when a suspension point is reached ✅
- * 13)  Parameterize all the above tests to have an intermediate commit ✅
- * 14)  Flow can continue processing normally after catching exception inside entity manager ✅
- *
- * I should also test constraint violations within a single entity manager
- *
- * entity manager inside an entity manager?
- */
-@RunWith(Parameterized::class)
-class FlowEntityManagerTest(var commitStatus: CommitStatus) {
-
-    private companion object {
-        val entityWithIdOne = CustomTableEntity(1, "Dan", "This won't work")
-        val anotherEntityWithIdOne = CustomTableEntity(1, "Rick", "I'm pretty sure this will work")
-        val entityWithIdTwo = CustomTableEntity(2, "Ivan", "This will break existing CorDapps")
-        val entityWithIdThree = CustomTableEntity(3, "Some other guy", "What am I doing here?")
-        val user = User("mark", "dadada", setOf(Permissions.all()))
-
-        @JvmStatic
-        @Parameterized.Parameters(name = "{0}")
-        fun data() = listOf(CommitStatus.INTERMEDIATE_COMMIT, CommitStatus.NO_INTERMEDIATE_COMMIT)
-    }
-
-    @CordaSerializable
-    enum class CommitStatus { INTERMEDIATE_COMMIT, NO_INTERMEDIATE_COMMIT }
+class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
 
     @Before
-    fun before() {
-        Configurator.setLevel("org.hibernate.SQL", Level.DEBUG)
-        StaffedFlowHospital.onFlowDischarged.clear()
-        StaffedFlowHospital.onFlowKeptForOvernightObservation.clear()
+    override fun before() {
         MyService.includeRawUpdates = false
+        super.before()
     }
 
     @Test(timeout = 300_000)
     fun `entities can be saved using entity manager without a flush`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
         var counter = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        val user = User("mark", "dadada", setOf(Permissions.all()))
-        driver(DriverParameters(startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(::EntityManagerSaveEntitiesWithoutAFlushFlow)
-                    .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(3, entities.size)
-            }
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.startFlow(::EntityManagerSaveEntitiesWithoutAFlushFlow)
+                .returnValue.getOrThrow(30.seconds)
+            assertEquals(0, counter)
+            val entities = alice.rpc.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+            assertEquals(3, entities.size)
         }
     }
 
     @Test(timeout = 300_000)
     fun `entities can be saved using entity manager with a flush`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
         var counter = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(::EntityManagerSaveEntitiesWithAFlushFlow)
-                    .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(3, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+
+            alice.rpc.startFlow(::EntityManagerSaveEntitiesWithAFlushFlow)
+                .returnValue.getOrThrow(30.seconds)
+            assertEquals(0, counter)
+            val entities = alice.rpc.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+            assertEquals(3, entities.size)
         }
     }
 
     @Test(timeout = 300_000)
     fun `entities saved inside an entity manager are only committed when a flow suspends`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
         var counter = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
 
-                var beforeCommitEntities: List<CustomTableEntity>? = null
-                EntityManagerSaveEntitiesWithoutAFlushFlow.beforeCommitHook = {
-                    beforeCommitEntities = it
-                }
-                var afterCommitEntities: List<CustomTableEntity>? = null
-                EntityManagerSaveEntitiesWithoutAFlushFlow.afterCommitHook = {
-                    afterCommitEntities = it
-                }
-
-                it.proxy.startFlow(::EntityManagerSaveEntitiesWithoutAFlushFlow)
-                    .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(3, entities.size)
-                assertEquals(0, beforeCommitEntities!!.size)
-                assertEquals(3, afterCommitEntities!!.size)
+            var beforeCommitEntities: List<CustomTableEntity>? = null
+            EntityManagerSaveEntitiesWithoutAFlushFlow.beforeCommitHook = {
+                beforeCommitEntities = it
             }
+            var afterCommitEntities: List<CustomTableEntity>? = null
+            EntityManagerSaveEntitiesWithoutAFlushFlow.afterCommitHook = {
+                afterCommitEntities = it
+            }
+
+            alice.rpc.startFlow(::EntityManagerSaveEntitiesWithoutAFlushFlow)
+                    .returnValue.getOrThrow(30.seconds)
+            assertEquals(0, counter)
+            val entities = alice.rpc.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+            assertEquals(3, entities.size)
+            assertEquals(0, beforeCommitEntities!!.size)
+            assertEquals(3, afterCommitEntities!!.size)
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation without a flush breaks`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                assertFailsWith<TimeoutException> {
-                    it.proxy.startFlow(::EntityManagerErrorWithoutAFlushFlow, commitStatus)
-                        .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
-                }
-                assertEquals(3, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                when (commitStatus) {
-                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(0, entities.size)
-                }
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerErrorWithoutAFlushFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 0
+            )
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerErrorWithoutAFlushFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 1
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation with a flush breaks`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                assertFailsWith<TimeoutException> {
-                    it.proxy.startFlow(::EntityManagerErrorWithAFlushFlow, commitStatus)
-                        .returnValue.getOrThrow(Duration.of(10, ChronoUnit.SECONDS))
-                }
-                assertEquals(3, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                when (commitStatus) {
-                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(0, entities.size)
-                }
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerErrorWithAFlushFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 0
+            )
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerErrorWithAFlushFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 1
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation with a flush that is caught inside an entity manager block saves none of the data inside of it`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(::EntityManagerWithAFlushCatchErrorInsideTheEntityManagerFlow, commitStatus)
-                    .returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                // 1 entity saved from the first entity manager block that does not get rolled back
-                // even if there is no intermediate commit to the database
-                assertEquals(1, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            // 1 entity saved from the first entity manager block that does not get rolled back
+            // even if there is no intermediate commit to the database
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerWithAFlushCatchErrorInsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerWithAFlushCatchErrorInsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation with a flush that is caught outside the entity manager block saves none of the data inside of it`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(::EntityManagerWithAFlushCatchErrorOutsideTheEntityManagerFlow, commitStatus)
-                    .returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                // 1 entity saved from the first entity manager block that does not get rolled back
-                // even if there is no intermediate commit to the database
-                assertEquals(1, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            // 1 entity saved from the first entity manager block that does not get rolled back
+            // even if there is no intermediate commit to the database
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerWithAFlushCatchErrorOutsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerWithAFlushCatchErrorOutsideTheEntityManagerFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation within a single entity manager block throws an exception and saves no data`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
         var dischargeCounter = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++dischargeCounter }
-        var observationCounter = 0
-        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ -> ++observationCounter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        val lock = Semaphore(0)
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ -> lock.release() }
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                assertFailsWith<TimeoutException> {
-                    it.proxy.startFlow(::EntityManagerErrorInsideASingleEntityManagerFlow)
-                        .returnValue.getOrThrow(20.seconds)
-                }
-                // Goes straight to observation due to throwing [EntityExistsException]
-                assertEquals(0, dischargeCounter)
-                assertEquals(1, observationCounter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(0, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.startFlow(::EntityManagerErrorInsideASingleEntityManagerFlow)
+            lock.acquire()
+            // Goes straight to observation due to throwing [EntityExistsException]
+            assertEquals(0, dischargeCounter)
+            val entities = alice.rpc.startFlow(::GetCustomEntities).returnValue.getOrThrow()
+            assertEquals(0, entities.size)
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation on a single entity when saving multiple entities throws an exception and does not save any data within the entity manager block`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                assertFailsWith<TimeoutException> {
-                    it.proxy.startFlow(::EntityManagerSavingMultipleEntitiesWithASingleErrorFlow, commitStatus)
-                        .returnValue.getOrThrow(20.seconds)
-                }
-                assertEquals(3, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                when (commitStatus) {
-                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(0, entities.size)
-                }
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerSavingMultipleEntitiesWithASingleErrorFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 0
+            )
+            alice.rpc.expectFlowFailureAndAssertCreatedEntities(
+                flow = ::EntityManagerSavingMultipleEntitiesWithASingleErrorFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 3,
+                numberOfExpectedEntities = 1
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation on a single entity when saving multiple entities and catching the error does not save any data within the entity manager block`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerSavingMultipleEntitiesWithASingleCaughtErrorFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                // 1 entity saved from the first entity manager block that does not get rolled back
-                // even if there is no intermediate commit to the database
-                assertEquals(1, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            // 1 entity saved from the first entity manager block that does not get rolled back
+            // even if there is no intermediate commit to the database
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerSavingMultipleEntitiesWithASingleCaughtErrorFlow,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerSavingMultipleEntitiesWithASingleCaughtErrorFlow,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation that is caught inside an entity manager and more data is saved afterwards inside a new entity manager should save the extra data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerCatchErrorAndSaveMoreEntitiesInANewEntityManager,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(3, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorAndSaveMoreEntitiesInANewEntityManager,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 3
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorAndSaveMoreEntitiesInANewEntityManager,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 3
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation that is caught inside an entity manager and more data is saved afterwards inside the same entity manager should not save the extra data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerCatchErrorAndSaveMoreEntitiesInTheSameEntityManager,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                when (commitStatus) {
-                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                }
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorAndSaveMoreEntitiesInTheSameEntityManager,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorAndSaveMoreEntitiesInTheSameEntityManager,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 1
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation that is caught outside an entity manager and more data is saved afterwards inside a new entity manager should save the extra data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(3, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager,
+                commitStatus = CommitStatus.NO_INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 3
+            )
+            alice.rpc.expectFlowSuccessAndAssertCreatedEntities(
+                flow = ::EntityManagerCatchErrorOutsideTheEntityManagerAndSaveMoreEntitiesInANewEntityManager,
+                commitStatus = CommitStatus.INTERMEDIATE_COMMIT,
+                numberOfDischarges = 0,
+                numberOfExpectedEntities = 3
+            )
         }
     }
 
     @Test(timeout = 300_000)
     fun `constraint violation that is caught inside an entity manager should allow a flow to continue processing as normal`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
         var counter = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
         driver(DriverParameters(startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            val nodeBHandle = startNode(providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                val txId =
-                    it.proxy.startFlow(::EntityManagerWithFlushCatchAndInteractWithOtherPartyFlow, nodeBHandle.nodeInfo.singleIdentity())
-                        .returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val txFromVault = it.proxy.stateMachineRecordedTransactionMappingSnapshot().firstOrNull()?.transactionId
-                assertEquals(txId, txFromVault)
-                val entity = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow().single()
-                assertEquals(entityWithIdOne, entity)
-            }
-        }
-        assertEquals(0, counter)
-    }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+            val bob = startNode(providedName = BOB_NAME).getOrThrow()
 
-    @Test(timeout = 300_000)
-    fun `data can be saved by a sql statement using entity manager`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(::EntityManagerSqlFlow).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(1, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `constraint violation caused by a sql statement should save no data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                assertFailsWith<TimeoutException> {
-                    it.proxy.startFlow(
-                        ::EntityManagerErrorFromSqlFlow,
-                        commitStatus
-                    ).returnValue.getOrThrow(20.seconds)
-                }
-                assertEquals(3, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                when (commitStatus) {
-                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(0, entities.size)
-                }
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `constraint violation caused by a sql statement that is caught inside an entity manager block saves none of the data inside of it`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerCatchErrorFromSqlInsideTheEntityManagerFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                // 1 entity saved from the first entity manager block that does not get rolled back
-                // even if there is no intermediate commit to the database
-                assertEquals(1, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `constraint violation caused by a sql statement that is caught outside an entity manager block saves none of the data inside of it`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerCatchErrorFromSqlOutsideTheEntityManagerFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                // 1 entity saved from the first entity manager block that does not get rolled back
-                // even if there is no intermediate commit to the database
-                assertEquals(1, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `constraint violation caused by a sql statement that is caught inside an entity manager and more data is saved afterwards inside the same entity manager should not save the extra data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInTheSameEntityManagerFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(1, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `constraint violation caused by a sql statement that is caught inside an entity manager and more data is saved afterwards inside a new entity manager should save the extra data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInNewEntityManagerFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(2, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager inside an entity manager saves all data`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(::EntityManagerInsideAnEntityManagerFlow).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(2, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager inside an entity manager that throws an error does not save any data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                assertFailsWith<TimeoutException> {
-                    it.proxy.startFlow(
-                        ::EntityManagerInsideAnEntityManagerThatThrowsAnExceptionFlow,
-                        commitStatus
-                    ).returnValue.getOrThrow(20.seconds)
-                }
-                assertEquals(3, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                when (commitStatus) {
-                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(0, entities.size)
-                }
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager that saves an entity with an entity manager inside it that throws an error after saving the entity does not save any data`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                assertFailsWith<TimeoutException> {
-                    it.proxy.startFlow(
-                        ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAfterSavingFlow,
-                        commitStatus
-                    ).returnValue.getOrThrow(20.seconds)
-                }
-                assertEquals(3, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                when (commitStatus) {
-                    CommitStatus.INTERMEDIATE_COMMIT -> assertEquals(1, entities.size)
-                    CommitStatus.NO_INTERMEDIATE_COMMIT -> assertEquals(0, entities.size)
-                }
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager that saves an entity with an entity manager inside it that throws an error and catching it around the entity manager after saving the entity saves the data from the external entity manager`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerAfterSavingFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(2, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager that saves an entity with an entity manager inside it that throws an error and catching it inside the entity manager after saving the entity saves the data from the external entity manager`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesInsideTheEntityManagerAfterSavingFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(2, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager that saves an entity with an entity manager inside it that throws an error and catching it around the entity manager before saving the entity saves the data from the external entity manager`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerBeforeSavingFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(2, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager with an entity manager inside it saves an entity, outer throws and catches the error outside itself after saving the entity does not save the data from the internal entity manager`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesAroundOuterEntityManagerAfterSavingFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(1, entities.size)
-            }
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `entity manager with an entity manager inside it saves an entity, outer throws and catches the error inside itself after saving the entity does not save the data from the internal entity manager`() {
-        var counter = 0
-        StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesInsideOuterEntityManagerAfterSavingFlow,
-                    commitStatus
-                ).returnValue.getOrThrow(20.seconds)
-                assertEquals(0, counter)
-                val entities = it.proxy.startFlow(::GetCustomEntities).returnValue.getOrThrow()
-                assertEquals(1, entities.size)
-            }
+            val txId =
+                alice.rpc.startFlow(::EntityManagerWithFlushCatchAndInteractWithOtherPartyFlow, bob.nodeInfo.singleIdentity())
+                    .returnValue.getOrThrow(20.seconds)
+            assertEquals(0, counter)
+            val txFromVault = alice.rpc.stateMachineRecordedTransactionMappingSnapshot().firstOrNull()?.transactionId
+            assertEquals(txId, txFromVault)
+            val entity = alice.rpc.startFlow(::GetCustomEntities).returnValue.getOrThrow().single()
+            assertEquals(entityWithIdOne, entity)
         }
     }
 
     @Test(timeout = 300_000)
     fun `data saved from an entity manager vault update should be visible within an entity manager block inside the same database transaction`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
         MyService.includeRawUpdates = true
         MyService.insertionType = MyService.InsertionType.ENTITY_MANAGER
         var counter = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
         driver(DriverParameters(startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                val entities =
-                    it.proxy.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(20.seconds)
-                assertEquals(3, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+
+            val entities =
+                alice.rpc.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(3, entities.size)
+            assertEquals(0, counter)
         }
-        assertEquals(0, counter)
     }
 
     @Test(timeout = 300_000)
     fun `data saved from a jdbc connection vault update should be visible within an entity manager block inside the same database transaction`() {
-        // Don't run this test with both parameters to save time
-        if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) return
         MyService.includeRawUpdates = true
         MyService.insertionType = MyService.InsertionType.CONNECTION
         var counter = 0
         StaffedFlowHospital.onFlowDischarged.add { _, _ -> ++counter }
         driver(DriverParameters(startNodesInProcess = true)) {
 
-            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
-            CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                val entities =
-                    it.proxy.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(20.seconds)
-                assertEquals(3, entities.size)
-            }
+            val alice = startNode(providedName = ALICE_NAME).getOrThrow()
+
+            val entities =
+                alice.rpc.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(3, entities.size)
+            assertEquals(0, counter)
         }
-        assertEquals(0, counter)
     }
 
     @StartableByRPC
@@ -954,8 +590,21 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
                     logger.info("Caught the exception!")
                 }
                 // These entities are not saved since the transaction is marked for rollback
-                persist(entityWithIdTwo)
-                persist(entityWithIdThree)
+                try {
+                    persist(entityWithIdTwo)
+                    persist(entityWithIdThree)
+                } catch (e: PersistenceException) {
+                    if (e.cause is ConstraintViolationException) {
+                        throw e
+                    } else {
+                        logger.info(
+                            """
+                            Caught exception from second set of persists inside the same broken entity manager
+                            This happens if the database has thrown an exception due to rolling back the db transaction
+                        """.trimIndent(), e
+                        )
+                    }
+                }
             }
             sleep(1.millis)
         }
@@ -1011,386 +660,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         }
     }
 
-    @StartableByRPC
-    class EntityManagerSqlFlow : FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                    .setParameter("id", anotherEntityWithIdOne.id)
-                    .setParameter("name", anotherEntityWithIdOne.name)
-                    .setParameter("quote", anotherEntityWithIdOne.name)
-                    .executeUpdate()
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerErrorFromSqlFlow(private val commitStatus: CommitStatus) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                    .setParameter("id", anotherEntityWithIdOne.id)
-                    .setParameter("name", anotherEntityWithIdOne.name)
-                    .setParameter("quote", anotherEntityWithIdOne.name)
-                    .executeUpdate()
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerCatchErrorFromSqlInsideTheEntityManagerFlow(private val commitStatus: CommitStatus) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                try {
-                    createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                        .setParameter("id", anotherEntityWithIdOne.id)
-                        .setParameter("name", anotherEntityWithIdOne.name)
-                        .setParameter("quote", anotherEntityWithIdOne.name)
-                        .executeUpdate()
-                } catch (e: PersistenceException) {
-                    logger.info("Caught the exception!")
-                }
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerCatchErrorFromSqlOutsideTheEntityManagerFlow(private val commitStatus: CommitStatus) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            try {
-                serviceHub.withEntityManager {
-                    createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                        .setParameter("id", anotherEntityWithIdOne.id)
-                        .setParameter("name", anotherEntityWithIdOne.name)
-                        .setParameter("quote", anotherEntityWithIdOne.name)
-                        .executeUpdate()
-                }
-            } catch (e: PersistenceException) {
-                logger.info("Caught the exception!")
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInTheSameEntityManagerFlow(private val commitStatus: CommitStatus) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                try {
-                    createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                        .setParameter("id", anotherEntityWithIdOne.id)
-                        .setParameter("name", anotherEntityWithIdOne.name)
-                        .setParameter("quote", anotherEntityWithIdOne.name)
-                        .executeUpdate()
-                } catch (e: PersistenceException) {
-                    logger.info("Caught the exception!")
-                }
-                // These entities are not saved since the transaction is marked for rollback
-                createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                    .setParameter("id", entityWithIdTwo.id)
-                    .setParameter("name", entityWithIdTwo.name)
-                    .setParameter("quote", entityWithIdTwo.name)
-                    .executeUpdate()
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerCatchErrorFromSqlAndSaveMoreEntitiesInNewEntityManagerFlow(private val commitStatus: CommitStatus) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            try {
-                serviceHub.withEntityManager {
-                    createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                        .setParameter("id", anotherEntityWithIdOne.id)
-                        .setParameter("name", anotherEntityWithIdOne.name)
-                        .setParameter("quote", anotherEntityWithIdOne.name)
-                        .executeUpdate()
-
-                }
-            } catch (e: PersistenceException) {
-                logger.info("Caught the exception!")
-            }
-            serviceHub.withEntityManager {
-                val query = createNativeQuery("INSERT INTO custom_table VALUES (:id, :name, :quote)")
-                    .setParameter("id", entityWithIdTwo.id)
-                    .setParameter("name", entityWithIdTwo.name)
-                    .setParameter("quote", entityWithIdTwo.name)
-                query.executeUpdate()
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerInsideAnEntityManagerFlow : FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-                serviceHub.withEntityManager {
-                    persist(entityWithIdTwo)
-                }
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerInsideAnEntityManagerThatThrowsAnExceptionFlow(private val commitStatus: CommitStatus) : FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                serviceHub.withEntityManager {
-                    persist(anotherEntityWithIdOne)
-                }
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAfterSavingFlow(private val commitStatus: CommitStatus) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                persist(entityWithIdTwo)
-                serviceHub.withEntityManager {
-                    persist(anotherEntityWithIdOne)
-                }
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerAfterSavingFlow(
-        private val commitStatus: CommitStatus
-    ) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                persist(entityWithIdTwo)
-                try {
-                    serviceHub.withEntityManager {
-                        persist(anotherEntityWithIdOne)
-                    }
-                } catch (e: PersistenceException) {
-                    logger.info("Caught the exception!")
-                }
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesInsideTheEntityManagerAfterSavingFlow(
-        private val commitStatus: CommitStatus
-    ) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                persist(entityWithIdTwo)
-                serviceHub.withEntityManager {
-                    try {
-                        persist(anotherEntityWithIdOne)
-                        flush()
-                    } catch (e: PersistenceException) {
-                        logger.info("Caught the exception!")
-                    }
-                }
-
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerThatSavesAnEntityWithAnEntityManagerInsideItThatThrowsAnExceptionAndCatchesAroundTheEntityManagerBeforeSavingFlow(
-        private val commitStatus: CommitStatus
-    ) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                try {
-                    serviceHub.withEntityManager {
-                        persist(anotherEntityWithIdOne)
-                    }
-                } catch (e: PersistenceException) {
-                    logger.info("Caught the exception!")
-                }
-                persist(entityWithIdTwo)
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesAroundOuterEntityManagerAfterSavingFlow(
-        private val commitStatus: CommitStatus
-    ) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            try {
-                serviceHub.withEntityManager {
-                    serviceHub.withEntityManager {
-                        persist(entityWithIdTwo)
-                    }
-                    persist(anotherEntityWithIdOne)
-                }
-            } catch (e: PersistenceException) {
-                logger.info("Caught the exception!")
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerThatSavesAnEntityUsingInternalEntityManagerAndThrowsFromOuterAndCatchesInsideOuterEntityManagerAfterSavingFlow(
-        private val commitStatus: CommitStatus
-    ) :
-        FlowLogic<Unit>() {
-
-        @Suspendable
-        override fun call() {
-            serviceHub.withEntityManager {
-                persist(entityWithIdOne)
-            }
-            if (commitStatus == CommitStatus.INTERMEDIATE_COMMIT) {
-                sleep(1.millis)
-            }
-            serviceHub.withEntityManager {
-                serviceHub.withEntityManager {
-                    persist(entityWithIdTwo)
-                }
-                try {
-                    persist(anotherEntityWithIdOne)
-                    flush()
-                } catch (e: PersistenceException) {
-                    logger.info("Caught the exception!")
-                }
-            }
-            sleep(1.millis)
-        }
-    }
-
-    @StartableByRPC
-    class EntityManagerWithinTheSameDatabaseTransactionFlow : FlowLogic<List<CustomTableEntity>>() {
-
-        @Suspendable
-        override fun call(): List<CustomTableEntity> {
-            val tx = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
-                addOutputState(DummyState(participants = listOf(ourIdentity)))
-                addCommand(DummyCommandData, ourIdentity.owningKey)
-            }
-            val stx = serviceHub.signInitialTransaction(tx)
-            serviceHub.recordTransactions(stx)
-            return serviceHub.withEntityManager {
-                val criteria = criteriaBuilder.createQuery(CustomTableEntity::class.java)
-                criteria.select(criteria.from(CustomTableEntity::class.java))
-                createQuery(criteria).resultList
-            }
-        }
-    }
-
     @InitiatingFlow
     class CreateATransactionFlow(val party: Party) : FlowLogic<SecureHash>() {
         @Suspendable
@@ -1419,15 +688,20 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
     }
 
     @StartableByRPC
-    class GetCustomEntities : FlowLogic<List<CustomTableEntity>>() {
+    class EntityManagerWithinTheSameDatabaseTransactionFlow : FlowLogic<List<CustomTableEntity>>() {
+
         @Suspendable
         override fun call(): List<CustomTableEntity> {
+            val tx = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
+                addOutputState(DummyState(participants = listOf(ourIdentity)))
+                addCommand(DummyCommandData, ourIdentity.owningKey)
+            }
+            val stx = serviceHub.signInitialTransaction(tx)
+            serviceHub.recordTransactions(stx)
             return serviceHub.withEntityManager {
                 val criteria = criteriaBuilder.createQuery(CustomTableEntity::class.java)
                 criteria.select(criteria.from(CustomTableEntity::class.java))
-                createQuery(criteria).resultList.also {
-                    logger.info("results = $it")
-                }
+                createQuery(criteria).resultList
             }
         }
     }
@@ -1438,7 +712,6 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         companion object {
             var includeRawUpdates = false
             var insertionType = InsertionType.ENTITY_MANAGER
-            val logger = contextLogger()
         }
 
         enum class InsertionType { ENTITY_MANAGER, CONNECTION }
@@ -1468,7 +741,7 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
         }
 
         private fun Connection.insert(entity: CustomTableEntity) {
-            prepareStatement("INSERT INTO custom_table VALUES (?, ?, ?)").apply {
+            prepareStatement("INSERT INTO $TABLE_NAME VALUES (?, ?, ?)").apply {
                 setInt(1, entity.id)
                 setString(2, entity.name)
                 setString(3, entity.quote)
@@ -1487,21 +760,4 @@ class FlowEntityManagerTest(var commitStatus: CommitStatus) {
             }.get()
         }
     }
-
-    @Entity
-    @Table(name = "custom_table")
-    @CordaSerializable
-    data class CustomTableEntity constructor(
-        @Id
-        @Column(name = "id", nullable = false)
-        var id: Int,
-        @Column(name = "name", nullable = false)
-        var name: String,
-        @Column(name = "quote", nullable = false)
-        var quote: String
-    )
-
-    object CustomSchema
-
-    object CustomMappedSchema : MappedSchema(CustomSchema::class.java, 1, listOf(CustomTableEntity::class.java))
 }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1201,8 +1201,19 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 block(savepoint)
             } finally {
                 // Release the save point even if we occur an error
-                connection.releaseSavepoint(savepoint)
+                if (savepoint.supportsReleasing()) {
+                    connection.releaseSavepoint(savepoint)
+                }
             }
+        }
+
+        /**
+         * Not all databases support releasing of savepoints.
+         * The type of savepoints are referenced by string names since we do not have access to the JDBC drivers
+         * at compile time.
+         */
+        private fun Savepoint.supportsReleasing(): Boolean {
+            return this::class.simpleName != "SQLServerSavepoint" && this::class.simpleName != "OracleSavepoint"
         }
 
         override fun withEntityManager(block: Consumer<EntityManager>) {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1188,6 +1188,8 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                             connection.rollback(savepoint)
                         }
                         throw e
+                    } finally {
+                        manager.close()
                     }
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1178,12 +1178,9 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                                 manager.flush()
                             } else {
                                 connection.rollback(savepoint)
-                                // mark flow as errored?
                             }
                         }
                     } catch (e: PersistenceException) {
-                        // do we need this if statement?
-                        // can we assume that receiving a persistence exception is enough to denote a rollback?
                         if (manager.transaction.rollbackOnly) {
                             connection.rollback(savepoint)
                         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -221,7 +221,10 @@ class ActionExecutorImpl(
 
     @Suspendable
     private fun executeRollbackTransaction() {
-        contextTransactionOrNull?.close()
+        contextTransactionOrNull?.run {
+            rollback()
+            close()
+        }
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt
@@ -43,7 +43,10 @@ class TransitionExecutorImpl(
             try {
                 actionExecutor.executeAction(fiber, action)
             } catch (exception: Exception) {
-                contextTransactionOrNull?.close()
+                contextTransactionOrNull?.run {
+                    rollback()
+                    close()
+                }
                 if (transition.newState.checkpoint.errorState is ErrorState.Errored) {
                     // If we errored while transitioning to an error state then we cannot record the additional
                     // error as that may result in an infinite loop, e.g. error propagation fails -> record error -> propagate fails again.

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -247,7 +247,6 @@ class NodeVaultService(
         fun flushBatch(previouslySeen: Boolean) {
             val updates = makeUpdates(batch, statesToRecord, previouslySeen)
             processAndNotify(updates)
-            currentDBSession().flush()
             batch.clear()
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -247,6 +247,7 @@ class NodeVaultService(
         fun flushBatch(previouslySeen: Boolean) {
             val updates = makeUpdates(batch, statesToRecord, previouslySeen)
             processAndNotify(updates)
+            currentDBSession().flush()
             batch.clear()
         }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt
@@ -5,6 +5,7 @@ import net.corda.core.utilities.loggerFor
 import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
+import net.corda.nodeapi.internal.persistence.RolledBackDatabaseSessionException
 import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.configureDatabase
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
@@ -179,6 +180,8 @@ class AppendOnlyPersistentMapTest(var scenario: Scenario) {
             }
         } catch (t: PersistenceException) {
             // This only helps if thrown on commit, otherwise other latches not counted down.
+            assertEquals(t.message, Outcome.SuccessButErrorOnCommit, a.outcome)
+        } catch (t: RolledBackDatabaseSessionException) {
             assertEquals(t.message, Outcome.SuccessButErrorOnCommit, a.outcome)
         }
         a.await(a::phase4)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultFlowTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultFlowTest.kt
@@ -1,7 +1,12 @@
 package net.corda.node.services.vault
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.*
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.node.services.queryBy
@@ -50,13 +55,11 @@ class VaultFlowTest {
     @After
     fun tearDown() {
         mockNetwork.stopNodes()
-        StaffedFlowHospital.DatabaseEndocrinologist.customConditions.clear()
         StaffedFlowHospital.onFlowKeptForOvernightObservation.clear()
     }
 
     @Test(timeout=300_000)
 	fun `Unique column constraint failing causes states to not persist to vaults`() {
-        StaffedFlowHospital.DatabaseEndocrinologist.customConditions.add( { t: Throwable -> t is javax.persistence.PersistenceException })
         partyA.startFlow(Initiator(listOf(partyA.info.singleIdentity(), partyB.info.singleIdentity()))).get()
         val hospitalLatch = CountDownLatch(1)
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ -> hospitalLatch.countDown() }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -236,11 +236,11 @@ open class MockServices private constructor(
                 override fun jdbcSession(): Connection = persistence.createSession()
 
                 override fun <T : Any?> withEntityManager(block: EntityManager.() -> T): T {
-                    return block(contextTransaction.restrictedEntityManager)
+                    return block(contextTransaction.entityManager)
                 }
 
                 override fun withEntityManager(block: Consumer<EntityManager>) {
-                    return block.accept(contextTransaction.restrictedEntityManager)
+                    return block.accept(contextTransaction.entityManager)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Improve the handling of database transactions when using
`withEntityManager` inside a flow.

Extra changes have been included to improve the safety and
correctness of Corda around handling database transactions.

This focuses on allowing flows to catch errors that occur inside an
entity manager and handle them accordingly.

Errors can be caught in two places:

- Inside `withEntityManager`
- Outside `withEntityManager`

Further changes have been included to ensure that transactions are
rolled back correctly.

## Catching errors inside `withEntityManager`

Errors caught inside `withEntityManager` require the flow to manually
`flush` the current session (the entity manager's individual session).
By manually flushing the session, a `try-catch` block can be placed
around the `flush` call, allowing possible exceptions to be caught.

Once an error is thrown from a call to `flush`, it is no longer possible
to use the same entity manager to trigger any database operations. The
only possible option is to rollback the changes from that session.
The flow can continue executing updates within the same session but they
will never be committed. What happens in this situation should be handled
by the flow. Explicitly restricting the scenario requires a lot of effort and
code. Instead, we should rely on the developer to control complex
workflows.

To continue updating the database after an error like this occurs, a new
`withEntityManager` block should be used (after catching the previous
error).

## Catching errors outside `withEntityManager`

Exceptions can be caught around `withEntityManager` blocks. This allows
errors to be handled in the same way as stated above, except the need to
manually `flush` the session is removed. `withEntityManager` will
automatically `flush` a session if it has not been marked for rollback
due to an earlier error.

A `try-catch` can then be placed around the whole of the
`withEntityManager` block, allowing the error to be caught while not
committing any changes to the underlying database transaction.

## Savepoints / Transactionality

To make `withEntityManager` blocks work like mini database transactions,
save points have been utilised. A new save point is created when opening
a `withEntityManager` block (along with a new session). It is then used
as a reference point to rollback to if the session errors and needs to
roll back. The save point is then released (independently from
completing successfully or failing).

Using save points means, that either all the statements inside the
entity manager are executed, or none of them are.

## Some implementation details

- A new session is created every time a entity manager is requested,
but this does not replace the flow's main underlying database session.
- `CordaPersistence.transaction` can now determine whether it needs
to execute its extra error handling code. This is needed to allow errors
escape `withEntityManager` blocks while allowing some of our exception
handling around subscribers (in `NodeVaultService`) to continue to work.