### PR TITLE
Changed frequency of Github Actions for sync between GH and Jira

### DIFF
--- a/.github/workflows/jira_assign_issue.yml
+++ b/.github/workflows/jira_assign_issue.yml
@@ -2,7 +2,7 @@ name: Sync assigned jira issues
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '15 * * * *'
 
 jobs:
   sync_assigned:

--- a/.github/workflows/jira_close_issue.yml
+++ b/.github/workflows/jira_close_issue.yml
@@ -2,7 +2,7 @@ name: Sync closed jira issues
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '30 * * * *'
 
 jobs:
   sync_closed:


### PR DESCRIPTION
* run every hour instead every 15 minutes
* assign & close executed at different times
* in response of connection problems occurring at random times