### PR TITLE
INFRA-315: add NexusIQ evalution for Corda

### DIFF
--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -1,29 +1,35 @@
+#!groovy
+/**
+ * Jenkins pipeline to run basic code checks.
+ */
+
+/**
+ * Kill already started job.
+ * Assume new commit takes precedence and results from previous
+ * unfinished builds are not required.
+ * This feature doesn't play well with disableConcurrentBuilds() option
+ */
 @Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 
+/*
+ * A placeholder of computed NexusIQ application id
+ */
+
+def nexusAppId = null
+
 pipeline {
-    agent { label 'k8s' }
+    agent { label 'standard' }
     options {
         timestamps()
         timeout(time: 3, unit: 'HOURS')
     }
 
-    environment {
-        PR_CONTEXT_STRING = "PR Code Checks"
-    }
-
     stages {
         stage('Detekt check') {
             steps {
-                script {
-                    pullRequest.createStatus(
-                            status: 'pending',
-                            context: "${PR_CONTEXT_STRING}",
-                            description: "Running code checks",
-                            targetUrl: "${env.BUILD_URL}")
-                }
                 sh "./gradlew --no-daemon clean detekt"
             }
         }
@@ -31,6 +37,25 @@ pipeline {
         stage('Compilation warnings check') {
             steps {
                 sh "./gradlew --no-daemon -Pcompilation.warningsAsErrors=true compileAll"
+            }
+        }
+
+        stage('Sonatype Check') {
+            steps {
+                sh "./gradlew --no-daemon -Pcompilation.warningsAsErrors=false jar"
+                script {
+                    sh "./gradlew  --no-daemon properties | grep -E '^(version|group):' >version-properties"
+                    def version = sh (returnStdout: true, script: "grep ^version: version-properties | sed -e 's/^version: //'").trim()
+                    def groupId = sh (returnStdout: true, script: "grep ^group: version-properties | sed -e 's/^group: //'").trim()
+                    def artifactId = 'corda'
+                    nexusAppId = "jenkins-${groupId}-${artifactId}-${version}-PR"
+                }
+                nexusPolicyEvaluation (
+                        failBuildOnNetworkError: false,
+                        iqApplication: manualApplication(nexusAppId),
+                        iqScanPatterns: [[scanPattern: 'node/capsule/build/libs/corda*.jar']],
+                        iqStage: 'build'
+                )
             }
         }
 
@@ -49,25 +74,6 @@ pipeline {
     }
 
     post {
-        success {
-            script {
-                pullRequest.createStatus(
-                        status: 'success',
-                        context: "${PR_CONTEXT_STRING}",
-                        description: 'Code checks passed',
-                        targetUrl: "${env.BUILD_URL}")
-            }
-        }
-
-        failure {
-            script {
-                pullRequest.createStatus(
-                        status: 'failure',
-                        context: "${PR_CONTEXT_STRING}",
-                        description: 'Code checks failed',
-                        targetUrl: "${env.BUILD_URL}")
-            }
-        }
         cleanup {
             deleteDir() /* clean up our workspace */
         }


### PR DESCRIPTION
Checking pull requests plugged into `PR Code Checks` and checking release branches added to regression tests.
See [NexusIQ scanning policy](https://r3-cev.atlassian.net/wiki/spaces/SEC/pages/1938161760/NexusIQ+scanning+policy) for details.

Changes:
* `PR Code Checks` moved to a non-K8S agent
* removed settings of Github status, that's done already by Jenkins master
