### PR TITLE
[EG-153]Adding sshd by default to docker node.conf template

### DIFF
--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -36,6 +36,9 @@ function generateGenericCZConfig() {
     : ${MY_LEGAL_NAME:? '$MY_LEGAL_NAME, the X500 name to use when joining must be set as environment variable'}
     : ${MY_EMAIL_ADDRESS:? '$MY_EMAIL_ADDRESS, the email to use when joining must be set as an environment variable'}
     : ${NETWORK_TRUST_PASSWORD=:? '$NETWORK_TRUST_PASSWORD, the password to the network store to use when joining must be set as environment variable'}
+    : ${NETWORK_TRUST_PASSWORD=:? '$NETWORK_TRUST_PASSWORD, the password to the network store to use when joining must be set as environment variable'}
+    : ${RPC_USER=:? '$RPC_USER, the name of the primary rpc user must be set as environment variable'}
+
 
     if [[ ! -f ${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} ]]; then
       die "Network Trust Root file not found"

--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -37,6 +37,7 @@ function generateGenericCZConfig() {
     : ${MY_EMAIL_ADDRESS:? '$MY_EMAIL_ADDRESS, the email to use when joining must be set as an environment variable'}
     : ${NETWORK_TRUST_PASSWORD=:? '$NETWORK_TRUST_PASSWORD, the password to the network store to use when joining must be set as environment variable'}
     : ${RPC_USER=:? '$RPC_USER, the name of the primary rpc user must be set as environment variable'}
+    : ${SSHPORT=:? 'SSHPORT, the port number for the SSHD must be set as enviroment variable'}
 
 
     if [[ ! -f ${CERTIFICATES_FOLDER}/${TRUST_STORE_NAME} ]]; then
@@ -51,6 +52,7 @@ function generateGenericCZConfig() {
       MY_RPC_ADMIN_PORT=${MY_RPC_ADMIN_PORT} \
       java -jar config-exporter.jar "GENERIC-CZ" "/opt/corda/starting-node.conf" "${CONFIG_FOLDER}/node.conf"
   fi
+
   java -Djava.security.egd=file:/dev/./urandom -Dcapsule.jvm.args="${JVM_ARGS}" -jar /opt/corda/bin/corda.jar \
     --initial-registration \
     --base-directory /opt/corda \

--- a/docker/src/bash/generate-config.sh
+++ b/docker/src/bash/generate-config.sh
@@ -36,7 +36,6 @@ function generateGenericCZConfig() {
     : ${MY_LEGAL_NAME:? '$MY_LEGAL_NAME, the X500 name to use when joining must be set as environment variable'}
     : ${MY_EMAIL_ADDRESS:? '$MY_EMAIL_ADDRESS, the email to use when joining must be set as an environment variable'}
     : ${NETWORK_TRUST_PASSWORD=:? '$NETWORK_TRUST_PASSWORD, the password to the network store to use when joining must be set as environment variable'}
-    : ${NETWORK_TRUST_PASSWORD=:? '$NETWORK_TRUST_PASSWORD, the password to the network store to use when joining must be set as environment variable'}
     : ${RPC_USER=:? '$RPC_USER, the name of the primary rpc user must be set as environment variable'}
 
 

--- a/docker/src/config/starting-node.conf
+++ b/docker/src/config/starting-node.conf
@@ -5,6 +5,10 @@ rpcSettings {
     adminAddress="0.0.0.0:"${MY_RPC_ADMIN_PORT}
 }
 
+sshd {
+    port=${SSHPORT}
+}
+
 security {
     authService {
         dataSource {

--- a/docker/src/config/starting-node.conf
+++ b/docker/src/config/starting-node.conf
@@ -19,7 +19,8 @@ security {
                     permissions=[
                         ALL
                     ]
-                    user=rpcUser
+                    user=${RPC_USER}
+
                 }
             ]
         }


### PR DESCRIPTION
Adding the sshd field and port by default to the node.conf template that is used by the docker images when generating node config on container start up. 