### PR TITLE
[EG-2116] Add aliases for version attribute errors

### DIFF
--- a/common/logging/src/main/resources/error-codes/cordapp-invalid-version-identifier.properties
+++ b/common/logging/src/main/resources/error-codes/cordapp-invalid-version-identifier.properties
@@ -1,4 +1,4 @@
 errorTemplate = Version identifier ({0}) for attribute {1} must be a whole number starting from 1.
 shortDescription = A version attribute with an invalid value was specified in the manifest of the CorDapp JAR. The version attribute value must be a whole number that is greater than or equal to 1.
 actionsToFix = Investigate the logs to find the invalid version attribute, and change its value to a valid one (a whole number greater than or equal to 1).
-aliases =
+aliases = 1nskd37

--- a/common/logging/src/main/resources/error-codes/cordapp-invalid-version-identifier_en_US.properties
+++ b/common/logging/src/main/resources/error-codes/cordapp-invalid-version-identifier_en_US.properties
@@ -1,4 +1,3 @@
 errorTemplate = Version identifier ({0}) for attribute {1} must be a whole number starting from 1.
 shortDescription = A version attribute with an invalid value was specified in the manifest of the CorDapp JAR. The version attribute value must be a whole number that is greater than or equal to 1.
 actionsToFix = Investigate the logs to find the invalid version attribute, and change its value to a valid one (a whole number greater than or equal to 1).
-aliases =

--- a/common/logging/src/main/resources/error-codes/cordapp-missing-version-attribute.properties
+++ b/common/logging/src/main/resources/error-codes/cordapp-missing-version-attribute.properties
@@ -1,4 +1,4 @@
 errorTemplate = Target versionId attribute {0} not specified. Please specify a whole number starting from 1.
 shortDescription =  A required version attribute was not specified in the manifest of the CorDapp JAR.
 actionsToFix = Investigate the logs to find out which version attribute was not specified, and add that version attribute to the CorDapp manifest.
-aliases =
+aliases = 1nskd37

--- a/common/logging/src/main/resources/error-codes/cordapp-missing-version-attribute_en_US.properties
+++ b/common/logging/src/main/resources/error-codes/cordapp-missing-version-attribute_en_US.properties
@@ -1,4 +1,3 @@
 errorTemplate = Target versionId attribute {0} not specified. Please specify a whole number starting from 1.
 shortDescription =  A required version attribute was not specified in the manifest of the CorDapp JAR.
 actionsToFix = Investigate the logs to find out which version attribute was not specified, and add that version attribute to the CorDapp manifest.
-aliases =


### PR DESCRIPTION
Small tweak to add some aliases identified by QA to resource files. This is already updated in docs, this is just to keep these in line.
