### PR TITLE
Add github actions to sync open and closed issues in jira

### DIFF
--- a/.github/workflows/jira_close_issue.yml
+++ b/.github/workflows/jira_close_issue.yml
@@ -1,0 +1,20 @@
+name: Sync closed jira issues
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+
+jobs:
+  sync_closed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close
+        uses: corda/jira-sync-closed-action@master
+        with:
+          project: CORDA
+          jiraBaseUrl: https://r3-cev.atlassian.net
+          jiraEmail: ${{ secrets.JIRA_USER_EMAIL }}
+          jiraToken: ${{ secrets.JIRA_API_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
+          owner: corda
+          repository: corda

--- a/.github/workflows/jira_create_issue.yml
+++ b/.github/workflows/jira_create_issue.yml
@@ -1,0 +1,36 @@
+name: Create jira issue from github issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  update_jira:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Jira Create issue
+        id: create
+        uses: corda/jira-create-issue-action@master
+        with:
+          jiraBaseUrl: https://r3-cev.atlassian.net
+          project: CORDA
+          issuetype: Bug
+          summary: ${{ github.event.issue.title }}
+          labels: community
+          jiraEmail: ${{ secrets.JIRA_USER_EMAIL }}
+          jiraToken: ${{ secrets.JIRA_API_TOKEN }}
+          description: |
+            ${{ github.event.issue.body }}
+
+            Created by github action.
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Automatically created Jira issue: ${{ steps.create.outputs.issue }}
+          reaction-type: '+1'


### PR DESCRIPTION
Adds two github actions that will automate opening jira issues for new github issues, and closing github issues when jira issues are set to close, syncing the two dashboards.

Github actions are run on the default branch, so merging is directed to 4.5.