### PR TITLE
[NOTICK]: Do not use Security.addProvider(BouncyCastleProvider()) in tests

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/X509NameConstraintsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/X509NameConstraintsTest.kt
@@ -12,7 +12,6 @@ import org.bouncycastle.asn1.x509.GeneralSubtree
 import org.bouncycastle.asn1.x509.NameConstraints
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Test
-import java.security.Security
 import java.security.UnrecoverableKeyException
 import java.security.cert.CertPathValidator
 import java.security.cert.CertPathValidatorException
@@ -95,7 +94,8 @@ class X509NameConstraintsTest {
 
     @Test(timeout=300_000)
     fun `x500 name with correct cn and extra attribute`() {
-        Security.addProvider(BouncyCastleProvider())
+        // Do not use Security.addProvider(BouncyCastleProvider()) to avoid EdDSA signature disruption in other tests.
+        Crypto.findProvider(BouncyCastleProvider.PROVIDER_NAME)
         val acceptableNames = listOf("CN=Bank A TLS, UID=", "O=Bank A")
                 .map { GeneralSubtree(GeneralName(X500Name(it))) }.toTypedArray()
 

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -58,7 +58,6 @@ import java.math.BigInteger
 import java.net.InetSocketAddress
 import java.security.KeyPair
 import java.security.PrivateKey
-import java.security.Security
 import java.security.cert.X509CRL
 import java.security.cert.X509Certificate
 import java.util.*
@@ -117,7 +116,8 @@ class CertificateRevocationListNodeTests {
 
     @Before
     fun setUp() {
-        Security.addProvider(BouncyCastleProvider())
+        // Do not use Security.addProvider(BouncyCastleProvider()) to avoid EdDSA signature disruption in other tests.
+        Crypto.findProvider(BouncyCastleProvider.PROVIDER_NAME)
         revokedNodeCerts.clear()
         server = CrlServer(NetworkHostAndPort("localhost", 0))
         server.start()


### PR DESCRIPTION
Possible fix for flaky test https://ci02.dev.r3.com/view/Build%20Monitor%20View/job/Corda%20Private%20Regression%20Tests/job/enterprise/job/release%252Fent%252F4.5/135/testReport/junit/net.corda.coretests.internal/ResolveTransactionsFlowTest/resolve_from_a_signed_transaction/ producing the following:
```
net.corda.coretests.internal.ResolveTransactionsFlowTest > resolve from a signed transaction FAILED
    net.corda.nodeapi.internal.cryptoservice.CryptoServiceException: Cannot import key with alias identity-private-key
        at net.corda.nodeapi.internal.cryptoservice.bouncycastle.BCCryptoService.importKey(BCCryptoService.kt:145)
        at net.corda.testing.node.internal.InternalMockNetwork$MockNode.generateKeyPair(InternalMockNetwork.kt:408)
        at net.corda.node.internal.AbstractNode.createAndStoreLegalIdentity(AbstractNode.kt:1227)
        at net.corda.node.internal.AbstractNode.obtainIdentity(AbstractNode.kt:1157)
        at net.corda.node.internal.AbstractNode.start(AbstractNode.kt:522)
        at net.corda.testing.node.internal.InternalMockNetwork$MockNode.start(InternalMockNetwork.kt:365)
        at net.corda.testing.node.internal.InternalMockNetwork.createNodeImpl(InternalMockNetwork.kt:504)
        at net.corda.testing.node.internal.InternalMockNetwork.createNode(InternalMockNetwork.kt:470)
        at net.corda.testing.node.internal.InternalMockNetwork.createNode(InternalMockNetwork.kt:465)
        at net.corda.testing.node.internal.InternalMockNetwork.createPartyNode(InternalMockNetwork.kt:582)
        at net.corda.testing.node.MockNetwork.createPartyNode(MockNetwork.kt:337)
        at net.corda.coretests.internal.ResolveTransactionsFlowTest.setup(ResolveTransactionsFlowTest.kt:70)

        Caused by:
        org.bouncycastle.cert.CertException: unable to process signature: exception on setup: java.security.NoSuchAlgorithmException: 1.3.101.112 Signature not available
            at org.bouncycastle.cert.X509CertificateHolder.isSignatureValid(Unknown Source)
            at net.corda.nodeapi.internal.crypto.X509Utilities.createCertificate(X509Utilities.kt:313)
            at net.corda.nodeapi.internal.crypto.X509Utilities.createCertificate$default(X509Utilities.kt:298)
            at net.corda.nodeapi.internal.crypto.X509Utilities.createSelfSignedCACertificate(X509Utilities.kt:121)
            at net.corda.nodeapi.internal.crypto.X509Utilities.createSelfSignedCACertificate$default(X509Utilities.kt:119)
            at net.corda.nodeapi.internal.cryptoservice.bouncycastle.BCCryptoService.importKey(BCCryptoService.kt:142)
            ... 11 more

            Caused by:
            org.bouncycastle.operator.OperatorCreationException: exception on setup: java.security.NoSuchAlgorithmException: 1.3.101.112 Signature not available
                at org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder.createSignatureStream(Unknown Source)
                at org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder.access$200(Unknown Source)
                at org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder$2.get(Unknown Source)
                ... 17 more

                Caused by:
                java.security.NoSuchAlgorithmException: 1.3.101.112 Signature not available
                    at java.security.Signature.getInstance(Signature.java:228)
                    at org.bouncycastle.jcajce.util.DefaultJcaJceHelper.createSignature(Unknown Source)
                    at org.bouncycastle.operator.jcajce.OperatorHelper.createSignature(Unknown Source)
                    ... 20 more
```

It's only possible to register one crypto provider under the same name, so using `Security.addProvider(BouncyCastleProvider())` first means that `cordaBouncyCastleProvider` won't be registered and EdDSA signing will be unavailable for subsequent tests using the same JVM.

Easy to reproduce:
```
./gradlew :core-tests:cleanTest :core-tests:test -i  --tests "net.corda.coretests.crypto.X509NameConstraintsTest.x500 name with correct cn and extra attribute" --tests "net.corda.coretests.internal.ResolveTransactionsFlowTest.resolve from a signed transaction"
```