### PR TITLE
ENT-4493 schema migration refactor

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/LiquibaseDatabaseFactory.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/LiquibaseDatabaseFactory.kt
@@ -1,0 +1,8 @@
+package net.corda.nodeapi.internal.persistence
+
+import liquibase.database.Database
+import liquibase.database.jvm.JdbcConnection
+
+interface LiquibaseDatabaseFactory {
+    fun getLiquibaseDatabase(conn: JdbcConnection): Database
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/LiquibaseDatabaseFactoryImpl.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/LiquibaseDatabaseFactoryImpl.kt
@@ -1,0 +1,11 @@
+package net.corda.nodeapi.internal.persistence
+
+import liquibase.database.Database
+import liquibase.database.DatabaseFactory
+import liquibase.database.jvm.JdbcConnection
+
+class LiquibaseDatabaseFactoryImpl : LiquibaseDatabaseFactory {
+    override fun getLiquibaseDatabase(conn: JdbcConnection): Database {
+        return DatabaseFactory.getInstance().findCorrectDatabaseImplementation(conn)
+    }
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -150,7 +150,7 @@ open class SchemaMigration(
         val liquibase = Liquibase(dynamicInclude, resourcesAndSourceInfo.single().first, databaseFactory.getLiquibaseDatabase(JdbcConnection(connection)))
 
         val unRunChanges = liquibase.listUnrunChangeSets(Contexts(), LabelExpression())
-        return Triple(liquibase, unRunChanges.size, true)
+        return Triple(liquibase, unRunChanges.size, !unRunChanges.isEmpty())
     }
 
     /** For existing database created before verions 4.0 add Liquibase support - creates DATABASECHANGELOG and DATABASECHANGELOGLOCK tables and marks changesets as executed. */


### PR DESCRIPTION
Refactor schema migration so it can be extended/customised in Enterprise. (compare https://github.com/corda/enterprise/tree/christians/ENT-4493-refactor-migration-for-alignment for an idea how that will work).
Also allows easier modification of SchemaMigration calls.