### PR TITLE
[EG-2564] Move printed error to logger

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -333,8 +333,7 @@ open class NodeStartup : NodeStartupLogging {
         if (devMode) return true
 
         if (!certDirectory.isDirectory()) {
-            printError("Unable to access certificates directory ${certDirectory}. This could be because the node has not been registered with the Identity Operator.")
-            printError("Node will now shutdown.")
+            logger.error("Unable to access certificates directory ${certDirectory}. This could be because the node has not been registered with the Identity Operator. Node will now shutdown")
             return false
         }
         return true


### PR DESCRIPTION
`NodeStartup` includes a number of error messages that are printed directly to the console because the logging framework has not been initialized. The error about certificates occurs after logging is initialized however, so it's safe to print this into the logs and let logging handle printing this to the console.
