### PR TITLE
Revert H2 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ buildscript {
     ext.jopt_simple_version = '5.0.2'
     ext.jansi_version = '1.18'
     ext.hibernate_version = '5.4.3.Final'
-    ext.h2_version = '1.4.200' // Update docs if renamed or removed.
+    ext.h2_version = '1.4.199' // Update docs if renamed or removed.
     ext.rxjava_version = '1.3.8'
     ext.dokka_version = '0.9.17'
     ext.eddsa_version = '0.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ buildscript {
     ext.jopt_simple_version = '5.0.2'
     ext.jansi_version = '1.18'
     ext.hibernate_version = '5.4.3.Final'
-    ext.h2_version = '1.4.199' // Update docs if renamed or removed.
+    ext.h2_version = '1.4.200' // Update docs if renamed or removed.
     ext.rxjava_version = '1.3.8'
     ext.dokka_version = '0.9.17'
     ext.eddsa_version = '0.3.0'

--- a/experimental/nodeinfo/build.gradle
+++ b/experimental/nodeinfo/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile "org.slf4j:jul-to-slf4j:$slf4j_version"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     compile "com.jcabi:jcabi-manifests:$jcabi_manifests_version"
+    compile "com.google.code.gson:gson:2.8.5"
     compile project(':core')
     compile project(':node-api')
 }

--- a/experimental/nodeinfo/src/main/kotlin/net.corda.nodeinfo/NodeInfo.kt
+++ b/experimental/nodeinfo/src/main/kotlin/net.corda.nodeinfo/NodeInfo.kt
@@ -163,7 +163,7 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
         } else if(additionalNodeInfosPath != null) {
             val nodeinfos = mutableListOf<SimplifiedNodeInfo>()
             Files.walk(additionalNodeInfosPath)
-                .filter{item -> Files.isRegularFile(item)}
+                .filter{item -> item.getFileName().toString().startsWith("nodeInfo-")}
                 .forEach{
                     val nodeinfo = nodeInfoFromFile(it.toFile())
                     nodeinfos.add(SimplifiedNodeInfo(nodeinfo.legalIdentities[0].name, nodeinfo.addresses[0]))
@@ -196,7 +196,7 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
         val nodeInfoSigned = generateNodeInfo()
         val fileNameHash = nodeInfoSigned.nodeInfo.legalIdentities[0].name.serialize().hash
 
-        val outputFile = outputDirectory!!.toString() / "nodeinfo-${fileNameHash.toString()}"
+        val outputFile = outputDirectory!!.toString() / "nodeInfo-${fileNameHash.toString()}"
 
         println(outputFile)
 

--- a/experimental/nodeinfo/src/main/kotlin/net.corda.nodeinfo/NodeInfo.kt
+++ b/experimental/nodeinfo/src/main/kotlin/net.corda.nodeinfo/NodeInfo.kt
@@ -4,6 +4,7 @@ import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.start
 import net.corda.core.crypto.sign
 import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.div
 import net.corda.core.internal.readAll
 import net.corda.core.node.NodeInfo
@@ -24,9 +25,12 @@ import net.corda.serialization.internal.amqp.amqpMagic
 import picocli.CommandLine.ITypeConverter
 import picocli.CommandLine.Option
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.HashMap
 import java.security.cert.CertificateFactory
-
+import com.google.gson.GsonBuilder
 /**
  * NodeInfo signing tool for Corda
  *
@@ -64,6 +68,12 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
 
     @Option(names = ["--display"], paramLabel = "nodeinfo-file", description = ["Path to NodeInfo"])
     private var displayPath: Path? = null
+
+    @Option(names = ["--network-map"], paramLabel = "directory", description = ["additional-node-infos directory"])
+    private var additionalNodeInfosPath: Path? = null
+
+    @Option(names = ["--outfile"], paramLabel = "file", description = ["Output file for JSON format network map"])
+    private var outputFile: Path? = null
 
     @Option(names = ["--address"], paramLabel = "host:port", description = ["Public address of node"], converter = [NetworkHostAndPortConverter::class])
     private var addressList: MutableList<NetworkHostAndPort> = mutableListOf<NetworkHostAndPort>()
@@ -136,6 +146,8 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
         return NodeInfoAndSignedNodeInfo(nodeInfo, sni)
     }
 
+    class SimplifiedNodeInfo(val identity : CordaX500Name, val address : NetworkHostAndPort)
+
     override fun runProgram(): Int {
 
         initialiseSerialization()
@@ -147,6 +159,25 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
             println("address:         " + nodeInfo.addresses[0])
             println("platformVersion: " + nodeInfo.platformVersion)
             println("serial           " + nodeInfo.serial)
+            return 0;
+        } else if(additionalNodeInfosPath != null) {
+            val nodeinfos = mutableListOf<SimplifiedNodeInfo>()
+            Files.walk(additionalNodeInfosPath)
+                .filter{item -> Files.isRegularFile(item)}
+                .forEach{
+                    val nodeinfo = nodeInfoFromFile(it.toFile())
+                    nodeinfos.add(SimplifiedNodeInfo(nodeinfo.legalIdentities[0].name, nodeinfo.addresses[0]))
+                };
+
+            val gson = GsonBuilder().setPrettyPrinting().create()
+            val prettyPrint = gson.toJson(nodeinfos)
+            println(prettyPrint)
+
+            if (outputFile != null) {
+                val file = outputFile!!.toString()
+                File(file).writeText(prettyPrint)
+            }
+
             return 0;
         }
         else {


### PR DESCRIPTION
Seeing these errors after the upgrade, reverted for now:

```
[ERROR] 06:56:05+0000 [main] changelog.ChangeSet. - Change Set migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda failed. Error: org.hibernate.exception.GenericJDBCException: could not extract ResultSet {changeSet=migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda, databaseChangeLog=master.changelog.json}
[INFO] 06:56:05+0000 [main] lockservice.StandardLockService. - Successfully released change log lock
[ERROR] 06:56:05+0000 [main] internal.NodeStartupLogging. - Could not create the DataSource: Migration failed for change set migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda:
   Reason: javax.persistence.PersistenceException: org.hibernate.exception.GenericJDBCException: could not extract ResultSet: Could not create the DataSource: Migration failed for change set migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda:
   Reason: javax.persistence.PersistenceException: org.hibernate.exception.GenericJDBCException: could not extract ResultSet [errorCode=9766y2, moreInformationAt=https://errors.corda.net/OS/4.4-SNAPSHOT/9766y2] (edited) 
```