### PR TITLE
EG-1991 Ignore warning for CORDA environment variables in all caps

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -91,6 +91,8 @@ object ConfigHelper {
                 .mapKeys {
                     val original = it.key as String
 
+                    // Reject environment variable that are in all caps 
+		    // since these cannot be properties.
                     if (original == original.toUpperCase()){
                         return@mapKeys original
                     }

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -36,6 +36,7 @@ object ConfigHelper {
     private const val UPPERCASE_PROPERTY_PREFIX = "CORDA."
 
     private val log = LoggerFactory.getLogger(javaClass)
+    @Suppress("LongParameterList")
     fun loadConfig(baseDirectory: Path,
                    configFile: Path = baseDirectory / "node.conf",
                    allowMissingConfig: Boolean = false,
@@ -88,7 +89,13 @@ object ConfigHelper {
         return ConfigFactory.parseMap(
                 toProperties()
                 .mapKeys {
-                    var newKey = (it.key as String)
+                    val original = it.key as String
+
+                    if (original == original.toUpperCase()){
+                        return@mapKeys original
+                    }
+
+                    var newKey = original
                                 .replace('_', '.')
                                 .replace(UPPERCASE_PROPERTY_PREFIX, CORDA_PROPERTY_PREFIX)
 


### PR DESCRIPTION
ConfigHelper displays the following error message on the console when it finds an environment variable prefixed by 'CORDA' whose suffix does not match any node configuration property.

! ATTENTION: CORDA_XXXXX (property or environment variable) cannot be mapped to an existing Corda config property thus won't be used as a config override! It won't be passed as a config override! If that was the intention double check the spelling and ensure there is such config key.

This warning is unnecessary if the environment property is in all caps since no node configuration property is in, or ever will be in, all caps.