### PR TITLE
EG-2654 - Ensure stack traces are printed to the logs in error reporting

### DIFF
--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.common.logging.errorReporting
 
 import org.slf4j.Logger
+import java.lang.Exception
 import java.text.MessageFormat
 import java.util.*
 
@@ -31,6 +32,10 @@ internal class ErrorReporterImpl(private val resourceLocation: String,
     override fun report(error: ErrorCode<*>, logger: Logger) {
         val errorResource = ErrorResource.fromErrorCode(error, resourceLocation, locale)
         val message = "${errorResource.getErrorMessage(error.parameters.toTypedArray())} ${getErrorInfo(error)}"
-        logger.error(message)
+        if (error is Exception) {
+            logger.error(message, error)
+        } else {
+            logger.error(message)
+        }
     }
 }

--- a/common/logging/src/main/resources/error-codes/database-failed-startup.properties
+++ b/common/logging/src/main/resources/error-codes/database-failed-startup.properties
@@ -1,4 +1,4 @@
-errorTemplate = Failed to create the datasource. See the logs for further information and the cause.
+errorTemplate = Failed to create the datasource: {0}. See the logs for further information and the cause.
 shortDescription = The datasource could not be created for unknown reasons.
 actionsToFix = The logs in the logs directory should contain more information on what went wrong.
 aliases =

--- a/common/logging/src/main/resources/error-codes/database-failed-startup_en_US.properties
+++ b/common/logging/src/main/resources/error-codes/database-failed-startup_en_US.properties
@@ -1,3 +1,3 @@
-errorTemplate = Failed to create the datasource. See the logs for further information and the cause.
+errorTemplate = Failed to create the datasource: {0}. See the logs for further information and the cause.
 shortDescription = The datasource could not be created for unknown reasons.
 actionsToFix = The logs in the logs directory should contain more information on what went wrong.

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/DatabaseErrorsTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/DatabaseErrorsTest.kt
@@ -6,7 +6,7 @@ import java.net.InetAddress
 class DatabaseErrorsTest : ErrorCodeTest<NodeDatabaseErrors>(NodeDatabaseErrors::class.java) {
     override val dataForCodes = mapOf(
             NodeDatabaseErrors.COULD_NOT_CONNECT to listOf<Any>(),
-            NodeDatabaseErrors.FAILED_STARTUP to listOf(),
+            NodeDatabaseErrors.FAILED_STARTUP to listOf("This is a test message"),
             NodeDatabaseErrors.MISSING_DRIVER to listOf(),
             NodeDatabaseErrors.PASSWORD_REQUIRED_FOR_H2 to listOf(InetAddress.getLocalHost())
     )

--- a/common/logging/src/test/resources/errorReporting/test-case4.properties
+++ b/common/logging/src/test/resources/errorReporting/test-case4.properties
@@ -1,0 +1,4 @@
+errorTemplate = This is the fourth test message
+shortDescription = Test description
+actionsToFix = Actions
+aliases =

--- a/common/logging/src/test/resources/errorReporting/test-case4_en_US.properties
+++ b/common/logging/src/test/resources/errorReporting/test-case4_en_US.properties
@@ -1,0 +1,4 @@
+errorTemplate = This is the fourth test message
+shortDescription = Test description
+actionsToFix = Actions
+aliases =

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1360,11 +1360,14 @@ fun CordaPersistence.startHikariPool(hikariProperties: Properties, databaseConfi
                     "Could not find the database driver class. Please add it to the 'drivers' folder.",
                     NodeDatabaseErrors.MISSING_DRIVER)
             ex is OutstandingDatabaseChangesException -> throw (DatabaseIncompatibleException(ex.message))
-            else ->
+            else -> {
+                val msg = ex.message ?: ex::class.java.canonicalName
                 throw CouldNotCreateDataSourceException(
                         "Could not create the DataSource: ${ex.message}",
                         NodeDatabaseErrors.FAILED_STARTUP,
-                        cause = ex)
+                        cause = ex,
+                        parameters = listOf(msg))
+            }
         }
     }
 }


### PR DESCRIPTION
Error reporting was unconditionally using the version of `logger.error` that does not take an exception parameter. In cases where the error object is a throwable (which is the majority of them), the stack trace should also be printed to the logs. This change ensures that this actually happens.

It also adds the exception message to the logged message for the catch all case for database exceptions.