### PR TITLE
NOTICK Non-database error handling in `withEntityManager`

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
@@ -40,6 +40,7 @@ import java.util.concurrent.Semaphore
 import javax.persistence.PersistenceException
 import kotlin.test.assertEquals
 
+@Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
 class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
 
     @Before

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
@@ -775,7 +775,7 @@ class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
                     persist(entityWithIdThree)
                     throw RuntimeException("die")
                 }
-            } catch (e: Exception) {
+            } catch (e: RuntimeException) {
                 logger.info("Caught error")
             }
             sleep(1.millis)
@@ -795,7 +795,7 @@ class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
                     flush()
                     throw RuntimeException("die")
                 }
-            } catch (e: Exception) {
+            } catch (e: RuntimeException) {
                 logger.info("Caught error")
             }
             sleep(1.millis)
@@ -824,7 +824,7 @@ class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
                     }
                     throw RuntimeException("die")
                 }
-            } catch (e: Exception) {
+            } catch (e: RuntimeException) {
                 logger.info("Caught error")
             }
             sleep(1.millis)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -183,7 +183,7 @@ import java.sql.Savepoint
 import java.time.Clock
 import java.time.Duration
 import java.time.format.DateTimeParseException
-import java.util.*
+import java.util.Properties
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -193,8 +193,6 @@ import java.util.concurrent.TimeUnit.MINUTES
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.function.Consumer
 import javax.persistence.EntityManager
-import javax.persistence.PersistenceException
-import kotlin.collections.ArrayList
 
 /**
  * A base node implementation that can be customised either for production (with real implementations that do real
@@ -1210,7 +1208,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                                 connection.rollback(savepoint)
                             }
                         }
-                    } catch (e: PersistenceException) {
+                    } catch (e: Exception) {
                         if (manager.transaction.rollbackOnly) {
                             connection.rollback(savepoint)
                         }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1194,6 +1194,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
          */
         override fun jdbcSession(): Connection = RestrictedConnection(database.createSession())
 
+        @Suppress("TooGenericExceptionCaught")
         override fun <T : Any?> withEntityManager(block: EntityManager.() -> T): T {
             return database.transaction(useErrorHandler = false) {
                 session.flush()


### PR DESCRIPTION
When a non-database exception is thrown out of a `withEntityManager`
block, always check if the session needs to be rolled back.

This means if a database error is caught and a new non-database error is
thrown out of the `withEntityManager` block, the transaction is still
rolled back. The flow can then continue progressing as normal.

---

I tested this against Postgres and MySQL locally.