### PR TITLE
CORDA-3892: Upgrade to Gradle 5.6.4 again, with build fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -662,7 +662,7 @@ if (file('corda-docs-only-build').exists() || (System.getenv('CORDA_DOCS_ONLY_BU
 }
 
 wrapper {
-    gradleVersion = "5.4.1"
+    gradleVersion = '5.6.4'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-jpa'
 apply plugin: 'net.corda.plugins.quasar-utils'
-apply plugin: 'net.corda.plugins.publish-utils'
 
 description 'Corda core tests'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.4.1-all.zip
+distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -20,6 +20,11 @@ ext {
     jolokia_version = constants.getProperty('jolokiaAgentVersion')
 }
 
+evaluationDependsOn(':core-deterministic')
+evaluationDependsOn(':serialization-deterministic')
+evaluationDependsOn(':serialization-djvm:deserializers')
+evaluationDependsOn(':node:djvm')
+
 //noinspection GroovyAssignabilityCheck
 configurations {
     integrationTestCompile.extendsFrom testCompile
@@ -256,13 +261,13 @@ tasks.withType(Test).configureEach {
     systemProperty 'deterministic-sources.path', configurations.deterministic.asPath
 }
 
-task integrationTest(type: Test) {
+tasks.register('integrationTest', Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     maxParallelForks = (System.env.CORDA_NODE_INT_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_INT_TESTING_FORKS".toInteger()
 }
 
-task slowIntegrationTest(type: Test) {
+tasks.register('slowIntegrationTest', Test) {
     testClassesDirs = sourceSets.slowIntegrationTest.output.classesDirs
     classpath = sourceSets.slowIntegrationTest.runtimeClasspath
     maxParallelForks = 1
@@ -320,7 +325,7 @@ publish {
     name jar.baseName
 }
 
-test {
+tasks.named('test', Test) {
     maxHeapSize = "3g"
     maxParallelForks = (System.env.CORDA_NODE_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_TESTING_FORKS".toInteger()
 }


### PR DESCRIPTION
Restore Gradle 5.6.4, with fixes for the `:node` module to prevent lazy task registration during some modules' `afterEvaluate` handlers.