### PR TITLE
[EG-503] Test cases for exposed notaryService

### DIFF
--- a/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
@@ -73,6 +73,15 @@ class NodeTest {
     }
 
     @Test(timeout=300_000)
+    fun `check node service availability`() {
+        val configuration = createConfig(ALICE_NAME)
+        val info = VersionInfo(789, "3.0", "SNAPSHOT", "R3")
+        val node = Node(configuration, info, initialiseSerialization = false)
+        // Regular nodes must not have internal access to the notary service
+        assertNull(node.services.notaryService)
+    }
+
+    @Test(timeout=300_000)
 	fun `clear network map cache works`() {
         val configuration = createConfig(ALICE_NAME)
         val (nodeInfo, _) = createNodeInfoAndSigned(ALICE_NAME)

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -24,6 +24,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class NotaryServiceTests {
     private lateinit var mockNet: InternalMockNetwork
@@ -53,6 +54,11 @@ class NotaryServiceTests {
     @Test(timeout=300_000)
 	fun `should reject a transaction with too many inputs`() {
         notariseWithTooManyInputs(aliceNode, alice, notary, mockNet)
+    }
+
+    @Test(timeout=300_000)
+    fun `notary node should have access to its notary service`() {
+        assertNotNull(mockNet.defaultNotaryNode.notaryService)
     }
 
     @Test(timeout=300_000)


### PR DESCRIPTION
Basic test cases to ensure regular nodes do not have notaryService exposed via ServiceHubCoreInternal, and notaries do.