### PR TITLE
ENT-4064, ENT-4608 - checking for unsigned cordapps in prod mode and checking the PV

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -114,6 +114,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
                     if (it.minimumPlatformVersion > versionInfo.platformVersion) {
                         logger.warn("Not loading CorDapp ${it.info.shortName} (${it.info.vendor}) as it requires minimum " +
                                 "platform version ${it.minimumPlatformVersion} (This node is running version ${versionInfo.platformVersion}).")
+                        invalidCordapps.put("Invalid platform version: ${it.minimumPlatformVersion}", it.jarPath)
                         false
                     } else {
                         true
@@ -128,9 +129,9 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
                         if (certificates.isEmpty() || (certificates - blockedCertificates).isNotEmpty())
                             true // Cordapp is not signed or it is signed by at least one non-blacklisted certificate
                         else {
-                            logger.warn("Not loading CorDapp ${it.info.shortName} (${it.info.vendor}) as it is signed by development key(s) only: " +
+                            logger.warn("Not loading CorDapp ${it.info.shortName} (${it.info.vendor}) as it is signed by blacklisted key(s) only (probably development key): " +
                                     "${blockedCertificates.map { it.publicKey }}.")
-                            invalidCordapps.put("Corresponding contracts are signed by development key only,", it.jarPath)
+                            invalidCordapps.put("Corresponding contracts are signed by blacklisted key(s) only (probably development key),", it.jarPath)
                             false
                         }
                     }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -5,6 +5,7 @@ import io.github.classgraph.ClassInfo
 import io.github.classgraph.ScanResult
 import net.corda.common.logging.errorReporting.CordappErrors
 import net.corda.common.logging.errorReporting.ErrorCode
+import net.corda.core.CordaRuntimeException
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
@@ -457,7 +458,7 @@ class MultipleCordappsForFlowException(
         message: String,
         flowName: String,
         jars: String
-) : Exception(message), ErrorCode<CordappErrors> {
+) : CordaRuntimeException(message), ErrorCode<CordappErrors> {
     override val code = CordappErrors.MULTIPLE_CORDAPPS_FOR_FLOW
     override val parameters = listOf(flowName, jars)
 }
@@ -469,15 +470,15 @@ class CordappInvalidVersionException(
         msg: String,
         override val code: CordappErrors,
         override val parameters: List<Any> = listOf()
-) : Exception(msg), ErrorCode<CordappErrors>
+) : CordaRuntimeException(msg), ErrorCode<CordappErrors>
 
 /**
  * Thrown if duplicate CorDapps are installed on the node
  */
 class DuplicateCordappsInstalledException(app: Cordapp, duplicates: Set<Cordapp>)
-    : IllegalStateException("The CorDapp (name: ${app.info.shortName}, file: ${app.name}) " +
+    : CordaRuntimeException("IllegalStateExcepion", "The CorDapp (name: ${app.info.shortName}, file: ${app.name}) " +
         "is installed multiple times on the node. The following files correspond to the exact same content: " +
-        "${duplicates.map { it.name }}"), ErrorCode<CordappErrors> {
+        "${duplicates.map { it.name }}", null), ErrorCode<CordappErrors> {
     override val code = CordappErrors.DUPLICATE_CORDAPPS_INSTALLED
     override val parameters = listOf(app.info.shortName, app.name, duplicates.map { it.name })
 }
@@ -485,7 +486,7 @@ class DuplicateCordappsInstalledException(app: Cordapp, duplicates: Set<Cordapp>
 /**
  * Thrown if an exception occurs during loading cordapps.
  */
-class InvalidCordappException(message: String) : Exception(message)
+class InvalidCordappException(message: String) : CordaRuntimeException(message)
 
 abstract class CordappLoaderTemplate : CordappLoader {
 

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -114,7 +114,6 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
                     if (it.minimumPlatformVersion > versionInfo.platformVersion) {
                         logger.warn("Not loading CorDapp ${it.info.shortName} (${it.info.vendor}) as it requires minimum " +
                                 "platform version ${it.minimumPlatformVersion} (This node is running version ${versionInfo.platformVersion}).")
-                        invalidCordapps.put("Invalid platform version: ${it.minimumPlatformVersion}", it.jarPath)
                         false
                     } else {
                         true

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -114,7 +114,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
                     if (it.minimumPlatformVersion > versionInfo.platformVersion) {
                         logger.warn("Not loading CorDapp ${it.info.shortName} (${it.info.vendor}) as it requires minimum " +
                                 "platform version ${it.minimumPlatformVersion} (This node is running version ${versionInfo.platformVersion}).")
-                        invalidCordapps.put("Invalid platform version: ${it.minimumPlatformVersion}", it.jarPath)
+                        invalidCordapps.put("CorDapp requires minimumPlatformVersion: ${it.minimumPlatformVersion}, but was: ${versionInfo.platformVersion}", it.jarPath)
                         false
                     } else {
                         true

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt
@@ -203,7 +203,7 @@ class CordappProviderImplTests {
             Files.copy(signedJarPath, duplicateJarPath)
             val urls = asList(signedJarPath.toUri().toURL(), duplicateJarPath.toUri().toURL())
             JarScanningCordappLoader.fromJarUrls(urls, VersionInfo.UNKNOWN).use {
-                assertFailsWith<IllegalStateException> {
+                assertFailsWith<DuplicateCordappsInstalledException> {
                     CordappProviderImpl(it, stubConfigProvider, attachmentStore).apply { start() }
                 }
             }

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
@@ -165,11 +165,10 @@ class JarScanningCordappLoaderTest {
         assertThat(loader.cordapps).hasSize(1)
     }
 
-    @Test(timeout=300_000)
+    @Test(expected = InvalidCordappException::class, timeout = 300_000)
 	fun `cordapp classloader does not load app signed by blacklisted certificate`() {
         val jar = JarScanningCordappLoaderTest::class.java.getResource("signed/signed-by-dev-key.jar")!!
-        val loader = JarScanningCordappLoader.fromJarUrls(listOf(jar), cordappsSignerKeyFingerprintBlacklist = DEV_PUB_KEY_HASHES)
-        assertThat(loader.cordapps).hasSize(0)
+        JarScanningCordappLoader.fromJarUrls(listOf(jar), cordappsSignerKeyFingerprintBlacklist = DEV_PUB_KEY_HASHES).cordapps
     }
 
     @Test(timeout=300_000)
@@ -192,14 +191,5 @@ class JarScanningCordappLoaderTest {
         Assume.assumeTrue(JavaVersion.isVersionAtLeast(JavaVersion.Java_11))
         val jar = JarScanningCordappLoaderTest::class.java.getResource("/contractClassAtVersion55.jar")!!
         JarScanningCordappLoader.fromJarUrls(listOf(jar)).cordapps
-    }
-
-    @Test(expected = InvalidCordappException::class, timeout = 300_000)
-    fun `cordapp classloader raises exception when cordapp is signed with blacklisted key`() {
-        val jar = JarScanningCordappLoaderTest::class.java.getResource("signed/signed-by-dev-key.jar")!!
-        JarScanningCordappLoader.fromJarUrls(
-                listOf(jar),
-                cordappsSignerKeyFingerprintBlacklist = DEV_PUB_KEY_HASHES
-        ).cordapps
     }
 }

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
@@ -137,11 +137,10 @@ class JarScanningCordappLoaderTest {
         assertThat(cordapp.minimumPlatformVersion).isEqualTo(2)
     }
 
-    @Test(timeout=300_000)
+    @Test(expected = InvalidCordappException::class, timeout = 300_000)
 	fun `cordapp classloader does not load apps when their min platform version is greater than the node platform version`() {
         val jar = JarScanningCordappLoaderTest::class.java.getResource("versions/min-2-no-target.jar")!!
-        val loader = JarScanningCordappLoader.fromJarUrls(listOf(jar), VersionInfo.UNKNOWN.copy(platformVersion = 1))
-        assertThat(loader.cordapps).hasSize(0)
+        JarScanningCordappLoader.fromJarUrls(listOf(jar), VersionInfo.UNKNOWN.copy(platformVersion = 1)).cordapps
     }
 
     @Test(timeout=300_000)

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
@@ -193,4 +193,13 @@ class JarScanningCordappLoaderTest {
         val jar = JarScanningCordappLoaderTest::class.java.getResource("/contractClassAtVersion55.jar")!!
         JarScanningCordappLoader.fromJarUrls(listOf(jar)).cordapps
     }
+
+    @Test(expected = InvalidCordappException::class, timeout = 300_000)
+    fun `cordapp classloader raises exception when cordapp is signed with blacklisted key`() {
+        val jar = JarScanningCordappLoaderTest::class.java.getResource("signed/signed-by-dev-key.jar")!!
+        JarScanningCordappLoader.fromJarUrls(
+                listOf(jar),
+                cordappsSignerKeyFingerprintBlacklist = DEV_PUB_KEY_HASHES
+        ).cordapps
+    }
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/ENT-4064

When there is an unsigned jar the following error message will show up on the screen and after that the node shuts down:
```
--- Corda Open Source 4.6-SNAPSHOT (5d48152) -------------------------------------------------------------


Logs can be found in                    : /Users/nikolettnagy/corda-open-source/samples/bank-of-corda-demo/build/nodes/BankOfCorda/logs
[ERROR] 10:59:11+0100 [main] internal.NodeStartupLogging. - Invalid Cordapps found, that couldn't be loaded: [Problem: Corresponding contracts are signed by development key only, in Cordapp file:/Users/nikolettnagy/corda-open-source/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps/corda-finance-workflows-4.6-SNAPSHOT.jar],  [errorCode=yy5hyu, moreInformationAt=https://errors.corda.net/OS/4.6-SNAPSHOT/yy5hyu]
```

https://r3-cev.atlassian.net/browse/ENT-4608

Similarly as before we are getting and error message and the node shuts down, when the platform version is less than required.

```
Logs can be found in                    : /Users/nikolettnagy/corda-open-source/samples/bank-of-corda-demo/build/nodes/BankOfCorda/logs
[ERROR] 17:10:11+0100 [main] internal.NodeStartupLogging. - Invalid Cordapps found, that couldn't be loaded: [Problem: CorDapp requires minimumPlatformVersion: 7, but was: 2 in Cordapp file:/Users/nikolettnagy/corda-open-source/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps/bank-of-corda-demo-4.6-SNAPSHOT.jar, Problem: CorDapp requires minimumPlatformVersion: 5, but was: 2 in Cordapp file:/Users/nikolettnagy/corda-open-source/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps/corda-finance-workflows-4.6-SNAPSHOT.jar],  [errorCode=yy5hyu, moreInformationAt=https://errors.corda.net/OS/4.6-SNAPSHOT/yy5hyu]
```