### PR TITLE
INFRA-415: Add empty javadoc to node-driver

### DIFF
--- a/testing/node-driver/README.md
+++ b/testing/node-driver/README.md
@@ -1,0 +1,2 @@
+## corda-node-driver.
+This artifact is the node-driver used for testing Corda.

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -73,9 +73,17 @@ jar {
     }
 }
 
+
+tasks.named('javadocJar', Jar) {
+    from 'README.md'
+    include 'README.md'
+}
+
+tasks.named('javadoc', Javadoc) {
+    enabled = false
+}
+
 publish {
-    publishSources = true
-    publishJavadoc = false
     name jar.baseName
 }
 


### PR DESCRIPTION
Maven central will not allow the node-driver to be published without a javadoc, even if it is empty
This adds an empty javadoc jar to the output.