### PR TITLE
INFRA-270 - Publish archived API docs to Artifactory when tagged

### DIFF
--- a/.ci/dev/publish-api-docs/Jenkinsfile
+++ b/.ci/dev/publish-api-docs/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
 
     stages {
         stage('Publish Archived API Docs to Artifactory') {
-            when { tag pattern: /release-os-V(\d+\.\d+)(\.\d+)*(-GA)*(-\d{4}-\d\d-\d\d-\d{4})*$/, comparator: 'REGEXP' }
+            when { tag pattern: /^release-os-V(\d+\.\d+)(\.\d+){0,1}(-GA){0,1}(-\d{4}-\d\d-\d\d-\d{4}){0,1}$/, comparator: 'REGEXP' }
             steps {
                 sh "./gradlew :clean :docs:artifactoryPublish -DpublishApiDocs " +
                     "-DcordaArtifactoryUsername=\"\${ARTIFACTORY_CREDENTIALS_USR}\" " +

--- a/.ci/dev/publish-api-docs/Jenkinsfile
+++ b/.ci/dev/publish-api-docs/Jenkinsfile
@@ -1,0 +1,34 @@
+@Library('corda-shared-build-pipeline-steps')
+
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+pipeline {
+    agent { label 'k8s' }
+    options {
+        timestamps()
+        timeout(time: 3, unit: 'HOURS')
+    }
+
+    environment {
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials-for-jenkins')
+    }
+
+    stages {
+        stage('Publish Archived API Docs to Artifactory') {
+            when { tag pattern: /release-os-V(\d+\.\d+)(\.\d+)*(-GA)*(-\d{4}-\d\d-\d\d-\d{4})*$/, comparator: 'REGEXP' }
+            steps {
+                sh "./gradlew :clean :docs:artifactoryPublish -DpublishApiDocs " +
+                    "-DcordaArtifactoryUsername=\"\${ARTIFACTORY_CREDENTIALS_USR}\" " +
+                    "-DcordaArtifactoryPassword=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" "
+            }
+        }
+    }
+
+    post {
+        cleanup {
+            deleteDir() /* clean up our workspace */
+        }
+    }
+}

--- a/.ci/dev/publish-api-docs/Jenkinsfile
+++ b/.ci/dev/publish-api-docs/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     environment {
-        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials-for-jenkins')
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials-for-jenkins-test')
     }
 
     stages {

--- a/build.gradle
+++ b/build.gradle
@@ -574,9 +574,15 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-            repoKey = 'corda-dev'
-            username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
-            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+            if (System.getProperty('publishApiDocs') != null) {
+                repoKey = 'corda-dependencies-dev'
+                username = System.getProperty('cordaArtifactoryUsername')
+                password = System.getProperty('cordaArtifactoryPassword')
+            } else {
+                repoKey = 'r3-corda-dev'
+                username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+            }
         }
 
         defaults {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,9 +1,10 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
-import java.nio.file.Files
-
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'kotlin'
+apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
 
 dependencies {
     compile rootProject
@@ -27,6 +28,7 @@ ext {
     dokkaSourceDirs = files('../core/src/main/kotlin', '../client/rpc/src/main/kotlin', '../finance/workflows/src/main/kotlin', '../finance/contracts/src/main/kotlin', '../client/jackson/src/main/kotlin',
             '../testing/test-utils/src/main/kotlin', '../testing/node-driver/src/main/kotlin')
     internalPackagePrefixes = internalPackagePrefixes(dokkaSourceDirs)
+    archivedApiDocsBaseFilename = 'api-docs'
 }
 
 dokka {
@@ -78,3 +80,27 @@ task makeDocs(type: Exec) {
 }
 
 apidocs.shouldRunAfter makeDocs
+
+task archiveApiDocs(type: Tar) {
+    dependsOn apidocs
+    from buildDir
+    include 'html/**'
+    extension 'tgz'
+    compression Compression.GZIP
+}
+
+publishing {
+    publications {
+        apiDocs(MavenPublication) {
+            artifact archiveApiDocs {
+                artifactId archivedApiDocsBaseFilename
+            }
+        }
+    }
+}
+
+artifactoryPublish {
+    publications('apiDocs')
+    version = version.replaceAll('-SNAPSHOT', '')
+    publishPom = false
+}


### PR DESCRIPTION
### Summary
This automates the manual process of building and uploading the archived API docs to Artifactory.
See [here](https://r3-cev.atlassian.net/wiki/spaces/EN/pages/1704166317/Documentation+repositories) for details.

This PR adds:
- Gradle task to build and archive the API docs.
- Jenkinsfile to enable the automatic publishing of this file to Artifactory triggered by a tag.

The proposed trigger tag format for OS is `release-os-*V(\d+\.\d+)(\.\d+)*(-GA)*(\-\d{4}\-\d\d\-\d\d\-\d{4})*$`.
e.g. `release-os-V4.3.1-GA-2020-06-02-1550`

Jenkins jobs will be configured in both ci01 and ci02 (for ENT) so that pushing any tag matching the pattern will result in the publication being triggered.
e.g. [ci01 - Publish API Docs](https://ci01.dev.r3.com/job/Docs-Builders/job/Publish%20API%20Docs/)

Similar PRs will have to be raised against all previous release versions of Corda OS, ENT and CENM.
