### PR TITLE
CORDA-3730: Specify new version enabled features with a constant

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/PlatformVersionSwitches.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/PlatformVersionSwitches.kt
@@ -1,0 +1,10 @@
+package net.corda.core.internal
+
+/*
+Constants for new features that can only be switched on at specific platform versions can be specified in this file.
+The text constant describes the feature and the numeric specifies the platform version the feature is enabled at.
+ */
+object PlatformVersionSwitches {
+    const val REMOVE_NO_OVERLAP_RULE_FOR_REFERENCE_DATA_ATTACHMENTS = 7
+    const val ENABLE_P2P_COMPRESSION = 7
+}


### PR DESCRIPTION
New file created where new features can be specified with a constant. The constant numeric will specify the minimum platform version that this feature is enabled at.