### PR TITLE
INFRA-438 Handle observers not having error handling

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -151,7 +151,7 @@ internal class RPCClientProxyHandler(
                 observable.onError(ConnectionFailureException())
             } catch (ex: OnErrorNotImplementedException) {
                 // Indicates the observer does not have any error handling.
-                log.warn("Closed connection on observable $observable whose observers have no error handling.")
+                log.trace("Closed connection on observable whose observers have no error handling.")
             } catch (ex: Exception) {
                 log.error("Unexpected exception when RPC connection failure handling", ex)
             }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -151,7 +151,7 @@ internal class RPCClientProxyHandler(
                 observable.onError(ConnectionFailureException())
             } catch (ex: OnErrorNotImplementedException) {
                 // Indicates the observer does not have any error handling.
-                log.debug("Closed connection on observable whose observers have no error handling.")
+                log.debug { "Closed connection on observable whose observers have no error handling." }
             } catch (ex: Exception) {
                 log.error("Unexpected exception when RPC connection failure handling", ex)
             }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -151,7 +151,7 @@ internal class RPCClientProxyHandler(
                 observable.onError(ConnectionFailureException())
             } catch (ex: OnErrorNotImplementedException) {
                 // Indicates the observer does not have any error handling.
-                log.trace("Closed connection on observable whose observers have no error handling.")
+                log.debug("Closed connection on observable whose observers have no error handling.")
             } catch (ex: Exception) {
                 log.error("Unexpected exception when RPC connection failure handling", ex)
             }


### PR DESCRIPTION
When the RPC client connection is closed, it notifies observers using onError(), which may not be the correct approach (TBD) but changing this is a much more invasive change. Where observers do not subscribe to error notifications, this is reflected to the calling client by an exception thrown.

This change catches that exception and lots it as debug rather an error level.
