### PR TITLE
CORDA-3817: Fixes Corda Expect DSL swallowing assertion errors and not unsubscribing from observable

### DIFF
--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt
@@ -179,7 +179,7 @@ fun <S, E : Any> S.genericExpectEvents(
             // Now run the matching piece of dsl
             try {
                 expectClosure()
-            } catch (exception: Exception) {
+            } catch (exception: Throwable) {
                 finishFuture.setException(exception)
             }
             if (state is ExpectComposeState.Finished) {

--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt
@@ -107,7 +107,7 @@ fun <E : Any> Observable<E>.expectEvents(isStrict: Boolean = true, expectCompose
     var subscription: Subscription? = null
 
     try {
-        return serialize().genericExpectEvents(
+        serialize().genericExpectEvents(
                 isStrict = isStrict,
                 stream = { action: (E) -> Unit ->
                     val lock = object {}


### PR DESCRIPTION
This PR fixes the following issues: 
- `genericExpectEvents` previously only caught `Exception`s while asserts throw `AssertionError` which inherits from `Throwable`. This resulted in `expectEvents` swallowing the assertion error and returning seemingly without any issues;
- `expectEvents` never unsubscribes from the observable, resulting in the stream action getting executed over and over again.


I hereby certify that my contribution is in accordance with the Developer Certificate of Origin ( https://developercertificate.org/).