### PR TITLE
CORDA-3844: bulk node infos request

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -1,10 +1,8 @@
 package net.corda.node.services.network
 
-import net.corda.core.contracts.requireThat
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
 import net.corda.core.crypto.sha256
-import net.corda.core.internal.SignedDataWithCert
 import net.corda.core.internal.openHttpConnection
 import net.corda.core.internal.post
 import net.corda.core.internal.responseAs
@@ -16,7 +14,7 @@ import net.corda.core.utilities.seconds
 import net.corda.core.utilities.trace
 import net.corda.node.VersionInfo
 import net.corda.node.utilities.registration.cacheControl
-import net.corda.node.utilities.registration.serverVersion
+import net.corda.node.utilities.registration.cordaServerVersion
 import net.corda.nodeapi.internal.SignedNodeInfo
 import net.corda.nodeapi.internal.network.NetworkMap
 import net.corda.nodeapi.internal.network.SignedNetworkMap
@@ -65,7 +63,7 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val versionInfo: Versi
         val signedNetworkMap = connection.responseAs<SignedNetworkMap>()
         val networkMap = signedNetworkMap.verifiedNetworkMapCert(trustRoot)
         val timeout = connection.cacheControl.maxAgeSeconds().seconds
-        val version = connection.serverVersion
+        val version = connection.cordaServerVersion
         logger.trace { "Fetched network map update from $url successfully: $networkMap" }
         return NetworkMapResponse(networkMap, timeout, version)
     }

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -31,7 +31,6 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val versionInfo: Versi
     }
 
     private val networkMapUrl = URL("$compatibilityZoneURL/network-map")
-    private val networkMapUrlV2 = URL("$compatibilityZoneURL/network-map/v2")
     private lateinit var trustRoot: X509Certificate
 
     fun start(trustRoot: X509Certificate) {
@@ -85,7 +84,7 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val versionInfo: Versi
     }
 
     fun getNodeInfos(): List<NodeInfo> {
-        val url = URL("$networkMapUrlV2/node-infos")
+        val url = URL("$networkMapUrl/node-infos")
         logger.trace { "Fetching node infos from $url." }
         val verifiedNodeInfo = url.openHttpConnection().responseAs<List<SignedNodeInfo>>().map { it.verified() }
         logger.trace { "Fetched node infos successfully. Node Infos size: ${verifiedNodeInfo.size}" }

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -250,6 +250,9 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
     }
 
     private fun getPrivateNetworkNodeHashes(version: String): List<SecureHash> {
+        // private networks are not supported by latest versions of Network Map
+        // for compatibility reasons, this call is still present for new nodes that communicate with old Network Map service versions
+        // but can be omitted if we know that the version of the Network Map is recent enough
         return if (version == "1") {
             extraNetworkMapKeys.flatMap {
                 try {

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -203,7 +203,12 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
     }
 
     private fun updateNodeInfos(allHashesFromNetworkMap: Set<SecureHash>) {
-        val nodeInfos = networkMapClient!!.getNodeInfos()
+        val nodeInfos = try {
+            networkMapClient!!.getNodeInfos()
+        } catch (e: Exception) {
+            logger.warn("Error encountered when downloading node infos", e)
+            emptyList<NodeInfo>()
+        }
         (allHashesFromNetworkMap - nodeInfos.map { it.serialize().sha256() }).forEach {
             logger.warn("Error encountered when downloading node info '$it', skipping...")
         }

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.MoreExecutors
 import net.corda.core.CordaRuntimeException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
+import net.corda.core.crypto.sha256
 import net.corda.core.internal.NetworkParametersStorage
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.copyTo
@@ -65,6 +66,7 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
     companion object {
         private val logger = contextLogger()
         private val defaultRetryInterval = 1.minutes
+        private const val bulkNodeInfoFetchThreshold = 50
     }
 
     private val parametersUpdatesTrack = PublishSubject.create<ParametersUpdateInfo>()
@@ -173,17 +175,9 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
         if (networkMapClient == null) {
             throw CordaRuntimeException("Network map cache can be updated only if network map/compatibility zone URL is specified")
         }
-        val (globalNetworkMap, cacheTimeout) = networkMapClient.getNetworkMap()
+        val (globalNetworkMap, cacheTimeout, version) = networkMapClient.getNetworkMap()
         globalNetworkMap.parametersUpdate?.let { handleUpdateNetworkParameters(networkMapClient, it) }
-        val additionalHashes = extraNetworkMapKeys.flatMap {
-            try {
-                networkMapClient.getNetworkMap(it).payload.nodeInfoHashes
-            } catch (e: Exception) {
-                // Failure to retrieve one network map using UUID shouldn't stop the whole update.
-                logger.warn("Error encountered when downloading network map with uuid '$it', skipping...", e)
-                emptyList<SecureHash>()
-            }
-        }
+        val additionalHashes = getPrivateNetworkNodeHashes(version)
         val allHashesFromNetworkMap = (globalNetworkMap.nodeInfoHashes + additionalHashes).toSet()
         if (currentParametersHash != globalNetworkMap.networkParameterHash) {
             exitOnParametersMismatch(globalNetworkMap)
@@ -194,6 +188,29 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
         val allNodeHashes = networkMapCache.allNodeHashes
         val nodeHashesToBeDeleted = (allNodeHashes - allHashesFromNetworkMap - nodeInfoWatcher.processedNodeInfoHashes)
                 .filter { it != ourNodeInfoHash }
+        if (version == "1" || (allHashesFromNetworkMap - allNodeHashes).size < bulkNodeInfoFetchThreshold)
+            updateNodeInfosV1(allHashesFromNetworkMap, allNodeHashes, networkMapClient)
+        else
+            updateNodeInfos(allHashesFromNetworkMap)
+        // NOTE: We remove nodes after any new/updates because updated nodes will have a new hash and, therefore, any
+        // nodes that we can actually pull out of the cache (with the old hashes) should be a truly removed node.
+        nodeHashesToBeDeleted.mapNotNull { networkMapCache.getNodeByHash(it) }.forEach(networkMapCache::removeNode)
+
+        // Mark the network map cache as ready on a successful poll of the HTTP network map, even on the odd chance that
+        // it's empty
+        networkMapCache.nodeReady.set(null)
+        return cacheTimeout
+    }
+
+    private fun updateNodeInfos(allHashesFromNetworkMap: Set<SecureHash>) {
+        val nodeInfos = networkMapClient!!.getNodeInfos()
+        (allHashesFromNetworkMap - nodeInfos.map { it.serialize().sha256() }).forEach {
+            logger.warn("Error encountered when downloading node info '$it', skipping...")
+        }
+        networkMapCache.addOrUpdateNodes(networkMapClient!!.getNodeInfos())
+    }
+
+    private fun updateNodeInfosV1(allHashesFromNetworkMap: Set<SecureHash>, allNodeHashes: List<SecureHash>, networkMapClient: NetworkMapClient) {
         //at the moment we use a blocking HTTP library - but under the covers, the OS will interleave threads waiting for IO
         //as HTTP GET is mostly IO bound, use more threads than CPU's
         //maximum threads to use = 24, as if we did not limit this on large machines it could result in 100's of concurrent requests
@@ -230,14 +247,22 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
                 executorToUseForInsertionIntoDB.shutdown()
             }.getOrThrow()
         }
-        // NOTE: We remove nodes after any new/updates because updated nodes will have a new hash and, therefore, any
-        // nodes that we can actually pull out of the cache (with the old hashes) should be a truly removed node.
-        nodeHashesToBeDeleted.mapNotNull { networkMapCache.getNodeByHash(it) }.forEach(networkMapCache::removeNode)
+    }
 
-        // Mark the network map cache as ready on a successful poll of the HTTP network map, even on the odd chance that
-        // it's empty
-        networkMapCache.nodeReady.set(null)
-        return cacheTimeout
+    private fun getPrivateNetworkNodeHashes(version: String): List<SecureHash> {
+        return if (version == "1") {
+            extraNetworkMapKeys.flatMap {
+                try {
+                    networkMapClient!!.getNetworkMap(it).payload.nodeInfoHashes
+                } catch (e: Exception) {
+                    // Failure to retrieve one network map using UUID shouldn't stop the whole update.
+                    logger.warn("Error encountered when downloading network map with uuid '$it', skipping...", e)
+                    emptyList<SecureHash>()
+                }
+            }
+        } else {
+            emptyList()
+        }
     }
 
     private fun exitOnParametersMismatch(networkMap: NetworkMap) {

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -207,7 +207,7 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
         (allHashesFromNetworkMap - nodeInfos.map { it.serialize().sha256() }).forEach {
             logger.warn("Error encountered when downloading node info '$it', skipping...")
         }
-        networkMapCache.addOrUpdateNodes(networkMapClient!!.getNodeInfos())
+        networkMapCache.addOrUpdateNodes(nodeInfos)
     }
 
     private fun updateNodeInfosV1(allHashesFromNetworkMap: Set<SecureHash>, allNodeHashes: List<SecureHash>, networkMapClient: NetworkMapClient) {

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt
@@ -70,7 +70,7 @@ val HttpURLConnection.cacheControl: CacheControl
         return CacheControl.parse(Headers.of(headerFields.filterKeys { it != null }.mapValues { it.value[0] }))
     }
 
-val HttpURLConnection.serverVersion: String
+val HttpURLConnection.cordaServerVersion: String
     get() {
         return headerFields["X-Corda-Server-Version"]?.singleOrNull() ?: "1"
     }

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt
@@ -69,3 +69,8 @@ val HttpURLConnection.cacheControl: CacheControl
     get() {
         return CacheControl.parse(Headers.of(headerFields.filterKeys { it != null }.mapValues { it.value[0] }))
     }
+
+val HttpURLConnection.serverVersion: String
+    get() {
+        return headerFields["X-Corda-Server-Version"]?.singleOrNull() ?: "1"
+    }

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
@@ -74,6 +74,7 @@ class NetworkMapClientTest {
 
     @Test(timeout=300_000)
     fun `registered node is added to the network map v2`() {
+        server.version = "2"
         val (nodeInfo, signedNodeInfo) = createNodeInfoAndSigned(ALICE_NAME)
 
         networkMapClient.publish(signedNodeInfo)

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
@@ -73,6 +73,28 @@ class NetworkMapClientTest {
     }
 
     @Test(timeout=300_000)
+    fun `registered node is added to the network map v2`() {
+        val (nodeInfo, signedNodeInfo) = createNodeInfoAndSigned(ALICE_NAME)
+
+        networkMapClient.publish(signedNodeInfo)
+
+        val nodeInfoHash = nodeInfo.serialize().sha256()
+
+        assertThat(networkMapClient.getNetworkMap().payload.nodeInfoHashes).containsExactly(nodeInfoHash)
+        assertEquals(nodeInfo, networkMapClient.getNodeInfos().single())
+
+        val (nodeInfo2, signedNodeInfo2) = createNodeInfoAndSigned(BOB_NAME)
+
+        networkMapClient.publish(signedNodeInfo2)
+
+        val nodeInfoHash2 = nodeInfo2.serialize().sha256()
+        assertThat(networkMapClient.getNetworkMap().payload.nodeInfoHashes).containsExactly(nodeInfoHash, nodeInfoHash2)
+        assertEquals(cacheTimeout, networkMapClient.getNetworkMap().cacheMaxAge)
+        assertEquals("2", networkMapClient.getNetworkMap().serverVersion)
+        assertThat(networkMapClient.getNodeInfos()).containsExactlyInAnyOrder(nodeInfo, nodeInfo2)
+    }
+
+    @Test(timeout=300_000)
 	fun `negative test - registered invalid node is added to the network map`() {
         val invalidLongNodeName = CordaX500Name(
                 commonName = "AB123456789012345678901234567890123456789012345678901234567890",

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.generateKeyPair
@@ -406,6 +405,7 @@ class NetworkMapUpdaterTest {
     }
 
     @Test(timeout=300_000)
+    @SuppressWarnings("SpreadOperator")
     fun `update nodes is successful for network map supporting bulk operations when high number of nodes is requested`() {
         server.version = "2"
         setUpdater()
@@ -423,6 +423,7 @@ class NetworkMapUpdaterTest {
     }
 
     @Test(timeout=300_000)
+    @SuppressWarnings("SpreadOperator")
     fun `update nodes is successful for network map not supporting bulk operations`() {
         setUpdater()
         val nodeInfos = (1..51).map { createNodeInfoAndSigned("info$it")

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -49,6 +49,8 @@ class NetworkMapServer(private val pollInterval: Duration,
     private val service = InMemoryNetworkMapService()
     private var parametersUpdate: ParametersUpdate? = null
     private var nextNetworkParameters: NetworkParameters? = null
+    // version toggle allowing to easily test behaviour of different version without spinning up a whole new server
+    var version: String = "1"
 
     init {
         server = Server(InetSocketAddress(hostAndPort.host, hostAndPort.port)).apply {
@@ -173,7 +175,7 @@ class NetworkMapServer(private val pollInterval: Duration,
             val signedNetworkMap = networkMapCertAndKeyPair.sign(networkMap)
             return Response.ok(signedNetworkMap.serialize().bytes)
                     .header("Cache-Control", "max-age=${pollInterval.seconds}")
-                    .header("X-Corda-Server-Version", 2)
+                    .apply { if (version != "1") this.header("X-Corda-Server-Version", version)}
                     .build()
         }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -211,8 +211,11 @@ class NetworkMapServer(private val pollInterval: Duration,
         @GET
         @Path("node-infos")
         @Produces(MediaType.APPLICATION_OCTET_STREAM)
-        fun getNodeInfos(): Response =
-                Response.ok(nodeInfoMap.values.toList().serialize().bytes).build()
+        fun getNodeInfos(): Response {
+            val networkMap = NetworkMap(nodeInfoMap.keys.toList(), signedNetParams.raw.hash, parametersUpdate)
+            val signedNetworkMap = networkMapCertAndKeyPair.sign(networkMap)
+            return Response.ok(Pair(signedNetworkMap, nodeInfoMap.values.toList()).serialize().bytes).build()
+        }
 
         @GET
         @Path("network-parameters/{var}")

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -171,7 +171,10 @@ class NetworkMapServer(private val pollInterval: Duration,
         private fun networkMapResponse(nodeInfoHashes: List<SecureHash>): Response {
             val networkMap = NetworkMap(nodeInfoHashes, signedNetParams.raw.hash, parametersUpdate)
             val signedNetworkMap = networkMapCertAndKeyPair.sign(networkMap)
-            return Response.ok(signedNetworkMap.serialize().bytes).header("Cache-Control", "max-age=${pollInterval.seconds}").build()
+            return Response.ok(signedNetworkMap.serialize().bytes)
+                    .header("Cache-Control", "max-age=${pollInterval.seconds}")
+                    .header("X-Corda-Server-Version", 2)
+                    .build()
         }
 
         // Remove nodeInfo for testing.
@@ -204,6 +207,12 @@ class NetworkMapServer(private val pollInterval: Duration,
                 Response.status(Response.Status.NOT_FOUND)
             }.build()
         }
+
+        @GET
+        @Path("v2/node-infos")
+        @Produces(MediaType.APPLICATION_OCTET_STREAM)
+        fun getNodeInfos(): Response =
+                Response.ok(nodeInfoMap.values.toList().serialize().bytes).build()
 
         @GET
         @Path("network-parameters/{var}")

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -209,7 +209,7 @@ class NetworkMapServer(private val pollInterval: Duration,
         }
 
         @GET
-        @Path("v2/node-infos")
+        @Path("node-infos")
         @Produces(MediaType.APPLICATION_OCTET_STREAM)
         fun getNodeInfos(): Response =
                 Response.ok(nodeInfoMap.values.toList().serialize().bytes).build()


### PR DESCRIPTION
Enables nodes to use the new bulk fetch NM REST protocol endpoint, instead of sequentially retrieving node information, when NM supports it.

This pr takes advantage of the functionality provided in https://github.com/corda/network-services/pull/1115.