### PR TITLE
CORDA-3701 Fix bugs in some iterator checkpoint serializers

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/CustomIteratorSerializers.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/CustomIteratorSerializers.kt
@@ -6,7 +6,9 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
-import java.util.*
+import java.util.LinkedHashMap
+import java.util.LinkedHashSet
+import java.util.LinkedList
 
 /**
  * The [LinkedHashMap] and [LinkedHashSet] have a problem with the default Quasar/Kryo serialisation

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/CustomIteratorSerializers.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/CustomIteratorSerializers.kt
@@ -4,7 +4,6 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
-import com.esotericsoftware.kryo.util.Util
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.util.*
@@ -38,39 +37,43 @@ internal object LinkedHashMapIteratorSerializer : Serializer<Iterator<*>>() {
         return when (type) {
             KEY_ITERATOR_CLASS -> {
                 val current = (kryo.readClassAndObject(input) as? Map.Entry<*, *>)?.key
-                outerMap.keys.iterator().returnToIteratorLocation(current)
+                outerMap.keys.iterator().returnToIteratorLocation(kryo, current)
             }
             VALUE_ITERATOR_CLASS -> {
                 val current = (kryo.readClassAndObject(input) as? Map.Entry<*, *>)?.value
-                outerMap.values.iterator().returnToIteratorLocation(current)
+                outerMap.values.iterator().returnToIteratorLocation(kryo, current)
             }
             MAP_ITERATOR_CLASS -> {
                 val current = (kryo.readClassAndObject(input) as? Map.Entry<*, *>)
-                outerMap.iterator().returnToIteratorLocation(current)
+                outerMap.iterator().returnToIteratorLocation(kryo, current)
             }
             else -> throw IllegalStateException("Invalid type")
         }
     }
 
-    private fun Iterator<*>.returnToIteratorLocation(current: Any?) : Iterator<*> {
+    private fun Iterator<*>.returnToIteratorLocation(kryo: Kryo, current: Any?): Iterator<*> {
         while (this.hasNext()) {
             val key = this.next()
-            if (iteratedObjectsEqual(key, current)) break
+            if (iteratedObjectsEqual(kryo, key, current)) break
         }
         return this
     }
 
-    private fun iteratedObjectsEqual(a: Any?, b: Any?): Boolean = if (a == null || b == null) {
+    private fun iteratedObjectsEqual(kryo: Kryo, a: Any?, b: Any?): Boolean = if (a == null || b == null) {
         a == b
     } else {
-        a === b || mapEntriesEqual(a, b) || kryoOptimisesAwayReferencesButEqual(a, b)
+        a === b || mapEntriesEqual(kryo, a, b) || kryoOptimisesAwayReferencesButEqual(kryo, a, b)
     }
 
-    private fun kryoOptimisesAwayReferencesButEqual(a: Any, b: Any) =
-            (Util.isWrapperClass(a.javaClass) && Util.isWrapperClass(b.javaClass) && a == b)
+    /**
+     * Kryo can substitute brand new created instances for some types during deserialization, making the identity check fail.
+     * Fall back to equality for those.
+     */
+    private fun kryoOptimisesAwayReferencesButEqual(kryo: Kryo, a: Any, b: Any) =
+            (!kryo.referenceResolver.useReferences(a.javaClass) && !kryo.referenceResolver.useReferences(b.javaClass) && a == b)
 
-    private fun mapEntriesEqual(a: Any, b: Any) =
-            (a is Map.Entry<*, *> && b is Map.Entry<*, *> && iteratedObjectsEqual(a.key, b.key))
+    private fun mapEntriesEqual(kryo: Kryo, a: Any, b: Any) =
+            (a is Map.Entry<*, *> && b is Map.Entry<*, *> && iteratedObjectsEqual(kryo, a.key, b.key))
 }
 
 /**

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoCheckpointTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoCheckpointTest.kt
@@ -103,7 +103,7 @@ class KryoCheckpointTest {
         assertEquals(testSize, lastValue)
     }
 
-    @Test
+    @Test(timeout = 300_000)
     fun `linked hash map values can checkpoint without error, even with repeats`() {
         var lastValue = "0"
         val dummyMap = linkedMapOf<String, String>()
@@ -120,7 +120,7 @@ class KryoCheckpointTest {
     }
 
     @Ignore("Kryo optimizes boxed primitives so this does not work.  Need to customise ReferenceResolver to stop it doing it.")
-    @Test
+    @Test(timeout = 300_000)
     fun `linked hash map values can checkpoint without error, even with repeats for boxed primitives`() {
         var lastValue = 0L
         val dummyMap = linkedMapOf<String, Long>()

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoCheckpointTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoCheckpointTest.kt
@@ -3,7 +3,7 @@ package net.corda.nodeapi.internal.serialization.kryo
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import java.util.*
+import java.util.LinkedList
 import kotlin.test.assertEquals
 
 class KryoCheckpointTest {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoCheckpointTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoCheckpointTest.kt
@@ -2,7 +2,7 @@ package net.corda.nodeapi.internal.serialization.kryo
 
 import org.junit.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import java.util.LinkedList
+import java.util.*
 import kotlin.test.assertEquals
 
 class KryoCheckpointTest {
@@ -47,12 +47,16 @@ class KryoCheckpointTest {
     @Test(timeout=300_000)
     fun `linked hash map with null values can checkpoint without error`() {
         val dummyMap = linkedMapOf<String?, Long?>().apply {
-                put(null, null)
+            put("foo", 2L)
+            put(null, null)
+            put("bar", 3L)
         }
         val it = dummyMap.iterator()
         val bytes = KryoCheckpointSerializer.serialize(it, KRYO_CHECKPOINT_CONTEXT)
 
         val itKeys = dummyMap.keys.iterator()
+        itKeys.next()
+        itKeys.next()
         val bytesKeys = KryoCheckpointSerializer.serialize(itKeys, KRYO_CHECKPOINT_CONTEXT)
 
         val itValues = dummyMap.values.iterator()
@@ -60,7 +64,8 @@ class KryoCheckpointTest {
 
         assertDoesNotThrow {
             KryoCheckpointSerializer.deserialize(bytes, it.javaClass, KRYO_CHECKPOINT_CONTEXT)
-            KryoCheckpointSerializer.deserialize(bytesKeys, itKeys.javaClass, KRYO_CHECKPOINT_CONTEXT)
+            val desItKeys = KryoCheckpointSerializer.deserialize(bytesKeys, itKeys.javaClass, KRYO_CHECKPOINT_CONTEXT)
+            assertEquals("bar", desItKeys.next())
             KryoCheckpointSerializer.deserialize(bytesValues, itValues.javaClass, KRYO_CHECKPOINT_CONTEXT)
         }
     }


### PR DESCRIPTION
I noticed some issues whilst discussing other iterator issues with @josephzunigadaly 

Sorry!

The test changes fail or hang without these modifications.  We actually need to override the `ReferenceResolver` implementation to make this work properly, but not got to it yet.

I also think Detekt is going to have a go at me as I spotted some wildcard imports.