### PR TITLE
[EG-1980] Remove stale docs links from OS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ buildscript {
             "unknown"
         }
     }()
-    ext.corda_docs_link = "https://docs.corda.net/docs/corda-os/$baseVersion/"
+    ext.corda_docs_link = "https://docs.corda.net/docs/corda-os/$baseVersion"
     repositories {
         mavenLocal()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ buildscript {
             "unknown"
         }
     }()
+    ext.corda_docs_link = "https://docs.corda.net/docs/corda-os/$baseVersion/"
     repositories {
         mavenLocal()
         mavenCentral()
@@ -309,6 +310,7 @@ allprojects {
             attributes('Corda-Revision': corda_revision)
             attributes('Corda-Vendor': 'Corda Open Source')
             attributes('Automatic-Module-Name': "net.corda.${task.project.name.replaceAll('-', '.')}")
+            attributes('Corda-Docs-Link': corda_docs_link)
         }
     }
 

--- a/common/logging/src/main/kotlin/net/corda/common/logging/CordaVersion.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/CordaVersion.kt
@@ -13,6 +13,7 @@ class CordaVersion  {
         val revision: String by lazy { manifestValue("Corda-Revision") ?: UNKNOWN }
         val vendor: String by lazy { manifestValue("Corda-Vendor") ?: UNKNOWN }
         val platformVersion: Int by lazy { manifestValue("Corda-Platform-Version")?.toInt() ?: 1 }
+        val docsLink: String by lazy { manifestValue("Corda-Docs-Link") ?: UNKNOWN }
 
         internal val semanticVersion: String by lazy { if(releaseVersion == UNKNOWN) CURRENT_MAJOR_RELEASE else releaseVersion }
     }

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/CordaErrorContextProvider.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/CordaErrorContextProvider.kt
@@ -11,21 +11,10 @@ import java.util.*
 class CordaErrorContextProvider : ErrorContextProvider {
 
     companion object {
-        private const val BASE_URL = "https://docs.corda.net/docs"
-        private const val OS_PAGES = "corda-os"
-        private const val ENTERPRISE_PAGES = "corda-enterprise"
         private const val ERROR_CODE_PAGE = "error-codes.html"
     }
 
     override fun getURL(locale: Locale): String {
-        val versionNumber = CordaVersion.releaseVersion
-
-        // This slightly strange block here allows the code to be merged across to Enterprise with no changes.
-        val productVersion = if (CordaVersion.platformEditionCode == "OS") {
-            OS_PAGES
-        } else {
-            ENTERPRISE_PAGES
-        }
-        return "$BASE_URL/$productVersion/$versionNumber/$ERROR_CODE_PAGE"
+        return "${CordaVersion.docsLink}/$ERROR_CODE_PAGE"
     }
 }

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
@@ -25,7 +25,7 @@ internal class ErrorReporterImpl(private val resourceLocation: String,
         val resource = "$resourceLocation/$ERROR_INFO_RESOURCE"
         val codeMessage = fetchAndFormat(resource, ERROR_CODE_MESSAGE, arrayOf(error.formatCode()))
         val urlMessage = fetchAndFormat(resource, ERROR_CODE_URL, arrayOf(errorContextProvider.getURL(locale)))
-        return "[$codeMessage, $urlMessage]"
+        return "[$codeMessage $urlMessage]"
     }
 
     override fun report(error: ErrorCode<*>, logger: Logger) {

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/CordaErrorContextProviderTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/CordaErrorContextProviderTest.kt
@@ -11,7 +11,8 @@ class CordaErrorContextProviderTest {
     @Test(timeout = 300_000)
     fun `check that correct URL is returned from context provider`() {
         val context = CordaErrorContextProvider()
-        val expectedURL = "https://docs.corda.net/docs/corda-os/${CordaVersion.releaseVersion}/error-codes.html"
+        val version = CordaVersion.releaseVersion.substringBefore("-") // Remove SNAPSHOT if present
+        val expectedURL = "https://docs.corda.net/docs/corda-os/$version/error-codes.html"
         // In this first release, there is only one localisation and the URL structure for future localisations is currently unknown. As
         // a result, the same URL is expected for all locales.
         assertEquals(expectedURL, context.getURL(Locale.getDefault()))

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
@@ -74,7 +74,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("en-US")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is a test message [Code: test-case1, URL: $TEST_URL/en-US]"), logs)
+        assertEquals(listOf("This is a test message [Code: test-case1 URL: $TEST_URL/en-US]"), logs)
     }
 
     @Test(timeout = 300_00)
@@ -84,7 +84,7 @@ class ErrorReporterImplTest {
         val testReporter = createReporterImpl("en-US")
         testReporter.report(error, loggerMock)
         val format = DateFormat.getDateInstance(DateFormat.LONG, Locale.forLanguageTag("en-US"))
-        assertEquals(listOf("This is the second case with string foo, number 1, date ${format.format(currentDate)} [Code: test-case2, URL: $TEST_URL/en-US]"), logs)
+        assertEquals(listOf("This is the second case with string foo, number 1, date ${format.format(currentDate)} [Code: test-case2 URL: $TEST_URL/en-US]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -92,7 +92,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("fr-FR")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is a test message [Code: test-case1, URL: $TEST_URL/fr-FR]"), logs)
+        assertEquals(listOf("This is a test message [Code: test-case1 URL: $TEST_URL/fr-FR]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -100,7 +100,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("ga-IE")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("Is teachtaireacht earráide é seo [Code: test-case1, URL: $TEST_URL/ga-IE]"), logs)
+        assertEquals(listOf("Is teachtaireacht earráide é seo [Code: test-case1 URL: $TEST_URL/ga-IE]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -108,7 +108,7 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_1
         val testReporter = createReporterImpl("es-ES")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is a test message [Code: test-case1, URL: $TEST_URL/es-ES]"), logs)
+        assertEquals(listOf("This is a test message [Code: test-case1 URL: $TEST_URL/es-ES]"), logs)
     }
 
     @Test(timeout = 300_000)
@@ -116,6 +116,6 @@ class ErrorReporterImplTest {
         val error = TEST_ERROR_3
         val testReporter = createReporterImpl("en-US")
         testReporter.report(error, loggerMock)
-        assertEquals(listOf("This is the third test message [Code: test-case-3, URL: $TEST_URL/en-US]"), logs)
+        assertEquals(listOf("This is the third test message [Code: test-case-3 URL: $TEST_URL/en-US]"), logs)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -229,8 +229,6 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
         """
             State of class ${state.data ::class.java.typeName} belongs to contract $requiredContractClassName, but
             is bundled in TransactionState with ${state.contract}.
-
-            For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
             """.trimIndent().replace('\n', ' '))
     }
 
@@ -243,8 +241,6 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             State of class ${state.data::class.java.typeName} does not have a specified owning contract.
             Add the @BelongsToContract annotation to this class to ensure that it can only be bundled in a TransactionState
             with the correct contract.
-
-            For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
             """.trimIndent())
     }
 
@@ -331,8 +327,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      */
     class PackageOwnershipException(txId: SecureHash, @Suppress("unused") val attachmentHash: AttachmentId, @Suppress("unused") val invalidClassName: String, val packageName: String) : TransactionVerificationException(txId,
             """The attachment JAR: $attachmentHash containing the class: $invalidClassName is not signed by the owner of package $packageName specified in the network parameters.
-           Please check the source of this attachment and if it is malicious contact your zone operator to report this incident.
-           For details see: https://docs.corda.net/network-map.html#network-parameters""".trimIndent(), null)
+           Please check the source of this attachment and if it is malicious contact your zone operator to report this incident.""".trimIndent(), null)
 
     class InvalidAttachmentException(txId: SecureHash, @Suppress("unused") val attachmentHash: AttachmentId) : TransactionVerificationException(txId,
             "The attachment $attachmentHash is not a valid ZIP or JAR file.".trimIndent(), null)
@@ -345,8 +340,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
     class UntrustedAttachmentsException(val txId: SecureHash, val ids: List<SecureHash>) :
             CordaException("Attempting to load untrusted transaction attachments: $ids. " +
                     "At this time these are not loadable because the DJVM sandbox has not yet been integrated. " +
-                    "You will need to manually install the CorDapp to whitelist it for use. " +
-                    "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
+                    "You will need to manually install the CorDapp to whitelist it for use.")
 
     /*
     If you add a new class extending [TransactionVerificationException], please add a test in `TransactionVerificationExceptionSerializationTests`

--- a/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
@@ -52,8 +52,6 @@ object JarSignatureCollector {
                     """
                     Mismatch between signers ${firstSignerSet.toOrderedPublicKeys()} for file $firstFile
                     and signers ${otherSignerSet.toOrderedPublicKeys()} for file ${otherFile}.
-                    See https://docs.corda.net/api-contract-constraints.html#signature-constraints for details of the
-                    constraints applied to attachment signatures.
                     """.trimIndent().replace('\n', ' '))
         }
         return firstSignerSet

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -265,8 +265,6 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
                 logger.warnOnce("""
                             State of class ${state.data::class.java.typeName} belongs to contract $requiredContractClassName, but
                             is bundled in TransactionState with ${state.contract}.
-
-                            For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
                             """.trimIndent().replace('\n', ' '))
             }
     }

--- a/core/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
@@ -32,8 +32,6 @@ object StateContractValidationEnforcementRule {
                 Unable to determine JAR location for contract state class ${state::class.java.name},
                 and consequently unable to determine target platform version.
                 Enforcing state/contract agreement validation by default.
-
-                For details see: https://docs.corda.net/api-contract-constraints.html#contract-state-agreement
             """.trimIndent().replace("\n", " "))
             return true
         }

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -116,8 +116,7 @@ class AttachmentsClassLoader(attachments: List<Attachment>,
 
         if (untrusted.isNotEmpty()) {
             log.warn("Cannot verify transaction $sampleTxId as the following attachment IDs are untrusted: $untrusted." +
-                    "You will need to manually install the CorDapp to whitelist it for use. " +
-                    "Please follow the operational steps outlined in https://docs.corda.net/cordapp-build-systems.html#cordapp-contract-attachments to learn more and continue.")
+                    "You will need to manually install the CorDapp to whitelist it for use.")
             throw TransactionVerificationException.UntrustedAttachmentsException(sampleTxId, untrusted)
         }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
@@ -18,5 +18,4 @@ class MissingContractAttachments
 @JvmOverloads
 constructor(val states: List<TransactionState<ContractState>>, contractsClassName: String? = null, minimumRequiredContractClassVersion: Version? = null) : FlowException(
         "Cannot find contract attachments for " +
-        "${contractsClassName ?: states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}. " +
-        "See https://docs.corda.net/api-contract-constraints.html#debugging")
+        "${contractsClassName ?: states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}.")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -265,8 +265,7 @@ class OutstandingDatabaseChangesException(@Suppress("MemberVisibilityCanBePrivat
 
 class CheckpointsException : DatabaseMigrationException("Attempting to update the database while there are flows in flight. " +
         "This is dangerous because the node might not be able to restore the flows correctly and could consequently fail. " +
-        "Updating the database would make reverting to the previous version more difficult. " +
-        "Please drain your node first. See: https://docs.corda.net/upgrading-cordapps.html#flow-drains")
+        "Updating the database would make reverting to the previous version more difficult.")
 
 class DatabaseIncompatibleException(@Suppress("MemberVisibilityCanBePrivate") private val reason: String) : DatabaseMigrationException(errorMessageFor(reason)) {
     internal companion object {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -912,8 +912,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             requireNotNull(getCertificateStores()) {
                 "One or more keyStores (identity or TLS) or trustStore not found. " +
                         "Please either copy your existing keys and certificates from another node, " +
-                        "or if you don't have one yet, fill out the config file and run corda.jar initial-registration. " +
-                        "Read more at: https://docs.corda.net/permissioning.html"
+                        "or if you don't have one yet, fill out the config file and run corda.jar initial-registration."
             }
         } catch (e: KeyStoreException) {
             throw IllegalArgumentException("At least one of the keystores or truststore passwords does not match configuration.")
@@ -1359,7 +1358,7 @@ fun CordaPersistence.startHikariPool(hikariProperties: Properties, databaseConfi
                     NodeDatabaseErrors.COULD_NOT_CONNECT,
                     cause = ex)
             ex.cause is ClassNotFoundException -> throw CouldNotCreateDataSourceException(
-                    "Could not find the database driver class. Please add it to the 'drivers' folder. See: https://docs.corda.net/corda-configuration-file.html",
+                    "Could not find the database driver class. Please add it to the 'drivers' folder.",
                     NodeDatabaseErrors.MISSING_DRIVER)
             ex is OutstandingDatabaseChangesException -> throw (DatabaseIncompatibleException(ex.message))
             else ->

--- a/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
@@ -84,19 +84,18 @@ object CheckpointVerifier {
 sealed class CheckpointIncompatibleException(override val message: String) : Exception() {
     class CannotBeDeserialisedException(val e: Exception) : CheckpointIncompatibleException(
             "Found checkpoint that cannot be deserialised using the current Corda version. Please revert to the previous version of Corda, " +
-                    "drain your node (see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again. Cause: ${e.message}")
+                    "drain your node, and try again. Cause: ${e.message}")
 
     class SubFlowCoreVersionIncompatibleException(val flowClass: Class<out FlowLogic<*>>, oldVersion: Int) : CheckpointIncompatibleException(
             "Found checkpoint for flow: $flowClass that is incompatible with the current Corda platform. Please revert to the previous " +
-                    "version of Corda (version $oldVersion), drain your node (see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again.")
+                    "version of Corda (version $oldVersion), drain your node, and try again.")
 
     class FlowVersionIncompatibleException(val flowClass: Class<out FlowLogic<*>>, val cordapp: Cordapp, oldHash: SecureHash) : CheckpointIncompatibleException(
             "Found checkpoint for flow: $flowClass that is incompatible with the current installed version of ${cordapp.name}. " +
-                    "Please reinstall the previous version of the CorDapp (with hash: $oldHash), drain your node " +
-                    "(see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again.")
+                    "Please reinstall the previous version of the CorDapp (with hash: $oldHash), drain your node, and try again.")
 
     class CordappNotInstalledException(classNotFound: String) : CheckpointIncompatibleException(
             "Found checkpoint for CorDapp that is no longer installed. Specifically, could not find class $classNotFound. Please install the " +
-                    "missing CorDapp, drain your node (see https://docs.corda.net/upgrading-cordapps.html#flow-drains), and try again.")
+                    "missing CorDapp, drain your node, and try again.")
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -334,7 +334,6 @@ open class NodeStartup : NodeStartupLogging {
 
         if (!certDirectory.isDirectory()) {
             printError("Unable to access certificates directory ${certDirectory}. This could be because the node has not been registered with the Identity Operator.")
-            printError("Please see https://docs.corda.net/joining-a-compatibility-zone.html for more information.")
             printError("Node will now shutdown.")
             return false
         }
@@ -350,9 +349,7 @@ open class NodeStartup : NodeStartupLogging {
             //
             // Also see https://bugs.openjdk.java.net/browse/JDK-8143378
             val messages = listOf(
-                    "Your computer took over a second to resolve localhost due an incorrect configuration. Corda will work but start very slowly until this is fixed. ",
-                    "Please see https://docs.corda.net/troubleshooting.html#slow-localhost-resolution for information on how to fix this. ",
-                    "It will only take a few seconds for you to resolve."
+                    "Your computer took over a second to resolve localhost due an incorrect configuration. Corda will work but start very slowly until this is fixed."
             )
             logger.warn(messages.joinToString(""))
             Emoji.renderIfSupported {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -563,7 +563,7 @@ val Class<out FlowLogic<*>>.flowVersionAndInitiatingClass: Pair<Int, Class<out F
             current = current.superclass
                     ?: return found
                     ?: throw IllegalArgumentException("$name, as a flow that initiates other flows, must be annotated with " +
-                            "${InitiatingFlow::class.java.name}. See https://docs.corda.net/api-flows.html#flowlogic-annotations.")
+                            "${InitiatingFlow::class.java.name}.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -339,8 +339,7 @@ class SingleThreadedStateMachineManager(
 
     private fun checkQuasarJavaAgentPresence() {
         check(JavaAgent.isActive()) {
-            """Missing the '-javaagent' JVM argument. Make sure you run the tests with the Quasar java agent attached to your JVM.
-               #See https://docs.corda.net/head/testing.html#running-tests-in-intellij - 'Fiber classes not instrumented' for more details.""".trimMargin("#")
+            "Missing the '-javaagent' JVM argument. Make sure you run the tests with the Quasar java agent attached to your JVM."
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -626,8 +626,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             e.message?.let { message ->
                 if (message.contains("Not an entity"))
                     throw VaultQueryException("""
-                    Please register the entity '${entityStateClass.name}'
-                    See https://docs.corda.net/api-persistence.html#custom-schema-registration for more information""")
+                    Please register the entity '${entityStateClass.name}'.""")
             }
             throw VaultQueryException("Parsing error: ${e.message}")
         }

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -112,8 +112,6 @@ class JarSignatureCollectorTest {
                 """
             Mismatch between signers [O=Alice Corp, L=Madrid, C=ES, O=Bob Plc, L=Rome, C=IT] for file _signable1
             and signers [O=Bob Plc, L=Rome, C=IT] for file _signable2.
-            See https://docs.corda.net/api-contract-constraints.html#signature-constraints for details of the
-            constraints applied to attachment signatures.
             """.trimIndent().replace('\n', ' ')
         ) { dir.getJarSigners(FILENAME) }
     }


### PR DESCRIPTION
This change removes stale links to the docs site from the OS codebase. As we move towards error codes and linking to the docs site that way, the old links have been dropped entirely. In many cases these pointed to pages that were unhelpful for explaining the problem, so hopefully as more error codes are added better advice can be given.

This also fixes a small grammatical error in the error reporting messages (reported under EG-1987) and moves the docs link to the manifest file.
