### PR TITLE
CORDA-3697 - making sure hibernate uses UTC time zone

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt
@@ -91,6 +91,7 @@ class HibernateConfiguration(
                 .setProperty("hibernate.hbm2ddl.auto", hbm2dll)
                 .setProperty("javax.persistence.validation.mode", "none")
                 .setProperty("hibernate.connection.isolation", databaseConfig.transactionIsolationLevel.jdbcValue.toString())
+                .setProperty("hibernate.jdbc.time_zone", "UTC")
 
         schemas.forEach { schema ->
             // TODO: require mechanism to set schemaOptions (databaseSchema, tablePrefix) which are not global to session


### PR DESCRIPTION
Making Hibernate to use UTC time zone for database entries.
