### PR TITLE
EG-2754, EG-2755 Group State and Contract for Business Network

### DIFF
--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/contracts/GroupContract.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/contracts/GroupContract.kt
@@ -1,0 +1,79 @@
+package net.corda.bn.contracts
+
+import net.corda.bn.states.GroupState
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.CommandWithParties
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.requireSingleCommand
+import net.corda.core.contracts.requireThat
+import net.corda.core.transactions.LedgerTransaction
+import java.lang.IllegalArgumentException
+import java.security.PublicKey
+
+/**
+ * Contract that verifies an evolution of [GroupState].
+ */
+open class GroupContract : Contract {
+
+    companion object {
+        const val CONTRACT_NAME = "net.corda.bn.contracts.GroupContract"
+    }
+
+    open class Commands(val requiredSigners: List<PublicKey>) : CommandData {
+        class Create(requiredSigners: List<PublicKey>) : Commands(requiredSigners)
+        class Modify(requiredSigners: List<PublicKey>) : Commands(requiredSigners)
+        class Exit(requiredSigners: List<PublicKey>) : Commands(requiredSigners)
+    }
+
+    @Suppress("ComplexMethod")
+    override fun verify(tx: LedgerTransaction) {
+        val command = tx.commands.requireSingleCommand<Commands>()
+        val input = if (tx.inputStates.isNotEmpty()) tx.inputs.single() else null
+        val inputState = input?.state?.data as? GroupState
+        val output = if (tx.outputStates.isNotEmpty()) tx.outputs.single() else null
+        val outputState = output?.data as? GroupState
+
+        requireThat {
+            input?.apply {
+                "Input state has to be validated by ${contractName()}" using (state.contract == contractName())
+            }
+            inputState?.apply {
+                "Input state's modified timestamp should be greater or equal to issued timestamp" using (issued <= modified)
+            }
+            output?.apply {
+                "Output state has to be validated by ${contractName()}" using (contract == contractName())
+            }
+            outputState?.apply {
+                "Output state's modified timestamp should be greater or equal to issued timestamp" using (issued <= modified)
+            }
+            if (inputState != null && outputState != null) {
+                "Input and output state should have same network IDs" using (inputState.networkId == outputState.networkId)
+                "Input and output state should have same issued timestamps" using (inputState.issued == outputState.issued)
+                "Output state's modified timestamp should be greater or equal than input's" using (inputState.modified <= outputState.modified)
+                "Input and output state should have same linear IDs" using (inputState.linearId == outputState.linearId)
+                "Transaction must be signed by all signers specified inside command" using (command.signers.toSet() == command.value.requiredSigners.toSet())
+            }
+        }
+
+        when (command.value) {
+            is Commands.Create -> verifyCreate(tx, command, outputState!!)
+            is Commands.Modify -> verifyModify(tx, command, inputState!!, outputState!!)
+            is Commands.Exit -> verifyExit(tx, command, inputState!!)
+            else -> throw IllegalArgumentException("Unsupported command ${command.value}")
+        }
+    }
+
+    open fun contractName() = CONTRACT_NAME
+
+    open fun verifyCreate(tx: LedgerTransaction, command: CommandWithParties<Commands>, outputGroup: GroupState) = requireThat {
+        "Membership request transaction shouldn't contain any inputs" using (tx.inputs.isEmpty())
+    }
+
+    open fun verifyModify(tx: LedgerTransaction, command: CommandWithParties<Commands>, inputGroup: GroupState, outputGroup: GroupState) = requireThat {
+        "Input and output states of group modification transaction should have different name or participants field" using (inputGroup.name != outputGroup.name || inputGroup.participants.toSet() != outputGroup.participants.toSet())
+    }
+
+    open fun verifyExit(tx: LedgerTransaction, command: CommandWithParties<Commands>, inputGroup: GroupState) = requireThat {
+        "Membership revocation transaction shouldn't contain any outputs" using (tx.outputs.isEmpty())
+    }
+}

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/contracts/MembershipContract.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/contracts/MembershipContract.kt
@@ -27,6 +27,7 @@ open class MembershipContract : Contract {
         class Revoke(requiredSigners: List<PublicKey>) : Commands(requiredSigners)
         class ModifyRoles(requiredSigners: List<PublicKey>, val bnCreation: Boolean = false) : Commands(requiredSigners)
         class ModifyBusinessIdentity(requiredSigners: List<PublicKey>, val initiator: Party) : Commands(requiredSigners)
+        class ModifyParticipants(requiredSigners: List<PublicKey>) : Commands(requiredSigners)
     }
 
     @Suppress("ComplexMethod")
@@ -68,6 +69,7 @@ open class MembershipContract : Contract {
             is Commands.Revoke -> verifyRevoke(tx, command, inputState!!)
             is Commands.ModifyRoles -> verifyModifyRoles(tx, command, inputState!!, outputState!!)
             is Commands.ModifyBusinessIdentity -> verifyModifyBusinessIdentity(tx, command, inputState!!, outputState!!)
+            is Commands.ModifyParticipants -> verifyModifyParticipants(tx, command, inputState!!, outputState!!)
             else -> throw IllegalArgumentException("Unsupported command ${command.value}")
         }
     }
@@ -91,6 +93,7 @@ open class MembershipContract : Contract {
         "Output state of membership activation transaction should be active" using (outputMembership.isActive())
         "Input and output state of membership activation transaction should have same roles set" using (inputMembership.roles == outputMembership.roles)
         "Input and output state of membership activation transaction should have same business identity" using (inputMembership.identity.businessIdentity == outputMembership.identity.businessIdentity)
+        "Input and output state of membership activation transaction should have same participants" using (inputMembership.participants.toSet() == outputMembership.participants.toSet())
         (command.value as Commands.Activate).apply {
             "Input membership owner shouldn't be required signer of membership activation transaction (with an exception of Business Network creation)" using (bnCreation || inputMembership.identity.cordaIdentity.owningKey !in requiredSigners)
         }
@@ -106,6 +109,7 @@ open class MembershipContract : Contract {
         "Output state of membership suspension transaction should be suspended" using (outputMembership.isSuspended())
         "Input and output state of membership suspension transaction should have same roles set" using (inputMembership.roles == outputMembership.roles)
         "Input and output state of membership suspension transaction should have same business identity" using (inputMembership.identity.businessIdentity == outputMembership.identity.businessIdentity)
+        "Input and output state of membership suspension transaction should have same participants" using (inputMembership.participants.toSet() == outputMembership.participants.toSet())
         "Input membership owner shouldn't be required signer of membership suspension transaction" using (inputMembership.identity.cordaIdentity.owningKey !in command.value.requiredSigners)
     }
 
@@ -128,6 +132,7 @@ open class MembershipContract : Contract {
         "Membership roles modification transaction can only be performed on active or suspended state" using (inputMembership.isActive() || inputMembership.isSuspended())
         "Input and output state of membership roles modification transaction should have different set of roles" using (inputMembership.roles != outputMembership.roles)
         "Input and output state of membership roles modification transaction should have same business identity" using (inputMembership.identity.businessIdentity == outputMembership.identity.businessIdentity)
+        "Input and output state of membership roles modification transaction should have same participants" using (inputMembership.participants.toSet() == outputMembership.participants.toSet())
         (command.value as Commands.ModifyRoles).apply {
             "Input membership owner shouldn't be required signer of membership roles modification transaction (with an exception of Business Network creation)" using (bnCreation || inputMembership.identity.cordaIdentity.owningKey !in requiredSigners)
         }
@@ -143,11 +148,24 @@ open class MembershipContract : Contract {
         "Membership business identity modification transaction can only be performed on active or suspended state" using (inputMembership.isActive() || inputMembership.isSuspended())
         "Input and output state of membership business identity modification transaction should have same roles" using (inputMembership.roles == outputMembership.roles)
         "Input and output state of membership business identity modification transaction should have different business identity" using (inputMembership.identity.businessIdentity != outputMembership.identity.businessIdentity)
+        "Input and output state of membership business identity modification transaction should have same participants" using (inputMembership.participants.toSet() == outputMembership.participants.toSet())
         (command.value as Commands.ModifyBusinessIdentity).apply {
             val selfModification = initiator == inputMembership.identity.cordaIdentity
             val memberIsSigner = inputMembership.identity.cordaIdentity.owningKey in requiredSigners
             "Input membership owner should be required signer of membership business identity modification transaction if it initiated it" using (!selfModification || memberIsSigner)
             "Input membership owner shouldn't be required signer of membership business identity modification transaction if it didn't initiate it" using (selfModification || !memberIsSigner)
         }
+    }
+
+    open fun verifyModifyParticipants(
+            tx: LedgerTransaction,
+            command: CommandWithParties<Commands>,
+            inputMembership: MembershipState,
+            outputMembership: MembershipState
+    ) = requireThat {
+        "Input and output state of membership participants modification transaction should have same status" using (inputMembership.status == outputMembership.status)
+        "Membership participants modification transaction can only be performed on active or suspended state" using (inputMembership.isActive() || inputMembership.isSuspended())
+        "Input and output state of membership participants modification transaction should have same roles" using (inputMembership.roles == outputMembership.roles)
+        "Input and output state of membership participants modification transaction should have same business identity" using (inputMembership.identity.businessIdentity == outputMembership.identity.businessIdentity)
     }
 }

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/GroupStateSchemaV1.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/GroupStateSchemaV1.kt
@@ -1,0 +1,17 @@
+package net.corda.bn.schemas
+
+import net.corda.bn.states.GroupState
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Table
+
+object GroupStateSchemaV1 : MappedSchema(schemaFamily = GroupState::class.java, version = 1, mappedTypes = listOf(PersistentGroupState::class.java)) {
+    @Entity
+    @Table(name = "group_state")
+    class PersistentGroupState(
+            @Column(name = "network_id")
+            val networkId: String
+    ) : PersistentState()
+}

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/GroupStateSchemaV1.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/GroupStateSchemaV1.kt
@@ -7,7 +7,16 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Table
 
+/**
+ * A database schema configured to represent [GroupState].
+ */
 object GroupStateSchemaV1 : MappedSchema(schemaFamily = GroupState::class.java, version = 1, mappedTypes = listOf(PersistentGroupState::class.java)) {
+
+    /**
+     * Mapped [GroupState] to be exported to a schema.
+     *
+     * @property networkId Mapped column for [GroupState.networkId].
+     */
     @Entity
     @Table(name = "group_state")
     class PersistentGroupState(

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
@@ -10,8 +10,19 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Table
 
+/**
+ * A database schema configured to represent [MembershipState].
+ */
 @CordaSerializable
 object MembershipStateSchemaV1 : MappedSchema(schemaFamily = MembershipState::class.java, version = 1, mappedTypes = listOf(PersistentMembershipState::class.java)) {
+
+    /**
+     * Mapped [MembershipState] to be exported to a schema.
+     *
+     * @property cordaIdentity Mapped column for Corda part of [MembershipState.identity].
+     * @property networkId Mapped column for [MembershipState.networkId].
+     * @property status Mapped column for [MembershipState.status].
+     */
     @Entity
     @Table(name = "membership_state")
     class PersistentMembershipState(

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/states/GroupState.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/states/GroupState.kt
@@ -1,0 +1,37 @@
+package net.corda.bn.states
+
+import net.corda.bn.contracts.GroupContract
+import net.corda.bn.schemas.GroupStateSchemaV1
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.Party
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.QueryableState
+import java.time.Instant
+
+/**
+ * Represents a Business Network groups on ledger.
+ *
+ * @property networkId Unique identifier of a Business Network group belongs to.
+ * @property name Name of group, more descriptive way to distinct groups rather than linear ID.
+ * @property issued Timestamp when the state has been issued.
+ * @property modified Timestamp when the state has been modified last time.
+ */
+@BelongsToContract(GroupContract::class)
+data class GroupState(
+        val networkId: String,
+        val name: String? = null,
+        val issued: Instant = Instant.now(),
+        val modified: Instant = issued,
+        override val linearId: UniqueIdentifier = UniqueIdentifier(),
+        override val participants: List<Party>
+) : LinearState, QueryableState {
+
+    override fun generateMappedObject(schema: MappedSchema) = when (schema) {
+        is GroupStateSchemaV1 -> GroupStateSchemaV1.PersistentGroupState(networkId = networkId)
+        else -> throw IllegalArgumentException("Unrecognised schema $schema")
+    }
+
+    override fun supportedSchemas() = listOf(GroupStateSchemaV1)
+}

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
@@ -55,6 +55,7 @@ data class MembershipState(
     fun canRevokeMembership() = AdminPermission.CAN_REVOKE_MEMBERSHIP in permissions()
     fun canModifyRoles() = AdminPermission.CAN_MODIFY_ROLE in permissions()
     fun canModifyBusinessIdentity() = AdminPermission.CAN_MODIFY_BUSINESS_IDENTITY in permissions()
+    fun canModifyGroups() = AdminPermission.CAN_MODIFY_GROUPS in permissions()
     fun canModifyMembership() = permissions().any { it is AdminPermission }
 }
 
@@ -155,5 +156,10 @@ enum class AdminPermission : BNPermission {
     /**
      * Enables member to modify memberships' business identity.
      */
-    CAN_MODIFY_BUSINESS_IDENTITY
+    CAN_MODIFY_BUSINESS_IDENTITY,
+
+    /**
+     * Enables member to modify Business Networks' associated [GroupState]s.
+     */
+    CAN_MODIFY_GROUPS
 }

--- a/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
+++ b/business-networks/contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
@@ -45,17 +45,41 @@ data class MembershipState(
 
     override fun supportedSchemas() = listOf(MembershipStateSchemaV1)
 
+    /** Indicates whether membership is in [MembershipStatus.PENDING] status. **/
     fun isPending() = status == MembershipStatus.PENDING
+
+    /** Indicates whether membership is in [MembershipStatus.ACTIVE] status. **/
     fun isActive() = status == MembershipStatus.ACTIVE
+
+    /** Indicates whether membership is in [MembershipStatus.SUSPENDED] status. **/
     fun isSuspended() = status == MembershipStatus.SUSPENDED
 
+    /**
+     * Iterates through all roles yielding set of all permissions given to them.
+     *
+     * @return Set of all roles given to all [MembershipState.roles].
+     */
     private fun permissions() = roles.flatMap { it.permissions }.toSet()
+
+    /** Indicates whether membership is authorised to activate memberships. **/
     fun canActivateMembership() = AdminPermission.CAN_ACTIVATE_MEMBERSHIP in permissions()
+
+    /** Indicates whether membership is authorised to suspend memberships. **/
     fun canSuspendMembership() = AdminPermission.CAN_SUSPEND_MEMBERSHIP in permissions()
+
+    /** Indicates whether membership is authorised to revoke memberships. **/
     fun canRevokeMembership() = AdminPermission.CAN_REVOKE_MEMBERSHIP in permissions()
+
+    /** Indicates whether membership is authorised to modify memberships' roles. **/
     fun canModifyRoles() = AdminPermission.CAN_MODIFY_ROLE in permissions()
+
+    /** Indicates whether membership is authorised to modify memberships' business identity. **/
     fun canModifyBusinessIdentity() = AdminPermission.CAN_MODIFY_BUSINESS_IDENTITY in permissions()
+
+    /** Indicates whether membership is authorised to modify memberships' groups. **/
     fun canModifyGroups() = AdminPermission.CAN_MODIFY_GROUPS in permissions()
+
+    /** Indicates whether membership has any administrative permission. **/
     fun canModifyMembership() = permissions().any { it is AdminPermission }
 }
 

--- a/business-networks/contracts/src/main/resources/group-state-schema-v1.changelog-init.xml
+++ b/business-networks/contracts/src/main/resources/group-state-schema-v1.changelog-init.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3 Corda" id="GroupStateSchemaV1">
+        <createTable tableName="group_state">
+            <column name="output_index" type="integer">
+                <constraints nullable="false"/>
+            </column>
+            <column name="transaction_id" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="network_id" type="varchar(255)"/>
+        </createTable>
+        <addPrimaryKey columnNames="output_index, transaction_id"
+                       constraintName="PK_GroupStateSchemaV1"
+                       tableName="group_state"/>
+    </changeSet>
+</databaseChangeLog>

--- a/business-networks/contracts/src/main/resources/group-state-schema-v1.changelog-master.xml
+++ b/business-networks/contracts/src/main/resources/group-state-schema-v1.changelog-master.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <include relativeToChangelogFile="true" file="group-state-schema-v1.changelog-init.xml"/>
+</databaseChangeLog>

--- a/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/GroupContractTest.kt
+++ b/business-networks/contracts/src/test/kotlin/net/corda/bn/contracts/GroupContractTest.kt
@@ -1,0 +1,161 @@
+package net.corda.bn.contracts
+
+import net.corda.bn.states.GroupState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.CordaX500Name
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.node.MockServices
+import net.corda.testing.node.ledger
+import org.junit.Test
+
+class GroupContractTest {
+
+    private val ledgerServices = MockServices(listOf("net.corda.bn.contracts"))
+
+    private val memberIdentity = TestIdentity(CordaX500Name.parse("O=Member,L=London,C=GB")).party
+    private val bnoIdentity = TestIdentity(CordaX500Name.parse("O=BNO,L=London,C=GB")).party
+
+    private val groupState = GroupState(networkId = "network-id", participants = listOf(memberIdentity, bnoIdentity))
+
+    @Test(timeout = 300_000)
+    fun `test common contract verification`() {
+        ledgerServices.ledger {
+            transaction {
+                val input = groupState
+                output(GroupContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, DummyCommand())
+                fails()
+            }
+            transaction {
+                val input = groupState
+                input(DummyContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Input state has to be validated by ${GroupContract.CONTRACT_NAME}"
+            }
+            transaction {
+                val input = groupState
+                input(GroupContract.CONTRACT_NAME, input)
+                output(DummyContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Output state has to be validated by ${GroupContract.CONTRACT_NAME}"
+            }
+            transaction {
+                val input = groupState.run { copy(modified = issued.minusSeconds(100)) }
+                input(GroupContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Exit(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Input state's modified timestamp should be greater or equal to issued timestamp"
+            }
+            transaction {
+                val output = groupState.run { copy(modified = issued.minusSeconds(100)) }
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Create(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Output state's modified timestamp should be greater or equal to issued timestamp"
+            }
+
+            val input = groupState
+            transaction {
+                val output = input.copy(networkId = "other-network-id")
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Input and output state should have same network IDs"
+            }
+            transaction {
+                val output = input.run { copy(issued = issued.minusSeconds(100)) }
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Input and output state should have same issued timestamps"
+            }
+            transaction {
+                val output = input.run { copy(modified = modified.plusSeconds(100)) }
+                input(GroupContract.CONTRACT_NAME, input.run { copy(modified = modified.plusSeconds(200)) })
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Output state's modified timestamp should be greater or equal than input's"
+            }
+            transaction {
+                val output = input.copy(linearId = UniqueIdentifier())
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Input and output state should have same linear IDs"
+            }
+            transaction {
+                val output = input.copy(name = "new-name")
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(emptyList()))
+                this `fails with` "Transaction must be signed by all signers specified inside command"
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test create group command contract verification`() {
+        ledgerServices.ledger {
+            val output = groupState
+            transaction {
+                input(GroupContract.CONTRACT_NAME, output)
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Create(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Membership request transaction shouldn't contain any inputs"
+            }
+            transaction {
+                output(GroupContract.CONTRACT_NAME, output)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Create(listOf(bnoIdentity.owningKey)))
+                verifies()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test modify group command contract verification`() {
+        ledgerServices.ledger {
+            val input = groupState
+            transaction {
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Input and output states of group modification transaction should have different name or participants field"
+            }
+            transaction {
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, input.copy(name = "new-name"))
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                verifies()
+            }
+            transaction {
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, input.copy(participants = listOf(bnoIdentity)))
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                verifies()
+            }
+            transaction {
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, input.copy(name = "new-name", participants = listOf(bnoIdentity)))
+                command(bnoIdentity.owningKey, GroupContract.Commands.Modify(listOf(bnoIdentity.owningKey)))
+                verifies()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test delete group command contract verification`() {
+        ledgerServices.ledger {
+            val input = groupState
+            transaction {
+                input(GroupContract.CONTRACT_NAME, input)
+                output(GroupContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Exit(listOf(bnoIdentity.owningKey)))
+                this `fails with` "Membership revocation transaction shouldn't contain any outputs"
+            }
+            transaction {
+                input(GroupContract.CONTRACT_NAME, input)
+                command(bnoIdentity.owningKey, GroupContract.Commands.Exit(listOf(bnoIdentity.owningKey)))
+                verifies()
+            }
+        }
+    }
+}

--- a/business-networks/contracts/src/test/kotlin/net/corda/bn/states/MembershipStateTest.kt
+++ b/business-networks/contracts/src/test/kotlin/net/corda/bn/states/MembershipStateTest.kt
@@ -42,6 +42,7 @@ class MembershipStateTest {
             assertTrue(canRevokeMembership())
             assertTrue(canModifyRoles())
             assertTrue(canModifyBusinessIdentity())
+            assertTrue(canModifyGroups())
             assertTrue(canModifyMembership())
         }
         mockMembership(roles = setOf(MemberRole())).apply {
@@ -50,6 +51,7 @@ class MembershipStateTest {
             assertFalse(canRevokeMembership())
             assertFalse(canModifyRoles())
             assertFalse(canModifyBusinessIdentity())
+            assertFalse(canModifyGroups())
             assertFalse(canModifyMembership())
         }
 
@@ -60,6 +62,7 @@ class MembershipStateTest {
             assertFalse(canRevokeMembership())
             assertFalse(canModifyRoles())
             assertFalse(canModifyBusinessIdentity())
+            assertFalse(canModifyGroups())
             assertTrue(canModifyMembership())
         }
 
@@ -69,6 +72,8 @@ class MembershipStateTest {
             assertFalse(canSuspendMembership())
             assertFalse(canRevokeMembership())
             assertFalse(canModifyRoles())
+            assertFalse(canModifyBusinessIdentity())
+            assertFalse(canModifyGroups())
             assertFalse(canModifyMembership())
         }
     }


### PR DESCRIPTION
## Description

This PR is the continuation of the second phase of Business Network membership management which takes care of Business Network Groups implementation. The idea is to have multiple membership lists inside a Business Network which enable creation of private Business Networks where members are only subscribed to their group participants changes. 

First we create new `GroupState` data class which represents Business Network Group and consists of following fields:
- `networkId` is the unique identifier of BN the group belongs to
- `name` is more convenient way of distinction between groups
- `linearId` is unique identifier of group
- `participants` is list of all members belonging to given group

We also add supporting KDocs to this new state and generate custom database schema with supporting liquibase migration script. This is created since we are going to query the vault based on custom group state's fields.

After that we implement belonging contract logic inside `GroupContract` containing following commands:
- `Create` for issuance of the new `GroupState`
- `Modify` for modifying `name` or `participants` field of `GroupState`
- `Exit` for marking `GroupState` historic

Notice we make this an open class since in future we'll leave possibility for users to write their own custom membership contract logic based on the one we provide. `verify()` method is divided in 2 parts:
- Standard common checks which are applied to all command types. Those checks can't be overriden by users
- Verification checks specialised for each command via `verifyCreate()`, `verifyModify()` and `verifyExit()` open methods

In the end we write supporting test coverage inside `GroupContractTest` class.

Next PR will introduce flows for Business Network Group creation, modification and deletion.

## Test Plan

Ensure all existing and new Business Network related tests pass.