### PR TITLE
NOTICK Update byteman dependencies

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -225,9 +225,9 @@ dependencies {
     
     // Byteman for runtime (termination) rules injection on the running node
     // Submission tool allowing to install rules on running nodes
-    slowIntegrationTestCompile "org.jboss.byteman:byteman-submit:4.0.3"
+    slowIntegrationTestCompile "org.jboss.byteman:byteman-submit:4.0.11"
     // The actual Byteman agent which should only be in the classpath of the out of process nodes
-    slowIntegrationTestCompile "org.jboss.byteman:byteman:4.0.3"
+    slowIntegrationTestCompile "org.jboss.byteman:byteman:4.0.11"
 
     testCompile(project(':test-cli'))
     testCompile(project(':test-utils'))


### PR DESCRIPTION
Tests that were using byteman when running on Java 11 were failing.
Updating the byteman version fixed the issue while still working on Java
8.