### PR TITLE
EG-2754, EG-2755 Group Management flows test coverage

### DIFF
--- a/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/CreateGroupFlowTest.kt
+++ b/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/CreateGroupFlowTest.kt
@@ -1,0 +1,115 @@
+package net.corda.bn.flows
+
+import net.corda.bn.contracts.GroupContract
+import net.corda.bn.states.GroupState
+import net.corda.bn.states.MembershipState
+import net.corda.core.contracts.UniqueIdentifier
+import org.junit.Test
+import java.lang.IllegalStateException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CreateGroupFlowTest : MembershipManagementFlowTest(numberOfAuthorisedMembers = 1, numberOfRegularMembers = 1) {
+
+    @Test(timeout = 300_000)
+    fun `create group flow should fail if business network doesn't exist`() {
+        val authorisedMember = authorisedMembers.first()
+        val invalidNetworkId = "invalid-network-id"
+
+        assertFailsWith<BusinessNetworkNotFoundException> { runCreateGroupFlow(authorisedMember, invalidNetworkId) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `create group flow should fail when trying to create group with already existing group ID`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val groupId = getAllGroupsFromVault(authorisedMember, networkId).single().linearId
+        assertFailsWith<DuplicateBusinessNetworkGroupException> { runCreateGroupFlow(authorisedMember, networkId, groupId) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `create group flow should fail if initiator is not part of the business network, its membership is not active or is not authorised`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+
+        runRequestAndSuspendMembershipFlow(regularMember, authorisedMember, networkId).apply {
+            val membership = tx.outputStates.single() as MembershipState
+
+            assertFailsWith<IllegalMembershipStatusException> { runCreateGroupFlow(regularMember, networkId) }
+
+            runActivateMembershipFlow(authorisedMember, membership.linearId)
+            assertFailsWith<MembershipAuthorisationException> { runCreateGroupFlow(regularMember, networkId) }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `create group flow should fail if invalid notary argument is provided`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        assertFailsWith<IllegalStateException> { runCreateGroupFlow(authorisedMember, networkId, notary = authorisedMember.identity()) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `create group flow should fail if any of the additional participants is not member of business network`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        assertFailsWith<MembershipNotFoundException> { runCreateGroupFlow(authorisedMember, networkId, additionalParticipants = setOf(UniqueIdentifier())) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `create group flow should fail if any of the additional participants memberships is in pending status`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val membership = runRequestMembershipFlow(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+        assertFailsWith<IllegalMembershipStatusException> { runCreateGroupFlow(authorisedMember, networkId, additionalParticipants = setOf(membership.linearId)) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `create group flow happy path`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = authorisedMembership.networkId
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val groupId = UniqueIdentifier()
+        val groupName = "group-name"
+        val (group, command) = runCreateGroupFlow(authorisedMember, networkId, groupId, groupName, setOf(regularMembership.linearId)).run {
+            assertTrue(tx.inputs.isEmpty())
+            verifyRequiredSignatures()
+            tx.outputs.single() to tx.commands.single()
+        }
+
+        group.apply {
+            assertEquals(GroupContract.CONTRACT_NAME, contract)
+            assertTrue(data is GroupState)
+            val data = data as GroupState
+            assertEquals(networkId, data.networkId)
+            assertEquals(groupName, data.name)
+            assertEquals(groupId, data.linearId)
+            assertEquals(setOf(authorisedMember.identity(), regularMember.identity()), data.participants.toSet())
+        }
+        assertTrue(command.value is GroupContract.Commands.Create)
+
+        // also check ledgers
+        listOf(authorisedMember, regularMember).forEach { member ->
+            getAllGroupsFromVault(member, networkId).run {
+                assertEquals(2, size)
+                single { it.linearId == groupId }
+            }.apply {
+                assertEquals(2, participants.size, "Vault size assertion failed for ${member.identity()}")
+                assertTrue(participants.any { it == authorisedMember.identity() }, "Expected to have ${authorisedMember.identity()} in new group of ${member.identity()} vault")
+                assertTrue(participants.any { it == regularMember.identity() }, "Expected to have ${regularMember.identity()} in new group of ${member.identity()} vault")
+            }
+        }
+    }
+}

--- a/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/DeleteGroupFlowTest.kt
+++ b/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/DeleteGroupFlowTest.kt
@@ -1,0 +1,82 @@
+package net.corda.bn.flows
+
+import net.corda.bn.states.GroupState
+import net.corda.bn.states.MembershipState
+import net.corda.core.contracts.UniqueIdentifier
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class DeleteGroupFlowTest : MembershipManagementFlowTest(numberOfAuthorisedMembers = 1, numberOfRegularMembers = 1) {
+
+    @Test(timeout = 300_000)
+    fun `delete group flow should fail if group with given ID doesn't exits`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val invalidGroupId = UniqueIdentifier()
+        assertFailsWith<BusinessNetworkGroupNotFoundException> { runDeleteGroupFlow(authorisedMember, invalidGroupId) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `delete group flow should fail if invalid notary argument is provided`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val groupId = (runCreateGroupFlow(authorisedMember, networkId).tx.outputStates.single() as GroupState).linearId
+
+        assertFailsWith<IllegalArgumentException> { runDeleteGroupFlow(authorisedMember, groupId, authorisedMember.identity()) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `delete group flow should fail if initiator is not part of the business network, its membership is not active or is not authorised`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+
+        runRequestAndSuspendMembershipFlow(regularMember, authorisedMember, networkId).apply {
+            val membership = tx.outputStates.single() as MembershipState
+            val group = runCreateGroupFlow(authorisedMember, networkId, additionalParticipants = setOf(membership.linearId)).tx.outputStates.single() as GroupState
+            val groupId = group.linearId
+
+            assertFailsWith<IllegalMembershipStatusException> { runDeleteGroupFlow(regularMember, groupId) }
+
+            runActivateMembershipFlow(authorisedMember, membership.linearId)
+            assertFailsWith<MembershipAuthorisationException> { runDeleteGroupFlow(regularMember, groupId) }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `delete group flow should fail if any member remains without any group participation`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val groupId = getAllGroupsFromVault(authorisedMember, networkId).single().linearId
+        assertFailsWith<MembershipMissingGroupParticipationException> { runDeleteGroupFlow(authorisedMember, groupId) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `delete group flow happy path`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = authorisedMembership.networkId
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val group = runCreateGroupFlow(authorisedMember, networkId, additionalParticipants = setOf(regularMembership.linearId)).tx.outputStates.single() as GroupState
+        runDeleteGroupFlow(authorisedMember, group.linearId).apply {
+            assertEquals(1, tx.inputs.size)
+            assertTrue(tx.outputs.isEmpty())
+            verifyRequiredSignatures()
+        }
+
+        // also check ledgers
+        listOf(authorisedMember, regularMember).forEach { member ->
+            val ledgerGroup = getAllGroupsFromVault(member, networkId).single()
+            assertNotEquals(group, ledgerGroup)
+        }
+    }
+}

--- a/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/MembershipManagementFlowTest.kt
+++ b/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/MembershipManagementFlowTest.kt
@@ -135,6 +135,20 @@ abstract class MembershipManagementFlowTest(
         return future.getOrThrow()
     }
 
+    @Suppress("LongParameterList")
+    protected fun runCreateGroupFlow(
+            initiator: StartedMockNode,
+            networkId: String,
+            groupId: UniqueIdentifier = UniqueIdentifier(),
+            groupName: String? = null,
+            additionalParticipants: Set<UniqueIdentifier> = emptySet(),
+            notary: Party? = null
+    ): SignedTransaction {
+        val future = initiator.startFlow(CreateGroupFlow(networkId, groupId, groupName, additionalParticipants, notary))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
     protected fun runModifyGroupFlow(
             initiator: StartedMockNode,
             groupId: UniqueIdentifier,
@@ -143,6 +157,12 @@ abstract class MembershipManagementFlowTest(
             notary: Party? = null
     ): SignedTransaction {
         val future = initiator.startFlow(ModifyGroupFlow(groupId, name, participants, notary))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runDeleteGroupFlow(initiator: StartedMockNode, groupId: UniqueIdentifier, notary: Party? = null): SignedTransaction {
+        val future = initiator.startFlow(DeleteGroupFlow(groupId, notary))
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }

--- a/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/ModifyGroupFlowTest.kt
+++ b/business-networks/workflows/src/test/kotlin/net/corda/bn/flows/ModifyGroupFlowTest.kt
@@ -1,0 +1,149 @@
+package net.corda.bn.flows
+
+import net.corda.bn.contracts.GroupContract
+import net.corda.bn.states.GroupState
+import net.corda.bn.states.MembershipState
+import net.corda.core.contracts.UniqueIdentifier
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ModifyGroupFlowTest : MembershipManagementFlowTest(numberOfAuthorisedMembers = 1, numberOfRegularMembers = 1) {
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if name and participants argument are not specified`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val groupId = getAllGroupsFromVault(authorisedMember, networkId).single().linearId
+
+        assertFailsWith<IllegalFlowArgumentException> { runModifyGroupFlow(authorisedMember, groupId) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if group with given ID doesn't exist`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val illegalGroupId = UniqueIdentifier()
+        assertFailsWith<BusinessNetworkGroupNotFoundException> { runModifyGroupFlow(authorisedMember, illegalGroupId, name = "new-name") }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if invalid notary argument is provided`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val groupId = getAllGroupsFromVault(authorisedMember, networkId).single().linearId
+
+        assertFailsWith<IllegalArgumentException> { runModifyGroupFlow(authorisedMember, groupId, name = "new-name", notary = authorisedMember.identity()) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if initiator is not part of the business network, its membership is not active or is not authorised`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+
+        runRequestAndSuspendMembershipFlow(regularMember, authorisedMember, networkId).apply {
+            val membership = tx.outputStates.single() as MembershipState
+            val group = runCreateGroupFlow(authorisedMember, networkId, additionalParticipants = setOf(membership.linearId)).tx.outputStates.single() as GroupState
+            val groupId = group.linearId
+
+            assertFailsWith<IllegalMembershipStatusException> { runModifyGroupFlow(regularMember, groupId, name = "new-name") }
+
+            runActivateMembershipFlow(authorisedMember, membership.linearId)
+            assertFailsWith<MembershipAuthorisationException> { runModifyGroupFlow(regularMember, groupId, name = "new-name") }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if any of the new participants is not member of business network`() {
+        val authorisedMember = authorisedMembers.first()
+
+        val membership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val groupId = getAllGroupsFromVault(authorisedMember, membership.networkId).single().linearId
+
+        assertFailsWith<MembershipNotFoundException> { runModifyGroupFlow(authorisedMember, groupId, participants = setOf(membership.linearId, UniqueIdentifier())) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if any of participants membership is in pending status`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val membership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = membership.networkId
+        val groupId = getAllGroupsFromVault(authorisedMember, networkId).single().linearId
+        val pendingMembership = runRequestMembershipFlow(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        assertFailsWith<IllegalMembershipStatusException> { runModifyGroupFlow(authorisedMember, groupId, participants = setOf(membership.linearId, pendingMembership.linearId)) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if initiator is not new group participant`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val membership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = membership.networkId
+        val groupId = getAllGroupsFromVault(authorisedMember, networkId).single().linearId
+        val activeMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        assertFailsWith<IllegalBusinessNetworkGroupStateException> { runModifyGroupFlow(authorisedMember, groupId, participants = setOf(activeMembership.linearId)) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow should fail if any member remains without any group participation`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val membership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = membership.networkId
+        val groupId = getAllGroupsFromVault(authorisedMember, networkId).single().linearId
+        runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        assertFailsWith<MembershipMissingGroupParticipationException> { runModifyGroupFlow(authorisedMember, groupId, participants = setOf(membership.linearId)) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `modify group flow happy path`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = authorisedMembership.networkId
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val group = runCreateGroupFlow(authorisedMember, networkId).tx.outputStates.single() as GroupState
+        val (newGroup, command) = runModifyGroupFlow(authorisedMember, group.linearId, name = "new-name", participants = setOf(authorisedMembership.linearId, regularMembership.linearId)).run {
+            assertEquals(1, tx.inputs.size)
+            verifyRequiredSignatures()
+            tx.outputs.single() to tx.commands.single()
+        }
+
+        newGroup.apply {
+            assertEquals(GroupContract.CONTRACT_NAME, contract)
+            assertTrue(data is GroupState)
+            val data = data as GroupState
+            assertEquals(networkId, data.networkId)
+            assertEquals("new-name", data.name)
+            assertEquals(setOf(authorisedMember.identity(), regularMember.identity()), data.participants.toSet())
+            assertEquals(group.linearId, data.linearId)
+        }
+        assertTrue(command.value is GroupContract.Commands.Modify)
+
+        // also check ledgers
+        listOf(authorisedMember, regularMember).forEach { member ->
+            getAllGroupsFromVault(member, networkId).run {
+                assertEquals(2, size)
+                single { it.linearId == group.linearId }
+            }.apply {
+                assertEquals(2, participants.size, "Vault size assertion failed for ${member.identity()}")
+                assertTrue(participants.any { it == authorisedMember.identity() }, "Expected to have ${authorisedMember.identity()} in new group of ${member.identity()} vault")
+                assertTrue(participants.any { it == regularMember.identity() }, "Expected to have ${regularMember.identity()} in new group of ${member.identity()} vault")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR is direct continuation to [Business Network Group management PR](https://github.com/corda/corda/pull/6444) in which we add supporting test coverage.

First we adapt `CreateBusinessNetworkFlowTest` and `MembershipManagementFlowTest` so they test group management related logic.

After that we introduce 3 new test classes which test new added group management flows:
- `CreateGroupFlowTest`
- `ModifyGroupFlowTest`
- `DeleteGroupFlowTest`

## Test Plan

Ensure all existing and new BN related tests pass.