### PR TITLE
WIP - Implement SecureHash.create() for hashes other than SHA-256.

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -396,7 +396,7 @@ object JacksonSupport {
     class SecureHashDeserializer<T : SecureHash> : JsonDeserializer<T>() {
         override fun deserialize(parser: JsonParser, context: DeserializationContext): T {
             try {
-                return uncheckedCast(SecureHash.parse(parser.text))
+                return uncheckedCast(SecureHash.create(parser.text))
             } catch (e: Exception) {
                 throw JsonParseException(parser, "Invalid hash ${parser.text}: ${e.message}")
             }

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -82,6 +82,7 @@ class CordaModule : SimpleModule("corda-core") {
         context.setMixInAnnotations(PublicKey::class.java, PublicKeyMixin::class.java)
         context.setMixInAnnotations(ByteSequence::class.java, ByteSequenceMixin::class.java)
         context.setMixInAnnotations(SecureHash.SHA256::class.java, SecureHashMixin::class.java)
+        context.setMixInAnnotations(SecureHash.HASH::class.java, SecureHashMixin::class.java)
         context.setMixInAnnotations(SecureHash::class.java, SecureHashMixin::class.java)
         context.setMixInAnnotations(SerializedBytes::class.java, SerializedBytesMixin::class.java)
         context.setMixInAnnotations(DigitalSignature.WithKey::class.java, ByteSequenceWithPropertiesMixin::class.java)

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -265,7 +265,7 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         println(mapper.writeValueAsString(json))
         val (wtxJson, signaturesJson) = json.assertHasOnlyFields("wire", "signatures")
         assertThat(signaturesJson.childrenAs<TransactionSignature>(mapper)).isEqualTo(stx.sigs)
-        val wtxFields = wtxJson.assertHasOnlyFields("id", "notary", "inputs", "attachments", "outputs", "commands", "timeWindow", "references", "privacySalt", "networkParametersHash")
+        val wtxFields = wtxJson.assertHasOnlyFields("id", "notary", "inputs", "attachments", "outputs", "commands", "timeWindow", "references", "privacySalt", "networkParametersHash", "hashAlgorithm")
         assertThat(wtxFields[0].valueAs<SecureHash>(mapper)).isEqualTo(wtx.id)
         assertThat(wtxFields[1].valueAs<Party>(mapper)).isEqualTo(wtx.notary)
         assertThat(wtxFields[2].childrenAs<StateRef>(mapper)).isEqualTo(wtx.inputs)
@@ -275,6 +275,7 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         assertThat(wtxFields[6].valueAs<TimeWindow>(mapper)).isEqualTo(wtx.timeWindow)
         assertThat(wtxFields[7].childrenAs<StateRef>(mapper)).isEqualTo(wtx.references)
         assertThat(wtxFields[8].valueAs<PrivacySalt>(mapper)).isEqualTo(wtx.privacySalt)
+        assertThat(wtxFields[10].valueAs<String>(mapper)).isEqualTo(wtx.hashAlgorithm)
         assertThat(mapper.convertValue<WireTransaction>(wtxJson)).isEqualTo(wtx)
         assertThat(mapper.convertValue<SignedTransaction>(json)).isEqualTo(stx)
     }

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/StringToMethodCallParserTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/StringToMethodCallParserTest.kt
@@ -13,7 +13,7 @@ class StringToMethodCallParserTest {
         fun simple() = "simple"
         fun string(noteTextWord: String) = noteTextWord
         fun twoStrings(a: String, b: String) = a + b
-        fun simpleObject(hash: SecureHash.SHA256) = hash.toString()
+        fun simpleObject(hash: SecureHash) = hash.toString()
         fun complexObject(pair: Pair<Int, String>) = pair
         fun complexNestedObject(pairs: Pair<Int, Deque<Char>>) = pairs
 

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -68,7 +68,7 @@ def patchCore = tasks.register('patchCore', Zip) {
     from(processResources)
     from(zipTree(originalJar)) {
         exclude 'net/corda/core/crypto/DelegatingSecureRandomService*.class'
-        exclude 'net/corda/core/crypto/SHA256DigestSupplier.class'
+        exclude 'net/corda/core/crypto/DigestSupplier.class'
         exclude 'net/corda/core/internal/*ToggleField*.class'
         exclude 'net/corda/core/serialization/*SerializationFactory*.class'
         exclude 'net/corda/core/serialization/internal/AttachmentsHolderImpl.class'

--- a/core-deterministic/src/main/kotlin/net/corda/core/crypto/DigestSupplier.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/crypto/DigestSupplier.kt
@@ -1,0 +1,10 @@
+package net.corda.core.crypto
+
+import java.security.MessageDigest
+import java.util.function.Supplier
+
+@Suppress("unused")
+private class DigestSupplier(private val algorithm: String) : Supplier<MessageDigest> {
+    override fun get(): MessageDigest = MessageDigest.getInstance(algorithm)
+    val digestLength: Int = get().digestLength
+}

--- a/core-deterministic/src/main/kotlin/net/corda/core/crypto/SHA256DigestSupplier.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/crypto/SHA256DigestSupplier.kt
@@ -1,9 +1,0 @@
-package net.corda.core.crypto
-
-import java.security.MessageDigest
-import java.util.function.Supplier
-
-@Suppress("unused")
-private class SHA256DigestSupplier : Supplier<MessageDigest> {
-    override fun get(): MessageDigest = MessageDigest.getInstance("SHA-256")
-}

--- a/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/contracts/PrivacySaltTest.kt
+++ b/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/contracts/PrivacySaltTest.kt
@@ -1,7 +1,6 @@
 package net.corda.deterministic.contracts
 
 import net.corda.core.contracts.PrivacySalt
-import net.corda.core.crypto.SecureHash.Companion.SHA2_256
 import org.junit.Test
 import kotlin.test.*
 
@@ -23,13 +22,13 @@ class PrivacySaltTest {
 
     @Test(timeout=300_000)
 	fun testTooShortPrivacySaltForSHA256() {
-        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE - 1) { 0x7f }).apply { validateFor(SHA2_256) } }
-        assertEquals("Privacy salt should be 32 bytes.", ex.message)
+        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE - 1) { 0x7f }) }
+        assertEquals("Privacy salt should be at least 32 bytes.", ex.message)
     }
 
     @Test(timeout=300_000)
-	fun testTooLongPrivacySaltForSHA256() {
-        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE + 1) { 0x7f }).apply { validateFor(SHA2_256) } }
-        assertEquals("Privacy salt should be 32 bytes.", ex.message)
+	fun testTooShortPrivacySaltForSHA512() {
+        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE) { 0x7f }).apply { validateFor("SHA-512") } }
+        assertEquals("Privacy salt should be at least 64 bytes for SHA-512.", ex.message)
     }
 }

--- a/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/contracts/PrivacySaltTest.kt
+++ b/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/contracts/PrivacySaltTest.kt
@@ -1,6 +1,7 @@
 package net.corda.deterministic.contracts
 
 import net.corda.core.contracts.PrivacySalt
+import net.corda.core.crypto.SecureHash.Companion.SHA2_256
 import org.junit.Test
 import kotlin.test.*
 
@@ -21,14 +22,14 @@ class PrivacySaltTest {
     }
 
     @Test(timeout=300_000)
-	fun testTooShortPrivacySalt() {
-        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE - 1) { 0x7f }) }
+	fun testTooShortPrivacySaltForSHA256() {
+        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE - 1) { 0x7f }).apply { validateFor(SHA2_256) } }
         assertEquals("Privacy salt should be 32 bytes.", ex.message)
     }
 
     @Test(timeout=300_000)
-	fun testTooLongPrivacySalt() {
-        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE + 1) { 0x7f }) }
+	fun testTooLongPrivacySaltForSHA256() {
+        val ex = assertFailsWith<IllegalArgumentException> { PrivacySalt(ByteArray(SALT_SIZE + 1) { 0x7f }).apply { validateFor(SHA2_256) } }
         assertEquals("Privacy salt should be 32 bytes.", ex.message)
     }
 }

--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/PartialMerkleTreeWithNamedHashTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/PartialMerkleTreeWithNamedHashTest.kt
@@ -12,6 +12,7 @@ import net.corda.core.crypto.MerkleTree
 import net.corda.core.crypto.MerkleTreeException
 import net.corda.core.crypto.PartialMerkleTree
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SecureHash.Companion.SHA3_256
 import net.corda.core.crypto.SecureHash.Companion.hashAs
 import net.corda.core.crypto.hashAs
 import net.corda.core.crypto.keys
@@ -65,10 +66,10 @@ class PartialMerkleTreeWithNamedHashTest {
         val MINI_CORP_PUBKEY get() = miniCorp.publicKey
 
         fun sha3_256(str: String): SecureHash {
-            return hashAs("SHA3-256", str.toByteArray())
+            return hashAs(SHA3_256, str.toByteArray())
         }
 
-        fun OpaqueBytes.sha3_256(): SecureHash = hashAs("SHA3-256")
+        fun OpaqueBytes.sha3_256(): SecureHash = hashAs(SHA3_256)
     }
 
     @Rule
@@ -86,7 +87,7 @@ class PartialMerkleTreeWithNamedHashTest {
     @Before
     fun init() {
         hashed = nodes.map { it.serialize().sha3_256() }
-        val zeroHash = SecureHash.zeroHashFor("SHA3-256")
+        val zeroHash = SecureHash.zeroHashFor(SHA3_256)
         expectedRoot = MerkleTree.getMerkleTree(hashed.toMutableList() + listOf(zeroHash, zeroHash)).hash
         merkleTree = MerkleTree.getMerkleTree(hashed)
 
@@ -145,7 +146,7 @@ class PartialMerkleTreeWithNamedHashTest {
 	fun `building Merkle tree odd number of nodes`() {
         val odd = hashed.subList(0, 3)
         val h1 = hashed[0].concatenate(hashed[1])
-        val h2 = hashed[2].concatenate(SecureHash.zeroHashFor("SHA3-256"))
+        val h2 = hashed[2].concatenate(SecureHash.zeroHashFor(SHA3_256))
         val expected = h1.concatenate(h2)
         val mt = MerkleTree.getMerkleTree(odd)
         assertEquals(mt.hash, expected)
@@ -153,7 +154,7 @@ class PartialMerkleTreeWithNamedHashTest {
 
     @Test(timeout=300_000)
 	fun `check full tree`() {
-        val h = SecureHash.random("SHA3-256")
+        val h = SecureHash.random(SHA3_256)
         val left = MerkleTree.Node(h, MerkleTree.Node(h, MerkleTree.Leaf(h), MerkleTree.Leaf(h)),
                 MerkleTree.Node(h, MerkleTree.Leaf(h), MerkleTree.Leaf(h)))
         val right = MerkleTree.Node(h, MerkleTree.Leaf(h), MerkleTree.Leaf(h))

--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -333,18 +333,21 @@ class PrivacySalt(bytes: ByteArray) : OpaqueBytes(bytes) {
 
     /** Constructs a salt with a randomly-generated 32 byte value. */
     @DeleteForDJVM
-    constructor() : this(32)
+    constructor() : this(MINIMUM_SIZE)
 
     init {
         require(bytes.any { it != 0.toByte() }) { "Privacy salt should not be all zeros." }
+        require(bytes.size >= MINIMUM_SIZE) { "Privacy salt should be at least $MINIMUM_SIZE bytes." }
     }
 
     fun validateFor(algorithm: String) {
         val digestLength = SecureHash.digestLengthFor(algorithm)
-        require(bytes.size == digestLength) { "Privacy salt should be $digestLength bytes." }
+        require(bytes.size >= digestLength) { "Privacy salt should be at least $digestLength bytes for $algorithm." }
     }
 
     companion object {
+        private const val MINIMUM_SIZE = 32
+
         @DeleteForDJVM
         @JvmStatic
         fun createFor(algorithm: String): PrivacySalt {

--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -153,6 +153,9 @@ interface SchedulableState : ContractState {
 /** Returns the SHA-256 hash of the serialised contents of this state (not cached!) */
 fun ContractState.hash(): SecureHash = SecureHash.sha256(serialize().bytes)
 
+/** Returns the hash of the serialised contents of this state (not cached!) */
+fun ContractState.hash(algorithm: String): SecureHash = SecureHash.hashAs(algorithm, serialize().bytes)
+
 /**
  * A stateref is a pointer (reference) to a state, this is an equivalent of an "outpoint" in Bitcoin. It records which
  * transaction defined the state and where in that transaction it was.

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -268,8 +268,16 @@ fun random63BitValue(): Long {
 fun componentHash(opaqueBytes: OpaqueBytes, privacySalt: PrivacySalt, componentGroupIndex: Int, internalIndex: Int): SecureHash =
         componentHash(computeNonce(privacySalt, componentGroupIndex, internalIndex), opaqueBytes)
 
-/** Return the SHA256(SHA256(nonce || serializedComponent)). */
-fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash = SecureHash.sha256Twice(nonce.bytes + opaqueBytes.bytes)
+/**
+ * Compute the hash of each serialised component so as to be used as Merkle tree leaf. The resultant output (leaf) is
+ * calculated using the SHA256d algorithm, thus SHA256(SHA256(nonce || serializedComponent)), where nonce is computed
+ * from [computeNonce].
+ */
+fun componentHash(algorithm: String, opaqueBytes: OpaqueBytes, privacySalt: PrivacySalt, componentGroupIndex: Int, internalIndex: Int): SecureHash =
+        componentHash(computeNonce(algorithm, privacySalt, componentGroupIndex, internalIndex), opaqueBytes)
+
+/** Return the HASH(HASH(nonce || serializedComponent)). */
+fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash = SecureHash.hashTwiceAs(nonce.algorithm, nonce.bytes + opaqueBytes.bytes)
 
 /**
  * Serialise the object and return the hash of the serialized bytes. Note that the resulting hash may not be deterministic
@@ -287,4 +295,15 @@ fun <T : Any> serializedHash(x: T): SecureHash = x.serialize(context = Serializa
  * @return SHA256(SHA256(privacySalt || groupIndex || internalIndex))
  */
 fun computeNonce(privacySalt: PrivacySalt, groupIndex: Int, internalIndex: Int) = SecureHash.sha256Twice(privacySalt.bytes + ByteBuffer.allocate(8).putInt(groupIndex).putInt(internalIndex).array())
+
+/**
+ * Method to compute a nonce based on privacySalt, component group index and component internal index.
+ * Double [algorithm] is used to prevent length extension attacks.
+ * @param algorithm The [java.security.MessageDigest] algorithm to use.
+ * @param privacySalt a [PrivacySalt].
+ * @param groupIndex the fixed index (ordinal) of this component group.
+ * @param internalIndex the internal index of this object in its corresponding components list.
+ * @return SHA256(SHA256(privacySalt || groupIndex || internalIndex))
+ */
+fun computeNonce(algorithm: String, privacySalt: PrivacySalt, groupIndex: Int, internalIndex: Int) = SecureHash.hashTwiceAs(algorithm, privacySalt.bytes + ByteBuffer.allocate(8).putInt(groupIndex).putInt(internalIndex).array())
 

--- a/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt
@@ -3,7 +3,6 @@ package net.corda.core.crypto
 import net.corda.core.CordaException
 import net.corda.core.CordaInternal
 import net.corda.core.KeepForDJVM
-import net.corda.core.crypto.SecureHash.Companion.zeroHash
 import net.corda.core.serialization.CordaSerializable
 import java.util.*
 
@@ -70,9 +69,9 @@ class PartialMerkleTree(val root: PartialTree) {
          */
         @Throws(IllegalArgumentException::class, MerkleTreeException::class)
         fun build(merkleRoot: MerkleTree, includeHashes: List<SecureHash>): PartialMerkleTree {
-            val usedHashes = ArrayList<SecureHash>()
-            require(zeroHash !in includeHashes) { "Zero hashes shouldn't be included in partial tree." }
+            require(includeHashes.none(SecureHash::isZero)) { "Zero hashes shouldn't be included in partial tree." }
             checkFull(merkleRoot) // Throws MerkleTreeException if it is not a full binary tree.
+            val usedHashes = ArrayList<SecureHash>()
             val tree = buildPartialTree(merkleRoot, includeHashes, usedHashes)
             // Too many included hashes or different ones.
             if (includeHashes.size != usedHashes.size)
@@ -144,7 +143,7 @@ class PartialMerkleTree(val root: PartialTree) {
                 is PartialTree.Node -> {
                     val leftHash = rootAndUsedHashes(node.left, usedHashes)
                     val rightHash = rootAndUsedHashes(node.right, usedHashes)
-                    leftHash.hashConcat(rightHash)
+                    leftHash.concatenate(rightHash)
                 }
             }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -105,6 +105,7 @@ sealed class SecureHash constructor(val algorithm: String, bytes: ByteArray) : O
     // Like static methods in Java, except the 'companion' is a singleton that can have state.
     companion object {
         const val SHA2_256 = "SHA-256"
+        const val SHA3_256 = "SHA3-256"
         const val DELIMITER = ':'
 
         private val BANNED: Set<String> = unmodifiableSet(setOf("MD5", "MD2", "SHA-1"))

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -202,7 +202,6 @@ sealed class SecureHash constructor(val algorithm: String, bytes: ByteArray) : O
             } else {
                 val digest = digestFor(upperAlgorithm).get()
                 val firstHash = digest.digest(bytes)
-                digest.reset()
                 HASH(upperAlgorithm, digest.digest(firstHash))
             }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -1,3 +1,4 @@
+@file:Suppress("TooManyFunctions", "MagicNumber")
 @file:KeepForDJVM
 package net.corda.core.crypto
 
@@ -10,6 +11,10 @@ import net.corda.core.utilities.parseAsHex
 import net.corda.core.utilities.toHexString
 import java.nio.ByteBuffer
 import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+import java.util.Collections.unmodifiableSet
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import java.util.function.Supplier
 
 /**
@@ -18,7 +23,9 @@ import java.util.function.Supplier
  */
 @KeepForDJVM
 @CordaSerializable
-sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
+sealed class SecureHash constructor(val algorithm: String, bytes: ByteArray) : OpaqueBytes(bytes) {
+    constructor(bytes: ByteArray): this(SHA2_256, bytes)
+
     /** SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes). */
     class SHA256(bytes: ByteArray) : SecureHash(bytes) {
         init {
@@ -27,7 +34,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            if (javaClass != other?.javaClass) return false
+            if (other !is SHA256 && !(other is HASH && other.algorithm == algorithm)) return false
             if (!super.equals(other)) return false
             return true
         }
@@ -35,18 +42,50 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         // This is an efficient hashCode, because there is no point in performing a hash calculation on a cryptographic hash.
         // It just takes the first 4 bytes and transforms them into an Int.
         override fun hashCode() = ByteBuffer.wrap(bytes).int
+
+        /**
+         * Convert the hash value to an uppercase hexadecimal [String].
+         */
+        override fun toString() = toHexString()
+
+        override fun generate(data: ByteArray): SecureHash {
+            return data.sha256()
+        }
     }
 
-    /**
-     * Convert the hash value to an uppercase hexadecimal [String].
-     */
-    override fun toString(): String = bytes.toHexString()
+    class HASH(algorithm: String, bytes: ByteArray) : SecureHash(algorithm, bytes) {
+        override fun equals(other: Any?): Boolean {
+            return when {
+                this === other -> true
+                other !is SecureHash -> false
+                else -> algorithm == other.algorithm && super.equals(other)
+            }
+        }
+
+        override fun hashCode() = ByteBuffer.wrap(bytes).int
+
+        override fun generate(data: ByteArray): SecureHash {
+            return HASH(algorithm, digestAs(algorithm, data))
+        }
+    }
+
+    fun toHexString(): String = bytes.toHexString()
+
+    override fun toString(): String {
+        return if (algorithm == SHA2_256) {
+            // This must remain consistent with the SHA256 class
+            // for the sake of backwards-compatibility.
+            toHexString()
+        } else {
+            "$algorithm$DELIMITER${toHexString()}"
+        }
+    }
 
     /**
      * Returns the first [prefixLen] hexadecimal digits of the [SecureHash] value.
      * @param prefixLen The number of characters in the prefix.
      */
-    fun prefixChars(prefixLen: Int = 6) = toString().substring(0, prefixLen)
+    fun prefixChars(prefixLen: Int = 6) = toHexString().substring(0, prefixLen)
 
     /**
      * Append a second hash value to this hash value, and then compute the SHA-256 hash of the result.
@@ -54,8 +93,56 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
      */
     fun hashConcat(other: SecureHash) = (this.bytes + other.bytes).sha256()
 
+    /**
+     * Append a second hash value to this hash value, and then compute the hash of the result.
+     * @param other The hash to append to this one.
+     */
+    fun concatenate(other: SecureHash): SecureHash {
+        require(algorithm == other.algorithm) {
+            "Cannot concatenate $algorithm with ${other.algorithm}"
+        }
+        return generate(this.bytes + other.bytes)
+    }
+
+    protected open fun generate(data: ByteArray): SecureHash {
+        throw UnsupportedOperationException("Not implemented for $algorithm")
+    }
+
     // Like static methods in Java, except the 'companion' is a singleton that can have state.
     companion object {
+        const val SHA2_256 = "SHA-256"
+        const val DELIMITER = ':'
+
+        private val BANNED: Set<String> = unmodifiableSet(setOf("MD5", "MD2", "SHA-1"))
+
+        @JvmStatic
+        fun create(str: String?): SecureHash {
+            val txt = str ?: throw IllegalArgumentException("Provided string is null")
+            val idx = txt.indexOf(DELIMITER)
+            return if (idx == -1) {
+                decode(SHA2_256, txt)
+            } else {
+                decode(txt.substring(0, idx).toUpperCase(), txt.substring(idx + 1))
+            }
+        }
+
+        /**
+         * @param algorithm [MessageDigest] algorithm name, in uppercase.
+         * @param value Hash value as a hexadecimal string.
+         */
+        private fun decode(algorithm: String, value: String): SecureHash {
+            val digestLength = try {
+                digestFor(algorithm).digestLength
+            } catch (_: NoSuchAlgorithmException) {
+                throw IllegalArgumentException("Unknown hash algorithm $algorithm")
+            }
+            val data = value.parseAsHex()
+            return when (data.size) {
+                digestLength -> HASH(algorithm, data)
+                else -> throw IllegalArgumentException("Provided string is ${data.size} bytes not $digestLength bytes in hex: $value")
+            }
+        }
+
         /**
          * Converts a SHA-256 hash value represented as a hexadecimal [String] into a [SecureHash].
          * @param str A sequence of 64 hexadecimal digits that represents a SHA-256 hash value.
@@ -71,14 +158,48 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
             } ?: throw IllegalArgumentException("Provided string is null")
         }
 
-        private val sha256MessageDigest = SHA256DigestSupplier()
+        private val messageDigests: ConcurrentMap<String, DigestSupplier> = ConcurrentHashMap()
+
+        private fun digestFor(algorithm: String): DigestSupplier {
+            require(algorithm !in BANNED) {
+                "$algorithm is forbidden!"
+            }
+            return messageDigests.computeIfAbsent(algorithm, ::DigestSupplier)
+        }
+
+        private fun digestAs(algorithm: String, bytes: ByteArray): ByteArray = digestFor(algorithm).get().digest(bytes)
+
+        /**
+         * Computes the hash value of the [ByteArray].
+         * @param algorithm Java provider name of the digest algorithm.
+         * @param bytes The [ByteArray] to hash.
+         */
+        @JvmStatic
+        fun hashAs(algorithm: String, bytes: ByteArray): SecureHash {
+            val upperAlgorithm = algorithm.toUpperCase()
+            return HASH(upperAlgorithm, digestAs(upperAlgorithm, bytes))
+        }
+
+        /**
+         * Computes the hash of the [ByteArray], and then computes the hash of the hash.
+         * @param algorithm The [MessageDigest] algorithm to use.
+         * @param bytes The [ByteArray] to hash.
+         */
+        @JvmStatic
+        fun hashTwiceAs(algorithm: String, bytes: ByteArray): SecureHash {
+            val upperAlgorithm = algorithm.toUpperCase()
+            val digest = digestFor(upperAlgorithm).get()
+            val firstHash = digest.digest(bytes)
+            digest.reset()
+            return HASH(upperAlgorithm, digest.digest(firstHash))
+        }
 
         /**
          * Computes the SHA-256 hash value of the [ByteArray].
          * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
-        fun sha256(bytes: ByteArray) = SHA256(sha256MessageDigest.get().digest(bytes))
+        fun sha256(bytes: ByteArray) = SHA256(digestAs(SHA2_256, bytes))
 
         /**
          * Computes the SHA-256 hash of the [ByteArray], and then computes the SHA-256 hash of the hash.
@@ -102,11 +223,22 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         fun randomSHA256() = sha256(secureRandomBytes(32))
 
         /**
+         * Generates a random hash value.
+         */
+        @DeleteForDJVM
+        @JvmStatic
+        fun random(algorithm: String): SecureHash {
+            val upperAlgorithm = algorithm.toUpperCase()
+            val digest = digestFor(upperAlgorithm)
+            return HASH(upperAlgorithm, digest.get().digest(secureRandomBytes(digest.digestLength)))
+        }
+
+        /**
          * A SHA-256 hash value consisting of 32 0x00 bytes.
          * This field provides more intuitive access from Java.
          */
         @JvmField
-        val zeroHash: SHA256 = SecureHash.SHA256(ByteArray(32) { 0.toByte() })
+        val zeroHash: SHA256 = SHA256(ByteArray(32) { 0.toByte() })
 
         /**
          * A SHA-256 hash value consisting of 32 0x00 bytes.
@@ -120,7 +252,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          * This field provides more intuitive access from Java.
          */
         @JvmField
-        val allOnesHash: SHA256 = SecureHash.SHA256(ByteArray(32) { 255.toByte() })
+        val allOnesHash: SHA256 = SHA256(ByteArray(32) { 255.toByte() })
 
         /**
          * A SHA-256 hash value consisting of 32 0xFF bytes.
@@ -128,9 +260,40 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          */
         @Suppress("Unused")
         fun getAllOnesHash(): SHA256 = allOnesHash
+
+        private val hashConstants: ConcurrentMap<String, HashConstants> = ConcurrentHashMap()
+
+        private fun getConstantsFor(algorithm: String): HashConstants {
+            return hashConstants.computeIfAbsent(algorithm.toUpperCase()) { algName ->
+                val digestLength = digestFor(algName).digestLength
+                HashConstants(
+                    zero = HASH(algName, ByteArray(digestLength)),
+                    allOnes = HASH(algName, ByteArray(digestLength) { 255.toByte() })
+                )
+            }
+        }
+
+        @JvmStatic
+        fun zeroHashFor(algorithm: String): SecureHash {
+            return getConstantsFor(algorithm).zero
+        }
+
+        @JvmStatic
+        fun allOnesHashFor(algorithm: String): SecureHash {
+            return getConstantsFor(algorithm).allOnes
+        }
     }
 
     // In future, maybe SHA3, truncated hashes etc.
+}
+
+val OpaqueBytes.isZero: Boolean get() {
+    for (b in bytes) {
+        if (b != 0.toByte()) {
+            return false
+        }
+    }
+    return true
 }
 
 /**
@@ -144,16 +307,29 @@ fun ByteArray.sha256(): SecureHash.SHA256 = SecureHash.sha256(this)
 fun OpaqueBytes.sha256(): SecureHash.SHA256 = SecureHash.sha256(this.bytes)
 
 /**
+ * Compute the [algorithm] hash for the contents of the [ByteArray].
+ */
+fun ByteArray.hashAs(algorithm: String): SecureHash = SecureHash.hashAs(algorithm, this)
+
+/**
+ * Compute the [algorithm] hash for the contents of the [OpaqueBytes].
+ */
+fun OpaqueBytes.hashAs(algorithm: String): SecureHash = SecureHash.hashAs(algorithm, bytes)
+
+/**
  * Hide the [FastThreadLocal] class behind a [Supplier] interface
  * so that we can remove it for core-deterministic.
  */
-private class SHA256DigestSupplier : Supplier<MessageDigest> {
-    private val threadLocalSha256MessageDigest = LocalSHA256Digest()
-    override fun get(): MessageDigest = threadLocalSha256MessageDigest.get()
+private class DigestSupplier(algorithm: String) : Supplier<MessageDigest> {
+    private val threadLocalMessageDigest = LocalDigest(algorithm)
+    override fun get(): MessageDigest = threadLocalMessageDigest.get()
+    val digestLength: Int = get().digestLength
 }
 
 // Declaring this as "object : FastThreadLocal<>" would have
 // created an extra public class in the API definition.
-private class LocalSHA256Digest : FastThreadLocal<MessageDigest>() {
-    override fun initialValue(): MessageDigest = MessageDigest.getInstance("SHA-256")
+private class LocalDigest(private val algorithm: String) : FastThreadLocal<MessageDigest>() {
+    override fun initialValue(): MessageDigest = MessageDigest.getInstance(algorithm)
 }
+
+private class HashConstants(val zero: SecureHash, val allOnes: SecureHash)

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -171,7 +171,7 @@ class NotaryFlow {
          */
         private fun generateRequestSignature(): NotarisationRequestSignature {
             // TODO: This is not required any more once our AMQP serialization supports turning off object referencing.
-            val notarisationRequest = NotarisationRequest(stx.inputs.map { it.copy(txhash = SecureHash.parse(it.txhash.toString())) }, stx.id)
+            val notarisationRequest = NotarisationRequest(stx.inputs.map { it.copy(txhash = SecureHash.create(it.txhash.toString())) }, stx.id)
             return notarisationRequest.generateSignature(serviceHub)
         }
     }

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -4,7 +4,7 @@ import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.componentHash
-import net.corda.core.crypto.sha256
+import net.corda.core.crypto.hashAs
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
 import net.corda.core.serialization.*
@@ -46,7 +46,7 @@ fun combinedHash(components: Iterable<SecureHash>): SecureHash {
     components.forEach {
         stream.write(it.bytes)
     }
-    return stream.toByteArray().sha256()
+    return stream.toByteArray().hashAs(components.first().algorithm)
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -174,7 +174,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
             fun constraintInfo(type: Type, data: ByteArray?): ConstraintInfo {
                 return when (type) {
                     Type.ALWAYS_ACCEPT -> ConstraintInfo(AlwaysAcceptAttachmentConstraint)
-                    Type.HASH -> ConstraintInfo(HashAttachmentConstraint(SecureHash.parse(data!!.toHexString())))
+                    Type.HASH -> ConstraintInfo(HashAttachmentConstraint(SecureHash.create(data!!.toHexString())))
                     Type.CZ_WHITELISTED -> ConstraintInfo(WhitelistedByZoneAttachmentConstraint)
                     Type.SIGNATURE -> ConstraintInfo(SignatureAttachmentConstraint(Crypto.decodePublicKey(data!!)))
                 }

--- a/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt
@@ -4,7 +4,6 @@ import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.utilities.toHexString
 import org.hibernate.annotations.Immutable
 import java.io.Serializable
 import javax.persistence.Column
@@ -90,16 +89,15 @@ class PersistentState(@EmbeddedId override var stateRef: PersistentStateRef? = n
 @KeepForDJVM
 @Embeddable
 @Immutable
-
 data class PersistentStateRef(
         @Suppress("MagicNumber") // column width
-        @Column(name = "transaction_id", length = 64, nullable = false)
+        @Column(name = "transaction_id", length = 80, nullable = false)
         var txId: String,
 
         @Column(name = "output_index", nullable = false)
         var index: Int
 ) : Serializable {
-    constructor(stateRef: StateRef) : this(stateRef.txhash.bytes.toHexString(), stateRef.index)
+    constructor(stateRef: StateRef) : this(stateRef.txhash.toString(), stateRef.index)
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -1,9 +1,11 @@
 package net.corda.core.transactions
 
 import net.corda.core.CordaInternal
+import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SecureHash.Companion.SHA2_256
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.componentHash
 import net.corda.core.crypto.computeNonce
@@ -14,6 +16,7 @@ import net.corda.core.internal.combinedHash
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.internal.AttachmentsClassLoaderBuilder
@@ -42,8 +45,17 @@ data class ContractUpgradeWireTransaction(
          */
         val serializedComponents: List<OpaqueBytes>,
         /** Required for hiding components in [ContractUpgradeFilteredTransaction]. */
-        val privacySalt: PrivacySalt = PrivacySalt()
+        val privacySalt: PrivacySalt,
+        val hashAlgorithm: String
 ) : CoreTransaction() {
+    @DeprecatedConstructorForDeserialization(1)
+    constructor(serializedComponents: List<OpaqueBytes>, privacySalt: PrivacySalt = PrivacySalt())
+         : this(serializedComponents, privacySalt, SHA2_256)
+
+    @DeleteForDJVM
+    constructor(serializedComponents: List<OpaqueBytes>, hashAlgorithm: String)
+        : this(serializedComponents, PrivacySalt.createFor(hashAlgorithm), hashAlgorithm)
+
     companion object {
         /**
          * Runs the explicit upgrade logic.
@@ -83,6 +95,14 @@ data class ContractUpgradeWireTransaction(
     init {
         check(inputs.isNotEmpty()) { "A contract upgrade transaction must have inputs" }
         checkBaseInvariants()
+        privacySalt.validateFor(hashAlgorithm)
+    }
+
+    /**
+     * Old version of [ContractUpgradeWireTransaction.copy] for sake of ABI compatibility.
+     */
+    fun copy(serializedComponents: List<OpaqueBytes>, privacySalt: PrivacySalt): ContractUpgradeWireTransaction {
+        return ContractUpgradeWireTransaction(serializedComponents, privacySalt, hashAlgorithm)
     }
 
     /**
@@ -105,8 +125,8 @@ data class ContractUpgradeWireTransaction(
     }
 
     /** Required for filtering transaction components. */
-    private val nonces = (0 until serializedComponents.size).map {
-        computeNonce(privacySalt, it, 0)
+    private val nonces = serializedComponents.indices.map {
+        computeNonce(hashAlgorithm, privacySalt, it, 0)
     }
 
     /** Resolves input states and contract attachments, and builds a ContractUpgradeLedgerTransaction. */

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -1,7 +1,6 @@
 package net.corda.core.transactions
 
 import net.corda.core.CordaInternal
-import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
@@ -51,10 +50,6 @@ data class ContractUpgradeWireTransaction(
     @DeprecatedConstructorForDeserialization(1)
     constructor(serializedComponents: List<OpaqueBytes>, privacySalt: PrivacySalt = PrivacySalt())
          : this(serializedComponents, privacySalt, SHA2_256)
-
-    @DeleteForDJVM
-    constructor(serializedComponents: List<OpaqueBytes>, hashAlgorithm: String)
-        : this(serializedComponents, PrivacySalt.createFor(hashAlgorithm), hashAlgorithm)
 
     companion object {
         /**

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -260,7 +260,7 @@ class FilteredTransaction internal constructor(
             // If we don't receive elements of a particular component, check if its ordinal is bigger that the
             // groupHashes.size or if the group hash is allOnesHash,
             // to ensure there were indeed no elements in the original wire transaction.
-            visibilityCheck(componentGroupEnum.ordinal >= groupHashes.size || groupHashes[componentGroupEnum.ordinal] == SecureHash.allOnesHash) {
+            visibilityCheck(componentGroupEnum.ordinal >= groupHashes.size || groupHashes[componentGroupEnum.ordinal] == SecureHash.allOnesHashFor(id.algorithm)) {
                 "Did not receive components for group ${componentGroupEnum.ordinal} and cannot verify they didn't exist in the original wire transaction"
             }
         } else {

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -828,8 +828,7 @@ open class TransactionBuilder(
         this.hashAlgorithm = hashAlgorithm
     }
 
-    fun resaltForHashAlgorithm(hashAlgorithm: String) = apply {
-        this.hashAlgorithm = hashAlgorithm
+    fun resalt() = apply {
         privacySalt = PrivacySalt.createFor(hashAlgorithm)
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -55,9 +55,6 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
     constructor(componentGroups: List<ComponentGroup>, privacySalt: PrivacySalt = PrivacySalt()) : this(componentGroups, privacySalt, SHA2_256)
 
     @DeleteForDJVM
-    constructor(componentGroups: List<ComponentGroup>, hashAlgorithm: String) : this(componentGroups, PrivacySalt.createFor(hashAlgorithm), hashAlgorithm)
-
-    @DeleteForDJVM
     constructor(componentGroups: List<ComponentGroup>) : this(componentGroups, PrivacySalt())
 
     @Deprecated("Required only in some unit-tests and for backwards compatibility purposes.",

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -55,6 +55,9 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
     constructor(componentGroups: List<ComponentGroup>, privacySalt: PrivacySalt = PrivacySalt()) : this(componentGroups, privacySalt, SHA2_256)
 
     @DeleteForDJVM
+    constructor(componentGroups: List<ComponentGroup>, hashAlgorithm: String) : this(componentGroups, PrivacySalt.createFor(hashAlgorithm), hashAlgorithm)
+
+    @DeleteForDJVM
     constructor(componentGroups: List<ComponentGroup>) : this(componentGroups, PrivacySalt())
 
     @Deprecated("Required only in some unit-tests and for backwards compatibility purposes.",
@@ -78,6 +81,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         check(inputs.isNotEmpty() || outputs.isNotEmpty()) { "A transaction must contain at least one input or output state" }
         check(commands.isNotEmpty()) { "A transaction must contain at least one command" }
         if (timeWindow != null) check(notary != null) { "Transactions with time-windows must be notarised" }
+        privacySalt.validateFor(hashAlgorithm)
     }
 
     /** The transaction id is represented by the root hash of Merkle tree over the transaction components. */

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -303,7 +303,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
      * see the user-guide section "Transaction tear-offs" to learn more about this topic.
      */
     internal val groupsMerkleRoots: Map<Int, SecureHash> by lazy {
-        availableComponentHashes.map { Pair(it.key, MerkleTree.getMerkleTree(it.value).hash) }.toMap()
+        availableComponentHashes.entries.associate { it.key to MerkleTree.getMerkleTree(it.value).hash }
     }
 
     /**
@@ -316,7 +316,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
      * nothing about the rest.
      */
     internal val availableComponentNonces: Map<Int, List<SecureHash>> by lazy {
-        componentGroups.map { Pair(it.groupIndex, it.components.mapIndexed { internalIndex, internalIt -> componentHash(hashAlgorithm, internalIt, privacySalt, it.groupIndex, internalIndex) }) }.toMap()
+        componentGroups.associate { it.groupIndex to it.components.mapIndexed { internalIndex, internalIt -> componentHash(hashAlgorithm, internalIt, privacySalt, it.groupIndex, internalIndex) } }
     }
 
     /**
@@ -325,7 +325,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
      * see the user-guide section "Transaction tear-offs" to learn more about this topic.
      */
     internal val availableComponentHashes: Map<Int, List<SecureHash>> by lazy {
-        componentGroups.map { Pair(it.groupIndex, it.components.mapIndexed { internalIndex, internalIt -> componentHash(availableComponentNonces[it.groupIndex]!![internalIndex], internalIt) }) }.toMap()
+        componentGroups.associate { it.groupIndex to it.components.mapIndexed { internalIndex, internalIt -> componentHash(availableComponentNonces[it.groupIndex]!![internalIndex], internalIt) } }
     }
 
     /**
@@ -369,7 +369,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
                 @Suppress("UNCHECKED_CAST")
                 when (coreTransaction) {
                     is WireTransaction -> coreTransaction.componentGroups
-                            .firstOrNull { it.groupIndex == ComponentGroupEnum.OUTPUTS_GROUP.ordinal }
+                            .firstOrNull { it.groupIndex == OUTPUTS_GROUP.ordinal }
                             ?.components
                             ?.get(stateRef.index) as SerializedBytes<TransactionState<ContractState>>?
                     is ContractUpgradeWireTransaction -> coreTransaction.resolveOutputComponent(services, stateRef, params)

--- a/core/src/test/kotlin/net/corda/core/crypto/SecureHashTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/SecureHashTest.kt
@@ -1,11 +1,70 @@
 package net.corda.core.crypto
 
+import net.corda.core.crypto.SecureHash.Companion.SHA2_256
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
 import kotlin.test.assertEquals
 
 class SecureHashTest {
     @Test(timeout=300_000)
 	fun `sha256 does not retain state between same-thread invocations`() {
         assertEquals(SecureHash.sha256("abc"), SecureHash.sha256("abc"))
+    }
+
+    @Test(timeout=300_000)
+    fun `new sha256 does not retain state between same-thread invocations`() {
+        assertEquals(SecureHash.hashAs("sha-256", "abc".toByteArray()), SecureHash.hashAs("sha-256", "abc".toByteArray()))
+    }
+
+    @Test(timeout = 300_000)
+    fun `test new sha256 secure hash`() {
+        val hash = SecureHash.hashAs("sha-256", byteArrayOf(0x64, -0x13, 0x42, 0x3a))
+        assertEquals(SecureHash.create("SHA-256:6D1687C143DF792A011A1E80670A4E4E0C25D0D87A39514409B1ABFC2043581F"), hash)
+        assertEquals("6D1687C143DF792A011A1E80670A4E4E0C25D0D87A39514409B1ABFC2043581F", hash.toString())
+    }
+
+    @Ignore("Requires Java 11+")
+    @Test(timeout = 300_000)
+    fun `test new sha3-256 secure hash`() {
+        val hash = SecureHash.hashAs("sha3-256", byteArrayOf(0x64, -0x13, 0x42, 0x3a))
+        assertEquals(SecureHash.create("SHA3-256:A243D53F7273F4C92ED901A14F11B372FDF6FF69583149AFD4AFA24BF17A8880"), hash)
+        assertEquals("SHA3-256:A243D53F7273F4C92ED901A14F11B372FDF6FF69583149AFD4AFA24BF17A8880", hash.toString())
+    }
+
+    @Test(timeout = 300_000)
+    fun `test sha2-256 equivalence`() {
+        val data = byteArrayOf(0x64, -0x13, 0x42, 0x3a)
+        val oldHash = SecureHash.sha256(data)
+        val newHash = SecureHash.hashAs("sha-256", data)
+        assertEquals(oldHash.hashCode(), newHash.hashCode())
+        assertEquals(oldHash, newHash)
+    }
+
+    @Test(timeout = 300_000)
+    fun `test unsafe sha-1 secure hash is banned`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            SecureHash.hashAs("sha-1", byteArrayOf(0x64, -0x13, 0x42, 0x3a))
+        }
+        assertThat(ex).hasMessage("SHA-1 is forbidden!")
+    }
+
+    @Test(timeout = 300_000)
+    fun `test double hashing is equivalent`() {
+        val data = byteArrayOf(0x64, -0x13, 0x42, 0x3a)
+        assertEquals(SecureHash.sha256Twice(data), SecureHash.hashTwiceAs(SHA2_256, data))
+    }
+
+    @Test(timeout = 300_000)
+    fun `test hash concatenation is equivalent`() {
+        val data = byteArrayOf(0x45, 0x33, -0x63, 0x2a, 0x76, -0x64, 0x01, 0x5f)
+        val oldHash = data.sha256()
+        val newHash = data.hashAs(SHA2_256)
+        val expectedHash = oldHash.hashConcat(oldHash)
+        assertEquals(expectedHash, newHash.concatenate(newHash))
+        assertEquals(expectedHash, newHash.concatenate(oldHash))
+        assertEquals(expectedHash, oldHash.concatenate(newHash))
     }
 }

--- a/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt
@@ -127,7 +127,7 @@ open class InternalUtilsTest {
 	fun `test SHA-256 hash for InputStream`() {
         val contents = arrayOfJunk(DEFAULT_BUFFER_SIZE * 2 + DEFAULT_BUFFER_SIZE / 2)
         assertThat(contents.inputStream().hash())
-            .isEqualTo(SecureHash.parse("A4759E7AA20338328866A2EA17EAF8C7FE4EC6BBE3BB71CEE7DF7C0461B3C22F"))
+            .isEqualTo(SecureHash.create("A4759E7AA20338328866A2EA17EAF8C7FE4EC6BBE3BB71CEE7DF7C0461B3C22F"))
     }
 
     @Test(timeout=300_000)

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
@@ -47,7 +47,7 @@ class CashExitFlow(private val amount: Amount<Currency>,
     @Throws(CashException::class)
     override fun call(): AbstractCashFlow.Result {
         progressTracker.currentStep = GENERATING_TX
-        val builder = TransactionBuilder(notary = null)
+        val builder = TransactionBuilder(notary = null).setHashAlgorithm("SHA3-256")
         val issuer = ourIdentity.ref(issuerRef)
         val exitStates = AbstractCashSelection
                 .getInstance { serviceHub.jdbcSession().metaData }

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
@@ -3,6 +3,7 @@ package net.corda.finance.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.InsufficientBalanceException
+import net.corda.core.crypto.SecureHash.Companion.SHA3_256
 import net.corda.core.flows.*
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.DEFAULT_PAGE_NUM
@@ -47,7 +48,7 @@ class CashExitFlow(private val amount: Amount<Currency>,
     @Throws(CashException::class)
     override fun call(): AbstractCashFlow.Result {
         progressTracker.currentStep = GENERATING_TX
-        val builder = TransactionBuilder(notary = null).setHashAlgorithm("SHA3-256")
+        val builder = TransactionBuilder(notary = null).setHashAlgorithm(SHA3_256)
         val issuer = ourIdentity.ref(issuerRef)
         val exitStates = AbstractCashSelection
                 .getInstance { serviceHub.jdbcSession().metaData }

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
@@ -40,7 +40,7 @@ class CashIssueFlow(private val amount: Amount<Currency>,
     @Suspendable
     override fun call(): AbstractCashFlow.Result {
         progressTracker.currentStep = GENERATING_TX
-        val builder = TransactionBuilder(notary)
+        val builder = TransactionBuilder(notary).setHashAlgorithm("SHA3-256")
         val issuer = ourIdentity.ref(issuerBankPartyRef)
         val signers = Cash().generateIssue(builder, amount.issuedBy(issuer), ourIdentity, notary)
         progressTracker.currentStep = SIGNING_TX

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
@@ -2,6 +2,7 @@ package net.corda.finance.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
+import net.corda.core.crypto.SecureHash.Companion.SHA3_256
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
@@ -40,7 +41,7 @@ class CashIssueFlow(private val amount: Amount<Currency>,
     @Suspendable
     override fun call(): AbstractCashFlow.Result {
         progressTracker.currentStep = GENERATING_TX
-        val builder = TransactionBuilder(notary).setHashAlgorithm("SHA3-256")
+        val builder = TransactionBuilder(notary).setHashAlgorithm(SHA3_256)
         val issuer = ourIdentity.ref(issuerBankPartyRef)
         val signers = Cash().generateIssue(builder, amount.issuedBy(issuer), ourIdentity, notary)
         progressTracker.currentStep = SIGNING_TX

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -59,7 +59,7 @@ open class CashPaymentFlow(
             recipient
         }
         progressTracker.currentStep = GENERATING_TX
-        val builder = TransactionBuilder(notary = notary ?: serviceHub.networkMapCache.notaryIdentities.first())
+        val builder = TransactionBuilder(notary = notary ?: serviceHub.networkMapCache.notaryIdentities.first()).setHashAlgorithm("SHA3-256")
         logger.info("Generating spend for: ${builder.lockId}")
         // TODO: Have some way of restricting this to states the caller controls
         val (spendTX, keysForSigning) = try {

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.confidential.SwapIdentitiesFlow
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.InsufficientBalanceException
+import net.corda.core.crypto.SecureHash.Companion.SHA3_256
 import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
@@ -59,7 +60,7 @@ open class CashPaymentFlow(
             recipient
         }
         progressTracker.currentStep = GENERATING_TX
-        val builder = TransactionBuilder(notary = notary ?: serviceHub.networkMapCache.notaryIdentities.first()).setHashAlgorithm("SHA3-256")
+        val builder = TransactionBuilder(notary = notary ?: serviceHub.networkMapCache.notaryIdentities.first()).setHashAlgorithm(SHA3_256)
         logger.info("Generating spend for: ${builder.lockId}")
         // TODO: Have some way of restricting this to states the caller controls
         val (spendTX, keysForSigning) = try {

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/CommercialPaperUtils.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/CommercialPaperUtils.kt
@@ -21,7 +21,7 @@ object CommercialPaperUtils {
     @JvmStatic
     fun generateIssue(issuance: PartyAndReference, faceValue: Amount<Issued<Currency>>, maturityDate: Instant, notary: Party): TransactionBuilder {
         val state = CommercialPaper.State(issuance, issuance.party, faceValue, maturityDate)
-        return TransactionBuilder(notary = notary).withItems(
+        return TransactionBuilder(notary = notary).setHashAlgorithm("SHA3-256").withItems(
                 StateAndContract(state, CommercialPaper.CP_PROGRAM_ID),
                 Command(CommercialPaper.Commands.Issue(), issuance.party.owningKey)
         )

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/CommercialPaperUtils.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/CommercialPaperUtils.kt
@@ -2,6 +2,7 @@ package net.corda.finance.workflows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
+import net.corda.core.crypto.SecureHash.Companion.SHA3_256
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
@@ -21,7 +22,7 @@ object CommercialPaperUtils {
     @JvmStatic
     fun generateIssue(issuance: PartyAndReference, faceValue: Amount<Issued<Currency>>, maturityDate: Instant, notary: Party): TransactionBuilder {
         val state = CommercialPaper.State(issuance, issuance.party, faceValue, maturityDate)
-        return TransactionBuilder(notary = notary).setHashAlgorithm("SHA3-256").withItems(
+        return TransactionBuilder(notary = notary).setHashAlgorithm(SHA3_256).withItems(
                 StateAndContract(state, CommercialPaper.CP_PROGRAM_ID),
                 Command(CommercialPaper.Commands.Issue(), issuance.party.owningKey)
         )

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
@@ -128,7 +128,7 @@ abstract class AbstractCashSelection(private val maxRetries : Int = 8, private v
                 var totalPennies = 0L
                 val stateRefs = mutableSetOf<StateRef>()
                 while (rs.next()) {
-                    val txHash = SecureHash.parse(rs.getString(1))
+                    val txHash = SecureHash.create(rs.getString(1))
                     val index = rs.getInt(2)
                     val pennies = rs.getLong(3)
                     totalPennies = rs.getLong(4)

--- a/finance/workflows/src/main/resources/migration/cash.changelog-master.xml
+++ b/finance/workflows/src/main/resources/migration/cash.changelog-master.xml
@@ -6,5 +6,6 @@
 
     <include file="migration/cash.changelog-init.xml"/>
     <include file="migration/cash.changelog-v1.xml"/>
+    <include file="migration/cash.changelog-v2.xml"/>
 
 </databaseChangeLog>

--- a/finance/workflows/src/main/resources/migration/cash.changelog-v1.xml
+++ b/finance/workflows/src/main/resources/migration/cash.changelog-v1.xml
@@ -2,8 +2,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
-                   logicalFilePath="migration/node-services.changelog-init.xml">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet id="1525793504" author="R3.Corda">
         <!-- drop indexes before adding not null constraints to the underlying table, recreating index immediately after -->

--- a/finance/workflows/src/main/resources/migration/cash.changelog-v2.xml
+++ b/finance/workflows/src/main/resources/migration/cash.changelog-v2.xml
@@ -3,9 +3,9 @@
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-
-    <include file="migration/commercial-paper.changelog-init.xml"/>
-    <include file="migration/commercial-paper.changelog-v1.xml"/>
-    <include file="migration/commercial-paper.changelog-v2.xml"/>
-
+    <changeSet id="extend_cash_states_transaction_id" author="R3.Corda">
+        <modifyDataType tableName="contract_cash_states"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+    </changeSet>
 </databaseChangeLog>

--- a/finance/workflows/src/main/resources/migration/commercial-paper.changelog-v2.xml
+++ b/finance/workflows/src/main/resources/migration/commercial-paper.changelog-v2.xml
@@ -3,9 +3,9 @@
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-
-    <include file="migration/commercial-paper.changelog-init.xml"/>
-    <include file="migration/commercial-paper.changelog-v1.xml"/>
-    <include file="migration/commercial-paper.changelog-v2.xml"/>
-
+    <changeSet id="extend_commercial_paper_transaction_id" author="R3.Corda">
+        <modifyDataType tableName="cp_states"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+    </changeSet>
 </databaseChangeLog>

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
@@ -119,7 +119,7 @@ const val DEV_CA_TRUST_STORE_PRIVATE_KEY_PASS: String = "trustpasskeypass"
 // https://github.com/corda/corda-gradle-plugins/blob/master/cordapp/src/main/resources/certificates/cordadevcodesign.jks
 const val DEV_CORDAPP_CODE_SIGNING_STR = "AA59D829F2CA8FDDF5ABEA40D815F937E3E54E572B65B93B5C216AE6594E7D6B"
 
-val DEV_PUB_KEY_HASHES: List<SecureHash.SHA256> get() = listOf(DEV_INTERMEDIATE_CA.certificate, DEV_ROOT_CA.certificate).map { it.publicKey.hash.sha256() } + SecureHash.parse(DEV_CORDAPP_CODE_SIGNING_STR).sha256()
+val DEV_PUB_KEY_HASHES: List<SecureHash.SHA256> get() = listOf(DEV_INTERMEDIATE_CA.certificate, DEV_ROOT_CA.certificate).map { it.publicKey.hash.sha256() } + SecureHash.create(DEV_CORDAPP_CODE_SIGNING_STR).sha256()
 
 // We need a class so that we can get hold of the class loader
 internal object DevCaHelper {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
@@ -119,7 +119,7 @@ const val DEV_CA_TRUST_STORE_PRIVATE_KEY_PASS: String = "trustpasskeypass"
 // https://github.com/corda/corda-gradle-plugins/blob/master/cordapp/src/main/resources/certificates/cordadevcodesign.jks
 const val DEV_CORDAPP_CODE_SIGNING_STR = "AA59D829F2CA8FDDF5ABEA40D815F937E3E54E572B65B93B5C216AE6594E7D6B"
 
-val DEV_PUB_KEY_HASHES: List<SecureHash.SHA256> get() = listOf(DEV_INTERMEDIATE_CA.certificate, DEV_ROOT_CA.certificate).map { it.publicKey.hash.sha256() } + SecureHash.create(DEV_CORDAPP_CODE_SIGNING_STR).sha256()
+val DEV_PUB_KEY_HASHES: List<SecureHash> get() = listOf(DEV_INTERMEDIATE_CA.certificate, DEV_ROOT_CA.certificate).map { it.publicKey.hash.sha256() } + SecureHash.create(DEV_CORDAPP_CODE_SIGNING_STR).sha256()
 
 // We need a class so that we can get hold of the class loader
 internal object DevCaHelper {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
@@ -229,11 +229,13 @@ object WireTransactionSerializer : Serializer<WireTransaction>() {
 object NotaryChangeWireTransactionSerializer : Serializer<NotaryChangeWireTransaction>() {
     override fun write(kryo: Kryo, output: Output, obj: NotaryChangeWireTransaction) {
         kryo.writeClassAndObject(output, obj.serializedComponents)
+        kryo.writeClassAndObject(output, obj.hashAlgorithm)
     }
 
     override fun read(kryo: Kryo, input: Input, type: Class<NotaryChangeWireTransaction>): NotaryChangeWireTransaction {
         val components: List<OpaqueBytes> = uncheckedCast(kryo.readClassAndObject(input))
-        return NotaryChangeWireTransaction(components)
+        val hashAlgorithm = kryo.readClassAndObject(input) as String
+        return NotaryChangeWireTransaction(components, hashAlgorithm)
     }
 }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
@@ -214,12 +214,14 @@ object WireTransactionSerializer : Serializer<WireTransaction>() {
     override fun write(kryo: Kryo, output: Output, obj: WireTransaction) {
         kryo.writeClassAndObject(output, obj.componentGroups)
         kryo.writeClassAndObject(output, obj.privacySalt)
+        kryo.writeClassAndObject(output, obj.hashAlgorithm)
     }
 
     override fun read(kryo: Kryo, input: Input, type: Class<WireTransaction>): WireTransaction {
         val componentGroups: List<ComponentGroup> = uncheckedCast(kryo.readClassAndObject(input))
         val privacySalt = kryo.readClassAndObject(input) as PrivacySalt
-        return WireTransaction(componentGroups, privacySalt)
+        val hashAlgorithm = kryo.readClassAndObject(input) as String
+        return WireTransaction(componentGroups, privacySalt, hashAlgorithm)
     }
 }
 
@@ -240,13 +242,14 @@ object ContractUpgradeWireTransactionSerializer : Serializer<ContractUpgradeWire
     override fun write(kryo: Kryo, output: Output, obj: ContractUpgradeWireTransaction) {
         kryo.writeClassAndObject(output, obj.serializedComponents)
         kryo.writeClassAndObject(output, obj.privacySalt)
+        kryo.writeClassAndObject(output, obj.hashAlgorithm)
     }
 
     override fun read(kryo: Kryo, input: Input, type: Class<ContractUpgradeWireTransaction>): ContractUpgradeWireTransaction {
         val components: List<OpaqueBytes> = uncheckedCast(kryo.readClassAndObject(input))
         val privacySalt = kryo.readClassAndObject(input) as PrivacySalt
-
-        return ContractUpgradeWireTransaction(components, privacySalt)
+        val hashAlgorithm = kryo.readClassAndObject(input) as String
+        return ContractUpgradeWireTransaction(components, privacySalt, hashAlgorithm)
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -847,10 +847,10 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         )
     }
 
-    private fun parseSecureHashConfiguration(unparsedConfig: List<String>, errorMessage: (String) -> String): List<SecureHash.SHA256> {
+    private fun parseSecureHashConfiguration(unparsedConfig: List<String>, errorMessage: (String) -> String): List<SecureHash> {
         return unparsedConfig.map {
             try {
-                SecureHash.parse(it)
+                SecureHash.create(it)
             } catch (e: IllegalArgumentException) {
                 log.error("${errorMessage(it)} due to - ${e.message}", e)
                 throw e

--- a/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
@@ -45,7 +45,7 @@ class DBNetworkParametersStorage(
                     toPersistentEntityKey = { it.toString() },
                     fromPersistentEntity = {
                         Pair(
-                                SecureHash.parse(it.hash),
+                                SecureHash.create(it.hash),
                                 it.signedNetworkParameters
                         )
                     },

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
@@ -100,7 +100,7 @@ open class CordappProviderImpl(val cordappLoader: CordappLoader,
                             )
                         }
                     } catch (faee: java.nio.file.FileAlreadyExistsException) {
-                        AttachmentId.parse(faee.message!!)
+                        AttachmentId.create(faee.message!!)
                     }
                 } to cordapp.jarPath
             }.toMap()

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -49,7 +49,7 @@ import kotlin.streams.toList
 class JarScanningCordappLoader private constructor(private val cordappJarPaths: List<RestrictedURL>,
                                                    private val versionInfo: VersionInfo = VersionInfo.UNKNOWN,
                                                    extraCordapps: List<CordappImpl>,
-                                                   private val signerKeyFingerprintBlacklist: List<SecureHash.SHA256> = emptyList()) : CordappLoaderTemplate() {
+                                                   private val signerKeyFingerprintBlacklist: List<SecureHash> = emptyList()) : CordappLoaderTemplate() {
     init {
         if (cordappJarPaths.isEmpty()) {
             logger.info("No CorDapp paths provided")
@@ -75,7 +75,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
         fun fromDirectories(cordappDirs: Collection<Path>,
                             versionInfo: VersionInfo = VersionInfo.UNKNOWN,
                             extraCordapps: List<CordappImpl> = emptyList(),
-                            signerKeyFingerprintBlacklist: List<SecureHash.SHA256> = emptyList()): JarScanningCordappLoader {
+                            signerKeyFingerprintBlacklist: List<SecureHash> = emptyList()): JarScanningCordappLoader {
             logger.info("Looking for CorDapps in ${cordappDirs.distinct().joinToString(", ", "[", "]")}")
             val paths = cordappDirs.distinct().flatMap(this::jarUrlsInDirectory).map { it.restricted() }
             return JarScanningCordappLoader(paths, versionInfo, extraCordapps, signerKeyFingerprintBlacklist)

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -87,7 +87,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
          * @param scanJars Uses the JAR URLs provided for classpath scanning and Cordapp detection.
          */
         fun fromJarUrls(scanJars: List<URL>, versionInfo: VersionInfo = VersionInfo.UNKNOWN, extraCordapps: List<CordappImpl> = emptyList(),
-                        cordappsSignerKeyFingerprintBlacklist: List<SecureHash.SHA256> = emptyList()): JarScanningCordappLoader {
+                        cordappsSignerKeyFingerprintBlacklist: List<SecureHash> = emptyList()): JarScanningCordappLoader {
             val paths = scanJars.map { it.restricted() }
             return JarScanningCordappLoader(paths, versionInfo, extraCordapps, cordappsSignerKeyFingerprintBlacklist)
         }

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -58,7 +58,7 @@ class VaultStateMigration : CordaMigration() {
     private fun getStateAndRef(persistentState: VaultSchemaV1.VaultStates): StateAndRef<ContractState> {
         val persistentStateRef = persistentState.stateRef ?:
                 throw VaultStateMigrationException("Persistent state ref missing from state")
-        val txHash = SecureHash.parse(persistentStateRef.txId)
+        val txHash = SecureHash.create(persistentStateRef.txId)
         val stateRef = StateRef(txHash, persistentStateRef.index)
         val state = try {
             servicesForResolution.loadState(stateRef)

--- a/node/src/main/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepository.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepository.kt
@@ -27,7 +27,7 @@ class PersistentScheduledFlowRepository(val database: CordaPersistence) : Schedu
     private fun fromPersistentEntity(scheduledStateRecord: NodeSchedulerService.PersistentScheduledState): Pair<StateRef, ScheduledStateRef> {
         val txId = scheduledStateRecord.output.txId
         val index = scheduledStateRecord.output.index
-        return Pair(StateRef(SecureHash.parse(txId), index), ScheduledStateRef(StateRef(SecureHash.parse(txId), index), scheduledStateRecord.scheduledAt))
+        return Pair(StateRef(SecureHash.create(txId), index), ScheduledStateRef(StateRef(SecureHash.create(txId), index), scheduledStateRecord.scheduledAt))
     }
 
     override fun delete(key: StateRef): Boolean {

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -68,7 +68,7 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
                         select(get<String>(NodeInfoSchemaV1.PersistentNodeInfo::hash.name))
                     }
                 }
-                session.createQuery(query).resultList.map { SecureHash.parse(it) }
+                session.createQuery(query).resultList.map { SecureHash.create(it) }
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionMappingStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionMappingStorage.kt
@@ -37,7 +37,7 @@ class DBTransactionMappingStorage(private val database: CordaPersistence) : Stat
         val from = cq.from(DBTransactionStorage.DBTransaction::class.java)
         cq.multiselect(from.get<String>(DBTransactionStorage.DBTransaction::stateMachineRunId.name), from.get<String>(DBTransactionStorage.DBTransaction::txId.name))
         cq.where(cb.isNotNull(from.get<String>(DBTransactionStorage.DBTransaction::stateMachineRunId.name)))
-        val flowIds = session.createQuery(cq).resultList.map { StateMachineTransactionMapping(StateMachineRunId(UUID.fromString(it[0] as String)), SecureHash.parse(it[1] as String)) }
+        val flowIds = session.createQuery(cq).resultList.map { StateMachineTransactionMapping(StateMachineRunId(UUID.fromString(it[0] as String)), SecureHash.create(it[1] as String)) }
         DataFeed(flowIds, updates.bufferUntilSubscribed().wrapWithDatabaseTransaction())
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -38,7 +38,7 @@ class DBTransactionStorage(private val database: CordaPersistence, cacheFactory:
     @Table(name = "${NODE_DATABASE_PREFIX}transactions")
     class DBTransaction(
             @Id
-            @Column(name = "tx_id", length = 64, nullable = false)
+            @Column(name = "tx_id", length = 80, nullable = false)
             val txId: String,
 
             @Column(name = "state_machine_run_id", length = 36, nullable = true)
@@ -120,7 +120,7 @@ class DBTransactionStorage(private val database: CordaPersistence, cacheFactory:
                     name = "DBTransactionStorage_transactions",
                     toPersistentEntityKey = SecureHash::toString,
                     fromPersistentEntity = {
-                        SecureHash.parse(it.txId) to TxCacheValue(
+                        SecureHash.create(it.txId) to TxCacheValue(
                                 it.transaction.deserialize(context = contextToUse()),
                                 it.status)
                     },

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -11,7 +11,6 @@ import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.SecureHash.Companion.SHA2_256
 import net.corda.core.crypto.sha256
 import net.corda.core.internal.*
 import net.corda.core.internal.Version
@@ -238,8 +237,7 @@ class NodeAttachmentService @JvmOverloads constructor(
         override fun open(): InputStream {
             val stream = super.open()
             // This is just an optional safety check. If it slows things down too much it can be disabled.
-            return if (checkOnLoad && id.algorithm == SHA2_256) HashCheckingStream(id, attachmentData.size, stream) else stream
-            //return if (checkOnLoad && id is SecureHash.SHA256) HashCheckingStream(id, attachmentData.size, stream) else stream
+            return if (checkOnLoad && id is SecureHash.SHA256) HashCheckingStream(id, attachmentData.size, stream) else stream
         }
 
         private class Token(

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -88,7 +88,7 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
     @javax.persistence.Table(name = "${NODE_DATABASE_PREFIX}notary_committed_txs")
     class CommittedTransaction(
             @Id
-            @Column(name = "transaction_id", nullable = false, length = 64)
+            @Column(name = "transaction_id", nullable = false, length = 80)
             val transactionId: String
     )
 
@@ -161,8 +161,8 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
                             val txId = it.id.txId
                             val index = it.id.index
                             Pair(
-                                    StateRef(txhash = SecureHash.parse(txId), index = index),
-                                    SecureHash.parse(it.consumingTxHash)
+                                    StateRef(txhash = SecureHash.create(txId), index = index),
+                                    SecureHash.create(it.consumingTxHash)
                             )
 
                         },

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -473,7 +473,7 @@ class NodeVaultService(
             val session = currentDBSession()
             val criteriaBuilder = session.criteriaBuilder
             fun execute(configure: Root<*>.(CriteriaUpdate<*>, Array<Predicate>) -> Any?) = criteriaBuilder.executeUpdate(session, null) { update, _ ->
-                val persistentStateRefs = stateRefs.map { PersistentStateRef(it.txhash.bytes.toHexString(), it.index) }
+                val persistentStateRefs = stateRefs.map { PersistentStateRef(it.txhash.toString(), it.index) }
                 val compositeKey = get<PersistentStateRef>(VaultSchemaV1.VaultStates::stateRef.name)
                 val stateRefsPredicate = criteriaBuilder.and(compositeKey.`in`(persistentStateRefs))
                 configure(update, arrayOf(stateRefsPredicate))
@@ -869,7 +869,7 @@ private fun CriteriaBuilder.executeUpdate(
         // Increase SQL server performance by, processing updates in chunks allowing the database's optimizer to make use of the index.
         var updatedRows = 0
         it.asSequence()
-            .map { stateRef -> PersistentStateRef(stateRef.txhash.bytes.toHexString(), stateRef.index) }
+            .map { stateRef -> PersistentStateRef(stateRef.txhash.toString(), stateRef.index) }
             .chunked(NodeVaultService.DEFAULT_SOFT_LOCKING_SQL_IN_CLAUSE_SIZE)
             .forEach { persistentStateRefs ->
                 updatedRows += doUpdate(persistentStateRefs)

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -715,7 +715,7 @@ class NodeVaultService(
                             if (!paging.isDefault && index == paging.pageSize) // skip last result if paged
                                 return@forEachIndexed
                             val vaultState = result[0] as VaultSchemaV1.VaultStates
-                            val stateRef = StateRef(SecureHash.parse(vaultState.stateRef!!.txId), vaultState.stateRef!!.index)
+                            val stateRef = StateRef(SecureHash.create(vaultState.stateRef!!.txId), vaultState.stateRef!!.index)
                             stateRefs.add(stateRef)
                             statesMeta.add(Vault.StateMetadata(stateRef,
                                     vaultState.contractStateClassName,

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -151,7 +151,7 @@ object VaultSchemaV1 : MappedSchema(
             @Column(name = "seq_no", nullable = false)
             var seqNo: Int,
 
-            @Column(name = "transaction_id", length = 64, nullable = true)
+            @Column(name = "transaction_id", length = 80, nullable = true)
             var txId: String?,
 
             @Column(name = "note", nullable = true)

--- a/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmartNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmartNotaryService.kt
@@ -132,7 +132,7 @@ class BFTSmartNotaryService(
     @Table(name = "${NODE_DATABASE_PREFIX}bft_committed_txs")
     class CommittedTransaction(
             @Id
-            @Column(name = "transaction_id", nullable = false, length = 64)
+            @Column(name = "transaction_id", nullable = false, length = 80)
             val transactionId: String
     )
 
@@ -150,8 +150,8 @@ class BFTSmartNotaryService(
                     val txId = it.id.txId
                     val index = it.id.index
                     Pair(
-                            StateRef(txhash = SecureHash.parse(txId), index = index),
-                            SecureHash.parse(it.consumingTxHash)
+                            StateRef(txhash = SecureHash.create(txId), index = index),
+                            SecureHash.create(it.consumingTxHash)
                     )
                 },
                 toPersistentEntity = { (txHash, index): StateRef, id: SecureHash ->

--- a/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
@@ -92,7 +92,13 @@ class RaftUniquenessProvider(
                 )
 
         fun StateRef.encoded() = "$txhash:$index"
-        fun String.parseStateRef() = split(":").let { StateRef(SecureHash.create(it[0]), it[1].toInt()) }
+        fun String.parseStateRef(): StateRef {
+            val idx = lastIndexOf(':')
+            require(idx != -1) {
+                "Encoding error for StateRef '$this'"
+            }
+            return StateRef(SecureHash.create(substring(0, idx)), substring(idx + 1).toInt())
+        }
     }
 
     @Entity

--- a/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
@@ -92,7 +92,7 @@ class RaftUniquenessProvider(
                 )
 
         fun StateRef.encoded() = "$txhash:$index"
-        fun String.parseStateRef() = split(":").let { StateRef(SecureHash.parse(it[0]), it[1].toInt()) }
+        fun String.parseStateRef() = split(":").let { StateRef(SecureHash.create(it[0]), it[1].toInt()) }
     }
 
     @Entity
@@ -115,7 +115,7 @@ class RaftUniquenessProvider(
     @Table(name = "${NODE_DATABASE_PREFIX}raft_committed_txs")
     class CommittedTransaction(
             @Id
-            @Column(name = "transaction_id", nullable = false, length = 64)
+            @Column(name = "transaction_id", nullable = false, length = 80)
             val transactionId: String
     )
 

--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -30,6 +30,8 @@
     <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
     <include file="migration/vault-schema.changelog-v9.xml"/>
 
+    <include file="migration/node-core.changelog-v17.xml"/>
+
     <include file="migration/node-core.changelog-v19.xml"/>
     <include file="migration/node-core.changelog-v19-postgres.xml"/>
     <include file="migration/node-core.changelog-v19-keys.xml"/>

--- a/node/src/main/resources/migration/node-core.changelog-v17.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v17.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="R3.Corda" id="node_transaction_id_size">
+        <modifyDataType tableName="node_transactions"
+                        columnName="tx_id"
+                        newDataType="NVARCHAR(80)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/main/resources/migration/node-notary.changelog-master.xml
+++ b/node/src/main/resources/migration/node-notary.changelog-master.xml
@@ -11,5 +11,6 @@
     <include file="migration/node-notary.changelog-committed-transactions-table.xml" />
     <include file="migration/node-notary.changelog-v3.xml" />
     <include file="migration/node-notary.changelog-worker-logging.xml" />
+    <include file="migration/node-notary.changelog-v100.xml"/>
 
 </databaseChangeLog>

--- a/node/src/main/resources/migration/node-notary.changelog-v100.xml
+++ b/node/src/main/resources/migration/node-notary.changelog-v100.xml
@@ -1,0 +1,20 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="R3.Corda" id="node_notary_transaction_id_size">
+        <modifyDataType tableName="node_notary_committed_txs"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="node_notary_committed_states"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="node_notary_committed_states"
+                        columnName="consuming_transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="node_notary_request_log"
+                        columnName="consuming_transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/main/resources/migration/notary-bft-smart.changelog-master.xml
+++ b/node/src/main/resources/migration/notary-bft-smart.changelog-master.xml
@@ -7,4 +7,5 @@
     <include file="migration/notary-bft-smart.changelog-v1.xml"/>
     <include file="migration/notary-bft-smart.changelog-pkey.xml"/>
     <include file="migration/notary-bft-smart.changelog-committed-transactions-table.xml"/>
+    <include file="migration/notary-bft-smart.changelog-v2.xml"/>
 </databaseChangeLog>

--- a/node/src/main/resources/migration/notary-bft-smart.changelog-v2.xml
+++ b/node/src/main/resources/migration/notary-bft-smart.changelog-v2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="R3.Corda" id="node_bft_transaction_id_size">
+        <modifyDataType tableName="node_bft_committed_txs"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="node_bft_committed_states"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="node_bft_committed_states"
+                        columnName="consuming_transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="node_notary_request_log"
+                        columnName="consuming_transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/main/resources/migration/notary-raft.changelog-master.xml
+++ b/node/src/main/resources/migration/notary-raft.changelog-master.xml
@@ -6,4 +6,5 @@
     <include file="migration/notary-raft.changelog-init.xml"/>
     <include file="migration/notary-raft.changelog-v1.xml"/>
     <include file="migration/notary-raft.changelog-committed-transactions-table.xml" />
+    <include file="migration/notary-raft.changelog-v2.xml"/>
 </databaseChangeLog>

--- a/node/src/main/resources/migration/notary-raft.changelog-v2.xml
+++ b/node/src/main/resources/migration/notary-raft.changelog-v2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="R3.Corda" id="node_raft_transaction_id_size">
+        <modifyDataType tableName="node_raft_committed_txs"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="node_notary_request_log"
+                        columnName="consuming_transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/main/resources/migration/vault-schema.changelog-master.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-master.xml
@@ -12,4 +12,5 @@
     <include file="migration/vault-schema.changelog-v7.xml"/>
     <include file="migration/vault-schema.changelog-v8.xml"/>
     <include file="migration/vault-schema.changelog-v11.xml"/>
+    <include file="migration/vault-schema.changelog-v12.xml"/>
 </databaseChangeLog>

--- a/node/src/main/resources/migration/vault-schema.changelog-v12.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-v12.xml
@@ -1,0 +1,29 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="R3.Corda" id="vault_transaction_id_size">
+        <modifyDataType tableName="vault_fungible_states"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="vault_fungible_states_parts"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="vault_linear_states"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="vault_linear_states_parts"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="vault_states"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="vault_transaction_notes"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+        <modifyDataType tableName="state_party"
+                        columnName="transaction_id"
+                        newDataType="NVARCHAR(80)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -953,7 +953,7 @@ class HibernateConfigurationTest {
             // DOCEND JdbcSession
             var count = 0
             while (rs.next()) {
-                val stateRef = StateRef(SecureHash.parse(rs.getString(1)), rs.getInt(2))
+                val stateRef = StateRef(SecureHash.create(rs.getString(1)), rs.getInt(2))
                 Assert.assertTrue(cashStates.map { it.ref }.contains(stateRef))
                 count++
             }
@@ -962,7 +962,7 @@ class HibernateConfigurationTest {
     }
 
     private fun toStateRef(pStateRef: PersistentStateRef): StateRef {
-        return StateRef(SecureHash.parse(pStateRef.txId), pStateRef.index)
+        return StateRef(SecureHash.create(pStateRef.txId), pStateRef.index)
     }
 
     @Test(timeout=300_000)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -647,7 +647,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         database.transaction {
             vaultFiller.fillWithSomeTestLinearStates(8)
             val issuedStates = vaultFiller.fillWithSomeTestLinearStates(2)
-            val stateRefs = issuedStates.states.map { it.ref }.toList()
+            val stateRefs = issuedStates.states.map { it.ref }
 
             // DOCSTART VaultQueryExample2
             val sortAttribute = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_TXN_ID)
@@ -657,7 +657,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
 
             assertThat(results.states).hasSize(2)
 
-            val sortedStateRefs = stateRefs.sortedBy { it.txhash.bytes.toHexString() }
+            val sortedStateRefs = stateRefs.sortedBy { it.txhash.toString() }
             assertThat(results.states.first().ref).isEqualTo(sortedStateRefs.first())
             assertThat(results.states.last().ref).isEqualTo(sortedStateRefs.last())
         }

--- a/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/CordappDependencies.kt
+++ b/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/CordappDependencies.kt
@@ -21,7 +21,7 @@ private fun loadDependencies(): List<SecureHash> {
     return URLClassLoader(arrayOf(cordappURL), null).use { cl ->
         val deps = cl.getResource("META-INF/Cordapp-Dependencies") ?: return emptyList()
         deps.openStream().bufferedReader().useLines { lines ->
-            lines.filterNot(String::isBlank).map(SecureHash.Companion::parse).toList()
+            lines.filterNot(String::isBlank).map(SecureHash.Companion::create).toList()
         }
     }
 }

--- a/samples/trader-demo/workflows-trader/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt
+++ b/samples/trader-demo/workflows-trader/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt
@@ -29,7 +29,7 @@ class CommercialPaperIssueFlow(private val amount: Amount<Currency>,
     constructor(amount: Amount<Currency>, issueRef: OpaqueBytes, recipient: Party, notary: Party) : this(amount, issueRef, recipient, notary, tracker())
 
     companion object {
-        val PROSPECTUS_HASH = SecureHash.parse("decd098666b9657314870e192ced0c3519c2c9d395507a238338f8d003929de9")
+        val PROSPECTUS_HASH = SecureHash.create("decd098666b9657314870e192ced0c3519c2c9d395507a238338f8d003929de9")
 
         object ISSUING : ProgressTracker.Step("Issuing and timestamping some commercial paper")
 

--- a/samples/trader-demo/workflows-trader/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
+++ b/samples/trader-demo/workflows-trader/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
@@ -21,7 +21,7 @@ class SellerFlow(private val otherParty: Party,
     constructor(otherParty: Party, amount: Amount<Currency>) : this(otherParty, amount, tracker())
 
     companion object {
-        val PROSPECTUS_HASH = SecureHash.parse("decd098666b9657314870e192ced0c3519c2c9d395507a238338f8d003929de9")
+        val PROSPECTUS_HASH = SecureHash.create("decd098666b9657314870e192ced0c3519c2c9d395507a238338f8d003929de9")
 
         object SELF_ISSUING : ProgressTracker.Step("Got session ID back, issuing and timestamping some commercial paper")
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -201,7 +201,7 @@ class NetworkMapServer(private val pollInterval: Duration,
         @Path("node-info/{var}")
         @Produces(MediaType.APPLICATION_OCTET_STREAM)
         fun getNodeInfo(@PathParam("var") nodeInfoHash: String): Response {
-            val hash = SecureHash.parse(nodeInfoHash)
+            val hash = SecureHash.create(nodeInfoHash)
             val signedNodeInfo = nodeInfoMap[hash]
             return if (signedNodeInfo != null) {
                 Response.ok(signedNodeInfo.serialize().bytes)
@@ -223,7 +223,7 @@ class NetworkMapServer(private val pollInterval: Duration,
         @Path("network-parameters/{var}")
         @Produces(MediaType.APPLICATION_OCTET_STREAM)
         fun getNetworkParameter(@PathParam("var") hash: String): Response {
-            val requestedHash = SecureHash.parse(hash)
+            val requestedHash = SecureHash.create(hash)
             val requestedParameters = if (requestedHash == signedNetParams.raw.hash) {
                 signedNetParams
             } else if (requestedHash == nextNetworkParameters?.serialize()?.hash) {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/services/InternalMockAttachmentStorage.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/services/InternalMockAttachmentStorage.kt
@@ -30,7 +30,7 @@ class InternalMockAttachmentStorage(storage: MockAttachmentStorage) : Attachment
         return try {
             importAttachment(jar, uploader, filename)
         } catch (faee: java.nio.file.FileAlreadyExistsException) {
-            AttachmentId.parse(faee.message!!)
+            AttachmentId.create(faee.message!!)
         }
     }
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt
@@ -83,7 +83,7 @@ class MockAttachmentStorage : AttachmentStorage, SingletonSerializeAsToken() {
         return try {
             importAttachment(jar, UNKNOWN_UPLOADER, null)
         } catch (e: java.nio.file.FileAlreadyExistsException) {
-            AttachmentId.parse(e.message!!)
+            AttachmentId.create(e.message!!)
         }
     }
 

--- a/testing/testserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
+++ b/testing/testserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
@@ -38,7 +38,7 @@ class AttachmentDownloadServlet : HttpServlet() {
         }
 
         try {
-            val hash = SecureHash.parse(reqPath.substringBefore('/'))
+            val hash = SecureHash.create(reqPath.substringBefore('/'))
             val rpc = servletContext.getAttribute("rpc") as CordaRPCOps
             val attachment = rpc.openAttachment(hash)
 

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt
@@ -235,7 +235,7 @@ class TransactionViewer : CordaView("Transactions") {
                         }
                         override fun computeValue(): SecureHash {
                             return if (hashList.isEmpty()) SecureHash.zeroHash
-                            else hashList.fold(hashList[0], { one, another -> one.hashConcat(another) })
+                            else hashList.fold(hashList[0], { one, another -> one.concatenate(another) })
                         }
                     }
                     graphicProperty().bind(hashBinding.map { identicon(it, 30.0) })


### PR DESCRIPTION
Implement `SecureHash.create(str)`, which supports `str` values like:
```
HASH-TYPE:HASH-VALUE
```
Anything without a `HASH-TYPE:` prefix is assumed to be SHA-256. The `HASH-TYPE` is the Java Provider name of the `MessageDigest`algorithm to use.