### PR TITLE
fixed bug in error reporting

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/lifecycle/NodeLifecycleEventsDistributor.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/lifecycle/NodeLifecycleEventsDistributor.kt
@@ -98,11 +98,12 @@ class NodeLifecycleEventsDistributor : Closeable {
                 orderedSnapshot.forEach {
                     log.debug("Distributing event $event to: $it")
                     val updateResult = it.update(event)
-                    if (updateResult.isSuccess) {
-                        log.debug("Event $event distribution outcome: $updateResult")
-                    } else {
-                        log.error("Failed to distribute event $event, failure outcome: $updateResult")
-                        handlePossibleFatalTermination(event, updateResult as Try.Failure<String>)
+                    when(updateResult) {
+                        is Try.Success -> log.debug("Event $event distribution outcome: $updateResult")
+                        is Try.Failure -> {
+                            log.error("Failed to distribute event $event, failure outcome: $updateResult", updateResult.exception)
+                            handlePossibleFatalTermination(event, updateResult)
+                        }
                     }
                 }
                 result.set(null)


### PR DESCRIPTION
the current code doesn't forward the exception to the logging system, this means that any cause inside the exception is lost as with all of the stacktraces (both the one of the thrown exception and the one belonging to its cause).
The correct way to log an exception is to pass both the message and the exception to the logging system.
