### PR TITLE
NOTICK: Fix some Gradle technical debt.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ allprojects {
         toolVersion = "0.8.3"
     }
 
-    tasks.withType(JavaCompile) {
+    tasks.withType(JavaCompile).configureEach {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-Xlint:-options" << "-parameters"
         options.compilerArgs << '-XDenableSunApiLintControl'
         if (warnings_as_errors) {
@@ -287,7 +287,7 @@ allprojects {
         options.encoding = 'UTF-8'
     }
 
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
             languageVersion = "1.2"
             apiVersion = "1.2"
@@ -302,7 +302,7 @@ allprojects {
         task.dependsOn tasks.withType(AbstractCompile)
     }
 
-    tasks.withType(Jar) { task ->
+    tasks.withType(Jar).configureEach { task ->
         // Includes War and Ear
         manifest {
             attributes('Corda-Release-Version': corda_release_version)
@@ -314,7 +314,7 @@ allprojects {
         }
     }
 
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
         forkEvery = 10
         ignoreFailures = project.hasProperty('tests.ignoreFailures') ? project.property('tests.ignoreFailures').toBoolean() : false
         failFast = project.hasProperty('tests.failFast') ? project.property('tests.failFast').toBoolean() : false
@@ -339,7 +339,7 @@ allprojects {
         systemProperty 'java.security.egd', 'file:/dev/./urandom'
     }
 
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
         if (name.contains("integrationTest")) {
             maxParallelForks = (System.env.CORDA_INT_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_INT_TESTING_FORKS".toInteger()
         }
@@ -520,7 +520,7 @@ tasks.register('detektBaseline', JavaExec) {
     args(params)
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     reports.html.destination = file("${reporting.baseDir}/${name}")
 }
 
@@ -626,7 +626,7 @@ dependxiesModule {
     skipTasks = "test,integrationTest,smokeTest,slowIntegrationTest"
 }
 
-task generateApi(type: net.corda.plugins.GenerateApi) {
+tasks.register('generateApi', net.corda.plugins.GenerateApi) {
     baseName = "api-corda"
 }
 

--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -99,7 +99,7 @@ configurations {
     testArtifacts.extendsFrom testRuntimeClasspath
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     // fork a new test process for every test class
     forkEvery = 10
 }

--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -16,7 +16,7 @@ ext {
     deterministic_rt_jar = jdk8uDeterministic.rt_jar
 }
 
-tasks.withType(AbstractCompile) {
+tasks.withType(AbstractCompile).configureEach {
     dependsOn jdkTask
 
     // This is a bit ugly, but Gradle isn't recognising the KotlinCompile task
@@ -29,7 +29,7 @@ tasks.withType(AbstractCompile) {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-bootclasspath' << deterministic_rt_jar
     sourceCompatibility = VERSION_1_8
     targetCompatibility = VERSION_1_8

--- a/experimental/avalanche/build.gradle
+++ b/experimental/avalanche/build.gradle
@@ -22,4 +22,7 @@ jar.enabled = false
 shadowJar {
     baseName = "avalanche"
 }
-assemble.dependsOn shadowJar
+
+artifacts {
+    archives shadowJar
+}

--- a/java8.gradle
+++ b/java8.gradle
@@ -6,7 +6,7 @@ import static org.gradle.api.JavaVersion.VERSION_1_8
  */
 apply plugin: 'kotlin'
 
-tasks.withType(AbstractCompile) {
+tasks.withType(AbstractCompile).configureEach {
     // This is a bit ugly, but Gradle isn't recognising the KotlinCompile task
     // as it does the built-in JavaCompile task.
     if (it.class.name.startsWith('org.jetbrains.kotlin.gradle.tasks.KotlinCompile')) {
@@ -16,7 +16,7 @@ tasks.withType(AbstractCompile) {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     sourceCompatibility = VERSION_1_8
     targetCompatibility = VERSION_1_8
 }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -243,12 +243,12 @@ dependencies {
     testCompile project(':testing:cordapps:dbfailure:dbfworkflows')
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     // Resolves a Gradle warning about not scanning for pre-processors.
     options.compilerArgs << '-proc:none'
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     if (JavaVersion.current() == JavaVersion.VERSION_11) {
         jvmArgs '-Djdk.attach.allowAttachSelf=true'
     }

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -119,9 +119,8 @@ task buildCordaJAR(type: FatCapsule, dependsOn: [
     }
 }
 
-assemble.dependsOn buildCordaJAR
-
 artifacts {
+    archives buildCordaJAR
     runtimeArtifacts buildCordaJAR
     publish buildCordaJAR {
         classifier ''

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -153,7 +153,7 @@ task integrationTest(type: Test, dependsOn: []) {
 
 // This fixes the "line too long" error when running this demo with windows CLI
 // TODO: Automatically apply to all projects via a plugin
-tasks.withType(CreateStartScripts).each { task ->
+tasks.withType(CreateStartScripts).configureEach { task ->
     task.doLast {
         String text = task.windowsScript.text
         // Replaces the per file classpath (which are all jars in "lib") with a wildcard on lib

--- a/serialization-djvm/build.gradle
+++ b/serialization-djvm/build.gradle
@@ -56,7 +56,7 @@ jar {
     }
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     useJUnitPlatform()
     systemProperty 'deterministic-rt.path', configurations.jdkRt.asPath
     systemProperty 'sandbox-libraries.path', configurations.sandboxTesting.asPath

--- a/testing/testserver/testcapsule/build.gradle
+++ b/testing/testserver/testcapsule/build.gradle
@@ -64,9 +64,8 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').tasks.jar) 
     }
 }
 
-assemble.dependsOn buildWebserverJar
-
 artifacts {
+    archives buildWebserverJar
     runtimeArtifacts buildWebserverJar
     publish buildWebserverJar {
         classifier ''

--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     testCompile "junit:junit:$junit_version"
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     // Resolves a Gradle warning about not scanning for pre-processors.
     options.compilerArgs << '-proc:none'
 }

--- a/tools/error-tool/build.gradle
+++ b/tools/error-tool/build.gradle
@@ -1,17 +1,13 @@
 apply plugin: 'kotlin'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(":common-logging")
     implementation project(":tools:cliutils")
     implementation "info.picocli:picocli:$picocli_version"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
 
-    testCompile "junit:junit:4.12"
+    testImplementation "junit:junit:$junit_version"
 }
 
 jar {
@@ -28,4 +24,6 @@ shadowJar {
     }
 }
 
-assemble.dependsOn shadowJar
+artifacts {
+    archives shadowJar
+}

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     // Resolves a Gradle warning about not scanning for pre-processors.
     options.compilerArgs << '-proc:none'
 }

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -41,9 +41,8 @@ task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').ta
     }
 }
 
-assemble.dependsOn buildExplorerJAR
-
 artifacts {
+    archives buildExplorerJAR
     runtimeArtifacts buildExplorerJAR
     publish buildExplorerJAR {
         classifier ""

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile "org.controlsfx:controlsfx:$controlsfx_version"
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     // Resolves a Gradle warning about not scanning for pre-processors.
     options.compilerArgs << '-proc:none'
 }
@@ -78,13 +78,13 @@ shadowJar {
     zip64 true
 }
 
-task buildNetworkBuilder(dependsOn: shadowJar)
-assemble.dependsOn buildNetworkBuilder
+tasks.register('buildNetworkBuilder') {
+    dependsOn shadowJar
+}
 
 artifacts {
-    publish shadowJar {
-        archiveClassifier = jdkClassifier
-    }
+    archives shadowJar
+    publish shadowJar
 }
 
 jar {

--- a/tools/shell-cli/build.gradle
+++ b/tools/shell-cli/build.gradle
@@ -27,16 +27,17 @@ processResources {
 }
 
 shadowJar {
+    archiveClassifier = jdkClassifier
     mergeServiceFiles()
 }
 
-task buildShellCli(dependsOn: shadowJar)
-assemble.dependsOn buildShellCli
+tasks.register('buildShellCli') {
+    dependsOn shadowJar
+}
 
 artifacts {
-    publish shadowJar {
-        archiveClassifier = jdkClassifier
-    }
+    archives shadowJar
+    publish shadowJar
 }
 
 jar {

--- a/tools/shell/build.gradle
+++ b/tools/shell/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     integrationTestCompile project(':node-driver')
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     // Resolves a Gradle warning about not scanning for pre-processors.
     options.compilerArgs << '-proc:none'
 }


### PR DESCRIPTION
- Use Gradle task configuration avoidance APIs wherever possible.
- Add artifacts to the `archives` configuration, which implicitly makes them dependencies of `assemble` task.

## :fire: But the _*BIGGEST*_ problem is that we are still using Gradle 5.4.1. :fire:
We can upgrade as far as Gradle 5.6.4 without breaking the Kotlin 1.2.71 plugin, and _we really need to do this._ The Gradle plugin API has evolved considerably since 5.4, and "plugin writers" (_cough, cough_) are needlessly tying themselves in knots working around problems that have already been solved in later Gradle releases.