### PR TITLE
CORDA-3657 Extract information from state machine

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -124,6 +124,7 @@ import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.services.statemachine.ExternalEvent
 import net.corda.node.services.statemachine.FlowLogicRefFactoryImpl
 import net.corda.node.services.statemachine.FlowMonitor
+import net.corda.node.services.statemachine.FlowOperator
 import net.corda.node.services.statemachine.FlowStateMachineImpl
 import net.corda.node.services.statemachine.SingleThreadedStateMachineManager
 import net.corda.node.services.statemachine.StateMachineManager
@@ -332,6 +333,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     @Suppress("LeakingThis")
     val smm = makeStateMachineManager()
     val flowStarter = FlowStarterImpl(smm, flowLogicRefFactory)
+    val flowOperator = FlowOperator(smm, platformClock)
     private val schedulerService = NodeSchedulerService(
             platformClock,
             database,
@@ -543,7 +545,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             // Shut down the SMM so no Fibers are scheduled.
             runOnStop += { smm.stop(acceptableLiveFiberCountOnStop()) }
             val flowMonitor = FlowMonitor(
-                    smm,
+                    flowOperator,
                     configuration.flowMonitorPeriodMillis,
                     configuration.flowMonitorSuspensionLoggingThresholdMillis
             )

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMonitor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMonitor.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 internal class FlowMonitor(
-    private val smm: StateMachineManager,
+    private val flowOperator: FlowOperator,
     private val monitoringPeriod: Duration,
     private val suspensionLoggingThreshold: Duration,
     private var scheduler: ScheduledExecutorService? = null
@@ -62,9 +62,7 @@ internal class FlowMonitor(
     @VisibleForTesting
     fun waitingFlowDurations(suspensionLoggingThreshold: Duration): Sequence<Pair<FlowStateMachineImpl<*>, Duration>> {
         val now = Instant.now()
-        return smm.snapshot()
-                .asSequence()
-                .filter { flow -> flow !in smm.flowHospital && flow.isStarted() && flow.isSuspended() }
+        return flowOperator.getWaitingFlows()
                 .map { flow -> flow to flow.ongoingDuration(now) }
                 .filter { (_, suspensionDuration) -> suspensionDuration >= suspensionLoggingThreshold }
     }
@@ -97,10 +95,6 @@ internal class FlowMonitor(
     private fun FlowStateMachineImpl<*>.ongoingDuration(now: Instant): Duration {
         return transientState?.value?.checkpoint?.timestamp?.let { Duration.between(it, now) } ?: Duration.ZERO
     }
-
-    private fun FlowStateMachineImpl<*>.isSuspended() = !snapshot().isFlowResumed
-
-    private fun FlowStateMachineImpl<*>.isStarted() = transientState?.value?.checkpoint?.flowState is FlowState.Started
 
     private operator fun StaffedFlowHospital.contains(flow: FlowStateMachine<*>) = contains(flow.id)
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowOperator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowOperator.kt
@@ -15,12 +15,12 @@ import java.time.Instant
  */
 interface FlowReadOperations {
 
-    fun getFlows(ids: List<StateMachineRunId>): List<FlowInfo>
+    fun getWaitingFlows(ids: List<StateMachineRunId>): Set<FlowInfo>
 
     fun getFlowsCurrentlyWaitingForParties(
         parties: List<Party>,
         onlyIfSuspendedLongerThan: Duration = 0.seconds
-    ): List<FlowInfo>
+    ): Set<FlowInfo>
 
     fun getFlowsCurrentlyWaitingForPartiesGrouped(
         parties: List<Party>,
@@ -37,23 +37,23 @@ interface FlowWriteOperations
 
 class FlowOperator(private val smm: StateMachineManager, private val clock: Clock) : FlowReadOperations, FlowWriteOperations {
 
-    override fun getFlows(ids: List<StateMachineRunId>): List<FlowInfo> {
+    override fun getWaitingFlows(ids: List<StateMachineRunId>): Set<FlowInfo> {
         val now = clock.instant()
         // this part is generic between the flow monitor
         return getWaitingFlows()
             .filter { flow -> flow.id in ids }
             .map { flow -> FlowInfo(flow.id, flow.suspendedTimestamp!!, flow.waitingForParties()) }
-            .toList()
+            .toSet()
     }
 
-    override fun getFlowsCurrentlyWaitingForParties(parties: List<Party>, onlyIfSuspendedLongerThan: Duration): List<FlowInfo> {
+    override fun getFlowsCurrentlyWaitingForParties(parties: List<Party>, onlyIfSuspendedLongerThan: Duration): Set<FlowInfo> {
         val now = clock.instant()
         // this part is generic between the flow monitor
         return getWaitingFlows()
             .filter { flow -> flow.isWaitingForParties(parties) }
             .filter { flow -> flow.ongoingDuration(now) >= onlyIfSuspendedLongerThan }
             .map { flow -> FlowInfo(flow.id, flow.suspendedTimestamp!!, flow.waitingForParties()) }
-            .toList()
+            .toSet()
     }
 
     override fun getFlowsCurrentlyWaitingForPartiesGrouped(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowOperator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowOperator.kt
@@ -38,7 +38,6 @@ interface FlowWriteOperations
 class FlowOperator(private val smm: StateMachineManager, private val clock: Clock) : FlowReadOperations, FlowWriteOperations {
 
     override fun getWaitingFlows(ids: List<StateMachineRunId>): Set<FlowMetaInfo> {
-        val now = clock.instant()
         // this part is generic between the flow monitor
         return getWaitingFlows()
             .filter { flow -> flow.id in ids }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowOperator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowOperator.kt
@@ -1,0 +1,118 @@
+package net.corda.node.services.statemachine
+
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.identity.Party
+import net.corda.core.internal.FlowIORequest
+import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.toMultiMap
+import net.corda.core.utilities.seconds
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Read operations that extract information about the flows running in the node.
+ */
+interface FlowReadOperations {
+
+    fun getFlows(ids: List<StateMachineRunId>): List<FlowInfo>
+
+    fun getFlowsCurrentlyWaitingForParties(
+        parties: List<Party>,
+        onlyIfSuspendedLongerThan: Duration = 0.seconds
+    ): List<FlowInfo>
+
+    fun getFlowsCurrentlyWaitingForPartiesGrouped(
+        parties: List<Party>,
+        onlyIfSuspendedLongerThan: Duration = 0.seconds
+    ): Map<Party, List<FlowInfo>>
+
+    fun getWaitingFlows(): Sequence<FlowStateMachineImpl<*>>
+}
+
+/**
+ * Write operations that interact with the flows running in the node.
+ */
+interface FlowWriteOperations
+
+class FlowOperator(private val smm: StateMachineManager, private val clock: Clock) : FlowReadOperations, FlowWriteOperations {
+
+    override fun getFlows(ids: List<StateMachineRunId>): List<FlowInfo> {
+        val now = clock.instant()
+        // this part is generic between the flow monitor
+        return getWaitingFlows()
+            .filter { flow -> flow.id in ids }
+            .map { flow -> FlowInfo(flow.id, flow.suspendedTimestamp!!, flow.waitingForParties()) }
+            .toList()
+    }
+
+    override fun getFlowsCurrentlyWaitingForParties(parties: List<Party>, onlyIfSuspendedLongerThan: Duration): List<FlowInfo> {
+        val now = clock.instant()
+        // this part is generic between the flow monitor
+        return getWaitingFlows()
+            .filter { flow -> flow.isWaitingForParties(parties) }
+            .filter { flow -> flow.ongoingDuration(now) >= onlyIfSuspendedLongerThan }
+            .map { flow -> FlowInfo(flow.id, flow.suspendedTimestamp!!, flow.waitingForParties()) }
+            .toList()
+    }
+
+    override fun getFlowsCurrentlyWaitingForPartiesGrouped(
+        parties: List<Party>,
+        onlyIfSuspendedLongerThan: Duration
+    ): Map<Party, List<FlowInfo>> {
+        return getFlowsCurrentlyWaitingForParties(parties, onlyIfSuspendedLongerThan)
+            .flatMap { info -> info.waitingForParties.map { it to info } }
+            .toMultiMap()
+    }
+
+    override fun getWaitingFlows(): Sequence<FlowStateMachineImpl<*>> {
+        return smm.snapshot()
+            .asSequence()
+            .filter { flow -> flow !in smm.flowHospital && flow.isStarted() && flow.isSuspended() }
+    }
+
+    private fun FlowStateMachineImpl<*>.isWaitingForParties(parties: List<Party>): Boolean {
+        return ioRequest?.let { request ->
+            when (request) {
+                is FlowIORequest.GetFlowInfo -> request.sessions.any { it.counterparty in parties }
+                is FlowIORequest.Receive -> request.sessions.any { it.counterparty in parties }
+                is FlowIORequest.Send -> request.sessionToMessage.keys.any { it.counterparty in parties }
+                is FlowIORequest.SendAndReceive -> request.sessionToMessage.keys.any { it.counterparty in parties }
+                else -> false
+            }
+        } ?: false
+    }
+
+    private fun FlowStateMachineImpl<*>.waitingForParties(): List<Party> {
+        return ioRequest?.let { request ->
+            when (request) {
+                is FlowIORequest.GetFlowInfo -> request.sessions.map { it.counterparty }
+                is FlowIORequest.Receive -> request.sessions.map { it.counterparty }
+                is FlowIORequest.Send -> request.sessionToMessage.keys.map { it.counterparty }
+                is FlowIORequest.SendAndReceive -> request.sessionToMessage.keys.map { it.counterparty }
+                else -> emptyList()
+            }
+        } ?: emptyList()
+    }
+}
+
+data class FlowInfo(val id: StateMachineRunId, val suspendedTimestamp: Instant, val waitingForParties: List<Party>)
+
+// should find a common place to put these functions
+// they have been copied from [FlowMonitor]
+// maybe even some of the filtering can be moved to a common place
+// maybe the code in general can be merged as flow monitor is so closely related to this class
+
+private val FlowStateMachineImpl<*>.ioRequest get() = (snapshot().checkpoint.flowState as? FlowState.Started)?.flowIORequest
+
+private fun FlowStateMachineImpl<*>.ongoingDuration(now: Instant): Duration {
+    return suspendedTimestamp?.let { Duration.between(it, now) } ?: Duration.ZERO
+}
+
+private val FlowStateMachineImpl<*>.suspendedTimestamp get() = transientState?.value?.checkpoint?.timestamp
+
+private fun FlowStateMachineImpl<*>.isSuspended() = !snapshot().isFlowResumed
+
+private fun FlowStateMachineImpl<*>.isStarted() = transientState?.value?.checkpoint?.flowState is FlowState.Started
+
+private operator fun StaffedFlowHospital.contains(flow: FlowStateMachine<*>) = contains(flow.id)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -248,7 +248,11 @@ class FlowFrameworkTests {
     }
 
     private fun monitorFlows(script: (FlowMonitor, FlowMonitor) -> Unit) {
-        script(FlowMonitor(aliceNode.smm, Duration.ZERO, Duration.ZERO), FlowMonitor(bobNode.smm, Duration.ZERO, Duration.ZERO))
+        val clock = Clock.systemUTC()
+        script(
+            FlowMonitor(FlowOperator(aliceNode.smm, clock), Duration.ZERO, Duration.ZERO),
+            FlowMonitor(FlowOperator(bobNode.smm, clock), Duration.ZERO, Duration.ZERO)
+        )
     }
 
     @Test(timeout = 300_000)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowOperatorTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowOperatorTests.kt
@@ -1,0 +1,216 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Suspendable
+import kotlin.test.assertTrue
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.requireThat
+import net.corda.core.flows.CollectSignaturesFlow
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveFinalityFlow
+import net.corda.core.flows.SignTransactionFlow
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.testing.node.internal.InternalMockNetwork
+import net.corda.testing.node.internal.InternalMockNodeParameters
+import net.corda.testing.node.internal.TestStartedNode
+import net.corda.testing.node.internal.enclosedCordapp
+import net.corda.testing.node.internal.startFlow
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.*
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+class FlowOperatorTests {
+
+    companion object {
+        val log = contextLogger()
+        val aliceX500Name = CordaX500Name("Alice", "AliceCorp", "GB")
+        val bobX500Name = CordaX500Name("Bob", "BobCorp", "GB")
+        val carolX500Name = CordaX500Name("Carol", "CarolCorp", "GB")
+        val daveX500Name = CordaX500Name("Dave", "DaveCorp", "GB")
+        val semaphores = mutableMapOf<String, Map<String, Pair<Semaphore, Semaphore>>>()
+
+        fun newSemaphore(vararg parties: Party): String {
+            if(parties.isEmpty()) {
+                error("Specify at least one party")
+            }
+            val marker = UUID.randomUUID().toString()
+            val partySemaphores = mutableMapOf<String, Pair<Semaphore, Semaphore>>()
+            parties.forEach {
+                val semaphore1 = Semaphore(1)
+                semaphore1.acquire() // initial state is to block
+                val semaphore2 = Semaphore(1)
+                semaphore2.acquire() // initial state is to block
+                partySemaphores[it.name.toString()] = Pair(semaphore1, semaphore2)
+            }
+            semaphores[marker] = partySemaphores
+            return marker
+        }
+
+        fun Map<String, Map<String, Pair<Semaphore, Semaphore>>>.waitToResumeAccepting(marker: String, party: Party) {
+            if(!getValue(marker).getValue(party.name.toString()).first.tryAcquire(5, TimeUnit.SECONDS)) {
+                error("(Party: $party) Waiting too long for the signal to continue...")
+            }
+            log.info("Party $party continues accepting the flow")
+        }
+
+        fun Map<String, Map<String, Pair<Semaphore, Semaphore>>>.enteredAccepting(marker: String, party: Party) {
+            log.info("Party $party entering accepting the flow")
+            getValue(marker).getValue(party.name.toString()).second.release()
+        }
+
+        fun Map<String, Map<String, Pair<Semaphore, Semaphore>>>.waitToContinueTest(marker: String, vararg parties: Party) {
+            parties.forEach {
+                if(!getValue(marker).getValue(it.name.toString()).second.tryAcquire(5, TimeUnit.SECONDS)) {
+                    error("(Party: $it) Waiting too long to kick off accepting flow...")
+                }
+            }
+        }
+
+        fun Map<String, Map<String, Pair<Semaphore, Semaphore>>>.resumeAccepting(marker: String, vararg parties: Party) {
+            parties.forEach {
+                getValue(marker).getValue(it.name.toString()).first.release()
+            }
+        }
+    }
+
+    lateinit var mockNet: InternalMockNetwork
+    lateinit var aliceNode: TestStartedNode
+    lateinit var aliceParty: Party
+    lateinit var bobNode: TestStartedNode
+    lateinit var bobParty: Party
+    lateinit var carolNode: TestStartedNode
+    lateinit var carolParty: Party
+    lateinit var daveNode: TestStartedNode
+    lateinit var daveParty: Party
+
+    @Before
+    fun setup() {
+        mockNet = InternalMockNetwork(
+                threadPerNode = true,
+                cordappsForAllNodes = listOf(enclosedCordapp())
+        )
+        aliceNode = mockNet.createNode(InternalMockNodeParameters(
+                legalName = aliceX500Name
+        ))
+        bobNode = mockNet.createNode(InternalMockNodeParameters(
+                legalName = bobX500Name
+        ))
+        carolNode = mockNet.createNode(InternalMockNodeParameters(
+                legalName = carolX500Name
+        ))
+        daveNode = mockNet.createNode(InternalMockNodeParameters(
+                legalName = daveX500Name
+        ))
+        mockNet.startNodes()
+        aliceParty = aliceNode.info.legalIdentities.first()
+        bobParty = bobNode.info.legalIdentities.first()
+        carolParty = carolNode.info.legalIdentities.first()
+        daveParty = daveNode.info.legalIdentities.first()
+    }
+
+    @After
+    fun cleanUp() {
+        mockNet.stopNodes()
+    }
+
+    @Test
+    fun `should return all parties for flows which are waiting for other party to process`() {
+        val otherParties = arrayOf(bobParty)
+        val queryParties = listOf(aliceParty, bobParty, carolParty, daveParty)
+        val marker = newSemaphore(*otherParties)
+        val future = aliceNode.services.startFlow(TestInitiatorFlow(marker, *otherParties)).resultFuture
+        val cut = FlowOperator(aliceNode.smm, aliceNode.services.clock)
+
+        semaphores.waitToContinueTest(marker, *otherParties)
+
+        var result1 = cut.getFlowsCurrentlyWaitingForParties(queryParties)
+        assertEquals(1, result1.size)
+        assertEquals(1, result1.first().waitingForParties.size)
+        assertTrue(result1.first().waitingForParties.any { it.name == bobX500Name })
+
+        semaphores.resumeAccepting(marker, *otherParties)
+        future.getOrThrow(5.seconds)
+
+        var result2 = cut.getFlowsCurrentlyWaitingForParties(queryParties)
+        assertEquals(0, result2.size)
+    }
+
+    @BelongsToContract(TestContract::class)
+    class TestState(val marker: String, val me: Party, vararg val otherParties: Party) : ContractState {
+        override val participants: List<AbstractParty> = listOf(me, *otherParties)
+    }
+
+    class TestContract : Contract {
+        companion object {
+            @JvmStatic
+            val ID = "net.corda.node.services.statemachine.FlowOperatorTests\$TestContract"
+        }
+
+        override fun verify(tx: LedgerTransaction) {
+        }
+
+        interface Commands : CommandData {
+            class Create : Commands
+        }
+    }
+
+    @InitiatingFlow
+    class TestInitiatorFlow(val semaphore: String, vararg val otherParties: Party) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val notary = serviceHub.networkMapCache.notaryIdentities.single()
+            val state = TestState(semaphore, serviceHub.myInfo.legalIdentities.first(), *otherParties)
+            val command = Command(TestContract.Commands.Create(), state.participants.map { it.owningKey })
+            val txBuilder = TransactionBuilder(notary)
+                    .addOutputState(state, TestContract.ID)
+                    .addCommand(command)
+            txBuilder.verify(serviceHub)
+            val partSignedTx = serviceHub.signInitialTransaction(txBuilder)
+
+            val otherPartySessions = mutableSetOf<FlowSession>()
+            otherParties.forEach {
+                log.info("Creating session for $it")
+                otherPartySessions.add(initiateFlow(it))
+            }
+            val fullySignedTx = subFlow(CollectSignaturesFlow(partSignedTx, otherPartySessions))
+            subFlow(FinalityFlow(fullySignedTx, otherPartySessions))
+        }
+    }
+
+    @InitiatedBy(TestInitiatorFlow::class)
+    class TestAcceptorFlow(val otherPartySession: FlowSession) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val signTransactionFlow = object : SignTransactionFlow(otherPartySession) {
+                override fun checkTransaction(stx: SignedTransaction) = requireThat {
+                    val marker = (stx.tx.outputStates[0] as TestState).marker
+                    val me = serviceHub.myInfo.legalIdentities.first()
+                    semaphores.enteredAccepting(marker, me)
+                    semaphores.waitToResumeAccepting(marker, me)
+                    return@requireThat
+                }
+            }
+            val txId = subFlow(signTransactionFlow).id
+            return subFlow(ReceiveFinalityFlow(otherPartySession, expectedTxId = txId))
+        }
+    }
+}


### PR DESCRIPTION
`FlowReadOperations` interface provides functions that extract
information about flows from the state machine manager.

`FlowOperator` implements this interface (along with another currently
empty interface).