### PR TITLE
CORDA-3727 Load CordaServices before NotaryService

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -527,8 +527,8 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             // the KMS is meant for derived temporary keys used in transactions, and we're not supposed to sign things with
             // the identity key. But the infrastructure to make that easy isn't here yet.
             keyManagementService.start(keyPairs)
-            notaryService = maybeStartNotaryService(myNotaryIdentity)
             installCordaServices()
+            notaryService = maybeStartNotaryService(myNotaryIdentity)
             contractUpgradeService.start()
             vaultService.start()
             ScheduledActivityObserver.install(vaultService, schedulerService, flowLogicRefFactory)


### PR DESCRIPTION
On node start, load CordaServices before starting the NotaryService,
so that the NotaryService can check that the services it requires are
available when starting.

Resolves #6172.

# PR Checklist:

- [X ] All tests succeed
- [X ] No changes to APIs
- [X ] Don't think addition to changelog/release notes is required
- [X] Have contributed before.