### PR TITLE
[EG-1980] Change docs links to point at given release version

### DIFF
--- a/common/logging/src/main/kotlin/net/corda/common/logging/CordaVersion.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/CordaVersion.kt
@@ -5,6 +5,10 @@ import com.jcabi.manifests.Manifests
 class CordaVersion  {
     companion object {
         private const val UNKNOWN = "Unknown"
+        private const val BASE_URL = "https://docs.corda.net/docs"
+        private const val OS_PAGES = "corda-os"
+        private const val ENTERPRISE_PAGES = "corda-enterprise"
+
         const val platformEditionCode = "OS"
 
         private fun manifestValue(name: String): String? = if (Manifests.exists(name)) Manifests.read(name) else null
@@ -13,6 +17,17 @@ class CordaVersion  {
         val revision: String by lazy { manifestValue("Corda-Revision") ?: UNKNOWN }
         val vendor: String by lazy { manifestValue("Corda-Vendor") ?: UNKNOWN }
         val platformVersion: Int by lazy { manifestValue("Corda-Platform-Version")?.toInt() ?: 1 }
+
+        /**
+         * Provide the root link to the docs site for this release.
+         *
+         * The returned link will be in the format "https://docs.corda.net/docs/<platform-edition>/<version-number>", without a trailing /.
+         */
+        fun rootDocsSiteLink() : String {
+            // This line allows this code to be merged to Enterprise with no changes.
+            val pages = if (platformEditionCode == "OS") OS_PAGES else ENTERPRISE_PAGES
+            return "$BASE_URL/$pages/$releaseVersion"
+        }
 
         internal val semanticVersion: String by lazy { if(releaseVersion == UNKNOWN) CURRENT_MAJOR_RELEASE else releaseVersion }
     }

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/CordaErrorContextProvider.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/CordaErrorContextProvider.kt
@@ -11,21 +11,10 @@ import java.util.*
 class CordaErrorContextProvider : ErrorContextProvider {
 
     companion object {
-        private const val BASE_URL = "https://docs.corda.net/docs"
-        private const val OS_PAGES = "corda-os"
-        private const val ENTERPRISE_PAGES = "corda-enterprise"
         private const val ERROR_CODE_PAGE = "error-codes.html"
     }
 
     override fun getURL(locale: Locale): String {
-        val versionNumber = CordaVersion.releaseVersion
-
-        // This slightly strange block here allows the code to be merged across to Enterprise with no changes.
-        val productVersion = if (CordaVersion.platformEditionCode == "OS") {
-            OS_PAGES
-        } else {
-            ENTERPRISE_PAGES
-        }
-        return "$BASE_URL/$productVersion/$versionNumber/$ERROR_CODE_PAGE"
+        return "${CordaVersion.rootDocsSiteLink()}/$ERROR_CODE_PAGE"
     }
 }

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
@@ -25,7 +25,7 @@ internal class ErrorReporterImpl(private val resourceLocation: String,
         val resource = "$resourceLocation/$ERROR_INFO_RESOURCE"
         val codeMessage = fetchAndFormat(resource, ERROR_CODE_MESSAGE, arrayOf(error.formatCode()))
         val urlMessage = fetchAndFormat(resource, ERROR_CODE_URL, arrayOf(errorContextProvider.getURL(locale)))
-        return "[$codeMessage, $urlMessage]"
+        return "[$codeMessage $urlMessage]"
     }
 
     override fun report(error: ErrorCode<*>, logger: Logger) {

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
@@ -74,7 +74,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("en-US")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is a test message [Code: test-case1, URL: $TEST_URL/en-US]"), logs)
+        assertEquals(listOf("This is a test message [Code: test-case1 URL: $TEST_URL/en-US]"), logs)
     }
 
     @Test(timeout = 300_00)
@@ -84,7 +84,7 @@ class ErrorReporterImplTest {
         val testReporter = createReporterImpl("en-US")
         testReporter.report(error, loggerMock)
         val format = DateFormat.getDateInstance(DateFormat.LONG, Locale.forLanguageTag("en-US"))
-        assertEquals(listOf("This is the second case with string foo, number 1, date ${format.format(currentDate)} [Code: test-case2, URL: $TEST_URL/en-US]"), logs)
+        assertEquals(listOf("This is the second case with string foo, number 1, date ${format.format(currentDate)} [Code: test-case2 URL: $TEST_URL/en-US]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -92,7 +92,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("fr-FR")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is a test message [Code: test-case1, URL: $TEST_URL/fr-FR]"), logs)
+        assertEquals(listOf("This is a test message [Code: test-case1 URL: $TEST_URL/fr-FR]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -100,7 +100,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("ga-IE")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("Is teachtaireacht earráide é seo [Code: test-case1, URL: $TEST_URL/ga-IE]"), logs)
+        assertEquals(listOf("Is teachtaireacht earráide é seo [Code: test-case1 URL: $TEST_URL/ga-IE]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -108,7 +108,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("es-ES")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is a test message [Code: test-case1, URL: $TEST_URL/es-ES]"), logs)
+        assertEquals(listOf("This is a test message [Code: test-case1 URL: $TEST_URL/es-ES]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -116,6 +116,6 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_3
         val testReporter = createReporterImpl("en-US")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is the third test message [Code: test-case-3, URL: $TEST_URL/en-US]"), logs)
+        assertEquals(listOf("This is the third test message [Code: test-case-3 URL: $TEST_URL/en-US]"), logs)
     }
 }

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     api "javax.persistence:javax.persistence-api:2.2"
     api "com.google.code.findbugs:jsr305:$jsr305_version"
     api "org.slf4j:slf4j-api:$slf4j_version"
+    api project(":common-logging")
 
     // These dependencies will become "runtime" scoped in our published POM.
     // See publish.dependenciesFrom.defaultScope.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,6 +79,8 @@ dependencies {
 
     compile group: "io.github.classgraph", name: "classgraph", version: class_graph_version
 
+    compile project(":common-logging")
+
     testCompile "org.ow2.asm:asm:$asm_version"
 
     // JDK11: required by Quasar at run-time

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -1,5 +1,6 @@
 package net.corda.core.contracts
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.CordaException
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
@@ -230,7 +231,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             State of class ${state.data ::class.java.typeName} belongs to contract $requiredContractClassName, but
             is bundled in TransactionState with ${state.contract}.
 
-            For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
+            For details see: ${CordaVersion.rootDocsSiteLink()}/api-contract-constraints.html#contractstate-agreement
             """.trimIndent().replace('\n', ' '))
     }
 
@@ -244,7 +245,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             Add the @BelongsToContract annotation to this class to ensure that it can only be bundled in a TransactionState
             with the correct contract.
 
-            For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
+            For details see: ${CordaVersion.rootDocsSiteLink()}/api-contract-constraints.html#contractstate-agreement
             """.trimIndent())
     }
 
@@ -332,7 +333,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
     class PackageOwnershipException(txId: SecureHash, @Suppress("unused") val attachmentHash: AttachmentId, @Suppress("unused") val invalidClassName: String, val packageName: String) : TransactionVerificationException(txId,
             """The attachment JAR: $attachmentHash containing the class: $invalidClassName is not signed by the owner of package $packageName specified in the network parameters.
            Please check the source of this attachment and if it is malicious contact your zone operator to report this incident.
-           For details see: https://docs.corda.net/network-map.html#network-parameters""".trimIndent(), null)
+           For details see: ${CordaVersion.rootDocsSiteLink()}/network-map.html#network-parameters""".trimIndent(), null)
 
     class InvalidAttachmentException(txId: SecureHash, @Suppress("unused") val attachmentHash: AttachmentId) : TransactionVerificationException(txId,
             "The attachment $attachmentHash is not a valid ZIP or JAR file.".trimIndent(), null)
@@ -346,7 +347,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             CordaException("Attempting to load untrusted transaction attachments: $ids. " +
                     "At this time these are not loadable because the DJVM sandbox has not yet been integrated. " +
                     "You will need to manually install the CorDapp to whitelist it for use. " +
-                    "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
+                    "Please follow the operational steps outlined in ${CordaVersion.rootDocsSiteLink()}/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
 
     /*
     If you add a new class extending [TransactionVerificationException], please add a test in `TransactionVerificationExceptionSerializationTests`

--- a/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
@@ -1,5 +1,6 @@
 package net.corda.core.internal
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.identity.Party
 import java.security.CodeSigner
 import java.security.PublicKey
@@ -52,7 +53,7 @@ object JarSignatureCollector {
                     """
                     Mismatch between signers ${firstSignerSet.toOrderedPublicKeys()} for file $firstFile
                     and signers ${otherSignerSet.toOrderedPublicKeys()} for file ${otherFile}.
-                    See https://docs.corda.net/api-contract-constraints.html#signature-constraints for details of the
+                    See ${CordaVersion.rootDocsSiteLink()}/api-contract-constraints.html#signature-constraints for details of the
                     constraints applied to attachment signatures.
                     """.trimIndent().replace('\n', ' '))
         }

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -1,5 +1,6 @@
 package net.corda.core.internal
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.concurrent.CordaFuture
@@ -266,7 +267,7 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
                             State of class ${state.data::class.java.typeName} belongs to contract $requiredContractClassName, but
                             is bundled in TransactionState with ${state.contract}.
 
-                            For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
+                            For details see: ${CordaVersion.rootDocsSiteLink()}/api-contract-constraints.html#contract-state-agreement
                             """.trimIndent().replace('\n', ' '))
             }
     }

--- a/core/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
@@ -1,5 +1,6 @@
 package net.corda.core.internal.rules
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.contracts.ContractState
 import net.corda.core.internal.cordapp.targetPlatformVersion
 import net.corda.core.internal.warnOnce
@@ -33,7 +34,7 @@ object StateContractValidationEnforcementRule {
                 and consequently unable to determine target platform version.
                 Enforcing state/contract agreement validation by default.
 
-                For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
+                For details see: ${CordaVersion.rootDocsSiteLink()}/api-contract-constraints.html#contract-state-agreement
             """.trimIndent().replace("\n", " "))
             return true
         }

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -1,5 +1,6 @@
 package net.corda.core.serialization.internal
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.TransactionVerificationException
@@ -117,7 +118,7 @@ class AttachmentsClassLoader(attachments: List<Attachment>,
         if (untrusted.isNotEmpty()) {
             log.warn("Cannot verify transaction $sampleTxId as the following attachment IDs are untrusted: $untrusted." +
                     "You will need to manually install the CorDapp to whitelist it for use. " +
-                    "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
+                    "Please follow the operational steps outlined in ${CordaVersion.rootDocsSiteLink()}/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
             throw TransactionVerificationException.UntrustedAttachmentsException(sampleTxId, untrusted)
         }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
@@ -1,5 +1,6 @@
 package net.corda.core.transactions
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.TransactionState
@@ -19,4 +20,4 @@ class MissingContractAttachments
 constructor(val states: List<TransactionState<ContractState>>, contractsClassName: String? = null, minimumRequiredContractClassVersion: Version? = null) : FlowException(
         "Cannot find contract attachments for " +
         "${contractsClassName ?: states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}. " +
-        "See https://docs.corda.net/api-contract-constraints.html#debugging")
+        "See ${CordaVersion.rootDocsSiteLink()}/api-contract-constraints.html#debugging")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -8,6 +8,7 @@ import liquibase.database.Database
 import liquibase.database.DatabaseFactory
 import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.ClassLoaderResourceAccessor
+import net.corda.common.logging.CordaVersion
 import net.corda.core.identity.CordaX500Name
 import net.corda.nodeapi.internal.MigrationHelpers.getMigrationResource
 import net.corda.core.schemas.MappedSchema
@@ -266,7 +267,7 @@ class OutstandingDatabaseChangesException(@Suppress("MemberVisibilityCanBePrivat
 class CheckpointsException : DatabaseMigrationException("Attempting to update the database while there are flows in flight. " +
         "This is dangerous because the node might not be able to restore the flows correctly and could consequently fail. " +
         "Updating the database would make reverting to the previous version more difficult. " +
-        "Please drain your node first. See: https://docs.corda.net/upgrading-cordapps.html#flow-drains")
+        "Please drain your node first. See: ${CordaVersion.rootDocsSiteLink()}/upgrading-cordapps.html#flow-drains")
 
 class DatabaseIncompatibleException(@Suppress("MemberVisibilityCanBePrivate") private val reason: String) : DatabaseMigrationException(errorMessageFor(reason)) {
     internal companion object {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -6,6 +6,7 @@ import com.google.common.collect.MutableClassToInstanceMap
 import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.zaxxer.hikari.pool.HikariPool
+import net.corda.common.logging.CordaVersion
 import net.corda.common.logging.errorReporting.NodeDatabaseErrors
 import net.corda.confidential.SwapIdentitiesFlow
 import net.corda.core.CordaException
@@ -913,7 +914,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 "One or more keyStores (identity or TLS) or trustStore not found. " +
                         "Please either copy your existing keys and certificates from another node, " +
                         "or if you don't have one yet, fill out the config file and run corda.jar initial-registration. " +
-                        "Read more at: https://docs.corda.net/permissioning.html"
+                        "Read more at: ${CordaVersion.rootDocsSiteLink()}/permissioning.html"
             }
         } catch (e: KeyStoreException) {
             throw IllegalArgumentException("At least one of the keystores or truststore passwords does not match configuration.")
@@ -1359,7 +1360,7 @@ fun CordaPersistence.startHikariPool(hikariProperties: Properties, databaseConfi
                     NodeDatabaseErrors.COULD_NOT_CONNECT,
                     cause = ex)
             ex.cause is ClassNotFoundException -> throw CouldNotCreateDataSourceException(
-                    "Could not find the database driver class. Please add it to the 'drivers' folder. See: https://docs.corda.net/corda-configuration-file.html",
+                    "Could not find the database driver class. Please add it to the 'drivers' folder. See: ${CordaVersion.rootDocsSiteLink()}/corda-configuration-file.html",
                     NodeDatabaseErrors.MISSING_DRIVER)
             ex is OutstandingDatabaseChangesException -> throw (DatabaseIncompatibleException(ex.message))
             else ->

--- a/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
@@ -1,5 +1,6 @@
 package net.corda.node.internal
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
@@ -84,19 +85,19 @@ object CheckpointVerifier {
 sealed class CheckpointIncompatibleException(override val message: String) : Exception() {
     class CannotBeDeserialisedException(val e: Exception) : CheckpointIncompatibleException(
             "Found checkpoint that cannot be deserialised using the current Corda version. Please revert to the previous version of Corda, " +
-                    "drain your node (see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again. Cause: ${e.message}")
+                    "drain your node (see ${CordaVersion.rootDocsSiteLink()}/upgrading-cordapps.html#flow-drains), and try again. Cause: ${e.message}")
 
     class SubFlowCoreVersionIncompatibleException(val flowClass: Class<out FlowLogic<*>>, oldVersion: Int) : CheckpointIncompatibleException(
             "Found checkpoint for flow: $flowClass that is incompatible with the current Corda platform. Please revert to the previous " +
-                    "version of Corda (version $oldVersion), drain your node (see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again.")
+                    "version of Corda (version $oldVersion), drain your node (see ${CordaVersion.rootDocsSiteLink()}/upgrading-cordapps.html#flow-drains), and try again.")
 
     class FlowVersionIncompatibleException(val flowClass: Class<out FlowLogic<*>>, val cordapp: Cordapp, oldHash: SecureHash) : CheckpointIncompatibleException(
             "Found checkpoint for flow: $flowClass that is incompatible with the current installed version of ${cordapp.name}. " +
                     "Please reinstall the previous version of the CorDapp (with hash: $oldHash), drain your node " +
-                    "(see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again.")
+                    "(see ${CordaVersion.rootDocsSiteLink()}/upgrading-cordapps.html#flow-drains), and try again.")
 
     class CordappNotInstalledException(classNotFound: String) : CheckpointIncompatibleException(
             "Found checkpoint for CorDapp that is no longer installed. Specifically, could not find class $classNotFound. Please install the " +
-                    "missing CorDapp, drain your node (see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again.")
+                    "missing CorDapp, drain your node (see ${CordaVersion.rootDocsSiteLink()}/upgrading-cordapps.html#flow-drains), and try again.")
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -334,7 +334,7 @@ open class NodeStartup : NodeStartupLogging {
 
         if (!certDirectory.isDirectory()) {
             printError("Unable to access certificates directory ${certDirectory}. This could be because the node has not been registered with the Identity Operator.")
-            printError("Please see https://docs.corda.net/joining-a-compatibility-zone.html for more information.")
+            printError("Please see ${CordaVersion.rootDocsSiteLink()}/joining-a-compatibility-zone.html for more information.")
             printError("Node will now shutdown.")
             return false
         }
@@ -351,7 +351,7 @@ open class NodeStartup : NodeStartupLogging {
             // Also see https://bugs.openjdk.java.net/browse/JDK-8143378
             val messages = listOf(
                     "Your computer took over a second to resolve localhost due an incorrect configuration. Corda will work but start very slowly until this is fixed. ",
-                    "Please see https://docs.corda.net/troubleshooting.html#slow-localhost-resolution for information on how to fix this. ",
+                    "Please see ${CordaVersion.rootDocsSiteLink()}/troubleshooting.html#slow-localhost-resolution for information on how to fix this. ",
                     "It will only take a few seconds for you to resolve."
             )
             logger.warn(messages.joinToString(""))

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -6,6 +6,7 @@ import co.paralleluniverse.fibers.FiberScheduler
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.channels.Channel
+import net.corda.common.logging.CordaVersion
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
 import net.corda.core.cordapp.Cordapp
@@ -563,7 +564,7 @@ val Class<out FlowLogic<*>>.flowVersionAndInitiatingClass: Pair<Int, Class<out F
             current = current.superclass
                     ?: return found
                     ?: throw IllegalArgumentException("$name, as a flow that initiates other flows, must be annotated with " +
-                            "${InitiatingFlow::class.java.name}. See https://docs.corda.net/api-flows.html#flowlogic-annotations.")
+                            "${InitiatingFlow::class.java.name}. See ${CordaVersion.rootDocsSiteLink()}/api-flows.html#flowlogic-annotations.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -7,6 +7,7 @@ import co.paralleluniverse.fibers.instrument.JavaAgent
 import co.paralleluniverse.strands.channels.Channels
 import com.codahale.metrics.Gauge
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import net.corda.common.logging.CordaVersion
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
 import net.corda.core.flows.FlowException
@@ -340,7 +341,7 @@ class SingleThreadedStateMachineManager(
     private fun checkQuasarJavaAgentPresence() {
         check(JavaAgent.isActive()) {
             """Missing the '-javaagent' JVM argument. Make sure you run the tests with the Quasar java agent attached to your JVM.
-               #See https://docs.corda.net/head/testing.html#running-tests-in-intellij - 'Fiber classes not instrumented' for more details.""".trimMargin("#")
+               #See ${CordaVersion.rootDocsSiteLink()}/testing.html#running-tests-in-intellij - 'Fiber classes not instrumented' for more details.""".trimMargin("#")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.vault
 
+import net.corda.common.logging.CordaVersion
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
@@ -627,7 +628,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                 if (message.contains("Not an entity"))
                     throw VaultQueryException("""
                     Please register the entity '${entityStateClass.name}'
-                    See https://docs.corda.net/api-persistence.html#custom-schema-registration for more information""")
+                    See ${CordaVersion.rootDocsSiteLink()}/api-persistence.html#custom-schema-registration for more information""")
             }
             throw VaultQueryException("Parsing error: ${e.message}")
         }

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -1,5 +1,6 @@
 package net.corda.testing.core
 
+import net.corda.common.logging.CordaVersion
 import net.corda.testing.core.internal.JarSignatureTestUtils.createJar
 import net.corda.testing.core.internal.JarSignatureTestUtils.generateKey
 import net.corda.testing.core.internal.JarSignatureTestUtils.getJarSigners
@@ -112,7 +113,7 @@ class JarSignatureCollectorTest {
                 """
             Mismatch between signers [O=Alice Corp, L=Madrid, C=ES, O=Bob Plc, L=Rome, C=IT] for file _signable1
             and signers [O=Bob Plc, L=Rome, C=IT] for file _signable2.
-            See https://docs.corda.net/api-contract-constraints.html#signature-constraints for details of the
+            See ${CordaVersion.rootDocsSiteLink()}/api-contract-constraints.html#signature-constraints for details of the
             constraints applied to attachment signatures.
             """.trimIndent().replace('\n', ' ')
         ) { dir.getJarSigners(FILENAME) }


### PR DESCRIPTION
This PR adjusts all hard coded docs links within strings that are printed to the logs to point to the correct version of the docs after the docs site migration. This ensures that docs links will continue to point to the docs for the correct OS version as new versions are released. On merging to ENT, it should also ensure that the links point to the ENT docs over the OS ones (although there may be further changes required there).

## Notes

I'm actually not sure about this change - in particular, previous versions of Corda would have pointed to the most recent released docs anyway, and so this issue has effectively existed for some time. Additionally, this change introduces a dependency on `common-logging` to `core`, and this may have unexpected side effects. As a result, I'd like an opinion from Kernel before proceeding with this.

An alternative would be to just adjust the docs links in the Enterprise repo to point at the latest Enterprise docs, and make a smaller adjustment to the hardcoded links here to point to the OS docs.
