### PR TITLE
CORDA-3747 - switch on the publishing of sources

### DIFF
--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -74,7 +74,7 @@ jar {
 }
 
 publish {
-    publishSources = false
+    publishSources = true
     publishJavadoc = false
     name jar.baseName
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-3747

Reverting the disabling of source publishing, according to @josecoll :
‘I did have a lot or problems with that module at the time because there was a direct dependency on it from serialization but that has now been de-coupled so should be fine.’
