### PR TITLE
ENT-5277: Reflect `node-api` changes in OS

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/SessionState.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/SessionState.kt
@@ -1,0 +1,34 @@
+package net.corda.nodeapi.internal.protonwrapper.engine
+
+import org.apache.qpid.proton.engine.Session
+
+/**
+ * In addition to holding the `Session` also tracks the state of it.
+ */
+internal class SessionState {
+
+    enum class Value {
+        UNINITIALIZED,
+        ACTIVE,
+        CLOSED
+    }
+
+    private var _value: Value = Value.UNINITIALIZED
+
+    private var _session: Session? = null
+
+    val value: Value get() = _value
+
+    val session: Session? get() = _session
+
+    fun init(session: Session) {
+        require(value == Value.UNINITIALIZED)
+        _value = Value.ACTIVE
+        _session = session
+    }
+
+    fun close() {
+        _value = Value.CLOSED
+        _session = null
+    }
+}


### PR DESCRIPTION
Please see Jira for details of the change.
This is related to: corda/enterprise#3347