### PR TITLE
EG-2854 Failing Test: net.corda.node.internal.NodeStartupCliTest.--nodeconf using absolute path will not be changed

### DIFF
--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -22,11 +22,13 @@ class NodeStartupCliTest {
 
     companion object {
         private lateinit var workingDirectory: Path
+        private lateinit var rootDirectory: Path
         private var customNodeConf = "custom_node.conf"
         @BeforeClass
         @JvmStatic
         fun initDirectories() {
             workingDirectory = Paths.get(".").normalize().toAbsolutePath()
+            rootDirectory = Paths.get("/").normalize().toAbsolutePath()
         }
     }
 
@@ -65,7 +67,7 @@ class NodeStartupCliTest {
     @Test(timeout=300_000)
     fun `--nodeconf using absolute path will not be changed`() {
         CommandLine.populateCommand(startup, CommonCliConstants.CONFIG_FILE, "/$customNodeConf")
-        Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo( Paths.get("/", customNodeConf))
+        Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo(rootDirectory / customNodeConf)
     }
 
     @Test(timeout=3_000)

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -65,7 +65,7 @@ class NodeStartupCliTest {
     @Test(timeout=300_000)
     fun `--nodeconf using absolute path will not be changed`() {
         CommandLine.populateCommand(startup, CommonCliConstants.CONFIG_FILE, "/$customNodeConf")
-        Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo( "/" / customNodeConf)
+        Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo( Paths.get("/", customNodeConf))
     }
 
     @Test(timeout=3_000)

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -66,7 +66,7 @@ class NodeStartupCliTest {
 
     @Test(timeout=300_000)
     fun `--nodeconf using absolute path will not be changed`() {
-        CommandLine.populateCommand(startup, CommonCliConstants.CONFIG_FILE, "/$customNodeConf")
+        CommandLine.populateCommand(startup, CommonCliConstants.CONFIG_FILE, (rootDirectory / customNodeConf).toString())
         Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo(rootDirectory / customNodeConf)
     }
 


### PR DESCRIPTION
fix test failing on Windows