### PR TITLE
ENT-5237: Remove DISTINCT

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -323,9 +323,10 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
     private fun queryIdentityByLegalName(session: Session, name: CordaX500Name): PartyAndCertificate? {
         val query = session.createQuery(
                 // We do the JOIN here to restrict results to those present in the network map
-                "SELECT DISTINCT l FROM ${NodeInfoSchemaV1.PersistentNodeInfo::class.java.name} n INNER JOIN n.legalIdentitiesAndCerts l WHERE l.name = :name",
+                "SELECT l FROM ${NodeInfoSchemaV1.PersistentNodeInfo::class.java.name} n INNER JOIN n.legalIdentitiesAndCerts l WHERE l.name = :name",
                 NodeInfoSchemaV1.DBPartyAndCertificate::class.java)
         query.setParameter("name", name.toString())
+        query.maxResults = 1 // instead of DISTINCT in the query, DISTINCT is not supported in Oracle when one of the columns is BLOB
         val candidates = query.resultList.map { it.toLegalIdentityAndCert() }
         // The map is restricted to holding a single identity for any X.500 name, so firstOrNull() is correct here.
         return candidates.firstOrNull()


### PR DESCRIPTION
Remove DISTINCT because Oracle cannot apply DISTINCT to BLOB fields