### PR TITLE
ENT-4967: Allow quasar_classifier to be either null or an empty string.

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -93,7 +93,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: [
         // See experimental/quasar-hook/README.md for how to generate.
         def quasarExcludeExpression = "x(antlr**;bftsmart**;co.paralleluniverse**;com.codahale**;com.esotericsoftware**;com.fasterxml**;com.google**;com.ibm**;com.intellij**;com.jcabi**;com.nhaarman**;com.opengamma**;com.typesafe**;com.zaxxer**;de.javakaffee**;groovy**;groovyjarjarantlr**;groovyjarjarasm**;io.atomix**;io.github**;io.netty**;jdk**;kotlin**;net.corda.djvm**;djvm**;net.bytebuddy**;net.i2p**;org.apache**;org.bouncycastle**;org.codehaus**;org.crsh**;org.dom4j**;org.fusesource**;org.h2**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.objectweb**;org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**;org.jolokia**;com.lmax**;picocli**;liquibase**;com.github.benmanes**;org.json**;org.postgresql**;nonapi.io.github.classgraph**)"
         def quasarClassLoaderExclusion = "l(net.corda.djvm.**;net.corda.core.serialization.internal.**)"
-        javaAgents = quasar_classifier == null ? ["quasar-core-${quasar_version}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"] : ["quasar-core-${quasar_version}-${quasar_classifier}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"]
+        javaAgents = quasar_classifier ? ["quasar-core-${quasar_version}-${quasar_classifier}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"] : ["quasar-core-${quasar_version}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"]
         systemProperties['visualvm.display.name'] = 'Corda'
         if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
             minJavaVersion = '1.8.0'

--- a/testing/testserver/testcapsule/build.gradle
+++ b/testing/testserver/testcapsule/build.gradle
@@ -43,7 +43,7 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').tasks.jar) 
 
     capsuleManifest {
         applicationVersion = corda_release_version
-        javaAgents = quasar_classifier == null ? ["quasar-core-${quasar_version}.jar"] : ["quasar-core-${quasar_version}-${quasar_classifier}.jar"]
+        javaAgents = quasar_classifier ? ["quasar-core-${quasar_version}-${quasar_classifier}.jar"] : ["quasar-core-${quasar_version}.jar"]
         systemProperties['visualvm.display.name'] = 'Corda Webserver'
         minJavaVersion = '1.8.0'
         minUpdateVersion['1.8'] = java8_minUpdateVersion


### PR DESCRIPTION
Groovy considers both an empty String and a null String to be "false", so rewrite the `quasar_classifer` logic inside our capsules to allow for both cases.