### PR TITLE
INFRA-270 - Publish archived API docs to Artifactory when tagged

### DIFF
--- a/.ci/dev/publish-api-docs/Jenkinsfile
+++ b/.ci/dev/publish-api-docs/Jenkinsfile
@@ -1,0 +1,34 @@
+@Library('corda-shared-build-pipeline-steps')
+
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+pipeline {
+    agent { label 'k8s' }
+    options {
+        timestamps()
+        timeout(time: 3, unit: 'HOURS')
+    }
+
+    environment {
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials-for-jenkins-test')
+    }
+
+    stages {
+        stage('Publish Archived API Docs to Artifactory') {
+            when { tag pattern: /^release-os-V(\d+\.\d+)(\.\d+){0,1}(-GA){0,1}(-\d{4}-\d\d-\d\d-\d{4}){0,1}$/, comparator: 'REGEXP' }
+            steps {
+                sh "./gradlew :clean :docs:artifactoryPublish -DpublishApiDocs " +
+                    "-DcordaArtifactoryUsername=\"\${ARTIFACTORY_CREDENTIALS_USR}\" " +
+                    "-DcordaArtifactoryPassword=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" "
+            }
+        }
+    }
+
+    post {
+        cleanup {
+            deleteDir() /* clean up our workspace */
+        }
+    }
+}

--- a/.ci/dev/publish-api-docs/Jenkinsfile
+++ b/.ci/dev/publish-api-docs/Jenkinsfile
@@ -5,23 +5,24 @@ import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 
 pipeline {
-    agent { label 'k8s' }
+    agent { label 'standard' }
     options {
+        ansiColor('xterm')
         timestamps()
         timeout(time: 3, unit: 'HOURS')
     }
 
     environment {
-        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials-for-jenkins-test')
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
     }
 
     stages {
         stage('Publish Archived API Docs to Artifactory') {
             when { tag pattern: /^release-os-V(\d+\.\d+)(\.\d+){0,1}(-GA){0,1}(-\d{4}-\d\d-\d\d-\d{4}){0,1}$/, comparator: 'REGEXP' }
             steps {
-                sh "./gradlew :clean :docs:artifactoryPublish -DpublishApiDocs " +
-                    "-DcordaArtifactoryUsername=\"\${ARTIFACTORY_CREDENTIALS_USR}\" " +
-                    "-DcordaArtifactoryPassword=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" "
+                sh "./gradlew :clean :docs:artifactoryPublish -DpublishApiDocs"
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -607,7 +607,7 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-            repoKey = 'testing-ci-uploads-dev-local'
+            repoKey = 'corda-dev'
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }

--- a/build.gradle
+++ b/build.gradle
@@ -607,9 +607,15 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-            repoKey = 'corda-dev'
-            username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
-            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+            if (System.getProperty('publishApiDocs') != null) {
+                repoKey = 'corda-dependencies-dev'
+                username = System.getProperty('cordaArtifactoryUsername')
+                password = System.getProperty('cordaArtifactoryPassword')
+            } else {
+                repoKey = 'r3-corda-dev'
+                username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+            }
         }
 
         defaults {

--- a/build.gradle
+++ b/build.gradle
@@ -607,15 +607,9 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-            if (System.getProperty('publishApiDocs') != null) {
-                repoKey = 'corda-dependencies-dev'
-                username = System.getProperty('cordaArtifactoryUsername')
-                password = System.getProperty('cordaArtifactoryPassword')
-            } else {
-                repoKey = 'r3-corda-dev'
-                username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
-                password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
-            }
+            repoKey = 'testing-ci-uploads-dev-local'
+            username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }
 
         defaults {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -94,9 +94,11 @@ task archiveApiDocs(type: Tar) {
 
 publishing {
     publications {
-        archivedApiDocs(MavenPublication) {
-            artifact archiveApiDocs {
-                artifactId archivedApiDocsBaseFilename
+        if (System.getProperty('publishApiDocs') != null) {
+            archivedApiDocs(MavenPublication) {
+                artifact archiveApiDocs {
+                    artifactId archivedApiDocsBaseFilename
+                }
             }
         }
     }
@@ -112,8 +114,7 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-//            repoKey = 'corda-dependencies-dev'
-            repoKey = 'testing-ci-uploads-release-local'
+            repoKey = 'corda-dependencies-dev'
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,14 +1,9 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
-
-dependencies {
-    compile rootProject
-}
 
 def internalPackagePrefixes(sourceDirs) {
     def prefixes = []
@@ -25,7 +20,7 @@ def internalPackagePrefixes(sourceDirs) {
 
 ext {
     // TODO: Add '../client/jfx/src/main/kotlin' and '../client/mock/src/main/kotlin' if we decide to make them into public API
-    dokkaSourceDirs = files('../client/rpc/src/main/kotlin', '../finance/workflows/src/main/kotlin', '../client/jackson/src/main/kotlin',
+    dokkaSourceDirs = files('../core/src/main/kotlin', '../client/rpc/src/main/kotlin', '../finance/workflows/src/main/kotlin', '../finance/contracts/src/main/kotlin', '../client/jackson/src/main/kotlin',
             '../testing/test-utils/src/main/kotlin', '../testing/node-driver/src/main/kotlin')
     internalPackagePrefixes = internalPackagePrefixes(dokkaSourceDirs)
     archivedApiDocsBaseFilename = 'api-docs'
@@ -65,7 +60,10 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
     }
 }
 
-task apidocs(dependsOn: ['dokka', 'dokkaJavadoc'])
+task apidocs(dependsOn: ['dokka', 'dokkaJavadoc']) {
+    group "Documentation"
+    description "Build API documentation"
+}
 
 task makeHTMLDocs(type: Exec){
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -96,18 +94,16 @@ task archiveApiDocs(type: Tar) {
 
 publishing {
     publications {
-        if (System.getProperty('publishApiDocs') != null) {
-            apiDocs(MavenPublication) {
-                artifact archiveApiDocs {
-                    artifactId archivedApiDocsBaseFilename
-                }
+        archivedApiDocs(MavenPublication) {
+            artifact archiveApiDocs {
+                artifactId archivedApiDocsBaseFilename
             }
         }
     }
 }
 
 artifactoryPublish {
-    publications('apiDocs')
+    publications('archivedApiDocs')
     version = version.replaceAll('-SNAPSHOT', '')
     publishPom = false
 }
@@ -116,8 +112,7 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-//            repoKey = 'corda-dependencies-dev'
-            repoKey = 'testing-ci-uploads-release-local'
+            repoKey = 'corda-dependencies-dev'
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -96,9 +96,11 @@ task archiveApiDocs(type: Tar) {
 
 publishing {
     publications {
-        apiDocs(MavenPublication) {
-            artifact archiveApiDocs {
-                artifactId archivedApiDocsBaseFilename
+        if (System.getProperty('publishApiDocs') != null) {
+            apiDocs(MavenPublication) {
+                artifact archiveApiDocs {
+                    artifactId archivedApiDocsBaseFilename
+                }
             }
         }
     }
@@ -108,4 +110,16 @@ artifactoryPublish {
     publications('apiDocs')
     version = version.replaceAll('-SNAPSHOT', '')
     publishPom = false
+}
+
+artifactory {
+    publish {
+        contextUrl = artifactory_contextUrl
+        repository {
+//            repoKey = 'corda-dependencies-dev'
+            repoKey = 'testing-ci-uploads-release-local'
+            username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+        }
+    }
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -112,7 +112,8 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-            repoKey = 'corda-dependencies-dev'
+//            repoKey = 'corda-dependencies-dev'
+            repoKey = 'testing-ci-uploads-release-local'
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,0 +1,111 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
+apply plugin: 'org.jetbrains.dokka'
+apply plugin: 'kotlin'
+apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
+
+dependencies {
+    compile rootProject
+}
+
+def internalPackagePrefixes(sourceDirs) {
+    def prefixes = []
+    // Kotlin allows packages to deviate from the directory structure, but let's assume they don't:
+    sourceDirs.collect { sourceDir ->
+        sourceDir.traverse(type: groovy.io.FileType.DIRECTORIES) {
+            if (it.name == 'internal') {
+                prefixes.add sourceDir.toPath().relativize(it.toPath()).toString().replace(File.separator, '.')
+            }
+        }
+    }
+    prefixes
+}
+
+ext {
+    // TODO: Add '../client/jfx/src/main/kotlin' and '../client/mock/src/main/kotlin' if we decide to make them into public API
+    dokkaSourceDirs = files('../client/rpc/src/main/kotlin', '../finance/workflows/src/main/kotlin', '../client/jackson/src/main/kotlin',
+            '../testing/test-utils/src/main/kotlin', '../testing/node-driver/src/main/kotlin')
+    internalPackagePrefixes = internalPackagePrefixes(dokkaSourceDirs)
+    archivedApiDocsBaseFilename = 'api-docs'
+}
+
+dokka {
+    outputDirectory = file("${rootProject.rootDir}/docs/build/html/api/kotlin")
+}
+
+task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+    outputFormat = "javadoc"
+    outputDirectory = file("${rootProject.rootDir}/docs/build/html/api/javadoc")
+}
+
+[dokka, dokkaJavadoc].collect {
+    it.configure {
+        moduleName = 'corda'
+        processConfigurations = ['compile']
+        sourceDirs = dokkaSourceDirs
+        includes = ['packages.md']
+        jdkVersion = 8
+        externalDocumentationLink {
+            url = new URL("http://fasterxml.github.io/jackson-core/javadoc/2.9/")
+        }
+        externalDocumentationLink {
+            url = new URL("https://docs.oracle.com/javafx/2/api/")
+        }
+        externalDocumentationLink {
+            url = new URL("http://www.bouncycastle.org/docs/docs1.5on/")
+        }
+        internalPackagePrefixes.collect { packagePrefix ->
+            packageOptions {
+                prefix = packagePrefix
+                suppress = true
+            }
+        }
+    }
+}
+
+task apidocs(dependsOn: ['dokka', 'dokkaJavadoc'])
+
+task makeHTMLDocs(type: Exec){
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine "docker", "run", "--rm", "-v", "${project.projectDir}:/opt/docs_builder", "-v", "${project.projectDir}/..:/opt", "corda/docs-builder:latest", "bash", "-c", "make-docsite-html.sh"
+    } else {
+        commandLine "bash", "-c",  "docker run --rm --user \$(id -u):\$(id -g) -v ${project.projectDir}:/opt/docs_builder -v ${project.projectDir}/..:/opt corda/docs-builder:latest bash -c make-docsite-html.sh"
+    }
+}
+
+task makePDFDocs(type: Exec){
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine "docker", "run", "--rm", "-v", "${project.projectDir}:/opt/docs_builder", "-v", "${project.projectDir}/..:/opt", "corda/docs-builder:latest", "bash", "-c", "make-docsite-pdf.sh"
+    } else {
+        commandLine "bash", "-c",  "docker run --rm --user \$(id -u):\$(id -g) -v ${project.projectDir}:/opt/docs_builder -v ${project.projectDir}/..:/opt corda/docs-builder:latest bash -c make-docsite-pdf.sh"
+    }
+}
+
+task makeDocs(dependsOn: ['makeHTMLDocs', 'makePDFDocs'])
+apidocs.shouldRunAfter makeDocs
+
+task archiveApiDocs(type: Tar) {
+    dependsOn apidocs
+    from buildDir
+    include 'html/**'
+    extension 'tgz'
+    compression Compression.GZIP
+}
+
+publishing {
+    publications {
+        apiDocs(MavenPublication) {
+            artifact archiveApiDocs {
+                artifactId archivedApiDocsBaseFilename
+            }
+        }
+    }
+}
+
+artifactoryPublish {
+    publications('apiDocs')
+    version = version.replaceAll('-SNAPSHOT', '')
+    publishPom = false
+}


### PR DESCRIPTION
### Summary
This automates the manual process of building and uploading the archived API docs to Artifactory.
See [here](https://r3-cev.atlassian.net/wiki/spaces/EN/pages/1704166317/Documentation+repositories) for details.

This PR adds:
- Gradle task to build and archive the API docs.
- Jenkinsfile to enable the automatic publishing of this file to Artifactory triggered by a tag.

The proposed trigger tag format for OS is `release-os-*V(\d+\.\d+)(\.\d+)*(-GA)*(\-\d{4}\-\d\d\-\d\d\-\d{4})*$`.
e.g. `release-os-V4.3.1-GA-2020-06-02-1550`

Jenkins jobs will be configured in both ci01 and ci02 so that pushing any tag matching the pattern will result in the publication being triggered.
e.g. [ci01 - Publish API Docs](https://ci01.dev.r3.com/job/Docs-Builders/job/Publish-API-Docs/)

Similar PRs will be raised against ENT and CENM.