### PR TITLE
CORDA-3850 Add a per flow lock

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -155,6 +155,16 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
 
     internal val softLockedStates = mutableSetOf<StateRef>()
 
+    internal inline fun <RESULT> withFlowLock(block: FlowStateMachineImpl<R>.() -> RESULT): RESULT {
+        transientState.lock.acquire()
+        return try {
+            block(this)
+        } finally {
+            transientState.lock.release()
+        }
+    }
+
+
     /**
      * Processes an event by creating the associated transition and executing it using the given executor.
      * Try to avoid using this directly, instead use [processEventsUntilFlowIsResumed] or [processEventImmediately]
@@ -162,20 +172,23 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
      */
     @Suspendable
     private fun processEvent(transitionExecutor: TransitionExecutor, event: Event): FlowContinuation {
-        setLoggingContext()
-        val stateMachine = transientValues.stateMachine
-        val oldState = transientState
-        val actionExecutor = transientValues.actionExecutor
-        val transition = stateMachine.transition(event, oldState)
-        val (continuation, newState) = transitionExecutor.executeTransition(this, oldState, event, transition, actionExecutor)
-        // Ensure that the next state that is being written to the transient state maintains the [isKilled] flag
-        // This condition can be met if a flow is killed during [TransitionExecutor.executeTransition]
-        if (oldState.isKilled && !newState.isKilled) {
-            newState.isKilled = true
+        return withFlowLock {
+            setLoggingContext()
+            val stateMachine = transientValues.stateMachine
+            val oldState = transientState
+            val actionExecutor = transientValues.actionExecutor
+            val transition = stateMachine.transition(event, oldState)
+            val (continuation, newState) = transitionExecutor.executeTransition(
+                this,
+                oldState,
+                event,
+                transition,
+                actionExecutor
+            )
+            transientState = newState
+            setLoggingContext()
+            continuation
         }
-        transientState = newState
-        setLoggingContext()
-        return continuation
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -22,6 +22,7 @@ import net.corda.node.services.messaging.DeduplicationHandler
 import java.lang.IllegalStateException
 import java.time.Instant
 import java.util.concurrent.Future
+import java.util.concurrent.Semaphore
 
 /**
  * The state of the state machine, capturing the state of a flow. It consists of two parts, an *immutable* part that is
@@ -41,9 +42,12 @@ import java.util.concurrent.Future
  * @param isRemoved true if the flow has been removed from the state machine manager. This is used to avoid any further
  *   work.
  * @param isKilled true if the flow has been marked as killed. This is used to cause a flow to move to a killed flow transition no matter
- * what event it is set to process next. [isKilled] is a `var` and set as [Volatile] to prevent concurrency errors that can occur if a flow
- * is killed during the middle of a state transition.
+ * what event it is set to process next.
  * @param senderUUID the identifier of the sending state machine or null if this flow is resumed from a checkpoint so that it does not participate in de-duplication high-water-marking.
+ * @param reloadCheckpointAfterSuspendCount The number of times a flow has been reloaded (not retried). This is [null] when
+ * [NodeConfiguration.reloadCheckpointAfterSuspendCount] is not enabled.
+ * @param lock The flow's lock, used to prevent the flow performing a transition while being interacted with from external threads, and
+ * vise-versa.
  */
 // TODO perhaps add a read-only environment to the state machine for things that don't change over time?
 // TODO evaluate persistent datastructure libraries to replace the inefficient copying we currently do.
@@ -57,10 +61,10 @@ data class StateMachineState(
     val isAnyCheckpointPersisted: Boolean,
     val isStartIdempotent: Boolean,
     val isRemoved: Boolean,
-    @Volatile
-    var isKilled: Boolean,
+    val isKilled: Boolean,
     val senderUUID: String?,
-    val reloadCheckpointAfterSuspendCount: Int?
+    val reloadCheckpointAfterSuspendCount: Int?,
+    val lock: Semaphore
 ) : KryoSerializable {
     override fun write(kryo: Kryo?, output: Output?) {
         throw IllegalStateException("${StateMachineState::class.qualifiedName} should never be serialized")


### PR DESCRIPTION
Add a lock to `StateMachineState` that is used when interacting with a
flow. This prevents multiple threads from interacting with a flow at the
same time, therefore stopping race conditions and weird timing issues.

To take the lock call `FlowStateMachineImpl.withFlowLock`.

The lock should be taken at all points where interaction with a flow
starts. Currently this includes starting a transition
(`FlowStateMachineImpl.processEvent`) and kill flow (`SMM.killFlow`).