### PR TITLE
CORDA-3831: Prevent CordappImpl TEST_INSTANCE from crashing node.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
@@ -47,7 +47,7 @@ data class CordappImpl(
     }
 
     companion object {
-        fun jarName(url: URL): String = url.toPath().fileName.toString().removeSuffix(".jar")
+        fun jarName(url: URL): String = (url.toPath().fileName ?: "").toString().removeSuffix(".jar")
 
         /** CorDapp manifest entries */
         const val CORDAPP_CONTRACT_NAME = "Cordapp-Contract-Name"
@@ -81,7 +81,7 @@ data class CordappImpl(
                 serializationCustomSerializers = emptyList(),
                 customSchemas = emptySet(),
                 jarPath = Paths.get("").toUri().toURL(),
-                info = CordappImpl.UNKNOWN_INFO,
+                info = UNKNOWN_INFO,
                 allFlows = emptyList(),
                 jarHash = SecureHash.allOnesHash,
                 minimumPlatformVersion = 1,


### PR DESCRIPTION
The `jarPath` property for `CordappImpl.TEST_INSTANCE` is set to `Paths.get("").fileName`, which is `null` if the JVM's current working directory is also a file-system root directory. This can happen e.g. when creating Docker containers. Just handle the `null` value for this case.