### PR TITLE
allow CorDapp developer to add their own modules to Jackson

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -160,6 +160,12 @@ object JacksonSupport {
         return configureMapper(mapper)
     }
 
+    private val customModules : MutableList<Module> = Collections.synchronizedList(ArrayList())
+
+    fun addCustomModule(module: Module) {
+        customModules.add(module)
+    }
+
     private fun configureMapper(mapper: ObjectMapper): ObjectMapper {
         return mapper.apply {
             enable(SerializationFeature.INDENT_OUTPUT)
@@ -179,6 +185,7 @@ object JacksonSupport {
             addMixIn(X500Principal::class.java, X500PrincipalMixin::class.java)
             addMixIn(X509Certificate::class.java, X509CertificateMixin::class.java)
             addMixIn(CertPath::class.java, CertPathMixin::class.java)
+            customModules.forEach { mapper.registerModule(it) }
         }
     }
 


### PR DESCRIPTION
this will provide a big benefit for CorDapp that are meant to be used by the CRASH shell, since it will allow
to create custom types from the shell iself in a user-friendly way.

Example:
`net.corda.core.contracts.Amount` is a declared like this

```
data class Amount<T : Any>(val quantity: Long, val displayTokenSize: BigDecimal, val token: T) : Comparable<Amount<T>> {
```

it has no constructor from a single string, it only has a static method named parseCurrency  that creates an instance of it from a string, yet CRASH knows it has to invoke parseCurrency  when it needs to create an amount instance from a String and it's indeed possible when invoking a flow to just specify amount: "10 GBP".

This works thanks to [this line](https://github.com/corda/corda/blob/release/os/4.5/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt#L72) that register a custom Jackson deserializer for it.

Since a new `ObjectMapper` instance is created at every flow invocation, timing is not important
(had a singleton instance been used, it would have been necessary to make sure custom modules were registered before the singleton's contruction).
In this way it is possible to simply put a `@CordaService` in your CorDapp, add a `cordaCompile` dependency to `net.corda:corda-jackson:${corda_version}` and immediately after receiving the event `net.corda.core.node.services.ServiceLifecycleEvent.STATE_MACHINE_STARTED` call

```
JacksonSupport.addCustomModule(myModule)
```
