### PR TITLE
CORDA-3725 Fix SQL deadlocks coming from soft locking states

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -134,20 +134,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
 
-    internal val softLockedStates = object : LinkedHashSet<StateRef>() {
-
-        override fun remove(element: StateRef): Boolean {
-            throw UnsupportedOperationException("Can only add locked states")
-        }
-
-        override fun removeAll(elements: Collection<StateRef>): Boolean {
-            throw UnsupportedOperationException("Can only add locked states")
-        }
-
-        override fun removeIf(filter: Predicate<in StateRef>): Boolean {
-            throw UnsupportedOperationException("Can only add locked states")
-        }
-    }
+    internal val softLockedStates = mutableSetOf<StateRef>()
 
     /**
      * Processes an event by creating the associated transition and executing it using the given executor.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -58,7 +58,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import java.util.concurrent.TimeUnit
-import java.util.function.Predicate
 import kotlin.reflect.KProperty1
 
 class FlowPermissionException(message: String) : FlowException(message)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -8,6 +8,7 @@ import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.channels.Channel
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
+import net.corda.core.contracts.StateRef
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.flows.Destination
 import net.corda.core.flows.FlowException
@@ -57,6 +58,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import java.util.concurrent.TimeUnit
+import java.util.function.Predicate
 import kotlin.reflect.KProperty1
 
 class FlowPermissionException(message: String) : FlowException(message)
@@ -132,10 +134,20 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
 
-    internal var hasSoftLockedStates: Boolean = false
-        set(value) {
-            if (value) field = value else throw IllegalArgumentException("Can only set to true")
+    internal val softLockedStates = object : LinkedHashSet<StateRef>() {
+
+        override fun remove(element: StateRef): Boolean {
+            throw UnsupportedOperationException("Can only add locked states")
         }
+
+        override fun removeAll(elements: Collection<StateRef>): Boolean {
+            throw UnsupportedOperationException("Can only add locked states")
+        }
+
+        override fun removeIf(filter: Predicate<in StateRef>): Boolean {
+            throw UnsupportedOperationException("Can only add locked states")
+        }
+    }
 
     /**
      * Processes an event by creating the associated transition and executing it using the given executor.
@@ -306,7 +318,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
             logger.info("Flow raised an error: ${t.message}. Sending it to flow hospital to be triaged.")
             Try.Failure<R>(t)
         }
-        val softLocksId = if (hasSoftLockedStates) logic.runId.uuid else null
+        val softLocksId = if (softLockedStates.isNotEmpty()) logic.runId.uuid else null
         val finalEvent = when (resultOrError) {
             is Try.Success -> {
                 Event.FlowFinish(resultOrError.value, softLocksId)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -58,7 +58,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import java.util.concurrent.TimeUnit
-import java.util.function.Predicate
 import kotlin.reflect.KProperty1
 
 class FlowPermissionException(message: String) : FlowException(message)
@@ -134,20 +133,18 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
 
-    internal val softLockedStates = object : LinkedHashSet<StateRef>() {
-
-        override fun remove(element: StateRef): Boolean {
-            throw UnsupportedOperationException("Can only add locked states")
+    internal var softLockedStatesDeactivated: Boolean = false
+        set(value) {
+            if (value) {
+                field = value
+                // Once attempted to soft lock by not our flow Id we fall back to the old release soft locks query mechanism.
+                // We will no longer use [softLockedStates]. We clear it, to reduce fiber's memory footprint.
+                softLockedStates.clear()
+            } else
+                throw IllegalArgumentException("Can only set to true")
         }
 
-        override fun removeAll(elements: Collection<StateRef>): Boolean {
-            throw UnsupportedOperationException("Can only add locked states")
-        }
-
-        override fun removeIf(filter: Predicate<in StateRef>): Boolean {
-            throw UnsupportedOperationException("Can only add locked states")
-        }
-    }
+    internal val softLockedStates = mutableSetOf<StateRef>()
 
     /**
      * Processes an event by creating the associated transition and executing it using the given executor.
@@ -318,7 +315,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
             logger.info("Flow raised an error: ${t.message}. Sending it to flow hospital to be triaged.")
             Try.Failure<R>(t)
         }
-        val softLocksId = if (softLockedStates.isNotEmpty()) logic.runId.uuid else null
+        val softLocksId = if (softLockedStates.isNotEmpty() || softLockedStatesDeactivated) logic.runId.uuid else null
         val finalEvent = when (resultOrError) {
             is Try.Success -> {
                 Event.FlowFinish(resultOrError.value, softLocksId)

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -484,7 +484,7 @@ class NodeVaultService(
         }
     }
 
-    @Suppress("NestedBlockDepth")
+    @Suppress("NestedBlockDepth", "ComplexMethod")
     @Throws(StatesNotAvailableException::class)
     override fun softLockReserve(lockId: UUID, stateRefs: NonEmptySet<StateRef>) {
         val softLockTimestamp = clock.instant()

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -54,8 +54,7 @@ private fun CriteriaBuilder.executeUpdate(
         }
     }
     return stateRefs?.let {
-        // divide [List<PersistentStateRef>] into [List<List<PersistentStateRef>>] of [MAX_SQL_IN_CLAUSE_SET] size each for sql server performance
-        // (so that the optimizer will make use of the index)
+        // Increase SQL server performance by, processing updates in chunks allowing the database's optimizer to make use of the index.
         var updatedRows = 0
         it.asSequence()
             .map { stateRef -> PersistentStateRef(stateRef.txhash.bytes.toHexString(), stateRef.index) }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -507,7 +507,11 @@ class NodeVaultService(
             }
             if (updatedRows > 0 && updatedRows == stateRefs.size) {
                 log.trace { "Reserving soft lock states for $lockId: $stateRefs" }
-                FlowStateMachineImpl.currentStateMachine()?.softLockedStates?.addAll(stateRefs)
+                FlowStateMachineImpl.currentStateMachine()?.let {
+                    if (lockId == it.id.uuid) {
+                        it.softLockedStates.addAll(stateRefs)
+                    }
+                }
             } else {
                 // revert partial soft locks
                 val revertUpdatedRows = execute { update, commonPredicates ->

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -484,6 +484,7 @@ class NodeVaultService(
         }
     }
 
+    @Suppress("NestedBlockDepth")
     @Throws(StatesNotAvailableException::class)
     override fun softLockReserve(lockId: UUID, stateRefs: NonEmptySet<StateRef>) {
         val softLockTimestamp = clock.instant()
@@ -534,6 +535,7 @@ class NodeVaultService(
         }
     }
 
+    @Suppress("NestedBlockDepth")
     override fun softLockRelease(lockId: UUID, stateRefs: NonEmptySet<StateRef>?) {
         val softLockTimestamp = clock.instant()
         val session = currentDBSession()

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -507,17 +507,7 @@ class NodeVaultService(
             }
             if (updatedRows > 0 && updatedRows == stateRefs.size) {
                 log.trace { "Reserving soft lock states for $lockId: $stateRefs" }
-                FlowStateMachineImpl.currentStateMachine()?.let {
-                    if (!it.softLockedStatesDeactivated) {
-                        if (lockId != it.id.uuid) {
-                            // Attempt to lock with an id which is not our flow id. Deactivate [flowStateMachineImpl.softLockedStates] as we will fall back to the old
-                            // query mechanism, i.e. we will not use the [flowStateMachineImpl.softLockedStates] in softLockRelease query.
-                            it.softLockedStatesDeactivated = true
-                        } else {
-                            FlowStateMachineImpl.currentStateMachine()?.softLockedStates?.addAll(stateRefs)
-                        }
-                    }
-                }
+                FlowStateMachineImpl.currentStateMachine()?.softLockedStates?.addAll(stateRefs)
             } else {
                 // revert partial soft locks
                 val revertUpdatedRows = execute { update, commonPredicates ->

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -581,9 +581,7 @@ class NodeVaultService(
                     log.trace { "Releasing $updatedRows soft locked states for $lockId and stateRefs $stateRefsToBeReleased" }
                 }
             } catch (e: Exception) {
-                log.error("""soft lock update error attempting to release states for $lockId and $stateRefsToBeReleased")
-                    $e.
-                """)
+                log.error("Soft lock update error attempting to release states for $lockId and $stateRefsToBeReleased", e)
                 throw e
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -548,9 +548,8 @@ class NodeVaultService(
             configure(update, arrayOf(stateStatusPredication, lockIdPredicate), persistentStateRefs)
         }
 
-        val flowStateMachineImpl = FlowStateMachineImpl.currentStateMachine()
         val stateRefsToBeReleased =
-            stateRefs ?: flowStateMachineImpl?.let {
+            stateRefs ?: FlowStateMachineImpl.currentStateMachine()?.let {
                 // We only hold states under our flowId. For all other lockId fall back to old query mechanism, i.e. stateRefsToBeReleased = null
                 if (lockId == it.id.uuid && it.softLockedStates.isNotEmpty()) {
                     NonEmptySet.copyOf(it.softLockedStates)
@@ -574,7 +573,7 @@ class NodeVaultService(
                     update.where(*commonPredicates, stateRefsPredicate)
                 }
                 if (updatedRows > 0) {
-                    flowStateMachineImpl?.let {
+                    FlowStateMachineImpl.currentStateMachine()?.let {
                         if (lockId == it.id.uuid) {
                             it.softLockedStates.removeAll(stateRefsToBeReleased)
                         }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -535,7 +535,7 @@ class NodeVaultService(
         }
     }
 
-    @Suppress("NestedBlockDepth")
+    @Suppress("NestedBlockDepth", "ComplexMethod")
     override fun softLockRelease(lockId: UUID, stateRefs: NonEmptySet<StateRef>?) {
         val softLockTimestamp = clock.instant()
         val session = currentDBSession()

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -548,11 +548,6 @@ class NodeVaultService(
             configure(update, arrayOf(stateStatusPredication, lockIdPredicate), persistentStateRefs)
         }
 
-        // CORDA-3725: Adding to the query explicitly the flow's locked states resolved the SQL Deadlocks in sql server.
-        // The SQL Deadlocks were caused from softLockRelease when only the lockId was specified. In that case the query optimizer
-        // would use lock_id_idx(lock_id, state_status) to search and update entries in vault_states table. However, all rest of the queries would follow the
-        // opposite direction meaning they would use PK's index(output_index, transaction_id) but they could also update the lock_id and therefore the lock_id_idx as well.
-        // That was causing a circular locking among the different transactions within the database.
         val flowStateMachineImpl = FlowStateMachineImpl.currentStateMachine()
         val stateRefsToBeReleased =
             stateRefs ?: flowStateMachineImpl?.let {

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -552,11 +552,12 @@ class NodeVaultService(
         // would use lock_id_idx(lock_id, state_status) to search and update entries in vault_states table. However, all rest of the queries would follow the
         // opposite direction meaning they would use PK's index(output_index, transaction_id) but they could also update the lock_id and therefore the lock_id_idx as well.
         // That was causing a circular locking among the different transactions within the database.
-        val softLockedStates = FlowStateMachineImpl.currentStateMachine()?.softLockedStates
+        val flowStateMachineImpl = FlowStateMachineImpl.currentStateMachine()
         val stateRefsToBeReleased =
-            stateRefs ?: softLockedStates?.let {
-                if (it.isNotEmpty()) {
-                    NonEmptySet.copyOf(it)
+            stateRefs ?: flowStateMachineImpl?.let {
+                // We only hold states under our flowId. For all other lockId fall back to old query mechanism, i.e. stateRefsToBeReleased = null
+                if (lockId == it.id.uuid && it.softLockedStates.isNotEmpty()) {
+                    NonEmptySet.copyOf(it.softLockedStates)
                 } else {
                     null
                 }
@@ -577,7 +578,11 @@ class NodeVaultService(
                     update.where(*commonPredicates, stateRefsPredicate)
                 }
                 if (updatedRows > 0) {
-                    softLockedStates?.removeAll(stateRefsToBeReleased)
+                    flowStateMachineImpl?.let {
+                        if (lockId == it.id.uuid) {
+                            it.softLockedStates.removeAll(stateRefsToBeReleased)
+                        }
+                    }
                     log.trace { "Releasing $updatedRows soft locked states for $lockId and stateRefs $stateRefsToBeReleased" }
                 }
             } catch (e: Exception) {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -1297,8 +1297,6 @@ internal class SoftLocksFLow(private val unlockedStates: List<StateAndRef<Cash.S
             serviceHub.vaultService.softLockRelease(randomUUID)
         }
         serviceHub.vaultService.softLockRelease(stateMachine.id.uuid)
-        assertEquals(lockSetRandomId, queryStates(QueryCriteria.SoftLockingType.LOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet())
-
         return true
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -1284,7 +1284,7 @@ internal class SoftLocksFLow(private val unlockedStates: List<StateAndRef<Cash.S
         serviceHub.vaultService.softLockRelease(randomUUID, lockSetRandomId)
         assertEquals(lockSetFlowId + lockSetRandomId, queryStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet())
 
-        // now lock with our flow Id, lock with other Id and then unlock passing in only our Id
+        // lock with our flow Id, lock with random Id and then unlock passing in only flow Id
         serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
         serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
         assertEquals(lockSetFlowId + lockSetRandomId, queryStates(QueryCriteria.SoftLockingType.LOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet())

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -1303,7 +1303,7 @@ object SoftLocks {
                 ).states
 
             var checkpointAfterReserves: Boolean = false
-            var hookAfterReleases: (FlowStateMachineImpl<*>) -> Unit = {}
+            var hookAfterReleases: () -> Unit = {}
         }
 
         @Suspendable
@@ -1365,7 +1365,7 @@ object SoftLocks {
             }
             serviceHub.vaultService.softLockRelease(stateMachine.id.uuid)
             assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-            hookAfterReleases((stateMachine as? FlowStateMachineImpl<*>)!!)
+            hookAfterReleases()
             return true
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -1316,6 +1316,8 @@ internal class SoftLocksFLow(private val unlockedStates: List<StateAndRef<Cash.S
         assertEquals(lockSetFlowId + lockSetRandomId, queryCashStates(QueryCriteria.SoftLockingType.LOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet())
         // the following if-block is intentionally put in the following order. We need to assure that while states are locked with the flowId,
         // and with random Ids, when unlocking with random Id it will not make use of [flowStateMachineImpl.softLockedStates]
+        // i.e. a. it will successfully remove these states (otherwise it would not, because it would include in the sql IN clause states that are not under this random Id)
+        //      b. it will leave [flowStateMachineImpl.softLockedStates] untouched (it will not remove any states in there since they do not belong to the random Id)
         if (releaseRandomId) {
             serviceHub.vaultService.softLockRelease(randomUUID)
         }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -848,7 +848,7 @@ class FlowFrameworkTests {
         assertEquals(null, persistedException)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow correctly soft locks and unlocks states - at the end keeps locked states reserved by random id`() {
         val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
         val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, false)).resultFuture.getOrThrow(30.seconds)
@@ -856,7 +856,7 @@ class FlowFrameworkTests {
         assertEquals(5, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow correctly soft locks and unlocks states - at the end releases states reserved by random id`() {
         val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
         val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
@@ -864,7 +864,7 @@ class FlowFrameworkTests {
         assertEquals(10, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow soft locks fungible state upon creation`() {
         var lockedStates = 0
         SoftLocks.CreateFungibleStateFLow.hook = { vaultService ->
@@ -878,7 +878,7 @@ class FlowFrameworkTests {
         assertEquals(1, lockedStates)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `when flow soft locks, then errors and retries from previous checkpoint, softLockedStates are reverted back correctly`() {
         var firstRun = true
         SoftLocks.LockingUnlockingFlow.checkpointAfterReserves = true

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -6,10 +6,7 @@ import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.concurrent.Semaphore
 import net.corda.client.rpc.notUsed
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.contracts.Command
 import net.corda.core.contracts.ContractState
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.flows.Destination
@@ -31,10 +28,7 @@ import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.node.services.PartyInfo
-import net.corda.core.node.services.Vault
-import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.queryBy
-import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
@@ -45,28 +39,20 @@ import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.ProgressTracker.Change
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
-import net.corda.core.utilities.toNonEmptySet
 import net.corda.core.utilities.unwrap
-import net.corda.finance.DOLLARS
-import net.corda.finance.contracts.asset.Cash
 import net.corda.node.services.persistence.CheckpointPerformanceRecorder
 import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.node.services.persistence.checkpoints
-import net.corda.node.services.vault.NodeVaultServiceTest
 import net.corda.nodeapi.internal.persistence.DatabaseTransaction
 import net.corda.nodeapi.internal.persistence.currentDBSession
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyState
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
-import net.corda.testing.core.BOC_NAME
-import net.corda.testing.core.DUMMY_NOTARY_NAME
-import net.corda.testing.core.TestIdentity
 import net.corda.testing.core.dummyCommand
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.flows.registerCordappFlowFactory
 import net.corda.testing.internal.LogHelper
-import net.corda.testing.internal.vault.VaultFiller
 import net.corda.testing.node.InMemoryMessagingNetwork.MessageTransfer
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
@@ -95,7 +81,7 @@ import java.sql.SQLTransientConnectionException
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.ArrayList
 import java.util.concurrent.TimeoutException
 import java.util.function.Predicate
 import kotlin.reflect.KClass
@@ -105,8 +91,6 @@ import kotlin.test.assertTrue
 
 class FlowFrameworkTests {
     companion object {
-        val dummyNotary = TestIdentity(DUMMY_NOTARY_NAME, 20)
-
         init {
             LogHelper.setLevel("+net.corda.flow")
         }
@@ -848,68 +832,6 @@ class FlowFrameworkTests {
         assertEquals(null, persistedException)
     }
 
-    @Test(timeout=300_000)
-    fun `flow correctly soft locks and unlocks states - at the end keeps locked states reserved by random id`() {
-        val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
-        val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, false)).resultFuture.getOrThrow(30.seconds)
-        assertTrue(completedSuccessfully)
-        assertEquals(5, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
-    }
-
-    @Test(timeout=300_000)
-    fun `flow correctly soft locks and unlocks states - at the end releases states reserved by random id`() {
-        val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
-        val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
-        assertTrue(completedSuccessfully)
-        assertEquals(10, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
-    }
-
-    @Test(timeout=300_000)
-    fun `flow soft locks fungible state upon creation`() {
-        var lockedStates = 0
-        SoftLocks.CreateFungibleStateFLow.hook = { vaultService ->
-            lockedStates = vaultService.queryBy<NodeVaultServiceTest.FungibleFoo>(
-                QueryCriteria.VaultQueryCriteria(
-                    softLockingCondition = QueryCriteria.SoftLockingCondition(QueryCriteria.SoftLockingType.LOCKED_ONLY)
-                )
-            ).states.size
-        }
-        aliceNode.services.startFlow(SoftLocks.CreateFungibleStateFLow()).resultFuture.getOrThrow(30.seconds)
-        assertEquals(1, lockedStates)
-    }
-
-    @Test(timeout=300_000)
-    fun `when flow soft locks, then errors and retries from previous checkpoint, softLockedStates are reverted back correctly`() {
-        var firstRun = true
-        SoftLocks.LockingUnlockingFlow.checkpointAfterReserves = true
-
-        SoftLocks.LockingUnlockingFlow.hookAfterReleases = {
-            if (firstRun) {
-                firstRun = false
-                throw SQLTransientConnectionException("connection is not available")
-            }
-        }
-
-        val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
-        val completedSuccessfully = aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
-        assertTrue(completedSuccessfully)
-    }
-
-    private fun fillVault(node: TestStartedNode, thisManyStates: Int): Vault<Cash.State>? {
-        val bankNode = mockNet.createPartyNode(BOC_NAME)
-        val bank = bankNode.info.singleIdentity()
-        val cashIssuer = bank.ref(1)
-        return node.database.transaction {
-            VaultFiller(node.services, dummyNotary, notaryIdentity, ::Random).fillWithSomeTestCash(
-                100.DOLLARS,
-                bankNode.services,
-                thisManyStates,
-                thisManyStates,
-                cashIssuer
-            )
-        }
-    }
-
     private inline fun <reified T> DatabaseTransaction.findRecordsFromDatabase(): List<T> {
         val criteria = session.criteriaBuilder.createQuery(T::class.java)
         criteria.select(criteria.from(T::class.java))
@@ -1282,112 +1204,5 @@ internal class SuspendingFlow : FlowLogic<Unit>() {
         stateMachine.hookBeforeCheckpoint()
         sleep(1.seconds) // flow checkpoints => checkpoint is in DB
         stateMachine.hookAfterCheckpoint()
-    }
-}
-
-object SoftLocks {
-
-    internal class LockingUnlockingFlow(
-        private val unlockedStates: List<StateAndRef<Cash.State>>,
-        private val releaseRandomId: Boolean = true
-    ) : FlowLogic<Boolean>() {
-
-        companion object {
-            fun queryCashStates(softLockingType: QueryCriteria.SoftLockingType, vaultService: VaultService) =
-                vaultService.queryBy<Cash.State>(
-                    QueryCriteria.VaultQueryCriteria(
-                        softLockingCondition = QueryCriteria.SoftLockingCondition(
-                            softLockingType
-                        )
-                    )
-                ).states
-
-            var checkpointAfterReserves: Boolean = false
-            var hookAfterReleases: () -> Unit = {}
-        }
-
-        @Suspendable
-        override fun call(): Boolean {
-            val unlockedStatesSize = unlockedStates.size
-            val emptySet = emptySet<StateRef>()
-            val lockSetFlowId = unlockedStates.subList(0, unlockedStatesSize / 2).map { it.ref }.toNonEmptySet()
-            val lockSetRandomId = unlockedStates.subList(unlockedStatesSize / 2, unlockedStatesSize).map { it.ref }.toNonEmptySet()
-
-            // lock and release with our flow Id
-            serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
-            assertEquals(
-                lockSetRandomId,
-                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            // states locked with our flow id are held by the fiber
-            assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-            serviceHub.vaultService.softLockRelease(stateMachine.id.uuid, lockSetFlowId)
-            assertEquals(
-                lockSetFlowId + lockSetRandomId,
-                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-
-            // lock and release with a random Id
-            val randomUUID = UUID.randomUUID()
-            serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
-            assertEquals(
-                lockSetFlowId,
-                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            // states locked with a random Id are NOT held by the fiber
-            assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates) // in memory locked states held by flow
-            serviceHub.vaultService.softLockRelease(randomUUID, lockSetRandomId)
-            assertEquals(
-                lockSetFlowId + lockSetRandomId,
-                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-
-            // lock with our flow Id, lock with random Id and then unlock passing in only flow Id
-            serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
-            serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
-            if (checkpointAfterReserves) {
-                stateMachine.suspend(FlowIORequest.ForceCheckpoint, false)
-            }
-            // only states locked with our flow id are held by the fiber
-            assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-            assertEquals(
-                lockSetFlowId + lockSetRandomId,
-                queryCashStates(QueryCriteria.SoftLockingType.LOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            // the following if-block is intentionally put in the following order. We need to assure that while states are locked with the flowId,
-            // and with random Ids, when unlocking with random Id it will not make use of [flowStateMachineImpl.softLockedStates]
-            // i.e. a. it will successfully remove these states (otherwise it would not, because it would include in the sql IN clause states that are not under this random Id)
-            //      b. it will leave [flowStateMachineImpl.softLockedStates] untouched (it will not remove any states in there since they do not belong to the random Id)
-            if (releaseRandomId) {
-                serviceHub.vaultService.softLockRelease(randomUUID)
-            }
-            serviceHub.vaultService.softLockRelease(stateMachine.id.uuid)
-            assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-            hookAfterReleases()
-            return true
-        }
-    }
-
-    internal class CreateFungibleStateFLow : FlowLogic<Unit>() {
-
-        companion object {
-            var hook: ((VaultService) -> Unit)? = null
-        }
-
-        @Suspendable
-        override fun call() {
-            val issuer = serviceHub.myInfo.legalIdentities.first()
-            val notary = serviceHub.networkMapCache.notaryIdentities[0]
-            val fungibleState = NodeVaultServiceTest.FungibleFoo(100.DOLLARS, listOf(issuer))
-            val txCommand = Command(DummyContract.Commands.Create(), issuer.owningKey)
-            val txBuilder = TransactionBuilder(notary)
-                .addOutputState(fungibleState, DummyContract.PROGRAM_ID)
-                .addCommand(txCommand)
-            val signedTx = serviceHub.signInitialTransaction(txBuilder)
-            serviceHub.recordTransactions(signedTx)
-            hook?.invoke(serviceHub.vaultService)
-        }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
@@ -1,0 +1,236 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.Party
+import net.corda.core.internal.FlowIORequest
+import net.corda.core.node.services.Vault
+import net.corda.core.node.services.VaultService
+import net.corda.core.node.services.queryBy
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.core.utilities.toNonEmptySet
+import net.corda.finance.DOLLARS
+import net.corda.finance.contracts.asset.Cash
+import net.corda.node.services.vault.NodeVaultServiceTest
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOC_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.internal.vault.VaultFiller
+import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.FINANCE_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.InternalMockNetwork
+import net.corda.testing.node.internal.InternalMockNodeParameters
+import net.corda.testing.node.internal.TestStartedNode
+import net.corda.testing.node.internal.startFlow
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.sql.SQLTransientConnectionException
+import java.util.*
+import kotlin.test.assertTrue
+
+class FlowSoftLocksTests {
+
+    companion object {
+        val dummyNotary = TestIdentity(DUMMY_NOTARY_NAME, 20)
+    }
+
+    private lateinit var mockNet: InternalMockNetwork
+    private lateinit var aliceNode: TestStartedNode
+    private lateinit var notaryIdentity: Party
+
+    @Before
+    fun setUpMockNet() {
+        mockNet = InternalMockNetwork(
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, FINANCE_CONTRACTS_CORDAPP),
+                servicePeerAllocationStrategy = RoundRobin()
+        )
+        aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
+        notaryIdentity = mockNet.defaultNotaryIdentity
+    }
+
+    @After
+    fun cleanUp() {
+        mockNet.stopNodes()
+    }
+
+    @Test(timeout=300_000)
+    fun `flow correctly soft locks and unlocks states - at the end keeps locked states reserved by random id`() {
+        val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
+        val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, false)).resultFuture.getOrThrow(30.seconds)
+        assertTrue(completedSuccessfully)
+        Assert.assertEquals(5, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
+    }
+
+    @Test(timeout=300_000)
+    fun `flow correctly soft locks and unlocks states - at the end releases states reserved by random id`() {
+        val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
+        val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
+        assertTrue(completedSuccessfully)
+        Assert.assertEquals(10, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
+    }
+
+    @Test(timeout=300_000)
+    fun `flow soft locks fungible state upon creation`() {
+        var lockedStates = 0
+        SoftLocks.CreateFungibleStateFLow.hook = { vaultService ->
+            lockedStates = vaultService.queryBy<NodeVaultServiceTest.FungibleFoo>(
+                    QueryCriteria.VaultQueryCriteria(
+                            softLockingCondition = QueryCriteria.SoftLockingCondition(QueryCriteria.SoftLockingType.LOCKED_ONLY)
+                    )
+            ).states.size
+        }
+        aliceNode.services.startFlow(SoftLocks.CreateFungibleStateFLow()).resultFuture.getOrThrow(30.seconds)
+        Assert.assertEquals(1, lockedStates)
+    }
+
+    @Test(timeout=300_000)
+    fun `when flow soft locks, then errors and retries from previous checkpoint, softLockedStates are reverted back correctly`() {
+        var firstRun = true
+        SoftLocks.LockingUnlockingFlow.checkpointAfterReserves = true
+
+        SoftLocks.LockingUnlockingFlow.hookAfterReleases = {
+            if (firstRun) {
+                firstRun = false
+                throw SQLTransientConnectionException("connection is not available")
+            }
+        }
+
+        val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
+        val completedSuccessfully = aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
+        assertTrue(completedSuccessfully)
+    }
+
+    private fun fillVault(node: TestStartedNode, thisManyStates: Int): Vault<Cash.State>? {
+        val bankNode = mockNet.createPartyNode(BOC_NAME)
+        val bank = bankNode.info.singleIdentity()
+        val cashIssuer = bank.ref(1)
+        return node.database.transaction {
+            VaultFiller(node.services, dummyNotary, notaryIdentity, ::Random).fillWithSomeTestCash(
+                    100.DOLLARS,
+                    bankNode.services,
+                    thisManyStates,
+                    thisManyStates,
+                    cashIssuer
+            )
+        }
+    }
+}
+
+object SoftLocks {
+
+    internal class LockingUnlockingFlow(
+            private val unlockedStates: List<StateAndRef<Cash.State>>,
+            private val releaseRandomId: Boolean = true
+    ) : FlowLogic<Boolean>() {
+
+        companion object {
+            fun queryCashStates(softLockingType: QueryCriteria.SoftLockingType, vaultService: VaultService) =
+                    vaultService.queryBy<Cash.State>(
+                            QueryCriteria.VaultQueryCriteria(
+                                    softLockingCondition = QueryCriteria.SoftLockingCondition(
+                                            softLockingType
+                                    )
+                            )
+                    ).states
+
+            var checkpointAfterReserves: Boolean = false
+            var hookAfterReleases: () -> Unit = {}
+        }
+
+        @Suspendable
+        override fun call(): Boolean {
+            val unlockedStatesSize = unlockedStates.size
+            val emptySet = emptySet<StateRef>()
+            val lockSetFlowId = unlockedStates.subList(0, unlockedStatesSize / 2).map { it.ref }.toNonEmptySet()
+            val lockSetRandomId = unlockedStates.subList(unlockedStatesSize / 2, unlockedStatesSize).map { it.ref }.toNonEmptySet()
+
+            // lock and release with our flow Id
+            serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
+            Assert.assertEquals(
+                    lockSetRandomId,
+                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+            )
+            // states locked with our flow id are held by the fiber
+            Assert.assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+            serviceHub.vaultService.softLockRelease(stateMachine.id.uuid, lockSetFlowId)
+            Assert.assertEquals(
+                    lockSetFlowId + lockSetRandomId,
+                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+            )
+            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+
+            // lock and release with a random Id
+            val randomUUID = UUID.randomUUID()
+            serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
+            Assert.assertEquals(
+                    lockSetFlowId,
+                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+            )
+            // states locked with a random Id are NOT held by the fiber
+            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates) // in memory locked states held by flow
+            serviceHub.vaultService.softLockRelease(randomUUID, lockSetRandomId)
+            Assert.assertEquals(
+                    lockSetFlowId + lockSetRandomId,
+                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+            )
+            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+
+            // lock with our flow Id, lock with random Id and then unlock passing in only flow Id
+            serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
+            serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
+            if (checkpointAfterReserves) {
+                stateMachine.suspend(FlowIORequest.ForceCheckpoint, false)
+            }
+            // only states locked with our flow id are held by the fiber
+            Assert.assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+            Assert.assertEquals(
+                    lockSetFlowId + lockSetRandomId,
+                    queryCashStates(QueryCriteria.SoftLockingType.LOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+            )
+            // the following if-block is intentionally put in the following order. We need to assure that while states are locked with the flowId,
+            // and with random Ids, when unlocking with random Id it will not make use of [flowStateMachineImpl.softLockedStates]
+            // i.e. a. it will successfully remove these states (otherwise it would not, because it would include in the sql IN clause states that are not under this random Id)
+            //      b. it will leave [flowStateMachineImpl.softLockedStates] untouched (it will not remove any states in there since they do not belong to the random Id)
+            if (releaseRandomId) {
+                serviceHub.vaultService.softLockRelease(randomUUID)
+            }
+            serviceHub.vaultService.softLockRelease(stateMachine.id.uuid)
+            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+            hookAfterReleases()
+            return true
+        }
+    }
+
+    internal class CreateFungibleStateFLow : FlowLogic<Unit>() {
+
+        companion object {
+            var hook: ((VaultService) -> Unit)? = null
+        }
+
+        @Suspendable
+        override fun call() {
+            val issuer = serviceHub.myInfo.legalIdentities.first()
+            val notary = serviceHub.networkMapCache.notaryIdentities[0]
+            val fungibleState = NodeVaultServiceTest.FungibleFoo(100.DOLLARS, listOf(issuer))
+            val txCommand = Command(DummyContract.Commands.Create(), issuer.owningKey)
+            val txBuilder = TransactionBuilder(notary)
+                    .addOutputState(fungibleState, DummyContract.PROGRAM_ID)
+                    .addCommand(txCommand)
+            val signedTx = serviceHub.signInitialTransaction(txBuilder)
+            serviceHub.recordTransactions(signedTx)
+            hook?.invoke(serviceHub.vaultService)
+        }
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
@@ -53,8 +53,7 @@ class FlowSoftLocksTests {
     @Before
     fun setUpMockNet() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, FINANCE_CONTRACTS_CORDAPP),
-                servicePeerAllocationStrategy = RoundRobin()
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, FINANCE_CONTRACTS_CORDAPP)
         )
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         notaryIdentity = mockNet.defaultNotaryIdentity

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
@@ -63,39 +63,39 @@ class FlowSoftLocksTests {
     @Test(timeout=300_000)
     fun `flow correctly soft locks and unlocks states - at the end keeps locked states reserved by random id`() {
         val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
-        val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, false)).resultFuture.getOrThrow(30.seconds)
+        val completedSuccessfully =  aliceNode.services.startFlow(LockingUnlockingFlow(vaultStates, false)).resultFuture.getOrThrow(30.seconds)
         assertTrue(completedSuccessfully)
-        Assert.assertEquals(5, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
+        Assert.assertEquals(5, LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
     }
 
     @Test(timeout=300_000)
     fun `flow correctly soft locks and unlocks states - at the end releases states reserved by random id`() {
         val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
-        val completedSuccessfully =  aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
+        val completedSuccessfully =  aliceNode.services.startFlow(LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
         assertTrue(completedSuccessfully)
-        Assert.assertEquals(10, SoftLocks.LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
+        Assert.assertEquals(10, LockingUnlockingFlow.queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, aliceNode.services.vaultService).size)
     }
 
     @Test(timeout=300_000)
     fun `flow soft locks fungible state upon creation`() {
         var lockedStates = 0
-        SoftLocks.CreateFungibleStateFLow.hook = { vaultService ->
+        CreateFungibleStateFLow.hook = { vaultService ->
             lockedStates = vaultService.queryBy<NodeVaultServiceTest.FungibleFoo>(
                     QueryCriteria.VaultQueryCriteria(
                             softLockingCondition = QueryCriteria.SoftLockingCondition(QueryCriteria.SoftLockingType.LOCKED_ONLY)
                     )
             ).states.size
         }
-        aliceNode.services.startFlow(SoftLocks.CreateFungibleStateFLow()).resultFuture.getOrThrow(30.seconds)
+        aliceNode.services.startFlow(CreateFungibleStateFLow()).resultFuture.getOrThrow(30.seconds)
         Assert.assertEquals(1, lockedStates)
     }
 
     @Test(timeout=300_000)
     fun `when flow soft locks, then errors and retries from previous checkpoint, softLockedStates are reverted back correctly`() {
         var firstRun = true
-        SoftLocks.LockingUnlockingFlow.checkpointAfterReserves = true
+        LockingUnlockingFlow.checkpointAfterReserves = true
 
-        SoftLocks.LockingUnlockingFlow.hookAfterReleases = {
+        LockingUnlockingFlow.hookAfterReleases = {
             if (firstRun) {
                 firstRun = false
                 throw SQLTransientConnectionException("connection is not available")
@@ -103,7 +103,7 @@ class FlowSoftLocksTests {
         }
 
         val vaultStates = fillVault(aliceNode, 10)!!.states.toList()
-        val completedSuccessfully = aliceNode.services.startFlow(SoftLocks.LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
+        val completedSuccessfully = aliceNode.services.startFlow(LockingUnlockingFlow(vaultStates, true)).resultFuture.getOrThrow(30.seconds)
         assertTrue(completedSuccessfully)
     }
 
@@ -123,109 +123,106 @@ class FlowSoftLocksTests {
     }
 }
 
-object SoftLocks {
+internal class LockingUnlockingFlow(
+        private val unlockedStates: List<StateAndRef<Cash.State>>,
+        private val releaseRandomId: Boolean = true
+) : FlowLogic<Boolean>() {
 
-    internal class LockingUnlockingFlow(
-            private val unlockedStates: List<StateAndRef<Cash.State>>,
-            private val releaseRandomId: Boolean = true
-    ) : FlowLogic<Boolean>() {
+    companion object {
+        fun queryCashStates(softLockingType: QueryCriteria.SoftLockingType, vaultService: VaultService) =
+                vaultService.queryBy<Cash.State>(
+                        QueryCriteria.VaultQueryCriteria(
+                                softLockingCondition = QueryCriteria.SoftLockingCondition(
+                                        softLockingType
+                                )
+                        )
+                ).states
 
-        companion object {
-            fun queryCashStates(softLockingType: QueryCriteria.SoftLockingType, vaultService: VaultService) =
-                    vaultService.queryBy<Cash.State>(
-                            QueryCriteria.VaultQueryCriteria(
-                                    softLockingCondition = QueryCriteria.SoftLockingCondition(
-                                            softLockingType
-                                    )
-                            )
-                    ).states
-
-            var checkpointAfterReserves: Boolean = false
-            var hookAfterReleases: () -> Unit = {}
-        }
-
-        @Suspendable
-        override fun call(): Boolean {
-            val unlockedStatesSize = unlockedStates.size
-            val emptySet = emptySet<StateRef>()
-            val lockSetFlowId = unlockedStates.subList(0, unlockedStatesSize / 2).map { it.ref }.toNonEmptySet()
-            val lockSetRandomId = unlockedStates.subList(unlockedStatesSize / 2, unlockedStatesSize).map { it.ref }.toNonEmptySet()
-
-            // lock and release with our flow Id
-            serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
-            Assert.assertEquals(
-                    lockSetRandomId,
-                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            // states locked with our flow id are held by the fiber
-            Assert.assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-            serviceHub.vaultService.softLockRelease(stateMachine.id.uuid, lockSetFlowId)
-            Assert.assertEquals(
-                    lockSetFlowId + lockSetRandomId,
-                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-
-            // lock and release with a random Id
-            val randomUUID = UUID.randomUUID()
-            serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
-            Assert.assertEquals(
-                    lockSetFlowId,
-                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            // states locked with a random Id are NOT held by the fiber
-            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates) // in memory locked states held by flow
-            serviceHub.vaultService.softLockRelease(randomUUID, lockSetRandomId)
-            Assert.assertEquals(
-                    lockSetFlowId + lockSetRandomId,
-                    queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-
-            // lock with our flow Id, lock with random Id and then unlock passing in only flow Id
-            serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
-            serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
-            if (checkpointAfterReserves) {
-                stateMachine.suspend(FlowIORequest.ForceCheckpoint, false)
-            }
-            // only states locked with our flow id are held by the fiber
-            Assert.assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-            Assert.assertEquals(
-                    lockSetFlowId + lockSetRandomId,
-                    queryCashStates(QueryCriteria.SoftLockingType.LOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
-            )
-            // the following if-block is intentionally put in the following order. We need to assure that while states are locked with the flowId,
-            // and with random Ids, when unlocking with random Id it will not make use of [flowStateMachineImpl.softLockedStates]
-            // i.e. a. it will successfully remove these states (otherwise it would not, because it would include in the sql IN clause states that are not under this random Id)
-            //      b. it will leave [flowStateMachineImpl.softLockedStates] untouched (it will not remove any states in there since they do not belong to the random Id)
-            if (releaseRandomId) {
-                serviceHub.vaultService.softLockRelease(randomUUID)
-            }
-            serviceHub.vaultService.softLockRelease(stateMachine.id.uuid)
-            Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
-            hookAfterReleases()
-            return true
-        }
+        var checkpointAfterReserves: Boolean = false
+        var hookAfterReleases: () -> Unit = {}
     }
 
-    internal class CreateFungibleStateFLow : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call(): Boolean {
+        val unlockedStatesSize = unlockedStates.size
+        val emptySet = emptySet<StateRef>()
+        val lockSetFlowId = unlockedStates.subList(0, unlockedStatesSize / 2).map { it.ref }.toNonEmptySet()
+        val lockSetRandomId = unlockedStates.subList(unlockedStatesSize / 2, unlockedStatesSize).map { it.ref }.toNonEmptySet()
 
-        companion object {
-            var hook: ((VaultService) -> Unit)? = null
-        }
+        // lock and release with our flow Id
+        serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
+        Assert.assertEquals(
+                lockSetRandomId,
+                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+        )
+        // states locked with our flow id are held by the fiber
+        Assert.assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+        serviceHub.vaultService.softLockRelease(stateMachine.id.uuid, lockSetFlowId)
+        Assert.assertEquals(
+                lockSetFlowId + lockSetRandomId,
+                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+        )
+        Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
 
-        @Suspendable
-        override fun call() {
-            val issuer = serviceHub.myInfo.legalIdentities.first()
-            val notary = serviceHub.networkMapCache.notaryIdentities[0]
-            val fungibleState = NodeVaultServiceTest.FungibleFoo(100.DOLLARS, listOf(issuer))
-            val txCommand = Command(DummyContract.Commands.Create(), issuer.owningKey)
-            val txBuilder = TransactionBuilder(notary)
-                    .addOutputState(fungibleState, DummyContract.PROGRAM_ID)
-                    .addCommand(txCommand)
-            val signedTx = serviceHub.signInitialTransaction(txBuilder)
-            serviceHub.recordTransactions(signedTx)
-            hook?.invoke(serviceHub.vaultService)
+        // lock and release with a random Id
+        val randomUUID = UUID.randomUUID()
+        serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
+        Assert.assertEquals(
+                lockSetFlowId,
+                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+        )
+        // states locked with a random Id are NOT held by the fiber
+        Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates) // in memory locked states held by flow
+        serviceHub.vaultService.softLockRelease(randomUUID, lockSetRandomId)
+        Assert.assertEquals(
+                lockSetFlowId + lockSetRandomId,
+                queryCashStates(QueryCriteria.SoftLockingType.UNLOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+        )
+        Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+
+        // lock with our flow Id, lock with random Id and then unlock passing in only flow Id
+        serviceHub.vaultService.softLockReserve(stateMachine.id.uuid, lockSetFlowId)
+        serviceHub.vaultService.softLockReserve(randomUUID, lockSetRandomId)
+        if (checkpointAfterReserves) {
+            stateMachine.suspend(FlowIORequest.ForceCheckpoint, false)
         }
+        // only states locked with our flow id are held by the fiber
+        Assert.assertEquals(lockSetFlowId, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+        Assert.assertEquals(
+                lockSetFlowId + lockSetRandomId,
+                queryCashStates(QueryCriteria.SoftLockingType.LOCKED_ONLY, serviceHub.vaultService).map { it.ref }.toNonEmptySet()
+        )
+        // the following if-block is intentionally put in the following order. We need to assure that while states are locked with the flowId,
+        // and with random Ids, when unlocking with random Id it will not make use of [flowStateMachineImpl.softLockedStates]
+        // i.e. a. it will successfully remove these states (otherwise it would not, because it would include in the sql IN clause states that are not under this random Id)
+        //      b. it will leave [flowStateMachineImpl.softLockedStates] untouched (it will not remove any states in there since they do not belong to the random Id)
+        if (releaseRandomId) {
+            serviceHub.vaultService.softLockRelease(randomUUID)
+        }
+        serviceHub.vaultService.softLockRelease(stateMachine.id.uuid)
+        Assert.assertEquals(emptySet, (stateMachine as? FlowStateMachineImpl<*>)!!.softLockedStates)
+        hookAfterReleases()
+        return true
+    }
+}
+
+internal class CreateFungibleStateFLow : FlowLogic<Unit>() {
+
+    companion object {
+        var hook: ((VaultService) -> Unit)? = null
+    }
+
+    @Suspendable
+    override fun call() {
+        val issuer = serviceHub.myInfo.legalIdentities.first()
+        val notary = serviceHub.networkMapCache.notaryIdentities[0]
+        val fungibleState = NodeVaultServiceTest.FungibleFoo(100.DOLLARS, listOf(issuer))
+        val txCommand = Command(DummyContract.Commands.Create(), issuer.owningKey)
+        val txBuilder = TransactionBuilder(notary)
+                .addOutputState(fungibleState, DummyContract.PROGRAM_ID)
+                .addCommand(txCommand)
+        val signedTx = serviceHub.signInitialTransaction(txBuilder)
+        serviceHub.recordTransactions(signedTx)
+        hook?.invoke(serviceHub.vaultService)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
@@ -42,10 +42,6 @@ import kotlin.test.assertTrue
 
 class FlowSoftLocksTests {
 
-    companion object {
-        val dummyNotary = TestIdentity(DUMMY_NOTARY_NAME, 20)
-    }
-
     private lateinit var mockNet: InternalMockNetwork
     private lateinit var aliceNode: TestStartedNode
     private lateinit var notaryIdentity: Party
@@ -116,7 +112,7 @@ class FlowSoftLocksTests {
         val bank = bankNode.info.singleIdentity()
         val cashIssuer = bank.ref(1)
         return node.database.transaction {
-            VaultFiller(node.services, dummyNotary, notaryIdentity, ::Random).fillWithSomeTestCash(
+            VaultFiller(node.services, TestIdentity(notaryIdentity.name, 20), notaryIdentity).fillWithSomeTestCash(
                     100.DOLLARS,
                     bankNode.services,
                     thisManyStates,

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowSoftLocksTests.kt
@@ -21,11 +21,9 @@ import net.corda.node.services.vault.NodeVaultServiceTest
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOC_NAME
-import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.internal.vault.VaultFiller
-import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.FINANCE_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.InternalMockNetwork

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -407,6 +407,47 @@ class NodeVaultServiceTest {
     }
 
     @Test(timeout=300_000)
+    fun `softLockRelease - correctly releases n locked states`() {
+        fun queryStates(softLockingType: SoftLockingType) =
+            vaultService.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(softLockingType))).states
+
+        database.transaction {
+            vaultFiller.fillWithSomeTestCash(100.DOLLARS, issuerServices, 100, DUMMY_CASH_ISSUER)
+        }
+
+        val softLockId = UUID.randomUUID()
+        val lockCount = NodeVaultService.MAX_SQL_IN_CLAUSE_SET * 2
+        database.transaction {
+            assertEquals(100, queryStates(SoftLockingType.UNLOCKED_ONLY).size)
+            val unconsumedStates = vaultService.queryBy<Cash.State>().states
+
+            val lockSet = mutableListOf<StateRef>()
+            for (i in 0 until lockCount) {
+                lockSet.add(unconsumedStates[i].ref)
+            }
+            vaultService.softLockReserve(softLockId, NonEmptySet.copyOf(lockSet))
+            assertEquals(lockCount, queryStates(SoftLockingType.LOCKED_ONLY).size)
+
+            val unlockSet0 = mutableSetOf<StateRef>()
+            for (i in 0 until NodeVaultService.MAX_SQL_IN_CLAUSE_SET + 1) {
+                unlockSet0.add(lockSet[i])
+            }
+            vaultService.softLockRelease(softLockId, NonEmptySet.copyOf(unlockSet0))
+            assertEquals(NodeVaultService.MAX_SQL_IN_CLAUSE_SET - 1, queryStates(SoftLockingType.LOCKED_ONLY).size)
+
+            val unlockSet1 = mutableSetOf<StateRef>()
+            for (i in NodeVaultService.MAX_SQL_IN_CLAUSE_SET + 1 until NodeVaultService.MAX_SQL_IN_CLAUSE_SET + 3) {
+                unlockSet1.add(lockSet[i])
+            }
+            vaultService.softLockRelease(softLockId, NonEmptySet.copyOf(unlockSet1))
+            assertEquals(NodeVaultService.MAX_SQL_IN_CLAUSE_SET - 1 - 2, queryStates(SoftLockingType.LOCKED_ONLY).size)
+
+            vaultService.softLockRelease(softLockId) // release the rest
+            assertEquals(100, queryStates(SoftLockingType.UNLOCKED_ONLY).size)
+        }
+    }
+
+    @Test(timeout=300_000)
 	fun `unconsumedStatesForSpending exact amount`() {
         database.transaction {
             vaultFiller.fillWithSomeTestCash(100.DOLLARS, issuerServices, 1, DUMMY_CASH_ISSUER)


### PR DESCRIPTION
Fix SQL deadlocks coming from soft locking states;

Adding to the query -explicitly- the flow's locked states resolved the SQL Deadlocks in SQL server. The SQL Deadlocks would come up  from `softLockRelease` when only the `lockId` was passed in as argument. In that case the query optimizer would use `lock_id_idx(lock_id, state_status)` to search and update entries in `VAULT_STATES` table. However, all rest of the queries would follow the opposite direction meaning they would use PK's `index(output_index, transaction_id)` but they would also update the `lock_id` column and therefore the `lock_id_idx` as well, because `lock_id` is a part of it. That was causing a circular locking among the different transactions (SQL processes) within the database.