### PR TITLE
EG-2293 Membership Contract for Business Networks

### DIFF
--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/contracts/MembershipContract.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/contracts/MembershipContract.kt
@@ -1,0 +1,103 @@
+package net.corda.bn.contracts
+
+import net.corda.bn.states.MembershipState
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.CommandWithParties
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.TypeOnlyCommandData
+import net.corda.core.contracts.requireSingleCommand
+import net.corda.core.contracts.requireThat
+import net.corda.core.transactions.LedgerTransaction
+import java.lang.IllegalArgumentException
+
+/**
+ * Contract that verifies an evolution of [MembershipState].
+ */
+open class MembershipContract : Contract {
+
+    companion object {
+        const val CONTRACT_NAME = "net.corda.bn.contracts.MembershipContract"
+    }
+
+    open class Commands : CommandData, TypeOnlyCommandData() {
+        class Request : Commands()
+        class Activate : Commands()
+        class Suspend : Commands()
+        class Revoke : Commands()
+    }
+
+    @Suppress("ComplexMethod")
+    override fun verify(tx: LedgerTransaction) {
+        val command = tx.commands.requireSingleCommand<Commands>()
+        val input = if (tx.inputStates.isNotEmpty()) tx.inputs.single() else null
+        val inputState = input?.state?.data as? MembershipState
+        val output = if (tx.outputStates.isNotEmpty()) tx.outputs.single() else null
+        val outputState = output?.data as? MembershipState
+
+        requireThat {
+            input?.apply {
+                "Input state has to be validated by ${contractName()}" using (input.state.contract == contractName())
+            }
+            inputState?.apply {
+                "Input state's modified timestamp should be greater or equal to issued timestamp" using (inputState.issued <= inputState.modified)
+            }
+            outputState?.apply {
+                "Output state's modified timestamp should be greater or equal to issued timestamp" using (outputState.issued <= outputState.modified)
+            }
+            output?.apply {
+                "Output state has to be validated by ${contractName()}" using (output.contract == contractName())
+            }
+            if (inputState != null && outputState != null) {
+                "Input and output state should have same Corda identity" using (inputState.identity == outputState.identity)
+                "Input and output state should have same network IDs" using (inputState.networkId == outputState.networkId)
+                "Input and output state should have same issued timestamps" using (inputState.issued == outputState.issued)
+                "Output state's modified timestamp should be greater or equal than input's" using (inputState.modified <= outputState.modified)
+                "Input and output state should have same linear IDs" using (inputState.linearId == outputState.linearId)
+                "Input and output state should have same participants" using (inputState.participants.toSet() == outputState.participants.toSet())
+            }
+        }
+
+        when (command.value) {
+            is Commands.Request -> verifyRequest(tx, command, outputState!!)
+            is Commands.Activate -> verifyActivate(tx, command, inputState!!, outputState!!)
+            is Commands.Suspend -> verifySuspend(tx, command, inputState!!, outputState!!)
+            is Commands.Revoke -> verifyRevoke(tx, command, inputState!!)
+            else -> throw IllegalArgumentException("Unsupported command ${command.value}")
+        }
+    }
+
+    open fun contractName() = CONTRACT_NAME
+
+    open fun verifyRequest(tx: LedgerTransaction, command: CommandWithParties<Commands>, outputMembership: MembershipState) = requireThat {
+        "Membership request transaction shouldn't contain any inputs" using (tx.inputs.isEmpty())
+        "Membership request transaction should contain output state in PENDING status" using (outputMembership.isPending())
+    }
+
+    open fun verifyActivate(
+            tx: LedgerTransaction,
+            command: CommandWithParties<Commands>,
+            inputMembership: MembershipState,
+            outputMembership: MembershipState
+    ) = requireThat {
+        "Input state of membership activation transaction shouldn't be already active" using (!inputMembership.isActive())
+        "Output state of membership activation transaction should be active" using (outputMembership.isActive())
+    }
+
+    open fun verifySuspend(
+            tx: LedgerTransaction,
+            command: CommandWithParties<Commands>,
+            inputMembership: MembershipState,
+            outputMembership: MembershipState
+    ) = requireThat {
+        "Input state of membership suspension transaction shouldn't be already suspended" using (!inputMembership.isSuspended())
+        "Output state of membership suspension transaction should be suspended" using (outputMembership.isSuspended())
+    }
+
+    open fun verifyRevoke(
+            tx: LedgerTransaction,
+            command: CommandWithParties<Commands>,
+            inputMembership: MembershipState
+    ) = requireThat {
+        "Membership revocation transaction shouldn't contain any outputs" using (tx.outputs.isEmpty())
+    }
+}

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
@@ -1,6 +1,8 @@
 package net.corda.bn.states
 
+import net.corda.bn.contracts.MembershipContract
 import net.corda.bn.schemas.MembershipStateSchemaV1
+import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
@@ -19,6 +21,7 @@ import java.time.Instant
  * @property issued Timestamp when the state has been issued.
  * @property modified Timestamp when the state has been modified last time.
  */
+@BelongsToContract(MembershipContract::class)
 data class MembershipState(
         val identity: Party,
         val networkId: String,

--- a/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
+++ b/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
@@ -1,0 +1,212 @@
+package net.corda.bn.contracts
+
+import net.corda.bn.states.MembershipState
+import net.corda.bn.states.MembershipStatus
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.TypeOnlyCommandData
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.node.MockServices
+import net.corda.testing.node.ledger
+import org.junit.Test
+
+class DummyContract : Contract {
+
+    companion object {
+        const val CONTRACT_NAME = "net.corda.bn.contracts.DummyContract"
+    }
+
+    override fun verify(tx: LedgerTransaction) {}
+}
+
+private class DummyCommand : TypeOnlyCommandData()
+
+class MembershipContractTest {
+
+    private val ledgerServices = MockServices(listOf("net.corda.bn.contracts"))
+
+    private val memberIdentity = TestIdentity(CordaX500Name.parse("O=Member,L=London,C=GB")).party
+    private val bnoIdentity = TestIdentity(CordaX500Name.parse("O=BNO,L=London,C=GB")).party
+
+    private fun membershipState() = MembershipState(
+            identity = memberIdentity,
+            networkId = "network-id",
+            status = MembershipStatus.PENDING,
+            participants = listOf(memberIdentity, bnoIdentity)
+    )
+
+    @Test(timeout = 300_000)
+    fun `test common contract verification`() {
+        ledgerServices.ledger {
+            transaction {
+                val input = membershipState()
+                output(MembershipContract.CONTRACT_NAME, input)
+                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), DummyCommand())
+                fails()
+            }
+            transaction {
+                val input = membershipState()
+                input(DummyContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input)
+                command(memberIdentity.owningKey, MembershipContract.Commands.Revoke())
+                this `fails with` "Input state has to be validated by ${MembershipContract.CONTRACT_NAME}"
+            }
+            transaction {
+                val output = membershipState()
+                input(MembershipContract.CONTRACT_NAME, output)
+                output(DummyContract.CONTRACT_NAME, output)
+                command(memberIdentity.owningKey, MembershipContract.Commands.Request())
+                this `fails with` "Output state has to be validated by ${MembershipContract.CONTRACT_NAME}"
+            }
+            transaction {
+                val input = membershipState().run { copy(modified = modified.minusSeconds(100)) }
+                input(MembershipContract.CONTRACT_NAME, input)
+                command(memberIdentity.owningKey, MembershipContract.Commands.Revoke())
+                this `fails with` "Input state's modified timestamp should be greater or equal to issued timestamp"
+            }
+            transaction {
+                val output = membershipState().run { copy(modified = modified.minusSeconds(100)) }
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(memberIdentity.owningKey, MembershipContract.Commands.Request())
+                this `fails with` "Output state's modified timestamp should be greater or equal to issued timestamp"
+            }
+
+            val input = membershipState()
+            transaction {
+                val output = input.copy(identity = bnoIdentity)
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                this `fails with` "Input and output state should have same Corda identity"
+            }
+            transaction {
+                val output = input.copy(networkId = "other-network-id")
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                this `fails with` "Input and output state should have same network IDs"
+            }
+            transaction {
+                val output = input.run { copy(issued = issued.minusSeconds(100)) }
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                this `fails with` "Input and output state should have same issued timestamps"
+            }
+            transaction {
+                val output = input.run { copy(modified = modified.plusSeconds(100)) }
+                input(MembershipContract.CONTRACT_NAME, input.run { copy(modified = modified.plusSeconds(200)) })
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                this `fails with` "Output state's modified timestamp should be greater or equal than input's"
+            }
+            transaction {
+                val output = input.copy(linearId = UniqueIdentifier())
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                this `fails with` "Input and output state should have same linear IDs"
+            }
+            transaction {
+                val output = input.copy(participants = emptyList())
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                this `fails with` "Input and output state should have same participants"
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test request membership command contract verification`() {
+        ledgerServices.ledger {
+            val output = membershipState()
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, output)
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request())
+                this `fails with` "Membership request transaction shouldn't contain any inputs"
+            }
+            transaction {
+                output(MembershipContract.CONTRACT_NAME, output.copy(status = MembershipStatus.ACTIVE))
+                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request())
+                this `fails with` "Membership request transaction should contain output state in PENDING status"
+            }
+            transaction {
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request())
+                verifies()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test activate membership command contract verification`() {
+        ledgerServices.ledger {
+            val input = membershipState()
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate())
+                this `fails with` "Input state of membership activation transaction shouldn't be already active"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate())
+                this `fails with` "Output state of membership activation transaction should be active"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate())
+                verifies()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test suspend membership command contract verification`() {
+        ledgerServices.ledger {
+            val input = membershipState()
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend())
+                this `fails with` "Input state of membership suspension transaction shouldn't be already suspended"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend())
+                this `fails with` "Output state of membership suspension transaction should be suspended"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend())
+                verifies()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test revoke membership command contract verification`() {
+        ledgerServices.ledger {
+            val input = membershipState()
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Revoke())
+                this `fails with` "Membership revocation transaction shouldn't contain any outputs"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Revoke())
+                verifies()
+            }
+        }
+    }
+}

--- a/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
+++ b/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
@@ -50,27 +50,33 @@ class MembershipContractTest {
                 val input = membershipState()
                 input(DummyContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input)
-                command(memberIdentity.owningKey, MembershipContract.Commands.Revoke())
+                command(memberIdentity.owningKey, MembershipContract.Commands.Revoke(listOf(memberIdentity.owningKey)))
                 this `fails with` "Input state has to be validated by ${MembershipContract.CONTRACT_NAME}"
             }
             transaction {
                 val output = membershipState()
                 input(MembershipContract.CONTRACT_NAME, output)
                 output(DummyContract.CONTRACT_NAME, output)
-                command(memberIdentity.owningKey, MembershipContract.Commands.Request())
+                command(memberIdentity.owningKey, MembershipContract.Commands.Request(listOf(memberIdentity.owningKey)))
                 this `fails with` "Output state has to be validated by ${MembershipContract.CONTRACT_NAME}"
             }
             transaction {
                 val input = membershipState().run { copy(modified = modified.minusSeconds(100)) }
                 input(MembershipContract.CONTRACT_NAME, input)
-                command(memberIdentity.owningKey, MembershipContract.Commands.Revoke())
+                command(memberIdentity.owningKey, MembershipContract.Commands.Revoke(listOf(memberIdentity.owningKey)))
                 this `fails with` "Input state's modified timestamp should be greater or equal to issued timestamp"
             }
             transaction {
                 val output = membershipState().run { copy(modified = modified.minusSeconds(100)) }
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(memberIdentity.owningKey, MembershipContract.Commands.Request())
+                command(memberIdentity.owningKey, MembershipContract.Commands.Request(listOf(memberIdentity.owningKey)))
                 this `fails with` "Output state's modified timestamp should be greater or equal to issued timestamp"
+            }
+            transaction {
+                val output = membershipState().run { copy(participants = listOf(memberIdentity)) }
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Request(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Required signers should be subset of all output state's participants"
             }
 
             val input = membershipState()
@@ -78,43 +84,42 @@ class MembershipContractTest {
                 val output = input.copy(identity = bnoIdentity)
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Input and output state should have same Corda identity"
             }
             transaction {
                 val output = input.copy(networkId = "other-network-id")
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Input and output state should have same network IDs"
             }
             transaction {
                 val output = input.run { copy(issued = issued.minusSeconds(100)) }
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Input and output state should have same issued timestamps"
             }
             transaction {
                 val output = input.run { copy(modified = modified.plusSeconds(100)) }
                 input(MembershipContract.CONTRACT_NAME, input.run { copy(modified = modified.plusSeconds(200)) })
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Output state's modified timestamp should be greater or equal than input's"
             }
             transaction {
                 val output = input.copy(linearId = UniqueIdentifier())
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Input and output state should have same linear IDs"
             }
             transaction {
-                val output = input.copy(participants = emptyList())
                 input(MembershipContract.CONTRACT_NAME, input)
-                output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate())
-                this `fails with` "Input and output state should have same participants"
+                output(MembershipContract.CONTRACT_NAME, input)
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey, memberIdentity.owningKey)))
+                this `fails with` "Transaction must be signed by all signers specified inside command"
             }
         }
     }
@@ -126,17 +131,22 @@ class MembershipContractTest {
             transaction {
                 input(MembershipContract.CONTRACT_NAME, output)
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request())
+                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request(listOf(bnoIdentity.owningKey, memberIdentity.owningKey)))
                 this `fails with` "Membership request transaction shouldn't contain any inputs"
             }
             transaction {
                 output(MembershipContract.CONTRACT_NAME, output.copy(status = MembershipStatus.ACTIVE))
-                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request())
+                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request(listOf(bnoIdentity.owningKey, memberIdentity.owningKey)))
                 this `fails with` "Membership request transaction should contain output state in PENDING status"
             }
             transaction {
                 output(MembershipContract.CONTRACT_NAME, output)
-                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request())
+                command(listOf(bnoIdentity.owningKey), MembershipContract.Commands.Request(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Pending membership owner should be required signer of membership request transaction"
+            }
+            transaction {
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), MembershipContract.Commands.Request(listOf(bnoIdentity.owningKey, memberIdentity.owningKey)))
                 verifies()
             }
         }
@@ -149,19 +159,25 @@ class MembershipContractTest {
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate())
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Input state of membership activation transaction shouldn't be already active"
             }
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate())
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Output state of membership activation transaction should be active"
             }
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate())
+                command(memberIdentity.owningKey, MembershipContract.Commands.Activate(listOf(memberIdentity.owningKey)))
+                this `fails with` "Input membership owner shouldn't be required signer of membership activation transaction"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Activate(listOf(bnoIdentity.owningKey)))
                 verifies()
             }
         }
@@ -174,19 +190,25 @@ class MembershipContractTest {
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend())
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Input state of membership suspension transaction shouldn't be already suspended"
             }
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend())
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Output state of membership suspension transaction should be suspended"
             }
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend())
+                command(memberIdentity.owningKey, MembershipContract.Commands.Suspend(listOf(memberIdentity.owningKey)))
+                this `fails with` "Input membership owner shouldn't be required signer of membership suspension transaction"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Suspend(listOf(bnoIdentity.owningKey)))
                 verifies()
             }
         }
@@ -199,12 +221,17 @@ class MembershipContractTest {
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input)
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Revoke())
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Revoke(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Membership revocation transaction shouldn't contain any outputs"
             }
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input)
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Revoke())
+                command(memberIdentity.owningKey, MembershipContract.Commands.Revoke(listOf(memberIdentity.owningKey)))
+                this `fails with` "Input membership owner shouldn't be required signer of membership revocation transaction"
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, MembershipContract.Commands.Revoke(listOf(bnoIdentity.owningKey)))
                 verifies()
             }
         }

--- a/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
+++ b/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
@@ -30,7 +30,7 @@ class MembershipContractTest {
     private val memberIdentity = TestIdentity(CordaX500Name.parse("O=Member,L=London,C=GB")).party
     private val bnoIdentity = TestIdentity(CordaX500Name.parse("O=BNO,L=London,C=GB")).party
 
-    private fun membershipState() = MembershipState(
+    private val membershipState = MembershipState(
             identity = memberIdentity,
             networkId = "network-id",
             status = MembershipStatus.PENDING,
@@ -41,45 +41,45 @@ class MembershipContractTest {
     fun `test common contract verification`() {
         ledgerServices.ledger {
             transaction {
-                val input = membershipState()
+                val input = membershipState
                 output(MembershipContract.CONTRACT_NAME, input)
                 command(listOf(bnoIdentity.owningKey, memberIdentity.owningKey), DummyCommand())
                 fails()
             }
             transaction {
-                val input = membershipState()
+                val input = membershipState
                 input(DummyContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input)
                 command(memberIdentity.owningKey, MembershipContract.Commands.Revoke(listOf(memberIdentity.owningKey)))
                 this `fails with` "Input state has to be validated by ${MembershipContract.CONTRACT_NAME}"
             }
             transaction {
-                val output = membershipState()
+                val output = membershipState
                 input(MembershipContract.CONTRACT_NAME, output)
                 output(DummyContract.CONTRACT_NAME, output)
                 command(memberIdentity.owningKey, MembershipContract.Commands.Request(listOf(memberIdentity.owningKey)))
                 this `fails with` "Output state has to be validated by ${MembershipContract.CONTRACT_NAME}"
             }
             transaction {
-                val input = membershipState().run { copy(modified = modified.minusSeconds(100)) }
+                val input = membershipState.run { copy(modified = modified.minusSeconds(100)) }
                 input(MembershipContract.CONTRACT_NAME, input)
                 command(memberIdentity.owningKey, MembershipContract.Commands.Revoke(listOf(memberIdentity.owningKey)))
                 this `fails with` "Input state's modified timestamp should be greater or equal to issued timestamp"
             }
             transaction {
-                val output = membershipState().run { copy(modified = modified.minusSeconds(100)) }
+                val output = membershipState.run { copy(modified = modified.minusSeconds(100)) }
                 output(MembershipContract.CONTRACT_NAME, output)
                 command(memberIdentity.owningKey, MembershipContract.Commands.Request(listOf(memberIdentity.owningKey)))
                 this `fails with` "Output state's modified timestamp should be greater or equal to issued timestamp"
             }
             transaction {
-                val output = membershipState().run { copy(participants = listOf(memberIdentity)) }
+                val output = membershipState.run { copy(participants = listOf(memberIdentity)) }
                 output(MembershipContract.CONTRACT_NAME, output)
                 command(bnoIdentity.owningKey, MembershipContract.Commands.Request(listOf(bnoIdentity.owningKey)))
                 this `fails with` "Required signers should be subset of all output state's participants"
             }
 
-            val input = membershipState()
+            val input = membershipState
             transaction {
                 val output = input.copy(identity = bnoIdentity)
                 input(MembershipContract.CONTRACT_NAME, input)
@@ -127,7 +127,7 @@ class MembershipContractTest {
     @Test(timeout = 300_000)
     fun `test request membership command contract verification`() {
         ledgerServices.ledger {
-            val output = membershipState()
+            val output = membershipState
             transaction {
                 input(MembershipContract.CONTRACT_NAME, output)
                 output(MembershipContract.CONTRACT_NAME, output)
@@ -155,7 +155,7 @@ class MembershipContractTest {
     @Test(timeout = 300_000)
     fun `test activate membership command contract verification`() {
         ledgerServices.ledger {
-            val input = membershipState()
+            val input = membershipState
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE))
@@ -186,7 +186,7 @@ class MembershipContractTest {
     @Test(timeout = 300_000)
     fun `test suspend membership command contract verification`() {
         ledgerServices.ledger {
-            val input = membershipState()
+            val input = membershipState
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
                 output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.SUSPENDED))
@@ -217,7 +217,7 @@ class MembershipContractTest {
     @Test(timeout = 300_000)
     fun `test revoke membership command contract verification`() {
         ledgerServices.ledger {
-            val input = membershipState()
+            val input = membershipState
             transaction {
                 input(MembershipContract.CONTRACT_NAME, input)
                 output(MembershipContract.CONTRACT_NAME, input)


### PR DESCRIPTION
## Description

This is the continuation of [membership state initial implementation PR](https://github.com/corda/corda/pull/6352) in which we implement associated contract logic.

The whole contract logic for `MembershipState` is contained inside `MembershipContract` class with following included commands:
- `Request` for membership state issuance in `PENDING` status
- `Activate` for moving membership state to `ACTIVE` status
- `Suspend` for moving membership state to `SUSPENDED` status
- `Revoke` for membership state exit

Notice we make this an `open class` since in future we'll leave possibility for users to write their own custom membership contract logic based on the one we provide. `verify()` method is divided in 2 parts:
- Standard common checks which are applied to all command types. Those checks can't be overriden by users
- Verification checks specialised for each command via `verifyRequest()`, `verifyActivate()`, `verifySuspend()` and `verifyRevoke()` open methods

*Notice we don't impose signature checks inside contract since by the design they will be dynamic and will depend on current set of active authorised members which means flows will handle those checks. We will revisit this part in future and possibly amend contract logic to support signature set checks if it proves to be feasible.*

In the end we write supporting test coverage inside `MembershipContractTest` class.

Next PRs will introduce flows which will implement transactions building and distribution based on the commands described above.

## Test Plan

Ensure all new and already existing `:business-networks:contracts` project tests pass.