### PR TITLE
ENT-4494 revert postgre to previous open source behaviour

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/factory/H2SessionFactoryFactory.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/factory/H2SessionFactoryFactory.kt
@@ -8,20 +8,4 @@ import org.hibernate.cfg.Configuration
 class H2SessionFactoryFactory : BaseSessionFactoryFactory() {
       override fun canHandleDatabase(jdbcUrl: String): Boolean = jdbcUrl.startsWith("jdbc:h2:")
       override val databaseType: String = "H2"
-
-      override fun buildHibernateConfig(databaseConfig: DatabaseConfig, metadataSources: MetadataSources): Configuration {
-            val config = super.buildHibernateConfig(databaseConfig, metadataSources)
-
-            val hbm2dll: String =
-                    if (databaseConfig.initialiseSchema && databaseConfig.initialiseAppSchema == SchemaInitializationType.UPDATE) {
-                          "update"
-                    } else if ((!databaseConfig.initialiseSchema && databaseConfig.initialiseAppSchema == SchemaInitializationType.UPDATE)
-                            || databaseConfig.initialiseAppSchema == SchemaInitializationType.VALIDATE) {
-                          "validate"
-                    } else {
-                          "none"
-                    }
-            config.setProperty("hibernate.hbm2ddl.auto", hbm2dll)
-            return config
-      }
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/factory/H2SessionFactoryFactory.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/factory/H2SessionFactoryFactory.kt
@@ -1,10 +1,5 @@
 package net.corda.nodeapi.internal.persistence.factory
 
-import net.corda.nodeapi.internal.persistence.DatabaseConfig
-import net.corda.nodeapi.internal.persistence.SchemaInitializationType
-import org.hibernate.boot.MetadataSources
-import org.hibernate.cfg.Configuration
-
 class H2SessionFactoryFactory : BaseSessionFactoryFactory() {
       override fun canHandleDatabase(jdbcUrl: String): Boolean = jdbcUrl.startsWith("jdbc:h2:")
       override val databaseType: String = "H2"


### PR DESCRIPTION
Harmonisation had broken the postgres initialisation on Corda open source. Reverting to original behaviour until the final database handling strategy is agreed and implemented.
Note: should not be merged to Enterprise!