### PR TITLE
[EG-2149] improved interactive shell flow lookup logic

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -336,7 +336,7 @@ object InteractiveShell {
                               ansiProgressRenderer: ANSIProgressRenderer,
                               inputObjectMapper: ObjectMapper = createYamlInputMapper(rpcOps)) {
         val matches = try {
-            rpcOps.registeredFlows().filter { nameFragment in it }
+            rpcOps.registeredFlows().filter { nameFragment in it }.sortedBy { it.length }
         } catch (e: PermissionException) {
             output.println(e.message ?: "Access denied", Decoration.bold, Color.red)
             return


### PR DESCRIPTION
the current logic when a user type
```
flow start SomeFlow
```
is to search for the string `SomeFlow` in all registered flow names, if there is at exactly flow that ends with that string, it will be selected, if there is more than one, the first in aphabetical order will be selected. If there are multiple flows that contains the string but no one that ends with it, it is considered ambiguous,
if there is exactly one containing the string it is instead selected (it doesn't matter whether it ends or not with it). All other cases are considered errors.
The goal of this change is to address the case where the node contains

```
net.corda.cordappp.AnotherSomeFlow
net.corda.cordappp.ImprovedSomeFlow
net.corda.cordappp.SomeFlow
```

typing
```
flow start SomeFlow
```
currently results in running `net.corda.cordappp.AnotherSomeFlow` because it comes first in alphabetical order, while `net.corda.cordappp.SomeFlow` is a better matches because the input substring matches a bigger portion of the full flow name
