### PR TITLE
NOTICK - Fix Oracle failing with specified length too long for its datatype

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -50,8 +50,8 @@ class DBCheckpointStorage(
         private const val HMAC_SIZE_BYTES = 16
 
         @VisibleForTesting
-        const val MAX_STACKTRACE_LENGTH = 4000
-        private const val MAX_EXC_MSG_LENGTH = 4000
+        const val MAX_STACKTRACE_LENGTH = 2000
+        private const val MAX_EXC_MSG_LENGTH = 2000
         private const val MAX_EXC_TYPE_LENGTH = 256
         private const val MAX_FLOW_NAME_LENGTH = 128
         private const val MAX_PROGRESS_STEP_LENGTH = 256

--- a/node/src/main/resources/migration/node-core.changelog-v19-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19-postgres.xml
@@ -72,10 +72,10 @@
             <column name="type" type="NVARCHAR(256)">
                 <constraints nullable="false"/>
             </column>
-            <column name="exception_message" type="NVARCHAR(4000)">
+            <column name="exception_message" type="NVARCHAR(2000)">
                 <constraints nullable="true"/>
             </column>
-            <column name="stack_trace" type="NVARCHAR(4000)">
+            <column name="stack_trace" type="NVARCHAR(2000)">
                 <constraints nullable="false"/>
             </column>
             <column name="exception_value" type="varbinary(33554432)">

--- a/node/src/main/resources/migration/node-core.changelog-v19.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19.xml
@@ -72,10 +72,10 @@
             <column name="type" type="NVARCHAR(256)">
                 <constraints nullable="false"/>
             </column>
-            <column name="exception_message" type="NVARCHAR(4000)">
+            <column name="exception_message" type="NVARCHAR(2000)">
                 <constraints nullable="true"/>
             </column>
-            <column name="stack_trace" type="NVARCHAR(4000)">
+            <column name="stack_trace" type="NVARCHAR(2000)">
                 <constraints nullable="false"/>
             </column>
             <column name="exception_value" type="blob">


### PR DESCRIPTION
Reduce `exception_message` and `stack_trace` lengths in table `node_flow_exceptions` from 4000 to 2000 to fix Oracle failing with: 'ORA-00910: specified length too long for its datatype'