### PR TITLE
ENT-4912: Enable CRL checking with embedded Artemis

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1594,7 +1594,7 @@
     <ID>TooGenericExceptionCaught:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ReconnectingObservable.kt$ReconnectingObservable.ReconnectingSubscriber$e: Exception</ID>
     <ID>TooGenericExceptionCaught:RpcServerObservableSerializerTests.kt$RpcServerObservableSerializerTests$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:SSLHelper.kt$LoggingTrustManagerWrapper$ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:SSLHelper.kt$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ScheduledFlowIntegrationTests.kt$ScheduledFlowIntegrationTests$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:SerializationOutputTests.kt$SerializationOutputTests$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:ShutdownManager.kt$ShutdownManager$t: Throwable</ID>

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
@@ -84,33 +84,33 @@ fun X509Certificate.distributionPointsToString() : String {
     }
 }
 
+fun certPathToString(certPath: Array<out X509Certificate>?): String {
+    if (certPath == null) {
+        return "<empty certpath>"
+    }
+    val certs = certPath.map {
+        val bcCert = it.toBc()
+        val subject = bcCert.subject.toString()
+        val issuer = bcCert.issuer.toString()
+        val keyIdentifier = try {
+            SubjectKeyIdentifier.getInstance(bcCert.getExtension(Extension.subjectKeyIdentifier).parsedValue).keyIdentifier.toHex()
+        } catch (ex: Exception) {
+            "null"
+        }
+        val authorityKeyIdentifier = try {
+            AuthorityKeyIdentifier.getInstance(bcCert.getExtension(Extension.authorityKeyIdentifier).parsedValue).keyIdentifier.toHex()
+        } catch (ex: Exception) {
+            "null"
+        }
+        "  $subject[$keyIdentifier] issued by $issuer[$authorityKeyIdentifier] [${it.distributionPointsToString()}]"
+    }
+    return certs.joinToString("\r\n")
+}
+
 @VisibleForTesting
 class LoggingTrustManagerWrapper(val wrapped: X509ExtendedTrustManager) : X509ExtendedTrustManager() {
     companion object {
         val log = contextLogger()
-    }
-
-    private fun certPathToString(certPath: Array<out X509Certificate>?): String {
-        if (certPath == null) {
-            return "<empty certpath>"
-        }
-        val certs = certPath.map {
-            val bcCert = it.toBc()
-            val subject = bcCert.subject.toString()
-            val issuer = bcCert.issuer.toString()
-            val keyIdentifier = try {
-                SubjectKeyIdentifier.getInstance(bcCert.getExtension(Extension.subjectKeyIdentifier).parsedValue).keyIdentifier.toHex()
-            } catch (ex: Exception) {
-                "null"
-            }
-            val authorityKeyIdentifier = try {
-                AuthorityKeyIdentifier.getInstance(bcCert.getExtension(Extension.authorityKeyIdentifier).parsedValue).keyIdentifier.toHex()
-            } catch (ex: Exception) {
-                "null"
-            }
-            "  $subject[$keyIdentifier] issued by $issuer[$authorityKeyIdentifier] [${it.distributionPointsToString()}]"
-        }
-        return certs.joinToString("\r\n")
     }
 
     private fun certPathToStringFull(chain: Array<out X509Certificate>?): String {

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
@@ -199,6 +199,7 @@ class AMQPBridgeTest {
             doReturn(signingCertificateStore).whenever(it).signingCertificateStore
             doReturn(p2pSslConfiguration).whenever(it).p2pSslOptions
             doReturn(crlCheckSoftFail).whenever(it).crlCheckSoftFail
+            doReturn(false).whenever(it).crlCheckArtemisServer
             doReturn(artemisAddress).whenever(it).p2pAddress
             doReturn(null).whenever(it).jmxMonitoringHttpPort
         }

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -29,7 +29,10 @@ import net.corda.coretesting.internal.DEV_INTERMEDIATE_CA
 import net.corda.coretesting.internal.DEV_ROOT_CA
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.coretesting.internal.stubs.CertificateStoreStubs
+import net.corda.node.services.messaging.ArtemisMessagingServer
+import net.corda.nodeapi.internal.ArtemisMessagingClient
 import net.corda.nodeapi.internal.protonwrapper.netty.toRevocationConfig
+import org.apache.activemq.artemis.api.core.RoutingType
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.*
@@ -625,5 +628,92 @@ class CertificateRevocationListNodeTests {
                 assertEquals(true, serverConnect.connected)
             }
         }
+    }
+
+    private fun createArtemisServerAndClient(port: Int, crlCheckSoftFail: Boolean, crlCheckArtemisServer: Boolean):
+            Pair<ArtemisMessagingServer, ArtemisMessagingClient> {
+        val baseDirectory = temporaryFolder.root.toPath() / "artemis"
+        val certificatesDirectory = baseDirectory / "certificates"
+        val signingCertificateStore = CertificateStoreStubs.Signing.withCertificatesDirectory(certificatesDirectory)
+        val p2pSslConfiguration = CertificateStoreStubs.P2P.withCertificatesDirectory(certificatesDirectory)
+        val artemisConfig = rigorousMock<AbstractNodeConfiguration>().also {
+            doReturn(baseDirectory).whenever(it).baseDirectory
+            doReturn(certificatesDirectory).whenever(it).certificatesDirectory
+            doReturn(CHARLIE_NAME).whenever(it).myLegalName
+            doReturn(signingCertificateStore).whenever(it).signingCertificateStore
+            doReturn(p2pSslConfiguration).whenever(it).p2pSslOptions
+            doReturn(NetworkHostAndPort("0.0.0.0", port)).whenever(it).p2pAddress
+            doReturn(null).whenever(it).jmxMonitoringHttpPort
+            doReturn(crlCheckSoftFail).whenever(it).crlCheckSoftFail
+            doReturn(crlCheckArtemisServer).whenever(it).crlCheckArtemisServer
+        }
+        artemisConfig.configureWithDevSSLCertificate()
+        val server = ArtemisMessagingServer(artemisConfig, artemisConfig.p2pAddress, MAX_MESSAGE_SIZE)
+        val client = ArtemisMessagingClient(artemisConfig.p2pSslOptions, artemisConfig.p2pAddress, MAX_MESSAGE_SIZE)
+        server.start()
+        client.start()
+        return server to client
+    }
+
+    private fun verifyMessageToArtemis(crlCheckSoftFail: Boolean,
+                                       crlCheckArtemisServer: Boolean,
+                                       expectedStatus: MessageStatus,
+                                       revokedNodeCert: Boolean = false,
+                                       nodeCrlDistPoint: String = "http://${server.hostAndPort}/crl/node.crl") {
+        val queueName = P2P_PREFIX + "Test"
+        val (artemisServer, artemisClient) = createArtemisServerAndClient(serverPort, crlCheckSoftFail, crlCheckArtemisServer)
+        artemisServer.use {
+            artemisClient.started!!.session.createQueue(queueName, RoutingType.ANYCAST, queueName, true)
+
+            val (amqpClient, nodeCert) = createClient(serverPort, true, nodeCrlDistPoint)
+            if (revokedNodeCert) {
+                revokedNodeCerts.add(nodeCert.serialNumber)
+            }
+            amqpClient.use {
+                val clientConnected = amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val clientConnect = clientConnected.get()
+                assertEquals(true, clientConnect.connected)
+
+                val msg = amqpClient.createMessage("Test".toByteArray(), queueName, CHARLIE_NAME.toString(), emptyMap())
+                amqpClient.write(msg)
+                assertEquals(expectedStatus, msg.onComplete.get())
+            }
+            artemisClient.stop()
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `Artemis server connection succeeds with soft fail CRL check`() {
+        verifyMessageToArtemis(crlCheckSoftFail = true, crlCheckArtemisServer = true, expectedStatus = MessageStatus.Acknowledged)
+    }
+
+    @Test(timeout = 300_000)
+    fun `Artemis server connection succeeds with hard fail CRL check`() {
+        verifyMessageToArtemis(crlCheckSoftFail = false, crlCheckArtemisServer = true, expectedStatus = MessageStatus.Acknowledged)
+    }
+
+    @Test(timeout = 300_000)
+    fun `Artemis server connection succeeds with soft fail CRL check on unavailable URL`() {
+        verifyMessageToArtemis(crlCheckSoftFail = true, crlCheckArtemisServer = true, expectedStatus = MessageStatus.Acknowledged,
+                nodeCrlDistPoint = "http://${server.hostAndPort}/crl/$FORBIDDEN_CRL")
+    }
+
+    @Test(timeout = 300_000)
+    fun `Artemis server connection fails with hard fail CRL check on unavailable URL`() {
+        verifyMessageToArtemis(crlCheckSoftFail = false, crlCheckArtemisServer = true, expectedStatus = MessageStatus.Rejected,
+                nodeCrlDistPoint = "http://${server.hostAndPort}/crl/$FORBIDDEN_CRL")
+    }
+
+    @Test(timeout = 300_000)
+    fun `Artemis server connection fails with soft fail CRL check on revoked node certificate`() {
+        verifyMessageToArtemis(crlCheckSoftFail = true, crlCheckArtemisServer = true, expectedStatus = MessageStatus.Rejected,
+                revokedNodeCert = true)
+    }
+
+    @Test(timeout = 300_000)
+    fun `Artemis server connection succeeds with disabled CRL check on revoked node certificate`() {
+        verifyMessageToArtemis(crlCheckSoftFail = false, crlCheckArtemisServer = false, expectedStatus = MessageStatus.Acknowledged,
+                revokedNodeCert = true)
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
@@ -424,6 +424,7 @@ class ProtonWrapperTests {
             doReturn(NetworkHostAndPort("0.0.0.0", artemisPort)).whenever(it).p2pAddress
             doReturn(null).whenever(it).jmxMonitoringHttpPort
             doReturn(true).whenever(it).crlCheckSoftFail
+            doReturn(true).whenever(it).crlCheckArtemisServer
         }
         artemisConfig.configureWithDevSSLCertificate()
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
@@ -87,6 +87,8 @@ class ArtemisMessagingTest {
             doReturn(NetworkHostAndPort("0.0.0.0", serverPort)).whenever(it).p2pAddress
             doReturn(null).whenever(it).jmxMonitoringHttpPort
             doReturn(FlowTimeoutConfiguration(5.seconds, 3, backoffBase = 1.0)).whenever(it).flowTimeout
+            doReturn(true).whenever(it).crlCheckSoftFail
+            doReturn(true).whenever(it).crlCheckArtemisServer
         }
         LogHelper.setLevel(PersistentUniquenessProvider::class)
         database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })

--- a/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt
@@ -1,11 +1,25 @@
 package net.corda.node.internal.artemis
 
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.utilities.contextLogger
+import net.corda.nodeapi.internal.crypto.X509CertificateFactory
 import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
+import net.corda.nodeapi.internal.protonwrapper.netty.certPathToString
 import java.security.KeyStore
+import java.security.cert.CertPathValidator
+import java.security.cert.CertPathValidatorException
 import java.security.cert.CertificateException
+import java.security.cert.PKIXBuilderParameters
+import java.security.cert.PKIXRevocationChecker
+import java.security.cert.X509CertSelector
+import java.util.EnumSet
 
 sealed class CertificateChainCheckPolicy {
+    companion object {
+        val log = contextLogger()
+    }
+
     @FunctionalInterface
     interface Check {
         @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
@@ -81,6 +95,47 @@ sealed class CertificateChainCheckPolicy {
         override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
             if (!theirChain.any { certificate -> CordaX500Name.parse(certificate.subjectDN.name).commonName == username }) {
                 throw CertificateException("Client certificate does not match login username.")
+            }
+        }
+    }
+
+    class RevocationCheck(val revocationMode: RevocationConfig.Mode) : CertificateChainCheckPolicy() {
+        override fun createCheck(keyStore: KeyStore, trustStore: KeyStore): Check {
+            return object : Check {
+                @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
+                override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
+                    if (revocationMode == RevocationConfig.Mode.OFF) {
+                        return
+                    }
+                    // Convert javax.security.cert.X509Certificate to java.security.cert.X509Certificate.
+                    val chain = theirChain.map { X509CertificateFactory().generateCertificate(it.encoded.inputStream()) }
+                    log.info("Check Client Certpath:\r\n${certPathToString(chain.toTypedArray())}")
+
+                    // Drop the last certificate which must be a trusted root (validated by RootMustMatch).
+                    // Assume that there is no more trusted roots (or corresponding public keys) in the remaining chain.
+                    // See PKIXValidator.engineValidate() for reference implementation.
+                    val certPath = X509Utilities.buildCertPath(chain.dropLast(1))
+                    val certPathValidator = CertPathValidator.getInstance("PKIX")
+                    val pkixRevocationChecker = certPathValidator.revocationChecker as PKIXRevocationChecker
+                    pkixRevocationChecker.options = EnumSet.of(
+                            // Prefer CRL over OCSP
+                            PKIXRevocationChecker.Option.PREFER_CRLS,
+                            // Don't fall back to OCSP checking
+                            PKIXRevocationChecker.Option.NO_FALLBACK)
+                    if (revocationMode == RevocationConfig.Mode.SOFT_FAIL) {
+                        // Allow revocation check to succeed if the revocation status cannot be determined for one of
+                        // the following reasons: The CRL or OCSP response cannot be obtained because of a network error.
+                        pkixRevocationChecker.options = pkixRevocationChecker.options + PKIXRevocationChecker.Option.SOFT_FAIL
+                    }
+                    val params = PKIXBuilderParameters(trustStore, X509CertSelector())
+                    params.addCertPathChecker(pkixRevocationChecker)
+                    try {
+                        certPathValidator.validate(certPath, params)
+                    } catch (ex: CertPathValidatorException) {
+                        log.error("Bad certificate path", ex)
+                        throw ex
+                    }
+                }
             }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -70,6 +70,7 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
     val flowMonitorPeriodMillis: Duration get() = DEFAULT_FLOW_MONITOR_PERIOD_MILLIS
     val flowMonitorSuspensionLoggingThresholdMillis: Duration get() = DEFAULT_FLOW_MONITOR_SUSPENSION_LOGGING_THRESHOLD_MILLIS
     val crlCheckSoftFail: Boolean
+    val crlCheckArtemisServer: Boolean
     val jmxReporterType: JmxReporterType? get() = defaultJmxReporterType
 
     val baseDirectory: Path

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -32,6 +32,7 @@ data class NodeConfigurationImpl(
         private val keyStorePassword: String,
         private val trustStorePassword: String,
         override val crlCheckSoftFail: Boolean,
+        override val crlCheckArtemisServer: Boolean = Defaults.crlCheckArtemisServer,
         override val dataSourceProperties: Properties,
         override val compatibilityZoneURL: URL? = Defaults.compatibilityZoneURL,
         override var networkServices: NetworkServicesConfig? = Defaults.networkServices,
@@ -91,6 +92,7 @@ data class NodeConfigurationImpl(
         val networkServices: NetworkServicesConfig? = null
         val tlsCertCrlDistPoint: URL? = null
         val tlsCertCrlIssuer: X500Principal? = null
+        const val crlCheckArtemisServer: Boolean = false
         val security: SecurityConfiguration? = null
         val additionalP2PAddresses: List<NetworkHostAndPort> = emptyList()
         val rpcAddress: NetworkHostAndPort? = null

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -47,6 +47,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
     private val flowMonitorPeriodMillis by duration().optional().withDefaultValue(Defaults.flowMonitorPeriodMillis)
     private val flowMonitorSuspensionLoggingThresholdMillis by duration().optional().withDefaultValue(Defaults.flowMonitorSuspensionLoggingThresholdMillis)
     private val crlCheckSoftFail by boolean()
+    private val crlCheckArtemisServer by boolean().optional().withDefaultValue(Defaults.crlCheckArtemisServer)
     private val jmxReporterType by enum(JmxReporterType::class).optional().withDefaultValue(Defaults.jmxReporterType)
     private val baseDirectory by string().mapValid(::toPath)
     private val flowOverrides by nested(FlowOverridesConfigSpec).optional()
@@ -86,6 +87,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     keyStorePassword = config[keyStorePassword],
                     trustStorePassword = config[trustStorePassword],
                     crlCheckSoftFail = config[crlCheckSoftFail],
+                    crlCheckArtemisServer = config[crlCheckArtemisServer],
                     dataSourceProperties = config[dataSourceProperties],
                     rpcUsers = config[rpcUsers],
                     verifierType = config[verifierType],

--- a/node/src/test/kotlin/net/corda/node/internal/artemis/RevocationCheckTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/artemis/RevocationCheckTest.kt
@@ -1,0 +1,214 @@
+package net.corda.node.internal.artemis
+
+import net.corda.core.crypto.Crypto
+import net.corda.core.utilities.days
+import net.corda.node.internal.artemis.CertificateChainCheckPolicy.RevocationCheck
+import net.corda.nodeapi.internal.crypto.CertificateType
+import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.CRLReason
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.asn1.x509.ExtensionsGenerator
+import org.bouncycastle.asn1.x509.GeneralName
+import org.bouncycastle.asn1.x509.GeneralNames
+import org.bouncycastle.asn1.x509.IssuingDistributionPoint
+import org.bouncycastle.cert.jcajce.JcaX509v2CRLBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import java.util.*
+import javax.security.auth.x500.X500Principal
+import kotlin.test.assertFails
+
+@RunWith(Parameterized::class)
+class RevocationCheckTest(private val revocationMode: RevocationConfig.Mode) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "revocationMode = {0}")
+        fun data() = listOf(RevocationConfig.Mode.OFF, RevocationConfig.Mode.SOFT_FAIL, RevocationConfig.Mode.HARD_FAIL)
+    }
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var rootCRL: File
+    private lateinit var doormanCRL: File
+    private lateinit var tlsCRL: File
+
+    private val keyStore = KeyStore.getInstance("JKS")
+    private val trustStore = KeyStore.getInstance("JKS")
+
+    private val rootKeyPair = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
+    private val tlsCRLIssuerKeyPair = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
+    private val doormanKeyPair = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
+    private val nodeCAKeyPair = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
+    private val tlsKeyPair = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
+
+    private lateinit var rootCert: X509Certificate
+    private lateinit var tlsCRLIssuerCert: X509Certificate
+    private lateinit var doormanCert: X509Certificate
+    private lateinit var nodeCACert: X509Certificate
+    private lateinit var tlsCert: X509Certificate
+
+    private val chain
+        get() = listOf(tlsCert, nodeCACert, doormanCert, rootCert).map {
+            javax.security.cert.X509Certificate.getInstance(it.encoded)
+        }.toTypedArray()
+
+    @Before
+    fun before() {
+        rootCRL = tempFolder.newFile("root.crl")
+        doormanCRL = tempFolder.newFile("doorman.crl")
+        tlsCRL = tempFolder.newFile("tls.crl")
+
+        rootCert = X509Utilities.createSelfSignedCACertificate(X500Principal("CN=root"), rootKeyPair)
+        tlsCRLIssuerCert = X509Utilities.createSelfSignedCACertificate(X500Principal("CN=issuer"), tlsCRLIssuerKeyPair)
+
+        trustStore.load(null, null)
+        trustStore.setCertificateEntry("cordatlscrlsigner", tlsCRLIssuerCert)
+        trustStore.setCertificateEntry("cordarootca", rootCert)
+
+        doormanCert = X509Utilities.createCertificate(
+                CertificateType.INTERMEDIATE_CA, rootCert, rootKeyPair, X500Principal("CN=doorman"), doormanKeyPair.public,
+                crlDistPoint = rootCRL.toURI().toString()
+        )
+        nodeCACert = X509Utilities.createCertificate(
+                CertificateType.NODE_CA, doormanCert, doormanKeyPair, X500Principal("CN=node"), nodeCAKeyPair.public,
+                crlDistPoint = doormanCRL.toURI().toString()
+        )
+        tlsCert = X509Utilities.createCertificate(
+                CertificateType.TLS, nodeCACert, nodeCAKeyPair, X500Principal("CN=tls"), tlsKeyPair.public,
+                crlDistPoint = tlsCRL.toURI().toString(), crlIssuer = X500Name.getInstance(tlsCRLIssuerCert.issuerX500Principal.encoded)
+        )
+
+        rootCRL.createCRL(rootCert, rootKeyPair.private, false)
+        doormanCRL.createCRL(doormanCert, doormanKeyPair.private, false)
+        tlsCRL.createCRL(tlsCRLIssuerCert, tlsCRLIssuerKeyPair.private, true)
+    }
+
+    private fun File.createCRL(certificate: X509Certificate, privateKey: PrivateKey, indirect: Boolean, vararg revoked: X509Certificate) {
+        val builder = JcaX509v2CRLBuilder(certificate.subjectX500Principal, Date())
+        builder.setNextUpdate(Date.from(Date().toInstant() + 7.days))
+        builder.addExtension(Extension.issuingDistributionPoint, true, IssuingDistributionPoint(null, indirect, false))
+        revoked.forEach {
+            val extensionsGenerator = ExtensionsGenerator()
+            extensionsGenerator.addExtension(Extension.reasonCode, false, CRLReason.lookup(CRLReason.keyCompromise))
+            // Certificate issuer is required for indirect CRL
+            val certificateIssuerName = X500Name.getInstance(it.issuerX500Principal.encoded)
+            extensionsGenerator.addExtension(Extension.certificateIssuer, true, GeneralNames(GeneralName(certificateIssuerName)))
+            builder.addCRLEntry(it.serialNumber, Date(), extensionsGenerator.generate())
+        }
+        val holder = builder.build(JcaContentSignerBuilder("SHA256withECDSA").setProvider(Crypto.findProvider("BC")).build(privateKey))
+        outputStream().use { it.write(holder.encoded) }
+    }
+
+    private fun assertFailsFor(vararg modes: RevocationConfig.Mode, block: () -> Unit) {
+        if (revocationMode in modes) assertFails(block) else block()
+    }
+
+    @Test(timeout = 300_000)
+    fun `ok with empty CRLs`() {
+        RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+    }
+
+    @Test(timeout = 300_000)
+    fun `soft fail with revoked TLS certificate`() {
+        tlsCRL.createCRL(tlsCRLIssuerCert, tlsCRLIssuerKeyPair.private, true, tlsCert)
+
+        assertFailsFor(RevocationConfig.Mode.SOFT_FAIL, RevocationConfig.Mode.HARD_FAIL) {
+            RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `hard fail with unavailable CRL in TLS certificate`() {
+        tlsCert = X509Utilities.createCertificate(
+                CertificateType.TLS, nodeCACert, nodeCAKeyPair, X500Principal("CN=tls"), tlsKeyPair.public,
+                crlDistPoint = "http://unknown-host:10000/certificate-revocation-list/tls",
+                crlIssuer = X500Name.getInstance(tlsCRLIssuerCert.issuerX500Principal.encoded)
+        )
+
+        assertFailsFor(RevocationConfig.Mode.HARD_FAIL) {
+            RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `hard fail with invalid CRL issuer in TLS certificate`() {
+        tlsCert = X509Utilities.createCertificate(
+                CertificateType.TLS, nodeCACert, nodeCAKeyPair, X500Principal("CN=tls"), tlsKeyPair.public,
+                crlDistPoint = tlsCRL.toURI().toString(), crlIssuer = X500Name("CN=unknown")
+        )
+
+        assertFailsFor(RevocationConfig.Mode.HARD_FAIL) {
+            RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `hard fail without CRL issuer in TLS certificate`() {
+        tlsCert = X509Utilities.createCertificate(
+                CertificateType.TLS, nodeCACert, nodeCAKeyPair, X500Principal("CN=tls"), tlsKeyPair.public,
+                crlDistPoint = tlsCRL.toURI().toString()
+        )
+
+        assertFailsFor(RevocationConfig.Mode.HARD_FAIL) {
+            RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `ok with other certificate in TLS CRL`() {
+        val otherKeyPair = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
+        val otherCert = X509Utilities.createCertificate(
+                CertificateType.TLS, nodeCACert, nodeCAKeyPair, X500Principal("CN=other"), otherKeyPair.public,
+                crlDistPoint = tlsCRL.toURI().toString(), crlIssuer = X500Name.getInstance(tlsCRLIssuerCert.issuerX500Principal.encoded)
+        )
+        tlsCRL.createCRL(tlsCRLIssuerCert, tlsCRLIssuerKeyPair.private, true, otherCert)
+
+        RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+    }
+
+    @Test(timeout = 300_000)
+    fun `soft fail with revoked node CA certificate`() {
+        doormanCRL.createCRL(doormanCert, doormanKeyPair.private, false, nodeCACert)
+
+        assertFailsFor(RevocationConfig.Mode.SOFT_FAIL, RevocationConfig.Mode.HARD_FAIL) {
+            RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `hard fail with unavailable CRL in node CA certificate`() {
+        nodeCACert = X509Utilities.createCertificate(
+                CertificateType.NODE_CA, doormanCert, doormanKeyPair, X500Principal("CN=node"), nodeCAKeyPair.public,
+                crlDistPoint = "http://unknown-host:10000/certificate-revocation-list/doorman"
+        )
+
+        assertFailsFor(RevocationConfig.Mode.HARD_FAIL) {
+            RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `ok with other certificate in doorman CRL`() {
+        val otherKeyPair = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
+        val otherCert = X509Utilities.createCertificate(
+                CertificateType.NODE_CA, doormanCert, doormanKeyPair, X500Principal("CN=other"), otherKeyPair.public,
+                crlDistPoint = doormanCRL.toURI().toString()
+        )
+        doormanCRL.createCRL(doormanCert, doormanKeyPair.private, false, otherCert)
+
+        RevocationCheck(revocationMode).createCheck(keyStore, trustStore).checkCertificateChain(chain)
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -276,6 +276,13 @@ class NodeConfigurationImplTest {
         }
     }
 
+    @Test(timeout=300_000)
+    fun `check crlCheckArtemisServer flag`() {
+        assertFalse(getConfig("working-config.conf").parseAsNodeConfiguration().value().crlCheckArtemisServer)
+        val rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("crlCheckArtemisServer" to true)))
+        assertTrue(rawConfig.parseAsNodeConfiguration().value().crlCheckArtemisServer)
+    }
+
     private fun configDebugOptions(devMode: Boolean, devModeOptions: DevModeOptions?): NodeConfigurationImpl {
         return testConfiguration.copy(devMode = devMode, devModeOptions = devModeOptions)
     }


### PR DESCRIPTION
To add CRL checking for inbound P2P connections into embedded Artemis server.
Previously only outbound connections (via internal bridge) were checked.

### Config
Added new `crlCheckArtemisServer` flag into `node.conf`.

> crlCheckArtemisServer
> Whether to enable CRL checking of TLS certificates for inbound P2P connections into the embedded Artemis messaging server. If enabled, the CRL checking mode is defined by `crlCheckSoftFail` option. 
> Default: false

> crlCheckSoftFail
> ...
> By default, CRL checking is applicable only for outbound P2P connections. To enable it also for inbound P2P connections set `crlCheckArtemisServer = true`.

### Implementation
Using `sun.security.provider.certpath.RevocationChecker` - same as for `BridgeControlListener`.

CRL check will be performed not on TLS handshake itself (as Artemis doesn't allow to inject custom checker there) rather on user authentication inside `BrokerJaasLoginModule`.

Due to constraints inside `RevocationChecker` it's only possible to use it from inside `CertPathValidator`, so other certificate validation checks will be also performed.

### Logging
Added logging similar to existing one in `AMQPClient`:
```
[INFO ] 2020-04-16T17:54:46,647Z [Thread-5 (activemq-netty-threads)] artemis.CertificateChainCheckPolicy. - Check Client Certpath:
  C=CH,L=Zurich,O=Notary Service[42BFCBB4BBF58657529452054D1366B56E5B7569] issued by C=CH,L=Zurich,O=Notary Service[27750EA5D13D937E01BC3836EA0666D8C3837B47] [NO CRLDP ext]
  C=CH,L=Zurich,O=Notary Service[27750EA5D13D937E01BC3836EA0666D8C3837B47] issued by CN=Test Identity Manager Service Certificate,OU=Corda,O=R3 HoldCo LLC,L=New York,C=US[FD424A8560ECB0BFC6C
6A29593095AA23870D9DA] [http://localhost:10000/certificate-revocation-list/doorman]
  CN=Test Identity Manager Service Certificate,OU=Corda,O=R3 HoldCo LLC,L=New York,C=US[FD424A8560ECB0BFC6C6A29593095AA23870D9DA] issued by CN=Test Subordinate CA Certificate,OU=Corda,O=R3 H
oldCo LLC,L=New York,C=US[2FBEFE6A78143EED3B8BBA48EEAA3B8C3455B1B5] [http://localhost:10000/certificate-revocation-list/subordinate]
  CN=Test Subordinate CA Certificate,OU=Corda,O=R3 HoldCo LLC,L=New York,C=US[2FBEFE6A78143EED3B8BBA48EEAA3B8C3455B1B5] issued by CN=Test Root Certificate,OU=Corda,O=R3 HoldCo LLC,L=New York
,C=US[2E7DF3F8E6B3B6800DF232A48FFE31BEE9C039EA] [http://localhost:10000/certificate-revocation-list/root]
  CN=Test Root Certificate,OU=Corda,O=R3 HoldCo LLC,L=New York,C=US[2E7DF3F8E6B3B6800DF232A48FFE31BEE9C039EA] issued by CN=Test Root Certificate,OU=Corda,O=R3 HoldCo LLC,L=New York,C=US[null
] [NO CRLDP ext] {}
```

There is a small downside, as these lines may be printed twice, as Artemis performs authentication 2 times: inside `onRemoteOpen()` for `Session` and for `Link`. 

### Proxy support (Enterprise only)
Proxy support for Artemis CRL checks is the same as for `BridgeControlListener`.

At the moment, node configuration proxy settings inside `networkServices` are not applicable for CRL checking because it's unclear how to pass them to `RevocationChecker`.

In order to enable proxy for CRL checks you need:
1. Add corresponding Java properties into command line, for example:
```
java -Dhttp.proxyHost=51.143.156.176 -Dhttp.proxyPort=3128 -jar corda.jar
```
2. Enable proxy configuration settings, for example:
```
networkServices {
    doormanURL = "http://my.example.com:10000"
    networkMapURL = "http://my.example.com:20000"
    proxyType = HTTP
    proxyAddress = "51.143.156.176:3128"
    proxyUser = myuser
    proxyPassword = mypassword
}
```
Note that it's not enough to specify Java properties only, as there will be no default `Authenticator` specified, so both steps are mandatory.

### Tests
Actual implementation is covered by `RevocationCheckTest`.
Added also a few integration tests, primarily to make sure that revocation check modes are properly configured and working inside Artemis.

Additional proxy manual testing is currently performed for CE.