### PR TITLE
CORDA-3714: Update commons-beanutils for security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ buildscript {
     ext.eddsa_version = '0.3.0'
     ext.dependency_checker_version = '5.2.0'
     ext.commons_collections_version = '4.3'
-    ext.beanutils_version = '1.9.3'
+    ext.beanutils_version = '1.9.4'
     ext.crash_version = '1.7.4'
     ext.jsr305_version = constants.getProperty("jsr305Version")
     ext.shiro_version = '1.4.1'


### PR DESCRIPTION
Small upgrade to the latest version.  Shouldn't have any noticeable impact, except making the security feature that we want on by default.