### PR TITLE
EG-3098 Add messagePrefix and messagePostfix properties to error reporting

### DIFF
--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporter.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporter.kt
@@ -12,5 +12,5 @@ internal interface ErrorReporter {
      * @param error The error to report
      * @param logger The logger to use when reporting this error
      */
-    fun report(error: ErrorCode<*>, logger: Logger)
+    fun report(error: ErrorCode<*>, logger: Logger, messagePrefix: String? = null, messagePostfix: String? = null)
 }

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporter.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporter.kt
@@ -11,6 +11,10 @@ internal interface ErrorReporter {
      *
      * @param error The error to report
      * @param logger The logger to use when reporting this error
+     * @param messagePrefix An optional string that will be prepended to the message,
+     * a trailing whitespace will be appended automatically if the prefix is defined.
+     * @param messagePostfix An optional string that will be appended to the message,
+     * a leading whitespace will be appended automatically if the postfix is defined.
      */
     fun report(error: ErrorCode<*>, logger: Logger, messagePrefix: String? = null, messagePostfix: String? = null)
 }

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
@@ -29,9 +29,13 @@ internal class ErrorReporterImpl(private val resourceLocation: String,
         return "[$codeMessage $urlMessage]"
     }
 
-    override fun report(error: ErrorCode<*>, logger: Logger) {
+    override fun report(error: ErrorCode<*>, logger: Logger, messagePrefix: String?, messagePostfix: String?) {
         val errorResource = ErrorResource.fromErrorCode(error, resourceLocation, locale)
-        val message = "${errorResource.getErrorMessage(error.parameters.toTypedArray())} ${getErrorInfo(error)}"
+
+        val message = (messagePrefix ?: "") +
+                "${errorResource.getErrorMessage(error.parameters.toTypedArray())} ${getErrorInfo(error)}" +
+                (messagePostfix ?: "")
+
         if (error is Exception) {
             logger.error(message, error)
         } else {

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReporterImpl.kt
@@ -32,9 +32,9 @@ internal class ErrorReporterImpl(private val resourceLocation: String,
     override fun report(error: ErrorCode<*>, logger: Logger, messagePrefix: String?, messagePostfix: String?) {
         val errorResource = ErrorResource.fromErrorCode(error, resourceLocation, locale)
 
-        val message = (messagePrefix ?: "") +
+        val message = (messagePrefix?.let { "$it " } ?: "") +
                 "${errorResource.getErrorMessage(error.parameters.toTypedArray())} ${getErrorInfo(error)}" +
-                (messagePostfix ?: "")
+                (messagePostfix?.let { " $it"  } ?: "")
 
         if (error is Exception) {
             logger.error(message, error)

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReportingUtils.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReportingUtils.kt
@@ -8,8 +8,10 @@ import org.slf4j.Logger
  * Doing this allows the error reporting framework to find the corresponding resources for the error and pick the correct locale.
  *
  * @param error The error that has occurred.
- * @param messagePrefix An optional string that will be prepended to the message
- * @param messagePostfix An optional string that will be appended to the message
+ * @param messagePrefix An optional string that will be prepended to the message,
+ * a trailing whitespace will be appended automatically if the prefix is defined.
+ * @param messagePostfix An optional string that will be appended to the message,
+ * a leading whitespace will be appended automatically if the postfix is defined.
  */
 fun Logger.report(error: ErrorCode<*>, messagePrefix: String? = null, messagePostfix: String? = null)
         = ErrorReporting().getReporter().report(error, this, messagePrefix, messagePostfix)

--- a/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReportingUtils.kt
+++ b/common/logging/src/main/kotlin/net/corda/common/logging/errorReporting/ErrorReportingUtils.kt
@@ -8,8 +8,11 @@ import org.slf4j.Logger
  * Doing this allows the error reporting framework to find the corresponding resources for the error and pick the correct locale.
  *
  * @param error The error that has occurred.
+ * @param messagePrefix An optional string that will be prepended to the message
+ * @param messagePostfix An optional string that will be appended to the message
  */
-fun Logger.report(error: ErrorCode<*>) = ErrorReporting().getReporter().report(error, this)
+fun Logger.report(error: ErrorCode<*>, messagePrefix: String? = null, messagePostfix: String? = null)
+        = ErrorReporting().getReporter().report(error, this, messagePrefix, messagePostfix)
 
 internal fun ErrorCode<*>.formatCode() : String {
     val namespaceString = this.code.namespace.toLowerCase().replace("_", "-")

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
@@ -139,10 +139,10 @@ class ErrorReporterImplTest {
     fun `error code with prefix and postfix printed correctly`() {
         val error = TEST_ERROR_3
         val testReporter = createReporterImpl("en-US")
-        val prefix = "DummyPrefix "
-        val postfix = " DummyPostfix"
+        val prefix = "DummyPrefix"
+        val postfix = "DummyPostfix"
         testReporter.report(error, loggerMock, prefix, postfix)
-        assertEquals(listOf("${prefix}This is the third test message [Code: test-case-3 URL: $TEST_URL/en-US]${postfix}"), logs)
+        assertEquals(listOf("$prefix This is the third test message [Code: test-case-3 URL: $TEST_URL/en-US] $postfix"), logs)
     }
 
     @Test(timeout = 300_000)

--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/errorReporting/ErrorReporterImplTest.kt
@@ -134,4 +134,22 @@ class ErrorReporterImplTest {
         testReporter.report(error, loggerMock)
         assertEquals(listOf("This is the fourth test message [Code: test-case4 URL: $TEST_URL/en-US]", error), logs)
     }
+
+    @Test(timeout = 300_000)
+    fun `error code with prefix and postfix printed correctly`() {
+        val error = TEST_ERROR_3
+        val testReporter = createReporterImpl("en-US")
+        val prefix = "DummyPrefix "
+        val postfix = " DummyPostfix"
+        testReporter.report(error, loggerMock, prefix, postfix)
+        assertEquals(listOf("${prefix}This is the third test message [Code: test-case-3 URL: $TEST_URL/en-US]${postfix}"), logs)
+    }
+
+    @Test(timeout = 300_000)
+    fun `error code with no prefix and postfix provided printed correctly`() {
+        val error = TEST_ERROR_3
+        val testReporter = createReporterImpl("en-US")
+        testReporter.report(error, loggerMock, null, null)
+        assertEquals(listOf("This is the third test message [Code: test-case-3 URL: $TEST_URL/en-US]"), logs)
+    }
 }


### PR DESCRIPTION
CENM builds prefix and postfix when logging error messages, to do that we had to modify error reporting on our end. We should be using the same codebase for error reporting as Corda so modifying this here.