### PR TITLE
CORDA-3709 corda-rpc does not free resources when querying stateMachinesSnapshot

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -162,9 +162,7 @@ internal class CordaRPCOpsImpl(
         }
 
     override fun stateMachinesSnapshot(): List<StateMachineInfo> {
-        val (snapshot, updates) = stateMachinesFeed()
-        updates.notUsed()
-        return snapshot
+        return smm.allStateMachines.map { stateMachineInfoFromFlowLogic(it) }
     }
 
     override fun killFlow(id: StateMachineRunId): Boolean = if (smm.killFlow(id)) true else smm.flowHospital.dropSessionInit(id)

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -162,7 +162,7 @@ internal class CordaRPCOpsImpl(
         }
 
     override fun stateMachinesSnapshot(): List<StateMachineInfo> {
-        return smm.allStateMachines.map { stateMachineInfoFromFlowLogic(it) }
+        return smm.allStateMachines.map { it.toStateMachineInfo() }
     }
 
     override fun killFlow(id: StateMachineRunId): Boolean = if (smm.killFlow(id)) true else smm.flowHospital.dropSessionInit(id)
@@ -171,7 +171,7 @@ internal class CordaRPCOpsImpl(
 
         val (allStateMachines, changes) = smm.track()
         return DataFeed(
-                allStateMachines.map { stateMachineInfoFromFlowLogic(it) },
+                allStateMachines.map { it.toStateMachineInfo() },
                 changes.map { stateMachineUpdateFromStateMachineChange(it) }
         )
     }
@@ -421,19 +421,19 @@ internal class CordaRPCOpsImpl(
         services.nodeProperties.flowsDrainingMode.setEnabled(enabled, propagateChange)
     }
 
-    private fun stateMachineInfoFromFlowLogic(flowLogic: FlowLogic<*>): StateMachineInfo {
+    private fun FlowLogic<*>.toStateMachineInfo(): StateMachineInfo{
         return StateMachineInfo(
-                flowLogic.runId,
-                flowLogic.javaClass.name,
-                flowLogic.stateMachine.context.toFlowInitiator(),
-                flowLogic.track(),
-                flowLogic.stateMachine.context
+                this.runId,
+                this.javaClass.name,
+                this.stateMachine.context.toFlowInitiator(),
+                this.track(),
+                this.stateMachine.context
         )
     }
 
     private fun stateMachineUpdateFromStateMachineChange(change: StateMachineManager.Change): StateMachineUpdate {
         return when (change) {
-            is StateMachineManager.Change.Add -> StateMachineUpdate.Added(stateMachineInfoFromFlowLogic(change.logic))
+            is StateMachineManager.Change.Add -> StateMachineUpdate.Added(change.logic.toStateMachineInfo())
             is StateMachineManager.Change.Removed -> StateMachineUpdate.Removed(change.logic.runId, change.result)
         }
     }


### PR DESCRIPTION
Implementation was overkill, using stateMachinesFeed() and tried to drop the updates observable following by the notUsed() method invocation, but the observable was sometimes pickup up by the cleaner before the notUsed() invocation, causing a long warning message.
The fix is a lot simpler implementation, avoiding the usage of observables.
The testing was done by wrapping the .notUsed() method in the previous implementation with logging to identify if the invocation happens before or after the "A hot observable returned from an RPC..." log warning. This warning happens when an observable is crated but not used (subscribed or unsubscribed) and the observable cleaner that runs periodically in a separate thread tries to free up the unused observables. So this issue cannot be reproduced deterministically, but when it occurred, it always did before the notUsed() invocation, causing the reported warning log message.
for the stateMachinesSnapshot() there is no need to use the observable (StateMachineManager.Change in this case), so all the above mentioned possible error scenario can be avoided.