### PR TITLE
CORDA-3848 Uncaught exception hospitalises flow

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StatemachineErrorHandlingTest.kt
@@ -110,6 +110,20 @@ abstract class StatemachineErrorHandlingTest {
     }
 
     @StartableByRPC
+    class ThrowAnErrorFlow : FlowLogic<String>() {
+        @Suspendable
+        override fun call(): String {
+            throwException()
+            return "cant get here"
+        }
+
+        private fun throwException() {
+            logger.info("Throwing exception in flow")
+            throw IllegalStateException("throwing exception in flow")
+        }
+    }
+
+    @StartableByRPC
     class GetNumberOfUncompletedCheckpointsFlow : FlowLogic<Long>() {
         override fun call(): Long {
             val sqlStatement = "select count(*) from node_checkpoints where status not in (${Checkpoint.FlowStatus.COMPLETED.ordinal})"

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -65,4 +65,6 @@ interface CheckpointStorage {
      * This method does not fetch [Checkpoint.Serialized.serializedFlowState] to save memory.
      */
     fun getPausedCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
+
+    fun updateStatus(runId: StateMachineRunId, flowStatus: Checkpoint.FlowStatus)
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -34,8 +34,6 @@ import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.OneToOne
 import javax.persistence.PrimaryKeyJoinColumn
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
 
 /**
  * Simple checkpoint key value storage in DB.

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -34,6 +34,8 @@ import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.OneToOne
 import javax.persistence.PrimaryKeyJoinColumn
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaUpdate
 
 /**
  * Simple checkpoint key value storage in DB.
@@ -497,6 +499,11 @@ class DBCheckpointStorage(
         return query.resultList.stream().map {
             StateMachineRunId(UUID.fromString(it.id)) to it.toSerializedCheckpoint()
         }
+    }
+
+    override fun updateStatus(runId: StateMachineRunId, flowStatus: FlowStatus) {
+        val update = "Update ${NODE_DATABASE_PREFIX}checkpoints set status = ${flowStatus.ordinal} where flow_id = '${runId.uuid}'"
+        currentDBSession().createNativeQuery(update).executeUpdate()
     }
 
     private fun createDBFlowMetadata(flowId: String, checkpoint: Checkpoint): DBFlowMetadata {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowDefaultUncaughtExceptionHandler.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowDefaultUncaughtExceptionHandler.kt
@@ -1,0 +1,60 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.strands.Strand
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.debug
+import net.corda.node.services.api.CheckpointStorage
+import net.corda.node.utilities.errorAndTerminate
+import net.corda.nodeapi.internal.persistence.CordaPersistence
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+class FlowDefaultUncaughtExceptionHandler(
+    private val flowHospital: StaffedFlowHospital,
+    private val checkpointStorage: CheckpointStorage,
+    private val database: CordaPersistence,
+    private val scheduledExecutor: ScheduledExecutorService
+) : Strand.UncaughtExceptionHandler {
+
+    private companion object {
+        val log = contextLogger()
+    }
+
+    override fun uncaughtException(fiber: Strand, throwable: Throwable) {
+        val id = (fiber as FlowStateMachineImpl<*>).id
+        if (throwable is VirtualMachineError) {
+            errorAndTerminate(
+                "Caught unrecoverable error from flow $id. Forcibly terminating the JVM, this might leave resources open, and most likely will.",
+                throwable
+            )
+        } else {
+            fiber.logger.warn("Caught exception from flow $id", throwable)
+            if (!fiber.resultFuture.isDone) {
+                fiber.transientState.let { state ->
+                    if (state != null) {
+                        fiber.logger.warn("Forcing flow $id into overnight observation")
+                        flowHospital.forceIntoOvernightObservation(state.value, listOf(throwable))
+                        val hospitalizedCheckpoint = state.value.checkpoint.copy(status = Checkpoint.FlowStatus.HOSPITALIZED)
+                        val hospitalizedState = state.value.copy(checkpoint = hospitalizedCheckpoint)
+                        fiber.transientState = TransientReference(hospitalizedState)
+                    } else {
+                        fiber.logger.warn("The fiber's transient state is not set, cannot force flow $id into in-memory overnight observation, status will still be updated in database")
+                    }
+                }
+                scheduledExecutor.schedule({ setFlowToHospitalizedRescheduleOnFailure(id) }, 0, TimeUnit.SECONDS)
+            }
+        }
+    }
+
+    private fun setFlowToHospitalizedRescheduleOnFailure(id: StateMachineRunId) {
+        try {
+            log.debug { "Updating the status of flow $id to hospitalized after uncaught exception" }
+            database.transaction { checkpointStorage.updateStatus(id, Checkpoint.FlowStatus.HOSPITALIZED) }
+            log.debug { "Updated the status of flow $id to hospitalized after uncaught exception" }
+        } catch (e: Exception) {
+            log.info("Failed to update the status of flow $id to hospitalized after uncaught exception, rescheduling", e)
+            scheduledExecutor.schedule({ setFlowToHospitalizedRescheduleOnFailure(id) }, 30, TimeUnit.SECONDS)
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -38,7 +38,6 @@ import net.corda.node.services.statemachine.interceptors.FiberDeserializationChe
 import net.corda.node.services.statemachine.interceptors.HospitalisingInterceptor
 import net.corda.node.services.statemachine.interceptors.PrintingInterceptor
 import net.corda.node.utilities.AffinityExecutor
-import net.corda.node.utilities.errorAndTerminate
 import net.corda.node.utilities.injectOldProgressTracker
 import net.corda.node.utilities.isEnabledTimedFlow
 import net.corda.nodeapi.internal.persistence.CordaPersistence


### PR DESCRIPTION
When an uncaught exception propagates all the way to the flow exception 
handler, the flow will be forced into observation/hospitalised.

The updating of the checkpoints status is done on a separate thread as 
the fiber cannot be relied on anymore. The new thread is needed to allow
database transaction to be created and committed. Failures to the status
update will be rescheduled to ensure that this information is eventually
reflected in the database.