### PR TITLE
INFRA-242 Adding github action to check PR titles

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, edited, reopened]
 
 jobs:
-  check-jira-title:
+  check-pr-title:
     runs-on: ubuntu-latest
     steps:
       - uses: morrisoncole/pr-lint-action@v1.1.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: 'PR title check'
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  check-jira-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: morrisoncole/pr-lint-action@v1.1.1
+        with:
+          title-regex: '^((CORDA|EG|ENT|INFRA)-\d+|NOTICK)(.*)'
+          on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This action will help inform developers to the correct standard for PR titles that way squash commits will link jira issues properly