### PR TITLE
CORDA-3892: Revert back to Gradle 5.4.1 to fix "clean" task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -662,7 +662,7 @@ if (file('corda-docs-only-build').exists() || (System.getenv('CORDA_DOCS_ONLY_BU
 }
 
 wrapper {
-    gradleVersion = "5.6.4"
+    gradleVersion = "5.4.1"
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6.4-all.zip
+distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The `publish-utils` Gradle plugin is using Gradle's `Project.afterEvaluate` handler in ways that Gradle 5.6 no longer allows, and which is breaking the "clean" task.

Revert to Gradle 5.4.1 until we can upgrade the Corda Gradle plugins with a fix.