### PR TITLE
ENT-5339 Failing tests against Oracle in VaultObserverExceptionTest

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/vault/VaultObserverExceptionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/vault/VaultObserverExceptionTest.kt
@@ -599,7 +599,12 @@ class VaultObserverExceptionTest {
     @Test(timeout=300_000)
     fun `Throw user error in VaultService rawUpdates during counterparty FinalityFlow blows up the flow but does not break the Observer`() {
         var observationCounter = 0
-        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ -> ++observationCounter }
+        // Semaphore is used to wait until [PassErroneousOwnableStateReceiver] gets hospitalized, only after that moment let testing thread assert 'observationCounter'
+        val counterPartyHospitalized = Semaphore(0)
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
+            ++observationCounter
+            counterPartyHospitalized.release()
+        }
 
         val rawUpdatesCount = ConcurrentHashMap<Party, Int>()
         DbListenerService.onNextVisited = { party ->
@@ -645,6 +650,7 @@ class VaultObserverExceptionTest {
             assertEquals(1, aliceNode.getStatesById(stateId, Vault.StateStatus.CONSUMED).size)
             assertEquals(0, bobNode.getStatesById(stateId, Vault.StateStatus.UNCONSUMED).size)
             assertEquals(1, notary.getNotarisedTransactionIds().size)
+            counterPartyHospitalized.acquire()
             assertEquals(1, observationCounter)
             assertEquals(2, rawUpdatesCount[aliceNode.nodeInfo.singleIdentity()])
             assertEquals(1, rawUpdatesCount[bobNode.nodeInfo.singleIdentity()])
@@ -654,6 +660,7 @@ class VaultObserverExceptionTest {
             assertEquals(2, aliceNode.getAllStates(Vault.StateStatus.CONSUMED).size)
             assertEquals(0, bobNode.getStatesById(stateId2, Vault.StateStatus.UNCONSUMED).size)
             assertEquals(2, notary.getNotarisedTransactionIds().size)
+            counterPartyHospitalized.acquire()
             assertEquals(2, observationCounter)
             assertEquals(4, rawUpdatesCount[aliceNode.nodeInfo.singleIdentity()])
             assertEquals(2, rawUpdatesCount[bobNode.nodeInfo.singleIdentity()])


### PR DESCRIPTION
1. Fix erroneous sql statement for Oracle. It was failing tests with 'ORA-00933: SQL command not properly ended'.

2. Fix flaky test.