### PR TITLE
CORDA-3818: Synchronize OS implementation of PublicKeyToOwningIdentityCache with CE

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/PublicKeyToOwningIdentityCache.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/PublicKeyToOwningIdentityCache.kt
@@ -11,7 +11,7 @@ interface PublicKeyToOwningIdentityCache {
     /**
      * Obtain the owning identity for a public key.
      *
-     * If the key is unknown to the node, then this will return null.
+     * If the key is unknown to the node, then this will return [KeyOwningIdentity.UnmappedIdentity].
      */
-    operator fun get(key: PublicKey): KeyOwningIdentity?
+    operator fun get(key: PublicKey): KeyOwningIdentity
 }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -413,6 +413,9 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
         return database.transaction {
             log.info("Linking: ${publicKey.hash} to ${party.name}")
             keyToName[publicKey.toStringShort()] = party.name
+            if (party == wellKnownPartyFromX500Name(ourNames.first())) {
+                _pkToIdCache[publicKey] = KeyOwningIdentity.UnmappedIdentity
+            }
         }
     }
 
@@ -422,7 +425,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     override fun externalIdForPublicKey(publicKey: PublicKey): UUID? {
-        return _pkToIdCache[publicKey]?.uuid
+        return _pkToIdCache[publicKey].uuid
     }
 
     private fun publicKeysForExternalId(externalId: UUID, table: Class<*>): List<PublicKey> {

--- a/node/src/test/kotlin/net/corda/node/services/persistence/PublicKeyToOwningIdentityCacheImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/PublicKeyToOwningIdentityCacheImplTest.kt
@@ -114,9 +114,9 @@ class PublicKeyToOwningIdentityCacheImplTest {
     }
 
     @Test(timeout=300_000)
-	fun `requesting a key unknown to the node returns null`() {
+	fun `requesting a key unknown to the node returns unmapped identity`() {
         val keys = generateKeyPair()
-        assertEquals(null, testCache[keys.public])
+        assertEquals(KeyOwningIdentity.UnmappedIdentity, testCache[keys.public])
     }
 
     @Test(timeout=300_000)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockPublicKeyToOwningIdentityCache.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockPublicKeyToOwningIdentityCache.kt
@@ -13,8 +13,8 @@ class MockPublicKeyToOwningIdentityCache : WritablePublicKeyToOwningIdentityCach
 
     private val cache: MutableMap<PublicKey, KeyOwningIdentity> = mutableMapOf<PublicKey, KeyOwningIdentity>().toSynchronised()
 
-    override fun get(key: PublicKey): KeyOwningIdentity? {
-        return cache[key]
+    override fun get(key: PublicKey): KeyOwningIdentity {
+        return cache[key] ?: KeyOwningIdentity.UnmappedIdentity
     }
 
     override fun set(key: PublicKey, value: KeyOwningIdentity) {


### PR DESCRIPTION
Make OS implementation of `PublicKeyToOwningIdentityCache` identical to CE, including changes from https://github.com/corda/enterprise/pull/3395.

Primarily needed to simplify further PKI changes (and rebase POC in https://github.com/corda/corda/pull/6218).

No changes in CE expected (during upcoming merge).