### PR TITLE
ENT-5131: Avoid NPE by throwing a catchable exception when openAttachment fails

### DIFF
--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -302,7 +302,12 @@ interface CordaRPCOps : RPCOps {
     /** Checks whether an attachment with the given hash is stored on the node. */
     fun attachmentExists(id: SecureHash): Boolean
 
-    /** Download an attachment JAR by ID. */
+    /**
+     * Download an attachment JAR by ID.
+     * @param id the id of the attachment to open
+     * @return the stream of the JAR
+     * @throws RPCException if the attachment doesn't exist
+     * */
     fun openAttachment(id: SecureHash): InputStream
 
     /** Uploads a jar to the node, returns it's hash. */

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.node.internal
 
+import net.corda.client.rpc.RPCException
 import net.corda.client.rpc.notUsed
 import net.corda.common.logging.CordaVersion
 import net.corda.core.CordaRuntimeException
@@ -263,7 +264,8 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun openAttachment(id: SecureHash): InputStream {
-        return services.attachments.openAttachment(id)!!.open()
+        return services.attachments.openAttachment(id)?.open() ?:
+            throw RPCException("Unable to open attachment with id: $id")
     }
 
     override fun uploadAttachment(jar: InputStream): SecureHash {


### PR DESCRIPTION
It would be better to make the return nullable like the underlying AttachmentService but with we can't change the public API now.

At least this way we avoid the NPE and get a clear reason why something went wrong.