### PR TITLE
EG-2684 Ensure original message is logged with old-style error codes

### DIFF
--- a/common/logging/src/main/kotlin/net/corda/common/logging/ExceptionsErrorCodeFunctions.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/ExceptionsErrorCodeFunctions.kt
@@ -32,8 +32,9 @@ fun Message.withErrorCodeFor(error: Throwable?, level: Level): Message {
 
     return when {
         error != null && level.isInRange(Level.FATAL, Level.WARN) -> {
+            val logMessage = this.formattedMessage
             val message = error.walkExceptionCausedByList().asSequence().mapNotNull(Throwable::message).joinToString(" - ")
-            CompositeMessage("$message [errorCode=${error.errorCode()}, moreInformationAt=${error.errorCodeLocationUrl()}]", format, parameters, throwable)
+            CompositeMessage("$logMessage - $message [errorCode=${error.errorCode()}, moreInformationAt=${error.errorCodeLocationUrl()}]", format, parameters, throwable)
         }
         else -> this
     }

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/ExceptionsErrorCodeFunctionsTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/ExceptionsErrorCodeFunctionsTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
 
 class ExceptionsErrorCodeFunctionsTest {
 
-    @Test
+    @Test(timeout=3_000)
     fun `error code for message prints out message and full stack trace`() {
         val originalMessage = SimpleMessage("This is a test message")
         var previous: Exception? = null

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/ExceptionsErrorCodeFunctionsTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/ExceptionsErrorCodeFunctionsTest.kt
@@ -1,0 +1,34 @@
+package net.corda.commmon.logging
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.contains
+import net.corda.common.logging.withErrorCodeFor
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.message.SimpleMessage
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ExceptionsErrorCodeFunctionsTest {
+
+    @Test
+    fun `error code for message prints out message and full stack trace`() {
+        val originalMessage = SimpleMessage("This is a test message")
+        var previous: Exception? = null
+        val throwables = (0..10).map {
+            val current = TestThrowable(it, previous)
+            previous = current
+            current
+        }
+        val exception = throwables.last()
+        val message = originalMessage.withErrorCodeFor(exception, Level.ERROR)
+        assertThat(message.formattedMessage, contains("This is a test message".toRegex()))
+        for (i in (0..10)) {
+            assertThat(message.formattedMessage, contains("This is exception $i".toRegex()))
+        }
+        assertEquals(message.format, originalMessage.format)
+        assertEquals(message.parameters, originalMessage.parameters)
+        assertEquals(message.throwable, originalMessage.throwable)
+    }
+
+    private class TestThrowable(index: Int, cause: Exception?) : Exception("This is exception $index", cause)
+}


### PR DESCRIPTION
Old-style error codes use a rewrite function to add the error code information to the log message. This was intended to also add messages from the full exception stack trace. While it does do this, it also lost the original log message. This PR ensures that the original log message remains.
