### PR TITLE
CORDA-3191: When querying for attachment ids only pull id from db

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -155,16 +155,12 @@ abstract class AbstractQueryCriteriaParser<Q : GenericQueryCriteria<Q,P>, in P: 
     }
 }
 
-class HibernateAttachmentQueryCriteriaParser(override val criteriaBuilder: CriteriaBuilder,
-                                             private val criteriaQuery: CriteriaQuery<NodeAttachmentService.DBAttachment>, val root: Root<NodeAttachmentService.DBAttachment>) :
+class HibernateAttachmentQueryCriteriaParser<T,R>(override val criteriaBuilder: CriteriaBuilder,
+                                             private val criteriaQuery: CriteriaQuery<R>, val root: Root<T>) :
         AbstractQueryCriteriaParser<AttachmentQueryCriteria, AttachmentsQueryCriteriaParser, AttachmentSort>(), AttachmentsQueryCriteriaParser {
 
     private companion object {
         private val log = contextLogger()
-    }
-
-    init {
-        criteriaQuery.select(root)
     }
 
     override fun parse(criteria: AttachmentQueryCriteria, sorting: AttachmentSort?): Collection<Predicate> {


### PR DESCRIPTION
When querying for attachment id's we now only retrieve the id from the database, rather than the whole object which is then discarded.