### PR TITLE
CORDA-3716: Fix Enum serializers to handle enums that override toString(). (#6159)

### DIFF
--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -48,7 +48,7 @@ class IRSDemoTest {
     private val rpcUsers = listOf(User("user", "password", setOf("ALL")))
     private val currentDate: LocalDate = LocalDate.now()
     private val futureDate: LocalDate = currentDate.plusMonths(6)
-    private val maxWaitTime: Duration = 60.seconds
+    private val maxWaitTime: Duration = 150.seconds
 
     @Test(timeout=300_000)
 	fun `runs IRS demo`() {

--- a/serialization-djvm/deserializers/src/main/kotlin/net/corda/serialization/djvm/deserializers/GetEnumNames.kt
+++ b/serialization-djvm/deserializers/src/main/kotlin/net/corda/serialization/djvm/deserializers/GetEnumNames.kt
@@ -1,0 +1,9 @@
+package net.corda.serialization.djvm.deserializers
+
+import java.util.function.Function
+
+class GetEnumNames : Function<Array<Enum<*>>, Array<String>> {
+    override fun apply(enumValues: Array<Enum<*>>): Array<String> {
+        return enumValues.map(Enum<*>::name).toTypedArray()
+    }
+}

--- a/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/Serialization.kt
+++ b/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/Serialization.kt
@@ -12,6 +12,7 @@ import net.corda.djvm.rewiring.createSandboxPredicate
 import net.corda.djvm.rewiring.SandboxClassLoader
 import net.corda.serialization.djvm.deserializers.CheckEnum
 import net.corda.serialization.djvm.deserializers.DescribeEnum
+import net.corda.serialization.djvm.deserializers.GetEnumNames
 import net.corda.serialization.djvm.serializers.PrimitiveSerializer
 import net.corda.serialization.internal.GlobalTransientClassWhiteList
 import net.corda.serialization.internal.SerializationContextImpl
@@ -60,7 +61,9 @@ fun createSandboxSerializationEnv(
     @Suppress("unchecked_cast")
     val isEnumPredicate = predicateFactory.apply(CheckEnum::class.java) as Predicate<Class<*>>
     @Suppress("unchecked_cast")
-    val enumConstants = taskFactory.apply(DescribeEnum::class.java) as Function<Class<*>, Array<out Any>>
+    val enumConstants = taskFactory.apply(DescribeEnum::class.java)
+        .andThen(taskFactory.apply(GetEnumNames::class.java))
+        .andThen { (it as Array<out Any>).map(Any::toString) } as Function<Class<*>, List<String>>
 
     val sandboxLocalTypes = BaseLocalTypes(
         collectionClass = classLoader.toSandboxClass(Collection::class.java),

--- a/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/DeserializeCustomisedEnumTest.kt
+++ b/serialization-djvm/src/test/kotlin/net/corda/serialization/djvm/DeserializeCustomisedEnumTest.kt
@@ -1,0 +1,60 @@
+package net.corda.serialization.djvm
+
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.internal._contextSerializationEnv
+import net.corda.core.serialization.serialize
+import net.corda.serialization.djvm.SandboxType.KOTLIN
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.util.function.Function
+
+@ExtendWith(LocalSerialization::class)
+class DeserializeCustomisedEnumTest : TestBase(KOTLIN) {
+    @ParameterizedTest
+    @EnumSource(UserRole::class)
+    fun `test deserialize enum with custom toString`(role: UserRole) {
+        val userEnumData = UserEnumData(role)
+        val data = userEnumData.serialize()
+
+        sandbox {
+            _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+
+            val sandboxData = data.deserializeFor(classLoader)
+
+            val taskFactory = classLoader.createRawTaskFactory()
+            val showUserEnumData = taskFactory.compose(classLoader.createSandboxFunction()).apply(ShowUserEnumData::class.java)
+            val result = showUserEnumData.apply(sandboxData) ?: fail("Result cannot be null")
+
+            assertEquals(ShowUserEnumData().apply(userEnumData), result.toString())
+            assertEquals("UserRole: name='${role.roleName}', ordinal='${role.ordinal}'", result.toString())
+            assertEquals(SANDBOX_STRING, result::class.java.name)
+        }
+    }
+
+    class ShowUserEnumData : Function<UserEnumData, String> {
+        override fun apply(input: UserEnumData): String {
+            return with(input) {
+                "UserRole: name='${role.roleName}', ordinal='${role.ordinal}'"
+            }
+        }
+    }
+}
+
+interface Role {
+    val roleName: String
+}
+
+@Suppress("unused")
+@CordaSerializable
+enum class UserRole(override val roleName: String) : Role {
+    CONTROLLER(roleName = "Controller"),
+    WORKER(roleName = "Worker");
+
+    override fun toString() = roleName
+}
+
+@CordaSerializable
+data class UserEnumData(val role: UserRole)

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumSerializer.kt
@@ -14,11 +14,12 @@ class EnumSerializer(declaredType: Type, declaredClass: Class<*>, factory: Local
     override val typeDescriptor = factory.createDescriptor(type)
 
     init {
+        @Suppress("unchecked_cast")
         typeNotation = RestrictedType(
                 AMQPTypeIdentifiers.nameForType(declaredType),
                 null, emptyList(), "list", Descriptor(typeDescriptor),
-                declaredClass.enumConstants.zip(IntRange(0, declaredClass.enumConstants.size)).map {
-                    Choice(it.first.toString(), it.second.toString())
+                (declaredClass as Class<out Enum<*>>).enumConstants.zip(IntRange(0, declaredClass.enumConstants.size)).map {
+                    Choice(it.first.name, it.second.toString())
                 })
     }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/WhitelistBasedTypeModelConfiguration.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/WhitelistBasedTypeModelConfiguration.kt
@@ -53,6 +53,7 @@ private val opaqueTypes = setOf(
         Symbol::class.java
 )
 
+@Suppress("unchecked_cast")
 private val DEFAULT_BASE_TYPES = BaseLocalTypes(
     collectionClass = Collection::class.java,
     enumSetClass = EnumSet::class.java,
@@ -60,5 +61,7 @@ private val DEFAULT_BASE_TYPES = BaseLocalTypes(
     mapClass = Map::class.java,
     stringClass = String::class.java,
     isEnum = Predicate { clazz -> clazz.isEnum },
-    enumConstants = Function { clazz -> clazz.enumConstants }
+    enumConstants = Function { clazz ->
+        (clazz as Class<out Enum<*>>).enumConstants.map(Enum<*>::name)
+    }
 )

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -119,7 +119,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                 AnEnum(
                     type,
                     typeIdentifier,
-                    enumConstants.map(Any::toString),
+                    enumConstants,
                     buildInterfaceInformation(type),
                     getEnumTransforms(type, enumConstants)
                 )
@@ -142,9 +142,9 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
         }
     }
 
-    private fun getEnumTransforms(type: Class<*>, enumConstants: Array<out Any>): EnumTransforms {
+    private fun getEnumTransforms(type: Class<*>, enumConstants: List<String>): EnumTransforms {
         try {
-            val constants = enumConstants.asSequence().mapIndexed { index, constant -> constant.toString() to index }.toMap()
+            val constants = enumConstants.asSequence().mapIndexed { index, constant -> constant to index }.toMap()
             return EnumTransforms.build(TransformsAnnotationProcessor.getTransformsSchema(type), constants)
         } catch (e: InvalidEnumTransformsException) {
             throw NotSerializableDetailedException(type.name, e.message!!)

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeModel.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeModel.kt
@@ -136,5 +136,5 @@ class BaseLocalTypes(
     val mapClass: Class<*>,
     val stringClass: Class<*>,
     val isEnum: Predicate<Class<*>>,
-    val enumConstants: Function<Class<*>, Array<out Any>>
+    val enumConstants: Function<Class<*>, List<String>>
 )

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/LocalTypeModelTests.kt
@@ -4,9 +4,11 @@ import com.google.common.reflect.TypeToken
 import net.corda.core.serialization.SerializableCalculatedProperty
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.jupiter.api.fail
 import java.lang.reflect.Type
 import java.util.*
 
@@ -202,6 +204,26 @@ class LocalTypeModelTests {
             assertEquals(
                 "Either ensure that the properties [b, c, d] are serializable, or provide a custom serializer for this type",
                 typeInformation.remedy
+            )
+        }
+    }
+
+    @Suppress("unused")
+    enum class CustomEnum {
+        ONE,
+        TWO;
+
+        override fun toString(): String {
+            return "[${name.toLowerCase()}]"
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test type information for customised enum`() {
+        modelWithoutOpacity.inspect(typeOf<CustomEnum>()).let { typeInformation ->
+            val anEnum = typeInformation as? LocalTypeInformation.AnEnum ?: fail("Not AnEnum!")
+            assertThat(anEnum.members).containsExactlyElementsOf(
+                CustomEnum::class.java.enumConstants.map(CustomEnum::name)
             )
         }
     }


### PR DESCRIPTION
* Fix SandboxEnumSerializer to handle enums that override toString().
* Remove more uses of Enum.toString() from Corda's EnumSerializer.
* Add test coverage for this case to standard enum serializer.
* Increase maxWaitTimeout in IRSDemoTest to 150 seconds.