### PR TITLE
ENT-5430: Fix deserialisation of commands containing generic types.

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/contracts/serialization/generics/DataObject.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/serialization/generics/DataObject.kt
@@ -1,0 +1,14 @@
+package net.corda.contracts.serialization.generics
+
+import net.corda.core.serialization.CordaSerializable
+
+@CordaSerializable
+data class DataObject(val value: Long) : Comparable<DataObject> {
+    override fun toString(): String {
+        return "$value data points"
+    }
+
+    override fun compareTo(other: DataObject): Int {
+        return value.compareTo(other.value)
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/serialization/generics/GenericTypeContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/serialization/generics/GenericTypeContract.kt
@@ -1,0 +1,37 @@
+package net.corda.contracts.serialization.generics
+
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.ContractState
+import net.corda.core.identity.AbstractParty
+import net.corda.core.transactions.LedgerTransaction
+import java.util.Optional
+
+@Suppress("unused")
+class GenericTypeContract : Contract {
+    override fun verify(tx: LedgerTransaction) {
+        val state = tx.outputsOfType<State>()
+        require(state.isNotEmpty()) {
+            "Requires at least one data state"
+        }
+    }
+
+    @Suppress("CanBeParameter", "MemberVisibilityCanBePrivate")
+    class State(val owner: AbstractParty, val data: DataObject) : ContractState {
+        override val participants: List<AbstractParty> = listOf(owner)
+
+        @Override
+        override fun toString(): String {
+            return data.toString()
+        }
+    }
+
+    /**
+     * The [price] field is the important feature of the [Purchase]
+     * class because its type is [Optional] with a CorDapp-specific
+     * generic type parameter. It does not matter that the [price]
+     * is not used; it only matters that the [Purchase] command
+     * must be serialized as part of building a new transaction.
+     */
+    class Purchase(val price: Optional<DataObject>) : CommandData
+}

--- a/node/src/integration-test/kotlin/net/corda/flows/serialization/generics/GenericTypeFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/serialization/generics/GenericTypeFlow.kt
@@ -1,0 +1,27 @@
+package net.corda.flows.serialization.generics
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.contracts.serialization.generics.DataObject
+import net.corda.contracts.serialization.generics.GenericTypeContract.Purchase
+import net.corda.contracts.serialization.generics.GenericTypeContract.State
+import net.corda.core.contracts.Command
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.transactions.TransactionBuilder
+import java.util.Optional
+
+@StartableByRPC
+class GenericTypeFlow(private val purchase: DataObject) : FlowLogic<SecureHash>() {
+    @Suspendable
+    override fun call(): SecureHash {
+        val notary = serviceHub.networkMapCache.notaryIdentities[0]
+        val stx = serviceHub.signInitialTransaction(
+            TransactionBuilder(notary)
+                .addOutputState(State(ourIdentity, purchase))
+                .addCommand(Command(Purchase(Optional.of(purchase)), ourIdentity.owningKey))
+        )
+        stx.verify(serviceHub, checkSufficientSignatures = false)
+        return stx.id
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithGenericTypeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithGenericTypeTest.kt
@@ -1,0 +1,52 @@
+package net.corda.node
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.contracts.serialization.generics.DataObject
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.loggerFor
+import net.corda.flows.serialization.generics.GenericTypeFlow
+import net.corda.node.services.Permissions
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.incrementalPortAllocation
+import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.User
+import net.corda.testing.node.internal.cordappWithPackages
+import org.junit.Test
+
+@Suppress("FunctionName")
+class ContractWithGenericTypeTest {
+    companion object {
+        const val DATA_VALUE = 5000L
+
+        @JvmField
+        val logger = loggerFor<ContractWithGenericTypeTest>()
+    }
+
+    @Test(timeout=300_000)
+	fun `flow with generic type`() {
+        val user = User("u", "p", setOf(Permissions.all()))
+        driver(DriverParameters(
+            portAllocation = incrementalPortAllocation(),
+            startNodesInProcess = false,
+            notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+            cordappsForAllNodes = listOf(
+                cordappWithPackages("net.corda.flows.serialization.generics").signed(),
+                cordappWithPackages("net.corda.contracts.serialization.generics").signed()
+            )
+        )) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val txID = CordaRPCClient(hostAndPort = alice.rpcAddress)
+                .start(user.username, user.password)
+                .use { client ->
+                    client.proxy.startFlow(::GenericTypeFlow, DataObject(DATA_VALUE))
+                        .returnValue
+                        .getOrThrow()
+                }
+            logger.info("TX-ID=$txID")
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithGenericTypeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithGenericTypeTest.kt
@@ -1,0 +1,59 @@
+package net.corda.node.services
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.contracts.serialization.generics.DataObject
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.loggerFor
+import net.corda.flows.serialization.generics.GenericTypeFlow
+import net.corda.node.DeterministicSourcesRule
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.incrementalPortAllocation
+import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.User
+import net.corda.testing.node.internal.cordappWithPackages
+import org.junit.ClassRule
+import org.junit.Test
+
+@Suppress("FunctionName")
+class DeterministicContractWithGenericTypeTest {
+    companion object {
+        const val DATA_VALUE = 5000L
+
+        @JvmField
+        val logger = loggerFor<DeterministicContractWithGenericTypeTest>()
+
+        @ClassRule
+        @JvmField
+        val djvmSources = DeterministicSourcesRule()
+    }
+
+    @Test(timeout=300_000)
+	fun `test DJVM can deserialise command with generic type`() {
+        val user = User("u", "p", setOf(Permissions.all()))
+        driver(DriverParameters(
+            portAllocation = incrementalPortAllocation(),
+            startNodesInProcess = false,
+            notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+            cordappsForAllNodes = listOf(
+                cordappWithPackages("net.corda.flows.serialization.generics").signed(),
+                cordappWithPackages("net.corda.contracts.serialization.generics").signed()
+            ),
+            djvmBootstrapSource = djvmSources.bootstrap,
+            djvmCordaSource = djvmSources.corda
+        )) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val txID = CordaRPCClient(hostAndPort = alice.rpcAddress)
+                .start(user.username, user.password)
+                .use { client ->
+                    client.proxy.startFlow(::GenericTypeFlow, DataObject(DATA_VALUE))
+                        .returnValue
+                        .getOrThrow()
+                }
+            logger.info("TX-ID=$txID")
+        }
+    }
+}

--- a/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/SandboxSerializerFactoryFactory.kt
+++ b/serialization-djvm/src/main/kotlin/net/corda/serialization/djvm/SandboxSerializerFactoryFactory.kt
@@ -75,7 +75,7 @@ class SandboxSerializerFactoryFactory(
             )
         )
 
-        val fingerPrinter = TypeModellingFingerPrinter(customSerializerRegistry)
+        val fingerPrinter = TypeModellingFingerPrinter(customSerializerRegistry, classLoader)
 
         val localSerializerFactory = DefaultLocalSerializerFactory(
             whitelist = context.whitelist,

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -7,7 +7,6 @@ import net.corda.core.utilities.debug
 import net.corda.core.utilities.trace
 import net.corda.serialization.internal.model.*
 import net.corda.serialization.internal.model.TypeIdentifier.*
-import net.corda.serialization.internal.model.TypeIdentifier.Companion.classLoaderFor
 import org.apache.qpid.proton.amqp.Symbol
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -161,7 +160,7 @@ class DefaultLocalSerializerFactory(
             val declaredGenericType = if (declaredType !is ParameterizedType
                     && localTypeInformation.typeIdentifier is Parameterised
                     && declaredClass != Class::class.java) {
-                localTypeInformation.typeIdentifier.getLocalType(classLoaderFor(declaredClass))
+                localTypeInformation.typeIdentifier.getLocalType(classloader)
             } else {
                 declaredType
             }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -103,7 +103,7 @@ object SerializerFactoryBuilder {
                         customSerializerRegistry))
 
         val fingerPrinter = overrideFingerPrinter ?:
-            TypeModellingFingerPrinter(customSerializerRegistry)
+            TypeModellingFingerPrinter(customSerializerRegistry, classCarpenter.classloader)
 
         val localSerializerFactory = DefaultLocalSerializerFactory(
                 whitelist,

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
@@ -12,7 +12,7 @@ class TypeModellingFingerPrinterTests {
 
     val descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry()
     val customRegistry = CachingCustomSerializerRegistry(descriptorBasedSerializerRegistry)
-    val fingerprinter = TypeModellingFingerPrinter(customRegistry, true)
+    val fingerprinter = TypeModellingFingerPrinter(customRegistry, ClassLoader.getSystemClassLoader(), true)
 
     // See https://r3-cev.atlassian.net/browse/CORDA-2266
     @Test(timeout=300_000)


### PR DESCRIPTION
Ensure that `ParameterizedType` is always recreated using the deserialization classloader, as this is the only classloader from which the raw type and all of the parameter types are guaranteed to be visible.

Also tidy up a few compiler and KDoc warnings.