### PR TITLE
INRFA-415: Publish empty source and JavaDoc for deterministic modules.

### DIFF
--- a/core-deterministic/README.md
+++ b/core-deterministic/README.md
@@ -1,0 +1,2 @@
+## corda-core-deterministic.
+This artifact is a deterministic subset of the binary contents of `corda-core`.

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -207,10 +207,18 @@ artifacts {
     publish file: deterministicJar, name: jarBaseName, type: 'jar', extension: 'jar', builtBy: metafix
 }
 
+tasks.named('sourceJar', Jar) {
+    from 'README.md'
+    include 'README.md'
+}
+
+tasks.named('javadocJar', Jar) {
+    from 'README.md'
+    include 'README.md'
+}
+
 publish {
     dependenciesFrom configurations.deterministicArtifacts
-    publishSources = false
-    publishJavadoc = false
     name jarBaseName
 }
 

--- a/serialization-deterministic/README.md
+++ b/serialization-deterministic/README.md
@@ -1,0 +1,2 @@
+## corda-serialization-deterministic.
+This artifact is a deterministic subset of the binary contents of `corda-serialization`.

--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -193,12 +193,20 @@ artifacts {
     publish file: deterministicJar, name: jarBaseName, type: 'jar', extension: 'jar', builtBy: metafix
 }
 
+tasks.named('sourceJar', Jar) {
+    from 'README.md'
+    include 'README.md'
+}
+
+tasks.named('javadocJar', Jar) {
+    from 'README.md'
+    include 'README.md'
+}
+
 publish {
     dependenciesFrom(configurations.deterministicArtifacts) {
         defaultScope = 'compile'
     }
-    publishSources = false
-    publishJavadoc = false
     name jarBaseName
 }
 


### PR DESCRIPTION
Create empty `source` and `javadoc` artifacts for the deterministic modules so that they can be published to Maven Central.

The current `README.md` files are empty, for your pleasure.