### PR TITLE
Make sonarqube step resilient to errors

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -64,23 +64,29 @@ pipeline {
 
                 stage('Generate sonarqube report') {
                     steps {
-                        // running this step here is the only way to not majorly affect the distributed test plugin,
-                        // as now that neither returns build files nor runs jacoco reports
-                        sh "./gradlew --no-daemon build jacocoRootReport --stacktrace"
-                        withSonarQubeEnv('sq01') {
-                            sh "./gradlew --no-daemon sonarqube -x test --stacktrace"
-                        }
-                        timeout(time: 3, unit: 'MINUTES') {
-                            script {
-                               try {
-                                    def qg = waitForQualityGate();
-                                    if (qg.status != 'OK') {
-                                        error "Pipeline aborted due to quality gate failure: ${qg.status}"
-                                    }
-                                } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
-                                    println('No sonarqube webhook response within timeout. Please check the webhook configuration in sonarqube.')
-                                    // continue the pipeline
+                        script {
+                            try {
+                                // running this step here is the only way to not majorly affect the distributed test plugin,
+                                // as now that neither returns build files nor runs jacoco reports
+                                sh "./gradlew --no-daemon build jacocoRootReport --stacktrace"
+                                withSonarQubeEnv('sq01') {
+                                    sh "./gradlew --no-daemon sonarqube -x test --stacktrace"
                                 }
+                                timeout(time: 3, unit: 'MINUTES') {
+                                    script {
+                                       try {
+                                            def qg = waitForQualityGate();
+                                            if (qg.status != 'OK') {
+                                                error "Pipeline aborted due to quality gate failure: ${qg.status}"
+                                            }
+                                        } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+                                            println('No sonarqube webhook response within timeout. Please check the webhook configuration in sonarqube.')
+                                            // continue the pipeline
+                                        }
+                                    }
+                                }
+                            } catch (err) {
+                                println('Error while trying to execute sonarqube analysis, will be skipped.')
                             }
                         }
                     }


### PR DESCRIPTION
Add a try-catch to make sure that a sonarqube failure does not break the regression build.
This is a fix that is mainly targeted to ent, but is useful here as well.