### PR TITLE
[EG-2225] Create log directory in correct place with verbose flag set

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -527,7 +527,6 @@ fun CliWrapperBase.initLogging(baseDirectory: Path): Boolean {
         return false
     }
 
-    System.setProperty("log-path", (baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
     SLF4JBridgeHandler.removeHandlersForRootLogger() // The default j.u.l config adds a ConsoleHandler.
     SLF4JBridgeHandler.install()
     return true

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -504,6 +504,7 @@ interface NodeStartupLogging {
 
 fun CliWrapperBase.initLogging(baseDirectory: Path): Boolean {
     System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
+    System.setProperty("log-path", (baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
     if (verbose) {
         System.setProperty("consoleLoggingEnabled", "true")
         System.setProperty("consoleLogLevel", specifiedLogLevel)

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -1,10 +1,8 @@
 package net.corda.node.internal
 
 import net.corda.cliutils.CommonCliConstants
-import net.corda.core.internal.deleteIfExists
 import net.corda.core.internal.div
 import net.corda.core.internal.exists
-import net.corda.core.utilities.contextLogger
 import net.corda.nodeapi.internal.config.UnknownConfigKeysPolicy
 import org.assertj.core.api.Assertions
 import org.junit.BeforeClass
@@ -15,7 +13,6 @@ import picocli.CommandLine
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.logging.Logger
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -58,7 +55,7 @@ class NodeStartupCliTest {
         Assertions.assertThat(startup.cmdLineOptions.networkRootTrustStorePathParameter).isEqualTo(null)
     }
 
-    @Test
+    @Test(timeout=3_000)
     fun `test logs are written to correct location correctly if verbose flag set`() {
         val node = NodeStartupCli()
         val dir = Files.createTempDirectory("verboseLoggingTest")


### PR DESCRIPTION
When starting a node, it is possible that the logs directory will be created in the wrong place. This can happen if the following conditions are met:
 - The base directory flag is passed with a directory that is not the current directory
 - The verbose flag is set

When the verbose flag is set, `initLogging` sets a property in the node's companion object. This forces the companion object to be initialized, and as part of that initialization a logger is accessed. This in turn causes the logging configuration to be parsed. The logging configuration depends on a few system properties, which in this particular flow are not set correctly at the point the configuration is parsed. As a result, logs are written to the default directory, which is the one the command was executed from, rather than the base directory.

This PR addresses the issue by rearranging the setup of the system properties to ensure it always happens before logging configuration is parsed. This ultimately feels brittle, and this area of code likely needs a rethink.
