### PR TITLE
Add github action for syncing assignees between github-jira

### DIFF
--- a/.github/workflows/jira_assign_issue.yml
+++ b/.github/workflows/jira_assign_issue.yml
@@ -1,0 +1,19 @@
+name: Sync assigned jira issues
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+
+jobs:
+  sync_assigned:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign
+        uses: corda/jira-sync-assigned-action@master
+        with:
+          jiraBaseUrl: ${{ secrets.JIRA_BASE_URL }}
+          jiraEmail: ${{ secrets.JIRA_USER_EMAIL }}
+          jiraToken: ${{ secrets.JIRA_API_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
+          owner: corda
+          repository: corda


### PR DESCRIPTION
Adds a new github action that gets triggered periodically and checks for new assignees in jira issues that have a related github issue.