### PR TITLE
CORDA-3676 Refactor error outcome transitions

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
@@ -59,13 +59,6 @@ sealed class Event {
     }
 
     /**
-     * Start error propagation on a errored flow. This may be triggered by e.g. a [FlowHospital].
-     */
-    object StartErrorPropagation : Event() {
-        override fun toString() = "StartErrorPropagation"
-    }
-
-    /**
      *
      * Scheduled by the flow.
      *
@@ -148,26 +141,38 @@ sealed class Event {
     data class AsyncOperationThrows(val throwable: Throwable) : Event()
 
     /**
-     * Retry a flow from the last checkpoint, or if there is no checkpoint, restart the flow with the same invocation details.
-     */
-    object RetryFlowFromSafePoint : Event() {
-        override fun toString() = "RetryFlowFromSafePoint"
-    }
-
-    /**
-     * Keeps a flow for overnight observation. Overnight observation practically sends the fiber to get suspended,
-     * in [FlowStateMachineImpl.processEventsUntilFlowIsResumed]. Since the fiber's channel will have no more events to process,
-     * the fiber gets suspended (i.e. hospitalized).
-     */
-    object OvernightObservation : Event() {
-        override fun toString() = "OvernightObservation"
-    }
-
-    /**
      * Wake a flow up from its sleep.
      */
     object WakeUpFromSleep : Event() {
         override fun toString() = "WakeUpSleepyFlow"
+    }
+
+    /**
+     * [ErrorOutcomeEvent] represents an event that is given to a flow after passing through the state machine's error handling.
+     */
+    sealed class ErrorOutcomeEvent : Event() {
+        /**
+         * Retry a flow from the last checkpoint, or if there is no checkpoint, restart the flow with the same invocation details.
+         */
+        object RetryFlowFromSafePoint : ErrorOutcomeEvent() {
+            override fun toString() = "RetryFlowFromSafePoint"
+        }
+
+        /**
+         * Keeps a flow for overnight observation. Overnight observation practically sends the fiber to get suspended,
+         * in [FlowStateMachineImpl.processEventsUntilFlowIsResumed]. Since the fiber's channel will have no more events to process,
+         * the fiber gets suspended (i.e. hospitalized).
+         */
+        object OvernightObservation : ErrorOutcomeEvent() {
+            override fun toString() = "OvernightObservation"
+        }
+
+        /**
+         * Start error propagation on an errored flow. This may be triggered by e.g. a [FlowHospital].
+         */
+        object StartErrorPropagation : ErrorOutcomeEvent() {
+            override fun toString() = "StartErrorPropagation"
+        }
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -219,19 +219,19 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
                 Diagnosis.DISCHARGE -> {
                     val backOff = calculateBackOffForChronicCondition(report, medicalHistory, currentState)
                     log.info("Flow error discharged from hospital (delay ${backOff.seconds}s) by ${report.by} (error was ${report.error.message})")
-                    onFlowDischarged.forEach { hook -> hook.invoke(flowFiber.id, report.by.map{it.toString()}) }
-                    Triple(Outcome.DISCHARGE, Event.RetryFlowFromSafePoint, backOff)
+                    onFlowDischarged.forEach { hook -> hook.invoke(flowFiber.id, report.by.map { it.toString() }) }
+                    Triple(Outcome.DISCHARGE, Event.ErrorOutcomeEvent.RetryFlowFromSafePoint, backOff)
                 }
                 Diagnosis.OVERNIGHT_OBSERVATION -> {
                     log.info("Flow error kept for overnight observation by ${report.by} (error was ${report.error.message})")
                     // We don't schedule a next event for the flow - it will automatically retry from its checkpoint on node restart
-                    onFlowKeptForOvernightObservation.forEach { hook -> hook.invoke(flowFiber.id, report.by.map{it.toString()}) }
-                    Triple(Outcome.OVERNIGHT_OBSERVATION, Event.OvernightObservation, 0.seconds)
+                    onFlowKeptForOvernightObservation.forEach { hook -> hook.invoke(flowFiber.id, report.by.map { it.toString() }) }
+                    Triple(Outcome.OVERNIGHT_OBSERVATION, Event.ErrorOutcomeEvent.OvernightObservation, 0.seconds)
                 }
                 Diagnosis.NOT_MY_SPECIALTY, Diagnosis.TERMINAL -> {
                     // None of the staff care for these errors, or someone decided it is a terminal condition, so we let them propagate
                     log.info("Flow error allowed to propagate", report.error)
-                    Triple(Outcome.UNTREATABLE, Event.StartErrorPropagation, 0.seconds)
+                    Triple(Outcome.UNTREATABLE, Event.ErrorOutcomeEvent.StartErrorPropagation, 0.seconds)
                 }
             }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -346,7 +346,7 @@ sealed class ErrorState {
     @CordaSerializable
     object Clean : ErrorState() {
         override fun addErrors(newErrors: List<FlowError>): ErrorState {
-            return Errored(newErrors, 0, false)
+            return Errored(newErrors, 0)
         }
         override fun toString() = "Clean"
     }
@@ -361,11 +361,7 @@ sealed class ErrorState {
      *   sessions associated with the flow have been (or about to be) dirtied in counter-flows.
      */
     @CordaSerializable
-    data class Errored(
-            val errors: List<FlowError>,
-            val propagatedIndex: Int,
-            val propagating: Boolean
-    ) : ErrorState() {
+    data class Errored(val errors: List<FlowError>, val propagatedIndex: Int) : ErrorState() {
         override fun addErrors(newErrors: List<FlowError>): ErrorState {
             return copy(errors = errors + newErrors)
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt
@@ -84,7 +84,6 @@ class TransitionExecutorImpl(
                             ),
                             isFlowResumed = false
                     )
-                    fiber.scheduleEvent(Event.DoRemainingWork)
                     return Pair(FlowContinuation.ProcessEvents, newState)
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt
@@ -46,7 +46,7 @@ class DumpHistoryOnErrorInterceptor(val delegate: TransitionExecutor) : Transiti
 
             // Just if we decide to propagate, and not if just on the way to the hospital. Only log at debug level here - the flow transition
             // information is often unhelpful in the logs, and the actual cause of the problem will be logged elsewhere.
-            if (nextState.checkpoint.errorState is ErrorState.Errored && nextState.checkpoint.errorState.propagating) {
+            if (event is Event.ErrorOutcomeEvent.StartErrorPropagation && nextState.checkpoint.errorState is ErrorState.Errored) {
                 log.warn("Flow ${fiber.id} errored, dumping all transitions:\n${record!!.joinToString("\n")}")
                 for (error in nextState.checkpoint.errorState.errors) {
                     log.warn("Flow ${fiber.id} error", error.exception)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -1,13 +1,15 @@
 package net.corda.node.services.statemachine.transitions
 
-import net.corda.node.services.statemachine.*
+import net.corda.node.services.statemachine.ErrorState
+import net.corda.node.services.statemachine.FlowState
+import net.corda.node.services.statemachine.StateMachineState
 
 /**
  * This transition checks the current state of the flow and determines whether anything needs to be done.
  */
 class DoRemainingWorkTransition(
-        override val context: TransitionContext,
-        override val startingState: StateMachineState
+    override val context: TransitionContext,
+    override val startingState: StateMachineState
 ) : Transition {
     override fun transition(): TransitionResult {
         val checkpoint = startingState.checkpoint
@@ -18,7 +20,10 @@ class DoRemainingWorkTransition(
         // Check whether the flow is errored
         return when (checkpoint.errorState) {
             is ErrorState.Clean -> cleanTransition()
-            is ErrorState.Errored -> erroredTransition(checkpoint.errorState)
+            is ErrorState.Errored -> builder {
+                // Being in an error state when processing this event is not expected but should not stop the flow from continuing
+                FlowContinuation.ProcessEvents
+            }
         }
     }
 
@@ -31,9 +36,5 @@ class DoRemainingWorkTransition(
             is FlowState.Completed -> throw IllegalStateException("Cannot transition a state with completed flow state.")
             is FlowState.Paused -> throw IllegalStateException("Cannot transition a state with paused flow state.")
         }
-    }
-
-    private fun erroredTransition(errorState: ErrorState.Errored): TransitionResult {
-        return ErrorFlowTransition(context, startingState, errorState).transition()
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
@@ -1,7 +1,15 @@
 package net.corda.node.services.statemachine.transitions
 
-import net.corda.core.flows.FlowException
-import net.corda.node.services.statemachine.*
+import net.corda.node.services.statemachine.Action
+import net.corda.node.services.statemachine.Checkpoint
+import net.corda.node.services.statemachine.ErrorSessionMessage
+import net.corda.node.services.statemachine.ErrorState
+import net.corda.node.services.statemachine.Event
+import net.corda.node.services.statemachine.Event.ErrorOutcomeEvent.OvernightObservation
+import net.corda.node.services.statemachine.Event.ErrorOutcomeEvent.RetryFlowFromSafePoint
+import net.corda.node.services.statemachine.Event.ErrorOutcomeEvent.StartErrorPropagation
+import net.corda.node.services.statemachine.FlowError
+import net.corda.node.services.statemachine.StateMachineState
 
 /**
  * This transition defines what should happen when a flow has errored.
@@ -17,10 +25,13 @@ import net.corda.node.services.statemachine.*
  * Both internal exceptions and uncaught user-raised exceptions cause the flow to be errored. This flags the flow as
  *   unable to be resumed. When a flow is in this state an external source (e.g. Flow hospital) may decide to
  *
- *   1. Retry it (not implemented yet). This throws away the errored state and re-tries from the last clean checkpoint.
+ *   1. Retry it. This throws away the errored state and re-tries from the last clean checkpoint.
  *   2. Start error propagation. This seals the flow as errored permanently and propagates the associated error(s) to
- *     all live sessions. This causes these sessions to errored on the other side, which may in turn cause the
- *     counter-flows themselves to errored.
+ *   all live sessions. This causes these sessions to errored on the other side, which may in turn cause the
+ *   counter-flows themselves to errored. This also updates the flow's checkpoint's status to [Checkpoint.FlowStatus.FAILED].
+ *   3. Keep the flow in for observation, to be retried at a later time. The flow will wait for new events to be passed
+ *   to it from an external source to start up again. This also updates the flow's checkpoint's status to
+ *   [Checkpoint.FlowStatus.HOSPITALIZED].
  *
  * See [net.corda.node.services.statemachine.interceptors.HospitalisingInterceptor] for how to detect flow errors.
  *
@@ -28,102 +39,89 @@ import net.corda.node.services.statemachine.*
  *   new errors may arise while the flow is in the errored state already.
  */
 class ErrorFlowTransition(
-        override val context: TransitionContext,
-        override val startingState: StateMachineState,
-        private val errorState: ErrorState.Errored
+    override val context: TransitionContext,
+    override val startingState: StateMachineState,
+    private val event: Event.ErrorOutcomeEvent
 ) : Transition {
     override fun transition(): TransitionResult {
-        val allErrors: List<FlowError> = errorState.errors
-        val remainingErrorsToPropagate: List<FlowError> = allErrors.subList(errorState.propagatedIndex, allErrors.size)
-        val errorMessages: List<ErrorSessionMessage> = remainingErrorsToPropagate.map(this::createErrorMessageFromError)
+        return when (event) {
+            OvernightObservation -> overnightObservationTransition()
+            RetryFlowFromSafePoint -> retryFlowFromSafePointTransition()
+            StartErrorPropagation -> startErrorPropagationTransition()
+        }
+    }
 
+    private fun overnightObservationTransition(): TransitionResult {
         return builder {
-            // If we're errored and propagating do the actual propagation and update the index.
-            if (remainingErrorsToPropagate.isNotEmpty() && errorState.propagating) {
-                val (initiatedSessions, newSessions) = bufferErrorMessagesInInitiatingSessions(
-                        startingState.checkpoint.checkpointState.sessions,
-                        errorMessages
-                )
-                val newCheckpoint = startingState.checkpoint.copy(
-                        errorState = errorState.copy(propagatedIndex = allErrors.size),
-                        checkpointState = startingState.checkpoint.checkpointState.copy(sessions = newSessions)
-                )
-                currentState = currentState.copy(checkpoint = newCheckpoint)
-                actions.add(Action.PropagateErrors(errorMessages, initiatedSessions, startingState.senderUUID))
-            }
-
-            // If we're errored but not propagating keep processing events.
-            if (remainingErrorsToPropagate.isNotEmpty() && !errorState.propagating) {
-                return@builder FlowContinuation.ProcessEvents
-            }
-
-            // If we haven't been removed yet remove the flow.
-            if (!currentState.isRemoved) {
-                val newCheckpoint = startingState.checkpoint.copy(status = Checkpoint.FlowStatus.FAILED)
-
-                actions.addAll(arrayOf(
-                        Action.CreateTransaction,
-                        Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = currentState.isAnyCheckpointPersisted),
-                        Action.PersistDeduplicationFacts(currentState.pendingDeduplicationHandlers),
-                        Action.ReleaseSoftLocks(context.id.uuid),
-                        Action.CommitTransaction,
-                        Action.AcknowledgeMessages(currentState.pendingDeduplicationHandlers),
-                        Action.RemoveSessionBindings(currentState.checkpoint.checkpointState.sessions.keys)
-                ))
-
-                currentState = currentState.copy(
-                        checkpoint = newCheckpoint,
-                        pendingDeduplicationHandlers = emptyList(),
-                        isRemoved = true
-                )
-
-                val removalReason = FlowRemovalReason.ErrorFinish(allErrors)
-                actions.add(Action.RemoveFlow(context.id, removalReason, currentState))
-                FlowContinuation.Abort
-            } else {
-                // Otherwise keep processing events. This branch happens when there are some outstanding initiating
-                // sessions that prevent the removal of the flow.
-                FlowContinuation.ProcessEvents
-            }
+            val newCheckpoint = startingState.checkpoint.copy(status = Checkpoint.FlowStatus.HOSPITALIZED)
+            actions += Action.CreateTransaction
+            actions += Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
+            actions += Action.CommitTransaction
+            currentState = currentState.copy(checkpoint = newCheckpoint)
+            FlowContinuation.ProcessEvents
         }
     }
 
-    private fun createErrorMessageFromError(error: FlowError): ErrorSessionMessage {
-        val exception = error.exception
-        // If the exception doesn't contain an originalErrorId that means it's a fresh FlowException that should
-        // propagate to the neighbouring flows. If it has the ID filled in that means it's a rethrown FlowException and
-        // shouldn't be propagated.
-        return if (exception is FlowException && exception.originalErrorId == null) {
-            ErrorSessionMessage(flowException = exception, errorId = error.errorId)
-        } else {
-            ErrorSessionMessage(flowException = null, errorId = error.errorId)
+    private fun retryFlowFromSafePointTransition(): TransitionResult {
+        return builder {
+            // Need to create a flow from the prior checkpoint or flow initiation.
+            actions += Action.CreateTransaction
+            actions += Action.RetryFlowFromSafePoint(startingState)
+            actions += Action.CommitTransaction
+            FlowContinuation.Abort
         }
     }
 
-    // Buffer error messages in Initiating sessions, return the initialised ones.
-    private fun bufferErrorMessagesInInitiatingSessions(
-            sessions: Map<SessionId, SessionState>,
-            errorMessages: List<ErrorSessionMessage>
-    ): Pair<List<SessionState.Initiated>, Map<SessionId, SessionState>> {
-        val newSessions = sessions.mapValues { (sourceSessionId, sessionState) ->
-            if (sessionState is SessionState.Initiating && sessionState.rejectionError == null) {
-                // *prepend* the error messages in order to error the other sessions ASAP. The other messages will
-                // be delivered all the same, they just won't trigger flow resumption because of dirtiness.
-                val errorMessagesWithDeduplication = errorMessages.map {
-                    DeduplicationId.createForError(it.errorId, sourceSessionId) to it
+    private fun startErrorPropagationTransition(): TransitionResult {
+        return propagateErrorBuilder {
+            val errorState = currentState.checkpoint.errorState
+            when (errorState) {
+                ErrorState.Clean -> {
+                    freshErrorTransition(UnexpectedEventInState())
+                    FlowContinuation.ProcessEvents
                 }
-                sessionState.copy(bufferedMessages = errorMessagesWithDeduplication + sessionState.bufferedMessages)
-            } else {
-                sessionState
+                is ErrorState.Errored -> {
+                    val allErrors: List<FlowError> = errorState.errors
+                    val remainingErrorsToPropagate: List<FlowError> = allErrors.subList(errorState.propagatedIndex, allErrors.size)
+                    val errorMessages: List<ErrorSessionMessage> = remainingErrorsToPropagate.map(::createErrorMessageFromError)
+                    if (remainingErrorsToPropagate.isNotEmpty()) {
+                        val (initiatedSessions, newSessions) = bufferErrorMessagesInInitiatingSessions(
+                            startingState.checkpoint.checkpointState.sessions,
+                            errorMessages
+                        )
+                        val newCheckpoint = startingState.checkpoint.copy(
+                            errorState = errorState.copy(propagatedIndex = allErrors.size),
+                            checkpointState = startingState.checkpoint.checkpointState.copy(sessions = newSessions)
+                        )
+                        currentState = currentState.copy(checkpoint = newCheckpoint)
+                        actions += Action.PropagateErrors(errorMessages, initiatedSessions, startingState.senderUUID)
+                    }
+                    if (!currentState.isRemoved) {
+                        val newCheckpoint = startingState.checkpoint.copy(status = Checkpoint.FlowStatus.FAILED)
+
+                        currentState = currentState.copy(
+                            checkpoint = newCheckpoint,
+                            pendingDeduplicationHandlers = emptyList(),
+                            isRemoved = true
+                        )
+
+                        actions += Action.CreateTransaction
+                        actions += Action.PersistCheckpoint(
+                            context.id,
+                            newCheckpoint,
+                            isCheckpointUpdate = currentState.isAnyCheckpointPersisted
+                        )
+
+                        addCleanupActions(allErrors)
+
+                        FlowContinuation.Abort
+                    } else {
+                        // Otherwise keep processing events. This branch happens when there are some outstanding initiating
+                        // sessions that prevent the removal of the flow.
+                        FlowContinuation.ProcessEvents
+                    }
+                }
             }
         }
-        val initiatedSessions = sessions.values.mapNotNull { session ->
-            if (session is SessionState.Initiated && session.errors.isEmpty()) {
-                session
-            } else {
-                null
-            }
-        }
-        return Pair(initiatedSessions, newSessions)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -1,17 +1,17 @@
 package net.corda.node.services.statemachine.transitions
 
-import net.corda.core.flows.FlowException
 import net.corda.core.flows.KilledFlowException
 import net.corda.node.services.statemachine.Action
-import net.corda.node.services.statemachine.DeduplicationId
-import net.corda.node.services.statemachine.ErrorSessionMessage
 import net.corda.node.services.statemachine.Event
 import net.corda.node.services.statemachine.FlowError
-import net.corda.node.services.statemachine.FlowRemovalReason
-import net.corda.node.services.statemachine.SessionId
-import net.corda.node.services.statemachine.SessionState
 import net.corda.node.services.statemachine.StateMachineState
 
+/**
+ * [KilledFlowTransition] is the transition that is performed when a flow is killed. Logically it is almost identical to the error
+ * propgation transition (found in [ErrorFlowTransition]).
+ *
+ * After completing the transition returned from [KilledFlowTransition], the flow will terminate.
+ */
 class KilledFlowTransition(
     override val context: TransitionContext,
     override val startingState: StateMachineState,
@@ -19,7 +19,7 @@ class KilledFlowTransition(
 ) : Transition {
 
     override fun transition(): TransitionResult {
-        return builder {
+        return propagateErrorBuilder {
 
             val killedFlowError = createKilledFlowError()
             val killedFlowErrorMessage = createErrorMessageFromError(killedFlowError)
@@ -31,37 +31,27 @@ class KilledFlowTransition(
             )
             val newCheckpoint = startingState.checkpoint.setSessions(sessions = newSessions)
             currentState = currentState.copy(checkpoint = newCheckpoint)
-            actions.add(
-                Action.PropagateErrors(
-                    errorMessages,
-                    initiatedSessions,
-                    startingState.senderUUID
-                )
+            actions += Action.PropagateErrors(
+                errorMessages,
+                initiatedSessions,
+                startingState.senderUUID
             )
 
             if (!startingState.isFlowResumed) {
-                actions.add(Action.CreateTransaction)
+                actions += Action.CreateTransaction
             }
             // The checkpoint and soft locks are also removed directly in [StateMachineManager.killFlow]
             if (startingState.isAnyCheckpointPersisted) {
                 actions.add(Action.RemoveCheckpoint(context.id))
             }
-            actions.addAll(
-                arrayOf(
-                    Action.PersistDeduplicationFacts(currentState.pendingDeduplicationHandlers),
-                    Action.ReleaseSoftLocks(context.id.uuid),
-                    Action.CommitTransaction,
-                    Action.AcknowledgeMessages(currentState.pendingDeduplicationHandlers),
-                    Action.RemoveSessionBindings(currentState.checkpoint.checkpointState.sessions.keys)
-                )
-            )
 
             currentState = currentState.copy(
                 pendingDeduplicationHandlers = emptyList(),
                 isRemoved = true
             )
 
-            actions.add(Action.RemoveFlow(context.id, createKilledRemovalReason(killedFlowError), currentState))
+            addCleanupActions(listOf(killedFlowError))
+
             FlowContinuation.Abort
         }
     }
@@ -72,50 +62,5 @@ class KilledFlowTransition(
             else -> KilledFlowException(context.id)
         }
         return FlowError(context.secureRandom.nextLong(), exception)
-    }
-
-    // Purposely left the same as [bufferErrorMessagesInInitiatingSessions] in [ErrorFlowTransition] so that it can be refactored
-    private fun createErrorMessageFromError(error: FlowError): ErrorSessionMessage {
-        val exception = error.exception
-        // If the exception doesn't contain an originalErrorId that means it's a fresh FlowException that should
-        // propagate to the neighbouring flows. If it has the ID filled in that means it's a rethrown FlowException and
-        // shouldn't be propagated.
-        return if (exception is FlowException && exception.originalErrorId == null) {
-            ErrorSessionMessage(flowException = exception, errorId = error.errorId)
-        } else {
-            ErrorSessionMessage(flowException = null, errorId = error.errorId)
-        }
-    }
-
-    // Purposely left the same as [bufferErrorMessagesInInitiatingSessions] in [ErrorFlowTransition] so that it can be refactored
-    // Buffer error messages in Initiating sessions, return the initialised ones.
-    private fun bufferErrorMessagesInInitiatingSessions(
-        sessions: Map<SessionId, SessionState>,
-        errorMessages: List<ErrorSessionMessage>
-    ): Pair<List<SessionState.Initiated>, Map<SessionId, SessionState>> {
-        val newSessions = sessions.mapValues { (sourceSessionId, sessionState) ->
-            if (sessionState is SessionState.Initiating && sessionState.rejectionError == null) {
-                // *prepend* the error messages in order to error the other sessions ASAP. The other messages will
-                // be delivered all the same, they just won't trigger flow resumption because of dirtiness.
-                val errorMessagesWithDeduplication = errorMessages.map {
-                    DeduplicationId.createForError(it.errorId, sourceSessionId) to it
-                }
-                sessionState.copy(bufferedMessages = errorMessagesWithDeduplication + sessionState.bufferedMessages)
-            } else {
-                sessionState
-            }
-        }
-        val initiatedSessions = sessions.values.mapNotNull { session ->
-            if (session is SessionState.Initiated && session.errors.isEmpty()) {
-                session
-            } else {
-                null
-            }
-        }
-        return Pair(initiatedSessions, newSessions)
-    }
-
-    private fun createKilledRemovalReason(error: FlowError): FlowRemovalReason.ErrorFinish {
-        return FlowRemovalReason.ErrorFinish(listOf(error))
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/PropagateErrorTransitionBuilder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/PropagateErrorTransitionBuilder.kt
@@ -1,0 +1,69 @@
+package net.corda.node.services.statemachine.transitions
+
+import net.corda.core.flows.FlowException
+import net.corda.node.services.statemachine.Action
+import net.corda.node.services.statemachine.DeduplicationId
+import net.corda.node.services.statemachine.ErrorSessionMessage
+import net.corda.node.services.statemachine.FlowError
+import net.corda.node.services.statemachine.FlowRemovalReason
+import net.corda.node.services.statemachine.SessionId
+import net.corda.node.services.statemachine.SessionState
+import net.corda.node.services.statemachine.StateMachineState
+
+/**
+ * [TransitionBuilder] that contains functions for performing error propagation.
+ */
+class PropagateErrorTransitionBuilder(context: TransitionContext, initialState: StateMachineState) : TransitionBuilder(context, initialState) {
+
+    fun addCleanupActions(errors: List<FlowError>) {
+        actions.addAll(
+            arrayOf(
+                Action.PersistDeduplicationFacts(currentState.pendingDeduplicationHandlers),
+                Action.ReleaseSoftLocks(context.id.uuid),
+                Action.CommitTransaction,
+                Action.AcknowledgeMessages(currentState.pendingDeduplicationHandlers),
+                Action.RemoveSessionBindings(currentState.checkpoint.checkpointState.sessions.keys),
+                Action.RemoveFlow(context.id, FlowRemovalReason.ErrorFinish(errors), currentState)
+            )
+        )
+    }
+
+    fun createErrorMessageFromError(error: FlowError): ErrorSessionMessage {
+        val exception = error.exception
+        // If the exception doesn't contain an originalErrorId that means it's a fresh FlowException that should
+        // propagate to the neighbouring flows. If it has the ID filled in that means it's a rethrown FlowException and
+        // shouldn't be propagated.
+        return if (exception is FlowException && exception.originalErrorId == null) {
+            ErrorSessionMessage(flowException = exception, errorId = error.errorId)
+        } else {
+            ErrorSessionMessage(flowException = null, errorId = error.errorId)
+        }
+    }
+
+    // Buffer error messages in Initiating sessions, return the initialised ones.
+    fun bufferErrorMessagesInInitiatingSessions(
+        sessions: Map<SessionId, SessionState>,
+        errorMessages: List<ErrorSessionMessage>
+    ): Pair<List<SessionState.Initiated>, Map<SessionId, SessionState>> {
+        val newSessions = sessions.mapValues { (sourceSessionId, sessionState) ->
+            if (sessionState is SessionState.Initiating && sessionState.rejectionError == null) {
+                // *prepend* the error messages in order to error the other sessions ASAP. The other messages will
+                // be delivered all the same, they just won't trigger flow resumption because of dirtiness.
+                val errorMessagesWithDeduplication = errorMessages.map {
+                    DeduplicationId.createForError(it.errorId, sourceSessionId) to it
+                }
+                sessionState.copy(bufferedMessages = errorMessagesWithDeduplication + sessionState.bufferedMessages)
+            } else {
+                sessionState
+            }
+        }
+        val initiatedSessions = sessions.values.mapNotNull { session ->
+            if (session is SessionState.Initiated && session.errors.isEmpty()) {
+                session
+            } else {
+                null
+            }
+        }
+        return Pair(initiatedSessions, newSessions)
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/Transition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/Transition.kt
@@ -24,6 +24,12 @@ interface Transition {
         val continuation = build(builder)
         return TransitionResult(builder.currentState, builder.actions, continuation)
     }
+
+    fun propagateErrorBuilder(build: PropagateErrorTransitionBuilder.() -> FlowContinuation): TransitionResult {
+        val builder = PropagateErrorTransitionBuilder(context, startingState)
+        val continuation = build(builder)
+        return TransitionResult(builder.currentState, builder.actions, continuation)
+    }
 }
 
 class TransitionContext(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TransitionBuilder.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TransitionBuilder.kt
@@ -3,7 +3,6 @@ package net.corda.node.services.statemachine.transitions
 import net.corda.core.flows.IdentifiableException
 import net.corda.node.services.statemachine.Action
 import net.corda.node.services.statemachine.ErrorState
-import net.corda.node.services.statemachine.Event
 import net.corda.node.services.statemachine.FlowError
 import net.corda.node.services.statemachine.SessionId
 import net.corda.node.services.statemachine.StateMachineState
@@ -13,7 +12,7 @@ import net.corda.node.services.statemachine.StateMachineState
 /**
  * A builder that helps creating [Transition]s. This allows for a more imperative style of specifying the transition.
  */
-class TransitionBuilder(val context: TransitionContext, initialState: StateMachineState) {
+open class TransitionBuilder(val context: TransitionContext, initialState: StateMachineState) {
     /** The current state machine state of the builder */
     var currentState = initialState
     /** The list of actions to execute */
@@ -50,10 +49,7 @@ class TransitionBuilder(val context: TransitionContext, initialState: StateMachi
                 isFlowResumed = false
         )
         actions.clear()
-        actions.addAll(arrayOf(
-                Action.RollbackTransaction,
-                Action.ScheduleEvent(Event.DoRemainingWork)
-        ))
+        actions += Action.RollbackTransaction
     }
 
     /**

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -928,12 +928,8 @@ class DBCheckpointStorageTests {
     private fun Checkpoint.addError(exception: Exception): Checkpoint {
         return copy(
             errorState = ErrorState.Errored(
-                listOf(
-                    FlowError(
-                        0,
-                        exception
-                    )
-                ), 0, false
+                listOf(FlowError(0, exception)),
+                0
             )
         )
     }


### PR DESCRIPTION
Refactor the code around error outcome transitions as well as the kill
flow transition, due to them being logically related and sharing code.

Move processing of all error outcome events into `ErrorFlowTransition`.
This includes:
* `StartErrorPropagation`
* `RetryFlowFromSafePoint`
* `OvernightObservation`

`Event.ErrorOutcomeEvent` created as a sealed class to contain the
events listed above.

Changed how error propagation works. Originally error propagation was
mutating the checkpoint's state and injecting another event which
checked the state and would propagate the error. Taking two events to
actually propagate made no sense. This is all done in a single event
now. Doing this meant that a number of `Event.DoRemainingWork` could be
removed.

`PropagateErrorTransitionBuilder` was created to allow code to be shared
 between `ErrorFlowTransition` and `KillFlowTransition` as they both
 need to propagate errors to counter parties and perform the same
 cleanup.