### PR TITLE
[EG-2225] Prevent extra directories being created when relative base directories are specified

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -320,6 +320,6 @@ publish {
 }
 
 test {
-    maxHeapSize = "1g"
+    maxHeapSize = "3g"
     maxParallelForks = (System.env.CORDA_NODE_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_TESTING_FORKS".toInteger()
 }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -320,6 +320,6 @@ publish {
 }
 
 test {
-    maxHeapSize = "3g"
+    maxHeapSize = "1g"
     maxParallelForks = (System.env.CORDA_NODE_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_TESTING_FORKS".toInteger()
 }

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -77,7 +77,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
         val messagingServerExternal = config[messagingServerExternal] ?: Defaults.messagingServerExternal(config[messagingServerAddress])
         val database = config[database] ?: Defaults.database(config[devMode])
         val baseDirectoryPath = config[baseDirectory]
-        val cordappDirectories = config[cordappDirectories] ?: Defaults.cordappsDirectories(baseDirectoryPath)
+        val cordappDirectories = config[cordappDirectories]?.map { baseDirectoryPath.resolve(it) } ?: Defaults.cordappsDirectories(baseDirectoryPath)
         val result = try {
             valid<NodeConfigurationImpl, Configuration.Validation.Error>(NodeConfigurationImpl(
                     baseDirectory = baseDirectoryPath,
@@ -127,7 +127,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     attachmentContentCacheSizeMegaBytes = config[attachmentContentCacheSizeMegaBytes],
                     h2port = config[h2port],
                     jarDirs = config[jarDirs],
-                    cordappDirectories = cordappDirectories.map { baseDirectoryPath.resolve(it) },
+                    cordappDirectories = cordappDirectories,
                     cordappSignerKeyFingerprintBlacklist = config[cordappSignerKeyFingerprintBlacklist],
                     blacklistedAttachmentSigningKeys = config[blacklistedAttachmentSigningKeys],
                     networkParameterAcceptanceSettings = config[networkParameterAcceptanceSettings],

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.io.File
 import java.net.URI
 import java.net.URL
 import java.nio.file.Paths
@@ -202,7 +203,7 @@ class NodeConfigurationImplTest {
     }
 
     @Test(timeout=300_000)
-	fun `relative path correctly parsed`() {
+	fun `absolute base directory leads to correct cordapp directories`() {
         val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
         // Override base directory to have predictable experience on diff OSes
@@ -217,6 +218,62 @@ class NodeConfigurationImplTest {
 
         val baseDirPath = tempFolder.root.toPath()
         assertEquals(listOf(baseDirPath / "./myCorDapps1", baseDirPath / "./myCorDapps2"), nodeConfiguration.value().cordappDirectories)
+    }
+
+    @Test(timeout=300_000)
+    fun `absolute base directory leads to correct default cordapp directory`() {
+        val rawConfig = ConfigFactory.parseResources("working-config-no-cordapps.conf", ConfigParseOptions.defaults().setAllowMissing(false))
+
+        // Override base directory to have predictable experience on diff OSes
+        val finalConfig = configOf(
+                // Add substitution values here
+                "baseDirectory" to tempFolder.root.canonicalPath)
+                .withFallback(rawConfig)
+                .resolve()
+
+        val nodeConfiguration = finalConfig.parseAsNodeConfiguration()
+        assertThat(nodeConfiguration.isValid).isTrue()
+
+        val baseDirPath = tempFolder.root.toPath()
+        assertEquals(listOf(baseDirPath / "cordapps"), nodeConfiguration.value().cordappDirectories)
+    }
+
+    @Test(timeout=300_000)
+    fun `relative base dir leads to correct cordapp directories`() {
+        val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
+
+        val path = tempFolder.root.relativeTo(tempFolder.root.parentFile).toString()
+        val fullPath = File(".").resolve(path).toString()
+        // Override base directory to have predictable experience on diff OSes
+        val finalConfig = configOf(
+                // Add substitution values here
+                "baseDirectory" to fullPath)
+                .withFallback(rawConfig)
+                .resolve()
+
+        val nodeConfiguration = finalConfig.parseAsNodeConfiguration()
+        assertThat(nodeConfiguration.isValid).isTrue()
+
+        assertEquals(listOf(fullPath / "./myCorDapps1", fullPath / "./myCorDapps2"), nodeConfiguration.value().cordappDirectories)
+    }
+
+    @Test(timeout=300_000)
+    fun `relative base dir leads to correct default cordapp directory`() {
+        val rawConfig = ConfigFactory.parseResources("working-config-no-cordapps.conf", ConfigParseOptions.defaults().setAllowMissing(false))
+
+        val path = tempFolder.root.relativeTo(tempFolder.root.parentFile).toString()
+        val fullPath = File(".").resolve(path).toString()
+        // Override base directory to have predictable experience on diff OSes
+        val finalConfig = configOf(
+                // Add substitution values here
+                "baseDirectory" to fullPath)
+                .withFallback(rawConfig)
+                .resolve()
+
+        val nodeConfiguration = finalConfig.parseAsNodeConfiguration()
+        assertThat(nodeConfiguration.isValid).isTrue()
+
+        assertEquals(listOf(fullPath / "cordapps"), nodeConfiguration.value().cordappDirectories)
     }
 
     @Test(timeout=300_000)

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -35,7 +35,7 @@ class NodeConfigurationImplTest {
     @JvmField
     val tempFolder = TemporaryFolder()
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `can't have dev mode options if not in dev mode`() {
         val debugOptions = DevModeOptions()
         configDebugOptions(true, debugOptions)
@@ -44,7 +44,7 @@ class NodeConfigurationImplTest {
         configDebugOptions(false, null)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `can't have tlsCertCrlDistPoint null when tlsCertCrlIssuer is given`() {
         val configValidationResult = configTlsCertCrlOptions(null, "C=US, L=New York, OU=Corda, O=R3 HoldCo LLC, CN=Corda Root CA").validate()
         assertTrue { configValidationResult.isNotEmpty() }
@@ -52,7 +52,7 @@ class NodeConfigurationImplTest {
         assertThat(configValidationResult.first()).contains("tlsCertCrlIssuer")
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `can't have tlsCertCrlDistPoint null when crlCheckSoftFail is false`() {
         val configValidationResult = configTlsCertCrlOptions(null, null, false).validate()
         assertTrue { configValidationResult.isNotEmpty() }
@@ -60,7 +60,7 @@ class NodeConfigurationImplTest {
         assertThat(configValidationResult.first()).contains("crlCheckSoftFail")
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `check devModeOptions flag helper`() {
         assertTrue { configDebugOptions(true, null).shouldCheckCheckpoints() }
         assertTrue { configDebugOptions(true, DevModeOptions()).shouldCheckCheckpoints() }
@@ -68,7 +68,7 @@ class NodeConfigurationImplTest {
         assertFalse { configDebugOptions(true, DevModeOptions(true)).shouldCheckCheckpoints() }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `check crashShell flags helper`() {
         assertFalse { testConfiguration.copy(sshd = null).shouldStartSSHDaemon() }
         assertTrue { testConfiguration.copy(sshd = SSHDConfiguration(1234)).shouldStartSSHDaemon() }
@@ -80,7 +80,7 @@ class NodeConfigurationImplTest {
         assertFalse { testConfiguration.copy(noLocalShell = true, sshd = null).shouldInitCrashShell() }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `Dev mode is autodetected correctly`() {
         val os = System.getProperty("os.name")
 
@@ -103,20 +103,20 @@ class NodeConfigurationImplTest {
         System.setProperty("os.name", os)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `Dev mode is read from the config over the autodetect logic`() {
         assertTrue(getConfig("test-config-DevMode.conf").getBooleanCaseInsensitive("devMode"))
         assertFalse(getConfig("test-config-noDevMode.conf").getBooleanCaseInsensitive("devMode"))
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `Dev mode is true if overriden`() {
         assertTrue(getConfig("test-config-DevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to true))).getBooleanCaseInsensitive("devMode"))
         assertTrue(getConfig("test-config-noDevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to true))).getBooleanCaseInsensitive("devMode"))
         assertTrue(getConfig("test-config-empty.conf", ConfigFactory.parseMap(mapOf("devMode" to true))).getBooleanCaseInsensitive("devMode"))
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `Dev mode is false if overriden`() {
         assertFalse(getConfig("test-config-DevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to false))).getBooleanCaseInsensitive("devMode"))
         assertFalse(getConfig("test-config-noDevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to false))).getBooleanCaseInsensitive("devMode"))
@@ -132,7 +132,7 @@ class NodeConfigurationImplTest {
         )
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `validation has error when compatibilityZoneURL is present and devMode is true`() {
         val configuration = testConfiguration.copy(
                 devMode = true,
@@ -143,7 +143,7 @@ class NodeConfigurationImplTest {
         assertThat(errors).hasOnlyOneElementSatisfying { error -> error.contains("compatibilityZoneURL") && error.contains("devMode") }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `validation succeeds when compatibilityZoneURL is present and devMode is true and allowCompatibilityZoneURL is set`() {
         val configuration = testConfiguration.copy(
                 devMode = true,
@@ -154,7 +154,7 @@ class NodeConfigurationImplTest {
         assertThat(errors).isEmpty()
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `errors for nested config keys contain path`() {
         var rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
         val missingPropertyPath = "rpcSettings.address"
@@ -166,7 +166,7 @@ class NodeConfigurationImplTest {
         }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `validation has error when compatibilityZone is present and devMode is true`() {
         val configuration = testConfiguration.copy(devMode = true, networkServices = NetworkServicesConfig(
                 URL("https://r3.com.doorman"),
@@ -177,7 +177,7 @@ class NodeConfigurationImplTest {
         assertThat(errors).hasOnlyOneElementSatisfying { error -> error.contains("networkServices") && error.contains("devMode") }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `validation has error when both compatibilityZoneURL and networkServices are configured`() {
         val configuration = testConfiguration.copy(
                 devMode = false,
@@ -193,7 +193,7 @@ class NodeConfigurationImplTest {
         }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `rpcAddress and rpcSettings_address are equivalent`() {
         var rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
         rawConfig = rawConfig.withoutPath("rpcSettings.address")
@@ -202,7 +202,7 @@ class NodeConfigurationImplTest {
         assertThat(rawConfig.parseAsNodeConfiguration().isValid).isTrue()
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `absolute base directory leads to correct cordapp directories`() {
         val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -214,13 +214,13 @@ class NodeConfigurationImplTest {
                 .resolve()
 
         val nodeConfiguration = finalConfig.parseAsNodeConfiguration()
-        assertThat(nodeConfiguration.isValid).isTrue()
+        assertTrue(nodeConfiguration.isValid)
 
         val baseDirPath = tempFolder.root.toPath()
         assertEquals(listOf(baseDirPath / "./myCorDapps1", baseDirPath / "./myCorDapps2"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
     fun `absolute base directory leads to correct default cordapp directory`() {
         val rawConfig = ConfigFactory.parseResources("working-config-no-cordapps.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -232,13 +232,13 @@ class NodeConfigurationImplTest {
                 .resolve()
 
         val nodeConfiguration = finalConfig.parseAsNodeConfiguration()
-        assertThat(nodeConfiguration.isValid).isTrue()
+        assertTrue(nodeConfiguration.isValid)
 
         val baseDirPath = tempFolder.root.toPath()
         assertEquals(listOf(baseDirPath / "cordapps"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
     fun `relative base dir leads to correct cordapp directories`() {
         val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -252,12 +252,12 @@ class NodeConfigurationImplTest {
                 .resolve()
 
         val nodeConfiguration = finalConfig.parseAsNodeConfiguration()
-        assertThat(nodeConfiguration.isValid).isTrue()
+        assertTrue(nodeConfiguration.isValid)
 
         assertEquals(listOf(fullPath / "./myCorDapps1", fullPath / "./myCorDapps2"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
     fun `relative base dir leads to correct default cordapp directory`() {
         val rawConfig = ConfigFactory.parseResources("working-config-no-cordapps.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -271,12 +271,12 @@ class NodeConfigurationImplTest {
                 .resolve()
 
         val nodeConfiguration = finalConfig.parseAsNodeConfiguration()
-        assertThat(nodeConfiguration.isValid).isTrue()
+        assertTrue(nodeConfiguration.isValid)
 
         assertEquals(listOf(fullPath / "cordapps"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `missing rpcSettings_adminAddress cause a graceful failure`() {
         var rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
         rawConfig = rawConfig.withoutPath("rpcSettings.adminAddress")
@@ -286,7 +286,7 @@ class NodeConfigurationImplTest {
         assertThat(config.errors.asSequence().map(Configuration.Validation.Error::message).filter { it.contains("rpcSettings.adminAddress") }.toList()).isNotEmpty
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `compatibilityZoneURL populates NetworkServices`() {
         val compatibilityZoneURL = URI.create("https://r3.com").toURL()
         val configuration = testConfiguration.copy(
@@ -298,14 +298,14 @@ class NodeConfigurationImplTest {
         assertEquals(compatibilityZoneURL, configuration.networkServices!!.networkMapURL)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `jmxReporterType is null and defaults to Jokolia`() {
         val rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("devMode" to true)))
         val nodeConfig = rawConfig.parseAsNodeConfiguration().value()
         assertEquals(JmxReporterType.JOLOKIA.toString(), nodeConfig.jmxReporterType.toString())
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `jmxReporterType is not null and is set to New Relic`() {
         var rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("devMode" to true)))
         rawConfig = rawConfig.withValue("jmxReporterType", ConfigValueFactory.fromAnyRef("NEW_RELIC"))
@@ -313,7 +313,7 @@ class NodeConfigurationImplTest {
         assertEquals(JmxReporterType.NEW_RELIC.toString(), nodeConfig.jmxReporterType.toString())
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `jmxReporterType is not null and set to Jokolia`() {
         var rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("devMode" to true)))
         rawConfig = rawConfig.withValue("jmxReporterType", ConfigValueFactory.fromAnyRef("JOLOKIA"))
@@ -321,7 +321,7 @@ class NodeConfigurationImplTest {
         assertEquals(JmxReporterType.JOLOKIA.toString(), nodeConfig.jmxReporterType.toString())
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
 	fun `network services`() {
         val rawConfig = getConfig("test-config-with-networkservices.conf")
         val nodeConfig = rawConfig.parseAsNodeConfiguration().value()
@@ -333,7 +333,7 @@ class NodeConfigurationImplTest {
         }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout=3_000)
     fun `check crlCheckArtemisServer flag`() {
         assertFalse(getConfig("working-config.conf").parseAsNodeConfiguration().value().crlCheckArtemisServer)
         val rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("crlCheckArtemisServer" to true)))

--- a/node/src/test/resources/working-config-no-cordapps.conf
+++ b/node/src/test/resources/working-config-no-cordapps.conf
@@ -1,0 +1,31 @@
+myLegalName = "O=Alice Corp, L=Madrid, C=ES"
+emailAddress = "admin@company.com"
+keyStorePassword = "cordacadevpass"
+trustStorePassword = "trustpass"
+crlCheckSoftFail = true
+baseDirectory = "/opt/corda"
+dataSourceProperties = {
+    dataSourceClassName = org.h2.jdbcx.JdbcDataSource
+    dataSource.url = "jdbc:h2:file:blah"
+    dataSource.user = "sa"
+    dataSource.password = ""
+}
+database = {
+    transactionIsolationLevel = "REPEATABLE_READ"
+    exportHibernateJMXStatistics = "false"
+}
+p2pAddress = "localhost:2233"
+h2port = 0
+useTestClock = false
+verifierType = InMemory
+rpcSettings = {
+    address = "locahost:3418"
+    adminAddress = "localhost:3419"
+    useSsl = false
+    standAloneBroker = false
+}
+flowTimeout {
+    timeout = 30 seconds
+    maxRestartCount = 3
+    backoffBase = 2.0
+}


### PR DESCRIPTION
There is a hidden `cordappDirectories` configuration option that informs the node where CorDapps are located. By default, this points to the `cordapps` directory within the base directory of the node. If the configuration option is not specified, then path resolution was being performed twice, resulting in the actual path appearing in the node configuration looking like `basepath/./basepath/./cordapps` if `basepath` is a relative path. The `CordappConfigFileProvider` uses the value of the `cordappDirectories` configuration to create the `config` directory if this doesn't exist. As a result, when a relative path is passed as the base directory, an extra set of directories would be created in the base directory as `node-name/cordapps/config`.

The fix is to ensure that the base directory is only resolved once.
