### PR TITLE
CORDA-3750: Delete unwanted methods from the deterministic artifacts.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -3,7 +3,6 @@ package net.corda.core.crypto
 import net.corda.core.CordaOID
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
-import net.corda.core.StubOutForDJVM
 import net.corda.core.crypto.internal.AliasPrivateKey
 import net.corda.core.crypto.internal.Instances.withSignature
 import net.corda.core.crypto.internal.`id-Curve25519ph`
@@ -220,11 +219,12 @@ object Crypto {
      * Map of supported digital signature schemes associated by [SignatureScheme.schemeNumberID].
      * SchemeNumberID is the scheme identifier attached to [SignatureMetadata].
      */
-    private val signatureSchemeNumberIDMap: Map<Int, SignatureScheme> = Crypto.supportedSignatureSchemes().associateBy { it.schemeNumberID }
+    private val signatureSchemeNumberIDMap: Map<Int, SignatureScheme> = supportedSignatureSchemes().associateBy { it.schemeNumberID }
 
     @JvmStatic
     fun supportedSignatureSchemes(): List<SignatureScheme> = ArrayList(signatureSchemeMap.values)
 
+    @DeleteForDJVM
     @JvmStatic
     fun findProvider(name: String): Provider {
         return providerMap[name] ?: throw IllegalArgumentException("Unrecognised provider: $name")
@@ -303,6 +303,7 @@ object Crypto {
      * @throws IllegalArgumentException on not supported scheme or if the given key specification
      * is inappropriate for this key factory to produce a private key.
      */
+    @DeleteForDJVM
     @JvmStatic
     fun decodePrivateKey(encodedKey: ByteArray): PrivateKey {
         val keyInfo = PrivateKeyInfo.getInstance(encodedKey)
@@ -314,6 +315,7 @@ object Crypto {
         return keyFactory.generatePrivate(PKCS8EncodedKeySpec(encodedKey))
     }
 
+    @DeleteForDJVM
     private fun decodeAliasPrivateKey(keyInfo: PrivateKeyInfo): PrivateKey {
         val encodable = keyInfo.parsePrivateKey() as DLSequence
         val derutF8String = encodable.getObjectAt(0)
@@ -329,6 +331,7 @@ object Crypto {
      * @throws IllegalArgumentException on not supported scheme or if the given key specification
      * is inappropriate for this key factory to produce a private key.
      */
+    @DeleteForDJVM
     @JvmStatic
     @Throws(InvalidKeySpecException::class)
     fun decodePrivateKey(schemeCodeName: String, encodedKey: ByteArray): PrivateKey {
@@ -407,7 +410,7 @@ object Crypto {
             val keyFactory = keyFactory(signatureScheme)
             return keyFactory.generatePublic(X509EncodedKeySpec(encodedKey))
         } catch (ikse: InvalidKeySpecException) {
-            throw throw InvalidKeySpecException("This public key cannot be decoded, please ensure it is X509 encoded and " +
+            throw InvalidKeySpecException("This public key cannot be decoded, please ensure it is X509 encoded and " +
                     "that it corresponds to the input scheme's code name.", ikse)
         }
     }
@@ -499,14 +502,14 @@ object Crypto {
     @JvmStatic
     @Throws(InvalidKeyException::class, SignatureException::class)
     fun doSign(keyPair: KeyPair, signableData: SignableData): TransactionSignature {
-        val sigKey: SignatureScheme = Crypto.findSignatureScheme(keyPair.private)
-        val sigMetaData: SignatureScheme = Crypto.findSignatureScheme(signableData.signatureMetadata.schemeNumberID)
+        val sigKey: SignatureScheme = findSignatureScheme(keyPair.private)
+        val sigMetaData: SignatureScheme = findSignatureScheme(signableData.signatureMetadata.schemeNumberID)
         // Special handling if the advertised SignatureScheme is CompositeKey.
         // TODO fix notaries that advertise [CompositeKey] in their signature Metadata. Currently, clustered notary nodes
         //      mention Crypto.COMPOSITE_KEY in their SignatureMetadata, but they are actually signing with a leaf-key
         //      (and if they refer to it as a Composite key, then we lose info about the actual type of their signing key).
         //      In short, their metadata should be the leaf key-type, until we support CompositeKey signatures.
-        require(sigKey == sigMetaData || sigMetaData == Crypto.COMPOSITE_KEY) {
+        require(sigKey == sigMetaData || sigMetaData == COMPOSITE_KEY) {
             "Metadata schemeCodeName: ${sigMetaData.schemeCodeName} is not aligned with the key type: ${sigKey.schemeCodeName}."
         }
         val signatureBytes = doSign(sigKey.schemeCodeName, keyPair.private, signableData.serialize().bytes)
@@ -601,7 +604,7 @@ object Crypto {
     @Throws(InvalidKeyException::class, SignatureException::class)
     fun doVerify(txId: SecureHash, transactionSignature: TransactionSignature): Boolean {
         val signableData = SignableData(originalSignedHash(txId, transactionSignature.partialMerkleTree), transactionSignature.signatureMetadata)
-        return Crypto.doVerify(transactionSignature.by, transactionSignature.bytes, signableData.serialize().bytes)
+        return doVerify(transactionSignature.by, transactionSignature.bytes, signableData.serialize().bytes)
     }
 
     /**
@@ -975,31 +978,12 @@ object Crypto {
     @JvmStatic
     fun validatePublicKey(key: PublicKey): Boolean = validatePublicKey(findSignatureScheme(key), key)
 
-    // Validate a key, by checking its algorithmic params.
-    private fun validateKey(signatureScheme: SignatureScheme, key: Key): Boolean {
-        return when (key) {
-            is PublicKey -> validatePublicKey(signatureScheme, key)
-            is PrivateKey -> validatePrivateKey(signatureScheme, key)
-            else -> throw IllegalArgumentException("Unsupported key type: ${key::class}")
-        }
-    }
-
     // Check if a public key satisfies algorithm specs (for ECC: key should lie on the curve and not being point-at-infinity).
     private fun validatePublicKey(signatureScheme: SignatureScheme, key: PublicKey): Boolean {
         return when (key) {
             is BCECPublicKey, is EdDSAPublicKey -> publicKeyOnCurve(signatureScheme, key)
             is BCRSAPublicKey -> key.modulus.bitLength() >= 2048 // Although the recommended RSA key size is 3072, we accept any key >= 2048bits.
             is BCSphincs256PublicKey -> true
-            else -> throw IllegalArgumentException("Unsupported key type: ${key::class}")
-        }
-    }
-
-    // Check if a private key satisfies algorithm specs.
-    private fun validatePrivateKey(signatureScheme: SignatureScheme, key: PrivateKey): Boolean {
-        return when (key) {
-            is BCECPrivateKey -> key.parameters == signatureScheme.algSpec
-            is EdDSAPrivateKey -> key.params == signatureScheme.algSpec
-            is BCRSAPrivateKey, is BCSphincs256PrivateKey -> true // TODO: Check if non-ECC keys satisfy params (i.e. approved/valid RSA modulus size).
             else -> throw IllegalArgumentException("Unsupported key type: ${key::class}")
         }
     }
@@ -1043,6 +1027,7 @@ object Crypto {
      * @throws IllegalArgumentException on not supported scheme or if the given key specification
      * is inappropriate for a supported key factory to produce a private key.
      */
+    @DeleteForDJVM
     @JvmStatic
     fun toSupportedPrivateKey(key: PrivateKey): PrivateKey {
         return when (key) {
@@ -1078,6 +1063,7 @@ object Crypto {
      * CRL & CSR checks etc.).
      */
     // TODO: perform all cryptographic operations via Crypto.
+    @DeleteForDJVM
     @JvmStatic
     fun registerProviders() {
         providerMap
@@ -1088,7 +1074,7 @@ object Crypto {
         setBouncyCastleRNG()
     }
 
-    @StubOutForDJVM
+    @DeleteForDJVM
     private fun setBouncyCastleRNG() {
         CryptoServicesRegistrar.setSecureRandom(newSecureRandom())
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
@@ -166,7 +166,6 @@ abstract class AbstractAMQPSerializationScheme(
 
 fun registerCustomSerializers(factory: SerializerFactory) {
     with(factory) {
-        register(net.corda.serialization.internal.amqp.custom.PrivateKeySerializer)
         register(net.corda.serialization.internal.amqp.custom.ThrowableSerializer(this))
         register(net.corda.serialization.internal.amqp.custom.BigDecimalSerializer)
         register(net.corda.serialization.internal.amqp.custom.BigIntegerSerializer)
@@ -205,6 +204,7 @@ fun registerCustomSerializers(factory: SerializerFactory) {
 @StubOutForDJVM
 private fun registerNonDeterministicSerializers(factory: SerializerFactory) {
     with(factory) {
+        register(net.corda.serialization.internal.amqp.custom.PrivateKeySerializer)
         register(net.corda.serialization.internal.amqp.custom.SimpleStringSerializer)
     }
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt
@@ -1,5 +1,6 @@
 package net.corda.serialization.internal.amqp.custom
 
+import net.corda.core.DeleteForDJVM
 import net.corda.core.crypto.Crypto
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationContext.UseCase.Storage
@@ -9,6 +10,7 @@ import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 import java.security.PrivateKey
 
+@DeleteForDJVM
 object PrivateKeySerializer
     : CustomSerializer.Implements<PrivateKey>(
         PrivateKey::class.java


### PR DESCRIPTION
- Delete funtions from `net.corda.core.crypto.Crypto` which have no purpose inside DJVM sandbox.
- Delete `PrivateKeySerializer` from serialization-deterministic.
- Resolve some compiler warnings, e.g. delete unused private methods.