### PR TITLE
CORDA-3753: Increase Artemis security-invalidation-interval to avoid frequent CRL checks

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
@@ -33,6 +33,9 @@ class ArtemisMessagingComponent {
         // This is a rough guess on the extra space needed on top of maxMessageSize to store the journal.
         // TODO: we might want to make this value configurable.
         const val JOURNAL_HEADER_SIZE = 1024
+        // Time interval after which every connected client is re-authenticated using BrokerJaasLoginModule.
+        // Setting it to 1 hour (instead of default value of 10 seconds) to avoid frequent expensive checks, e.g. CRL check.
+        const val SECURITY_INVALIDATION_INTERVAL = 3600 * 1000L
 
         object P2PMessagingHeaders {
             // This is a "property" attached to an Artemis MQ message object, which contains our own notion of "topic".

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -7,6 +7,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
+import net.corda.core.utilities.hours
 import net.corda.node.internal.artemis.*
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.NODE_P2P_ROLE
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.PEER_ROLE
@@ -162,6 +163,9 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
         val nodeInternalRole = Role(NODE_P2P_ROLE, true, true, true, true, true, true, true, true, true, true)
         securityRoles["$INTERNAL_PREFIX#"] = setOf(nodeInternalRole)  // Do not add any other roles here as it's only for the node
         securityRoles["$P2P_PREFIX#"] = setOf(nodeInternalRole, restrictedRole(PEER_ROLE, send = true))
+        // Time interval after which every connected client is re-authenticated using BrokerJaasLoginModule.
+        // Keeping bigger than default value (10 seconds) to avoid to frequent expensive checks, e.g. CRL check.
+        securityInvalidationInterval = 1.hours.toMillis()
         return this
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -164,7 +164,7 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
         securityRoles["$INTERNAL_PREFIX#"] = setOf(nodeInternalRole)  // Do not add any other roles here as it's only for the node
         securityRoles["$P2P_PREFIX#"] = setOf(nodeInternalRole, restrictedRole(PEER_ROLE, send = true))
         // Time interval after which every connected client is re-authenticated using BrokerJaasLoginModule.
-        // Keeping bigger than default value (10 seconds) to avoid to frequent expensive checks, e.g. CRL check.
+        // Keeping bigger than default value (10 seconds) to avoid frequent expensive checks, e.g. CRL check.
         securityInvalidationInterval = 1.hours.toMillis()
         return this
     }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -7,7 +7,6 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
-import net.corda.core.utilities.hours
 import net.corda.node.internal.artemis.*
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.NODE_P2P_ROLE
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.PEER_ROLE
@@ -18,6 +17,7 @@ import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.INTERNAL_P
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.JOURNAL_HEADER_SIZE
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NOTIFICATIONS_ADDRESS
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_PREFIX
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.SECURITY_INVALIDATION_INTERVAL
 import net.corda.nodeapi.internal.ArtemisTcpTransport.Companion.p2pAcceptorTcpTransport
 import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
 import net.corda.nodeapi.internal.requireOnDefaultFileSystem
@@ -163,9 +163,7 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
         val nodeInternalRole = Role(NODE_P2P_ROLE, true, true, true, true, true, true, true, true, true, true)
         securityRoles["$INTERNAL_PREFIX#"] = setOf(nodeInternalRole)  // Do not add any other roles here as it's only for the node
         securityRoles["$P2P_PREFIX#"] = setOf(nodeInternalRole, restrictedRole(PEER_ROLE, send = true))
-        // Time interval after which every connected client is re-authenticated using BrokerJaasLoginModule.
-        // Keeping bigger than default value (10 seconds) to avoid frequent expensive checks, e.g. CRL check.
-        securityInvalidationInterval = 1.hours.toMillis()
+        securityInvalidationInterval = SECURITY_INVALIDATION_INTERVAL
         return this
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
@@ -76,6 +76,7 @@ internal class RpcBrokerConfiguration(baseDirectory: Path, maxMessageSize: Int, 
         securityRoles["${ArtemisMessagingComponent.INTERNAL_PREFIX}#"] = setOf(nodeInternalRole)
         securityRoles[RPCApi.RPC_SERVER_QUEUE_NAME] = setOf(nodeInternalRole, restrictedRole(BrokerJaasLoginModule.RPC_ROLE, send = true))
         securitySettingPlugins.add(rolesAdderOnLogin)
+        securityInvalidationInterval = ArtemisMessagingComponent.SECURITY_INVALIDATION_INTERVAL
     }
 
     private fun enableJmx() {


### PR DESCRIPTION
### Description

To increase Artemis server `security-invalidation-interval` parameter from 10 seconds to 1 hour.
This is needed to avoid expensive frequent CRL checks (introduced in https://github.com/corda/corda/pull/6154) as well as other checks.

1 hour seems to be reasonable compromise for re-doing TLS security checks.

Note that this setting affects all Artemis users, incl. remote peers, local client and RPC connections.

### Background

https://activemq.apache.org/components/artemis/documentation/2.6.0/security.html
"For performance reasons security is cached and invalidated every so long. To change this period set the property security-invalidation-interval, which is in milliseconds. The default is 10000 ms."

Before performing some operation (e.g. create queue/address, consume etc), Artemis checks whether corresponding user/role is eligible for such operaration.
Normally such check is based on cached values, however every `security-invalidation-interval` the cache is invalidated, which means that current user has to be re-authenticated via `BrokerJaasLoginModule` every 10 seconds by default.
It affects every P2P or RPC user performing any activity, so it can be quite expensive, especially when performing CRL check for external P2P users.

### Tests
Manually verified basic flows with pinger on CE.