### PR TITLE
CORDA-3176 Inefficient query generated on vault queries with custom p…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -539,12 +539,15 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                         entityRoot
                     }
 
-            val joinPredicate = if(IndirectStatePersistable::class.java.isAssignableFrom(entityRoot.javaType)) {
-                        criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<IndirectStatePersistable<*>>("compositeKey").get<PersistentStateRef>("stateRef"))
-                    } else {
-                criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
+            if (entityRoot != vaultStates){ // to avoid self join
+                val joinPredicate = if(IndirectStatePersistable::class.java.isAssignableFrom(entityRoot.javaType)) {
+                    criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<IndirectStatePersistable<*>>("compositeKey").get<PersistentStateRef>("stateRef"))
+                }
+                else {
+                    criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
+                }
+                predicateSet.add(joinPredicate)
             }
-            predicateSet.add(joinPredicate)
 
             // resolve general criteria expressions
             @Suppress("UNCHECKED_CAST")

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -455,6 +455,38 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             assertThat(queriedStates).containsExactlyElementsOf(allStates)
         }
     }
+    
+    @Test(timeout=300_000)
+    fun `query with sort criteria and pagination on large volume of states should complete in time`() {
+        val numberOfStates = 1000
+        val pageSize = 1000
+        (1..50).forEach{
+            database.transaction {
+                vaultFiller.fillWithSomeTestLinearStates(numberOfStates, linearNumber = 100L)
+            }
+        }
+        val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+
+        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "stateRef")
+
+        Sort.Direction.values().forEach { sortDirection ->
+
+            val sorting = Sort(listOf(Sort.SortColumn(sortAttribute, sortDirection)))
+
+            val start = System.currentTimeMillis()
+            val queriedStates = mutableListOf<StateAndRef<*>>()
+            var pageNumber = 0
+            while (pageNumber * pageSize < numberOfStates) {
+                val paging = PageSpecification(pageNumber = pageNumber + 1, pageSize = pageSize)
+                val page = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = paging, criteria = criteria)
+                queriedStates += page.states
+                pageNumber++
+            }
+
+            val elapsed = System.currentTimeMillis() - start
+            assertThat(elapsed).isLessThan(1000)
+        }
+    }
 
     @Test(timeout=300_000)
 	fun `unconsumed states with count`() {

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -460,11 +460,13 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     fun `query with sort criteria and pagination on large volume of states should complete in time`() {
         val numberOfStates = 1000
         val pageSize = 1000
-        (1..50).forEach{
+
+        for (i in 1..50) {
             database.transaction {
                 vaultFiller.fillWithSomeTestLinearStates(numberOfStates, linearNumber = 100L)
             }
         }
+
         val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
 
         val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "stateRef")


### PR DESCRIPTION
CORDA-3176 Inefficient query generated on vault queries with custom paging

a check added to avoid self joins
local postgres db tests were executed on large volume test data (50k states) to ensure that the DB optimizes the suspicious query and so it does not cuase performance issues.
A test added to check that a pagination query on large volume of sorted data is completed in a reasonable time
based on 4.6

original jpqlQeuery querystring:
```SQL
select count(generatedAlias0.recordedTime) from VaultSchemaV1$VaultStates as generatedAlias0 where ( generatedAlias0.contractStateClassName in (:param0) ) and ( generatedAlias0.stateRef=generatedAlias0.stateRef )
```

query string after fix:
```SQL
select count(generatedAlias0.recordedTime) from VaultSchemaV1$VaultStates as generatedAlias0 where ( generatedAlias0.contractStateClassName in (:param0) ) and ( 1=1 )
```


1=1 is generated by Hibernate and does not make any harm