### PR TITLE
ENT-5430: Increase test coverage when serializing Optional fields.

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/flows/serialization/generics/GenericTypeFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/serialization/generics/GenericTypeFlow.kt
@@ -12,14 +12,14 @@ import net.corda.core.transactions.TransactionBuilder
 import java.util.Optional
 
 @StartableByRPC
-class GenericTypeFlow(private val purchase: DataObject) : FlowLogic<SecureHash>() {
+class GenericTypeFlow(private val purchase: DataObject?) : FlowLogic<SecureHash>() {
     @Suspendable
     override fun call(): SecureHash {
         val notary = serviceHub.networkMapCache.notaryIdentities[0]
         val stx = serviceHub.signInitialTransaction(
             TransactionBuilder(notary)
                 .addOutputState(State(ourIdentity, purchase))
-                .addCommand(Command(Purchase(Optional.of(purchase)), ourIdentity.owningKey))
+                .addCommand(Command(Purchase(Optional.ofNullable(purchase)), ourIdentity.owningKey))
         )
         stx.verify(serviceHub, checkSufficientSignatures = false)
         return stx.id

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithGenericTypeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithGenericTypeTest.kt
@@ -2,6 +2,7 @@ package net.corda.node
 
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.contracts.serialization.generics.DataObject
+import net.corda.core.contracts.TransactionVerificationException.ContractRejection
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
@@ -15,7 +16,9 @@ import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.cordappWithPackages
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 
 @Suppress("FunctionName")
 class ContractWithGenericTypeTest {
@@ -24,29 +27,52 @@ class ContractWithGenericTypeTest {
 
         @JvmField
         val logger = loggerFor<ContractWithGenericTypeTest>()
+
+        @JvmField
+        val user = User("u", "p", setOf(Permissions.all()))
+
+        fun parameters(): DriverParameters {
+            return DriverParameters(
+                portAllocation = incrementalPortAllocation(),
+                startNodesInProcess = false,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                cordappsForAllNodes = listOf(
+                    cordappWithPackages("net.corda.flows.serialization.generics").signed(),
+                    cordappWithPackages("net.corda.contracts.serialization.generics").signed()
+                )
+            )
+        }
     }
 
-    @Test(timeout=300_000)
-	fun `flow with generic type`() {
-        val user = User("u", "p", setOf(Permissions.all()))
-        driver(DriverParameters(
-            portAllocation = incrementalPortAllocation(),
-            startNodesInProcess = false,
-            notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
-            cordappsForAllNodes = listOf(
-                cordappWithPackages("net.corda.flows.serialization.generics").signed(),
-                cordappWithPackages("net.corda.contracts.serialization.generics").signed()
-            )
-        )) {
+    @Test(timeout = 300_000)
+	fun `flow with value of generic type`() {
+        driver(parameters()) {
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
             val txID = CordaRPCClient(hostAndPort = alice.rpcAddress)
                 .start(user.username, user.password)
                 .use { client ->
                     client.proxy.startFlow(::GenericTypeFlow, DataObject(DATA_VALUE))
-                        .returnValue
-                        .getOrThrow()
+                    .returnValue
+                    .getOrThrow()
                 }
             logger.info("TX-ID=$txID")
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `flow without value of generic type`() {
+        driver(parameters()) {
+            val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val ex = assertThrows<ContractRejection> {
+                CordaRPCClient(hostAndPort = alice.rpcAddress)
+                    .start(user.username, user.password)
+                    .use { client ->
+                        client.proxy.startFlow(::GenericTypeFlow, null)
+                            .returnValue
+                            .getOrThrow()
+                    }
+            }
+            assertThat(ex).hasMessageContaining("Contract verification failed: Failed requirement: Purchase has a price,")
         }
     }
 }


### PR DESCRIPTION
No functional change - just better integration test coverage of the generic `Optional` field to ensure we reach the `Contract.verify()` step.