### PR TITLE
EG-2690: Add persistent Artemis volume

### DIFF
--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /opt/corda/cordapps && \
     mkdir -p /opt/corda/persistence && \
+    mkdir -p /opt/corda/artemis && \
     mkdir -p /opt/corda/certificates && \
     mkdir -p /opt/corda/drivers && \
     mkdir -p /opt/corda/logs && \
@@ -20,6 +21,7 @@ RUN apt-get update && \
 
 ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
     PERSISTENCE_FOLDER="/opt/corda/persistence" \
+    ARTEMIS_FOLDER="/opt/corda/artemis" \
     CERTIFICATES_FOLDER="/opt/corda/certificates" \
     DRIVERS_FOLDER="/opt/corda/drivers" \
     CONFIG_FOLDER="/etc/corda" \
@@ -34,6 +36,8 @@ ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
 VOLUME ["/opt/corda/cordapps"]
 ##PERSISTENCE FOLDER
 VOLUME ["/opt/corda/persistence"]
+##ARTEMIS FOLDER
+VOLUME ["/opt/corda/artemis"]
 ##CERTS FOLDER
 VOLUME ["/opt/corda/certificates"]
 ##OPTIONAL JDBC DRIVERS FOLDER

--- a/docker/src/docker/Dockerfile11
+++ b/docker/src/docker/Dockerfile11
@@ -19,6 +19,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /opt/corda/cordapps && \
     mkdir -p /opt/corda/persistence && \
+    mkdir -p /opt/corda/artemis && \
     mkdir -p /opt/corda/certificates && \
     mkdir -p /opt/corda/drivers && \
     mkdir -p /opt/corda/logs && \
@@ -36,6 +37,7 @@ RUN apt-get update && \
 
 ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
     PERSISTENCE_FOLDER="/opt/corda/persistence" \
+    ARTEMIS_FOLDER="/opt/corda/artemis" \
     CERTIFICATES_FOLDER="/opt/corda/certificates" \
     DRIVERS_FOLDER="/opt/corda/drivers" \
     CONFIG_FOLDER="/etc/corda" \
@@ -50,6 +52,8 @@ ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
 VOLUME ["/opt/corda/cordapps"]
 ##PERSISTENCE FOLDER
 VOLUME ["/opt/corda/persistence"]
+##ARTEMIS FOLDER
+VOLUME ["/opt/corda/artemis"]
 ##CERTS FOLDER
 VOLUME ["/opt/corda/certificates"]
 ##OPTIONAL JDBC DRIVERS FOLDER

--- a/docker/src/docker/DockerfileAL
+++ b/docker/src/docker/DockerfileAL
@@ -10,6 +10,7 @@ RUN amazon-linux-extras enable corretto8 && \
     rm -rf /var/cache/yum && \
     mkdir -p /opt/corda/cordapps && \
     mkdir -p /opt/corda/persistence && \
+    mkdir -p /opt/corda/artemis && \
     mkdir -p /opt/corda/certificates && \
     mkdir -p /opt/corda/drivers && \
     mkdir -p /opt/corda/logs && \
@@ -23,6 +24,7 @@ RUN amazon-linux-extras enable corretto8 && \
 
 ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
     PERSISTENCE_FOLDER="/opt/corda/persistence" \
+    ARTEMIS_FOLDER="/opt/corda/artemis" \
     CERTIFICATES_FOLDER="/opt/corda/certificates" \
     DRIVERS_FOLDER="/opt/corda/drivers" \
     CONFIG_FOLDER="/etc/corda" \
@@ -37,6 +39,8 @@ ENV CORDAPPS_FOLDER="/opt/corda/cordapps" \
 VOLUME ["/opt/corda/cordapps"]
 ##PERSISTENCE FOLDER
 VOLUME ["/opt/corda/persistence"]
+##ARTEMIS FOLDER
+VOLUME ["/opt/corda/artemis"]
 ##CERTS FOLDER
 VOLUME ["/opt/corda/certificates"]
 ##OPTIONAL JDBC DRIVERS FOLDER


### PR DESCRIPTION
Storing Artemis data inside the container - without persistence - may result in an inconsistent backchain across restarts, leading to node(s) being unable to spend their state(s). This change addresses that risk by adding a persistent volume for Artemis.