### PR TITLE
NOTICK - Correct node_flow_exceptions type length

### DIFF
--- a/node/src/main/resources/migration/node-core.changelog-v19-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19-postgres.xml
@@ -69,7 +69,7 @@
             <column name="flow_id" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
-            <column name="type" type="NVARCHAR(255)">
+            <column name="type" type="NVARCHAR(256)">
                 <constraints nullable="false"/>
             </column>
             <column name="exception_message" type="NVARCHAR(4000)">

--- a/node/src/main/resources/migration/node-core.changelog-v19.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19.xml
@@ -69,7 +69,7 @@
             <column name="flow_id" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
-            <column name="type" type="NVARCHAR(255)">
+            <column name="type" type="NVARCHAR(256)">
                 <constraints nullable="false"/>
             </column>
             <column name="exception_message" type="NVARCHAR(4000)">


### PR DESCRIPTION
Corrects/ reverts back to 256 the length of column 'type' in table 'node_flow_exceptions'.