### PR TITLE
CORDA-3698: Require no classifier for Open Core and DJVM-related modules.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -101,7 +101,8 @@ task copyQuasarJar(type: Copy) {
 
 jar {
     finalizedBy(copyQuasarJar)
-    baseName 'corda-core'
+    archiveBaseName = 'corda-core'
+    archiveClassifier = ''
 }
 
 configurations {

--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -30,9 +30,7 @@ tasks.withType(AbstractCompile) {
 }
 
 tasks.withType(JavaCompile) {
-    // Disable the bootclasspath for now - it breaks compiling
-    // the finance-contracts Java classes.
-    //options.compilerArgs << '-bootclasspath' << deterministic_rt_jar
+    options.compilerArgs << '-bootclasspath' << deterministic_rt_jar
     sourceCompatibility = VERSION_1_8
     targetCompatibility = VERSION_1_8
 }

--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -30,7 +30,9 @@ tasks.withType(AbstractCompile) {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs << '-bootclasspath' << deterministic_rt_jar
+    // Disable the bootclasspath for now - it breaks compiling
+    // the finance-contracts Java classes.
+    //options.compilerArgs << '-bootclasspath' << deterministic_rt_jar
     sourceCompatibility = VERSION_1_8
     targetCompatibility = VERSION_1_8
 }

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'com.jfrog.artifactory'
+apply from: "${rootProject.projectDir}/deterministic.gradle"
 
 description 'Corda finance module - contracts'
 
@@ -31,7 +32,8 @@ configurations {
 }
 
 jar {
-    baseName 'corda-finance-contracts'
+    archiveBaseName = 'corda-finance-contracts'
+    archiveClassifier = ''
     manifest {
         attributes('Corda-Revision': 'n/a')
         attributes('Corda-Vendor': 'Corda Open Source')

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'com.jfrog.artifactory'
-apply from: "${rootProject.projectDir}/deterministic.gradle"
+apply from: "${rootProject.projectDir}/java8.gradle"
 
 description 'Corda finance module - contracts'
 

--- a/java8.gradle
+++ b/java8.gradle
@@ -1,0 +1,22 @@
+import static org.gradle.api.JavaVersion.VERSION_1_8
+
+/*
+ * Gradle script plugin: Configure a module such that Java and Kotlin
+ * are always compiled for Java 8.
+ */
+apply plugin: 'kotlin'
+
+tasks.withType(AbstractCompile) {
+    // This is a bit ugly, but Gradle isn't recognising the KotlinCompile task
+    // as it does the built-in JavaCompile task.
+    if (it.class.name.startsWith('org.jetbrains.kotlin.gradle.tasks.KotlinCompile')) {
+        kotlinOptions {
+            jvmTarget = VERSION_1_8
+        }
+    }
+}
+
+tasks.withType(JavaCompile) {
+    sourceCompatibility = VERSION_1_8
+    targetCompatibility = VERSION_1_8
+}

--- a/node/djvm/build.gradle
+++ b/node/djvm/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
 jar {
     archiveBaseName = 'corda-node-djvm'
+    archiveClassifier = ''
     manifest {
         attributes('Automatic-Module-Name': 'net.corda.node.djvm')
         attributes('Sealed': true)

--- a/serialization-djvm/build.gradle
+++ b/serialization-djvm/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import static org.gradle.api.JavaVersion.VERSION_1_8
 
 plugins {
@@ -7,6 +8,11 @@ plugins {
     id 'java-library'
     id 'idea'
 }
+
+// The DJVM only supports Java 8 byte-code, so the tests must
+// be compiled for Java 8. The main artifact is only compiled
+// for Java 8 because it belongs to "Open Core".
+apply from: "${rootProject.projectDir}/java8.gradle"
 
 description 'Serialization support for the DJVM'
 
@@ -41,20 +47,9 @@ dependencies {
     sandboxTesting "org.slf4j:slf4j-nop:$slf4j_version"
 }
 
-// The DJVM only supports Java 8 byte-code.
-compileTestJava {
-    sourceCompatibility = VERSION_1_8
-    targetCompatibility = VERSION_1_8
-}
-
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = VERSION_1_8
-    }
-}
-
 jar {
     archiveBaseName = 'corda-serialization-djvm'
+    archiveClassifier = ''
     manifest {
         attributes('Automatic-Module-Name': 'net.corda.serialization.djvm')
         attributes('Sealed': true)

--- a/serialization-djvm/deserializers/build.gradle
+++ b/serialization-djvm/deserializers/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
 jar {
     archiveBaseName = 'corda-deserializers-djvm'
+    archiveClassifier = ''
     manifest {
         attributes('Automatic-Module-Name': 'net.corda.serialization.djvm.deserializers')
         attributes('Sealed': true)

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -63,7 +63,8 @@ artifacts {
 }
 
 jar {
-    baseName 'corda-serialization'
+    archiveBaseName = 'corda-serialization'
+    archiveClassifier = ''
 }
 
 publish {


### PR DESCRIPTION
The `corda-node-djvm` and `corda-deserializers-djvm` are always compiled to Java 8 byte-code, even if we are compiling them with a Java 11 JDK. Ensure that these artifacts are not assigned the `jdk11` classifier.

The same logic applies for `corda-core`, `corda-serialization` and `corda-finance-contracts` too. Ideally, `corda-finance-contracts` should also be compiled against `core-deterministic` and tested against `core` but the necessary :sparkles: Gradle Magic :sparkles: is currently too nasty...