### PR TITLE
ENT-5069 - empty lists vault query fix

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -303,7 +303,13 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
                 status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
                 contractStateTypes: Set<Class<out ContractState>>? = null,
                 relevancyStatus: Vault.RelevancyStatus = Vault.RelevancyStatus.ALL
-        ) : this(participants, linearId?.map { it.id }, linearId?.mapNotNull { it.externalId }, status, contractStateTypes, relevancyStatus)
+        ) : this(participants,
+                linearId?.map { it.id }.takeIf { it != null && it.isNotEmpty() },
+                linearId?.mapNotNull { it.externalId }.takeIf { it != null && it.isNotEmpty() },
+                status,
+                contractStateTypes,
+                relevancyStatus
+        )
 
         // V3 c'tor
         @DeprecatedConstructorForDeserialization(version = 1)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -260,6 +260,24 @@ class NodeAttachmentServiceTest {
     }
 
     @Test(timeout=300_000)
+    fun `AttachmentsQueryCriteria returns empty resultset without errors if there is an empty list after the 'in' clause`() {
+        SelfCleaningDir().use { file ->
+            val contractJar = makeTestContractJar(file.path, "com.example.MyContract")
+            contractJar.read { storage.importAttachment(it, "uploaderB", "contract.jar") }
+
+            assertEquals(
+                    1,
+                    storage.queryAttachments(AttachmentsQueryCriteria(contractClassNamesCondition = Builder.equal(listOf("com.example.MyContract")))).size
+            )
+
+            assertEquals(
+                    0,
+                    storage.queryAttachments(AttachmentsQueryCriteria(contractClassNamesCondition = Builder.equal(emptyList()))).size
+            )
+        }
+    }
+
+    @Test(timeout=300_000)
 	fun `contract class, versioning and signing metadata can be used to search`() {
         SelfCleaningDir().use { file ->
             val (sampleJar, _) = makeTestJar()

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -267,6 +267,31 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         }
     }
 
+    @Test(timeout=300_000)
+    fun `VaultQueryCriteria returns empty resultset without errors if there is an empty list after the 'in' clause`() {
+        database.transaction {
+            val states = vaultFiller.fillWithSomeTestLinearStates(1, "TEST")
+            val stateRefs = states.states.map { it.ref }
+
+            val criteria = VaultQueryCriteria(notary = listOf(DUMMY_NOTARY))
+            val results = vaultService.queryBy<LinearState>(criteria)
+            assertThat(results.states).hasSize(1)
+
+            val emptyCriteria = VaultQueryCriteria(notary = emptyList())
+            val emptyResults = vaultService.queryBy<LinearState>(emptyCriteria)
+            assertThat(emptyResults.states).hasSize(0)
+
+            val stateCriteria = VaultQueryCriteria(stateRefs = stateRefs)
+            val stateResults = vaultService.queryBy<LinearState>(stateCriteria)
+            assertThat(stateResults.states).hasSize(1)
+
+            val emptyStateCriteria = VaultQueryCriteria(stateRefs = emptyList())
+            val emptyStateResults = vaultService.queryBy<LinearState>(emptyStateCriteria)
+            assertThat(emptyStateResults.states).hasSize(0)
+
+        }
+    }
+
     /** Generic Query tests
     (combining both FungibleState and LinearState contract types) */
 
@@ -1824,6 +1849,33 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     /** LinearState tests */
 
     @Test(timeout=300_000)
+    fun `LinearStateQueryCriteria returns empty resultset without errors if there is an empty list after the 'in' clause`() {
+        database.transaction {
+            val uid = UniqueIdentifier("999")
+            vaultFiller.fillWithSomeTestLinearStates(numberToCreate = 1, uniqueIdentifier = uid)
+            vaultFiller.fillWithSomeTestLinearStates(numberToCreate = 1, externalId = "1234")
+
+            val uuidCriteria = LinearStateQueryCriteria(uuid = listOf(uid.id))
+            val externalIdCriteria = LinearStateQueryCriteria(externalId = listOf("1234"))
+
+            val uuidResults = vaultService.queryBy<ContractState>(uuidCriteria)
+            val externalIdResults = vaultService.queryBy<ContractState>(externalIdCriteria)
+
+            assertThat(uuidResults.states).hasSize(1)
+            assertThat(externalIdResults.states).hasSize(1)
+
+            val uuidCriteriaEmpty = LinearStateQueryCriteria(uuid = emptyList())
+            val externalIdCriteriaEmpty = LinearStateQueryCriteria(externalId = emptyList())
+
+            val uuidResultsEmpty = vaultService.queryBy<ContractState>(uuidCriteriaEmpty)
+            val externalIdResultsEmpty = vaultService.queryBy<ContractState>(externalIdCriteriaEmpty)
+
+            assertThat(uuidResultsEmpty.states).hasSize(0)
+            assertThat(externalIdResultsEmpty.states).hasSize(0)
+        }
+    }
+
+    @Test(timeout=300_000)
 	fun `unconsumed linear heads for linearId without external Id`() {
         database.transaction {
             val issuedStates = vaultFiller.fillWithSomeTestLinearStates(10)
@@ -2029,6 +2081,46 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     }
 
     /** FungibleAsset tests */
+
+    @Test(timeout=300_000)
+    fun `FungibleAssetQueryCriteria returns empty resultset without errors if there is an empty list after the 'in' clause`() {
+        database.transaction {
+            vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 1, MEGA_CORP.ref(0))
+
+            val ownerCriteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP))
+            val ownerResults = vaultService.queryBy<FungibleAsset<*>>(ownerCriteria)
+
+            assertThat(ownerResults.states).hasSize(1)
+
+            val emptyOwnerCriteria = FungibleAssetQueryCriteria(owner = emptyList())
+            val emptyOwnerResults = vaultService.queryBy<FungibleAsset<*>>(emptyOwnerCriteria)
+
+            assertThat(emptyOwnerResults.states).hasSize(0)
+
+            // Issuer field checks
+            val issuerCriteria = FungibleAssetQueryCriteria(issuer = listOf(MEGA_CORP))
+            val issuerResults = vaultService.queryBy<FungibleAsset<*>>(issuerCriteria)
+
+            assertThat(issuerResults.states).hasSize(1)
+
+            val emptyIssuerCriteria = FungibleAssetQueryCriteria(issuer = emptyList())
+            val emptyIssuerResults = vaultService.queryBy<FungibleAsset<*>>(emptyIssuerCriteria)
+
+            assertThat(emptyIssuerResults.states).hasSize(0)
+
+            // Issuer Ref field checks
+            val issuerRefCriteria = FungibleAssetQueryCriteria(issuerRef = listOf(MINI_CORP.ref(0).reference))
+            val issuerRefResults = vaultService.queryBy<FungibleAsset<*>>(issuerRefCriteria)
+
+            assertThat(issuerRefResults.states).hasSize(1)
+
+            val emptyIssuerRefCriteria = FungibleAssetQueryCriteria(issuerRef = emptyList())
+            val emptyIssuerRefResults = vaultService.queryBy<FungibleAsset<*>>(emptyIssuerRefCriteria)
+
+            assertThat(emptyIssuerRefResults.states).hasSize(0)
+
+        }
+    }
 
     @Test(timeout=300_000)
 	fun `unconsumed fungible assets for specific issuer party and refs`() {


### PR DESCRIPTION
The fix for the empty uuid list. We are checking for empty lists which are going to be checked 'where x in list' clauses and concatenate 'and 1=0' instead of them to the criteria to force it to return nothing.

https://r3-cev.atlassian.net/browse/ENT-5069