### PR TITLE
Removed wrong targets from the pre distributed testing stage

### DIFF
--- a/.ci/dev/nightly-regression/Jenkinsfile
+++ b/.ci/dev/nightly-regression/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                                 "-Ddocker.push.password=\"\${DOCKER_PUSH_PWD}\" " +
                                 "-Ddocker.work.dir=\"/tmp/\${EXECUTOR_NUMBER}\" " +
                                 "-Ddocker.build.tag=\"\${DOCKER_TAG_TO_USE}\"" +
-                                " clean jar deployNodes install pushBuildImage --stacktrace"
+                                " clean pushBuildImage --stacktrace"
                     }
                     sh "kubectl auth can-i get pods"
                 }

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                             "-Ddocker.push.password=\"\${DOCKER_PUSH_PWD}\" " +
                             "-Ddocker.work.dir=\"/tmp/\${EXECUTOR_NUMBER}\" " +
                             "-Ddocker.build.tag=\"\${DOCKER_TAG_TO_USE}\"" +
-                            " clean jar deployNodes install pushBuildImage --stacktrace"
+                            " clean pushBuildImage --stacktrace"
                 }
                 sh "kubectl auth can-i get pods"
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,14 @@ pipeline {
                                 " allParallelUnitTest --stacktrace"
                     }
                 }
+                stage('Node Deploy') {
+                    steps {
+                        sh "./gradlew --no-daemon " +
+                                "-Dartifactory.username=\"\${ARTIFACTORY_CREDENTIALS_USR}\" " +
+                                "-Dartifactory.password=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" " +
+                                " clean jar deployNodes install --stacktrace"
+                    }
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                             "-Ddocker.push.password=\"\${DOCKER_PUSH_PWD}\" " +
                             "-Ddocker.work.dir=\"/tmp/\${EXECUTOR_NUMBER}\" " +
                             "-Ddocker.build.tag=\"\${DOCKER_TAG_TO_USE}\"" +
-                            " clean jar deployNodes pushBuildImage --stacktrace"
+                            " clean pushBuildImage --stacktrace"
                 }
                 sh "kubectl auth can-i get pods"
             }


### PR DESCRIPTION
This stage is meant to create Docker images for distributed testing.
Nothing is actually build in the agent's context, so these targets should be never started in the first place.
Additionally they add about 20 minutes of the build time.