### PR TITLE
EG-2292 Membership State for Business Networks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -549,6 +549,7 @@ bintrayConfig {
             'corda-deterministic-verifier',
             'corda-deserializers-djvm',
             'corda',
+            'corda-business-network-contracts',
             'corda-finance-workflows',
             'corda-finance-contracts',
             'corda-node',

--- a/business-networks/contracts/build.gradle
+++ b/business-networks/contracts/build.gradle
@@ -1,0 +1,18 @@
+apply plugin: 'kotlin'
+apply plugin: 'net.corda.plugins.cordapp'
+apply plugin: 'kotlin-jpa'
+
+description 'Corda Business Networks Contracts'
+
+dependencies {
+    cordaCompile project(':core')
+
+    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+
+    // Bring in the MockNode infrastructure for writing protocol unit tests.
+    testCompile project(":node-driver")
+}
+
+jar {
+    baseName 'corda-business-network-contracts'
+}

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
@@ -1,0 +1,25 @@
+package net.corda.bn.schemas
+
+import net.corda.bn.states.MembershipState
+import net.corda.bn.states.MembershipStatus
+import net.corda.core.identity.Party
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import net.corda.core.serialization.CordaSerializable
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Table
+
+@CordaSerializable
+object MembershipStateSchemaV1 : MappedSchema(schemaFamily = MembershipState::class.java, version = 1, mappedTypes = listOf(PersistentMembershipState::class.java)) {
+    @Entity
+    @Table(name = "membership_state")
+    class PersistentMembershipState(
+            @Column(name = "corda_identity")
+            val cordaIdentity: Party,
+            @Column(name = "network_id")
+            val networkId: String,
+            @Column(name = "status")
+            val status: MembershipStatus
+    ) : PersistentState()
+}

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
@@ -1,0 +1,67 @@
+package net.corda.bn.states
+
+import net.corda.bn.schemas.MembershipStateSchemaV1
+import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.QueryableState
+import net.corda.core.serialization.CordaSerializable
+import java.time.Instant
+
+/**
+ * Represents a membership on the ledger.
+ *
+ * @property identity Corda Identity of a member.
+ * @property networkId Unique identifier of a Business Network membership belongs to.
+ * @property status Status of the state (i.e. PENDING, ACTIVE, SUSPENDED).
+ * @property issued Timestamp when the state has been issued.
+ * @property modified Timestamp when the state has been modified last time.
+ */
+data class MembershipState(
+        val identity: Party,
+        val networkId: String,
+        val status: MembershipStatus,
+        val issued: Instant = Instant.now(),
+        val modified: Instant = issued,
+        override val linearId: UniqueIdentifier = UniqueIdentifier(),
+        override val participants: List<AbstractParty>
+) : LinearState, QueryableState {
+
+    override fun generateMappedObject(schema: MappedSchema) = when (schema) {
+        is MembershipStateSchemaV1 -> MembershipStateSchemaV1.PersistentMembershipState(
+                cordaIdentity = identity,
+                networkId = networkId,
+                status = status
+        )
+        else -> throw IllegalArgumentException("Unrecognised schema $schema")
+    }
+
+    override fun supportedSchemas() = listOf(MembershipStateSchemaV1)
+
+    fun isPending() = status == MembershipStatus.PENDING
+    fun isActive() = status == MembershipStatus.ACTIVE
+    fun isSuspended() = status == MembershipStatus.SUSPENDED
+}
+
+/**
+ * Statuses that membership can go through.
+ */
+@CordaSerializable
+enum class MembershipStatus {
+    /**
+     * Newly submitted state which hasn't been approved by authorised member yet. Pending members can't transact on the Business Network.
+     */
+    PENDING,
+
+    /**
+     * Active members can transact on the Business Network and modify other memberships if they are authorised.
+     */
+    ACTIVE,
+
+    /**
+     * Suspended members can't transact on the Business Network or modify other memberships. Suspended members can be activated back.
+     */
+    SUSPENDED
+}

--- a/business-networks/contracts/src/main/resources/membership-state-schema-v1.changelog-init.xml
+++ b/business-networks/contracts/src/main/resources/membership-state-schema-v1.changelog-init.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3 Corda" id="MembershipStateSchemaV1">
+        <createTable tableName="membership_state">
+            <column name="output_index" type="integer">
+                <constraints nullable="false"/>
+            </column>
+            <column name="transaction_id" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="corda_identity" type="varchar(255)"/>
+            <column name="network_id" type="varchar(255)"/>
+            <column name="status" type="integer"/>
+        </createTable>
+        <addPrimaryKey columnNames="output_index, transaction_id"
+                       constraintName="PK_MembershipStateSchemaV1"
+                       tableName="membership_state"/>
+    </changeSet>
+</databaseChangeLog>

--- a/business-networks/contracts/src/main/resources/membership-state-schema-v1.changelog-master.xml
+++ b/business-networks/contracts/src/main/resources/membership-state-schema-v1.changelog-master.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <include relativeToChangelogFile="true" file="membership-state-schema-v1.changelog-init.xml"/>
+</databaseChangeLog>

--- a/business-networks/contracts/src/test/kotlin/net/corda/bn/states/MembershipStateTest.kt
+++ b/business-networks/contracts/src/test/kotlin/net/corda/bn/states/MembershipStateTest.kt
@@ -1,0 +1,35 @@
+package net.corda.bn.states
+
+import com.nhaarman.mockito_kotlin.mock
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MembershipStateTest {
+
+    private fun mockMembership(status: MembershipStatus) = MembershipState(
+            identity = mock(),
+            networkId = "",
+            status = status,
+            participants = mock()
+    )
+
+    @Test(timeout = 300_000)
+    fun `membership state status helper methods should work`() {
+        mockMembership(MembershipStatus.PENDING).apply {
+            assertTrue(isPending())
+            assertFalse(isActive())
+            assertFalse(isSuspended())
+        }
+        mockMembership(MembershipStatus.ACTIVE).apply {
+            assertFalse(isPending())
+            assertTrue(isActive())
+            assertFalse(isSuspended())
+        }
+        mockMembership(MembershipStatus.SUSPENDED).apply {
+            assertFalse(isPending())
+            assertFalse(isActive())
+            assertTrue(isSuspended())
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ pluginManagement {
 // The project is named 'corda-project' and not 'corda' because if this is named the same as the
 // output JAR from the capsule then the buildCordaJAR task goes into an infinite loop.
 rootProject.name = 'corda-project'
+include 'business-networks:contracts'
 include 'confidential-identities'
 include 'finance:contracts'
 include 'finance:workflows'


### PR DESCRIPTION
## Description

This is first of many Business Network (BN) primitives PRs to come. In here we introduce state by which we model BN membership on ledger and supporting tests.

First we create `MembershipState` which implements `LinearState` and `QueryableState` interface since we need to have unique identification of the state and possibility to query the vault by custom class field criteria. This data class has following crucial fields:
- `identity` describes to which `Party` object membership state belongs to
- `networkId` is the unique identifier of the BN that given membership belongs to
- `status` can be `PENDING`, `ACTIVE` or `SUSPENDED`
- `issued` is the timestamp when the state has been issued
- `modified` is the timestamp when the state has been last modified

We also add supporting KDocs for class and simple unit tests which test helper methods this class contains.

In the end we create supported database schema for the class in form of the `MembershipStateSchemaV1` object. Notice we only decide to persist identity, network ID and status field since we predict flows will query vault by those criteria. We also add liquibase migration scripts for the new schema.

Next PRs will introduce associated contract logic for `MembershipState` and flows which will be responsible for moving state's status and distribution between BN members.

## Test Plan

Ensure new project builds correctly and that all new unit tests pass.