### PR TITLE
NOTICK: Avoid configuring more Gradle tasks in the deterministic modules.

### DIFF
--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -54,8 +54,8 @@ tasks.named('jar', Jar) {
     enabled = false
 }
 
-def coreJarTask = tasks.getByPath(':core:jar')
-def originalJar = coreJarTask.outputs.files.singleFile
+def coreJarTask = project(':core').tasks.named('jar', Jar)
+def originalJar = coreJarTask.map { it.outputs.files.singleFile }
 
 def patchCore = tasks.register('patchCore', Zip) {
     dependsOn coreJarTask
@@ -132,7 +132,7 @@ def jarFilter = tasks.register('jarFilter', JarFilterTask) {
     }
 }
 
-task determinise(type: ProGuardTask) {
+def determinise = tasks.register('determinise', ProGuardTask) {
     injars jarFilter
     outjars file("$buildDir/proguard/$jarBaseName-${project.version}.jar")
 
@@ -166,17 +166,20 @@ task determinise(type: ProGuardTask) {
     keepclassmembers 'class net.corda.core.** { public synthetic <methods>; }'
 }
 
-task metafix(type: MetaFixerTask) {
+def checkDeterminism = tasks.register('checkDeterminism', ProGuardTask)
+
+def metafix = tasks.register('metafix', MetaFixerTask) {
     outputDir file("$buildDir/libs")
     jars determinise
     suffix ""
 
     // Strip timestamps from the JAR to make it reproducible.
     preserveTimestamps = false
+    finalizedBy checkDeterminism
 }
 
 // DOCSTART 01
-def checkDeterminism = tasks.register('checkDeterminism', ProGuardTask) {
+checkDeterminism.configure {
     dependsOn jdkTask
     injars metafix
 
@@ -197,14 +200,17 @@ def checkDeterminism = tasks.register('checkDeterminism', ProGuardTask) {
 // DOCEND 01
 
 defaultTasks "determinise"
-determinise.finalizedBy metafix
-metafix.finalizedBy checkDeterminism
-assemble.dependsOn checkDeterminism
+determinise.configure {
+    finalizedBy metafix
+}
+tasks.named('assemble') {
+    dependsOn checkDeterminism
+}
 
-def deterministicJar = metafix.outputs.files.singleFile
+def deterministicJar = metafix.map { it.outputs.files.singleFile }
 artifacts {
-    deterministicArtifacts file: deterministicJar, name: jarBaseName, type: 'jar', extension: 'jar', builtBy: metafix
-    publish file: deterministicJar, name: jarBaseName, type: 'jar', extension: 'jar', builtBy: metafix
+    deterministicArtifacts deterministicJar
+    publish deterministicJar
 }
 
 tasks.named('sourceJar', Jar) {

--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -11,7 +11,7 @@ evaluationDependsOn(':jdk8u-deterministic')
 def jdk8uDeterministic = project(':jdk8u-deterministic')
 
 ext {
-    jdkTask = jdk8uDeterministic.assemble
+    jdkTask = jdk8uDeterministic.tasks.named('assemble')
     deterministic_jdk_home = jdk8uDeterministic.jdk_home
     deterministic_rt_jar = jdk8uDeterministic.rt_jar
 }

--- a/jdk8u-deterministic/build.gradle
+++ b/jdk8u-deterministic/build.gradle
@@ -37,7 +37,9 @@ def copyJdk = tasks.register('copyJdk', Copy) {
     }
 }
 
-assemble.dependsOn copyJdk
+tasks.named('assemble') {
+    dependsOn copyJdk
+}
 tasks.named('jar', Jar)  {
     enabled = false
 }

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -39,9 +39,9 @@ capsule {
 def nodeProject = project(':node')
 
 task buildCordaJAR(type: FatCapsule, dependsOn: [
-        nodeProject.tasks.jar,
-        project(':core-deterministic').tasks.assemble,
-        project(':serialization-deterministic').tasks.assemble
+        nodeProject.tasks.named('jar'),
+        project(':core-deterministic').tasks.named('assemble'),
+        project(':serialization-deterministic').tasks.named('assemble')
     ]) {
     applicationClass 'net.corda.node.Corda'
     archiveBaseName = 'corda'

--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -50,8 +50,8 @@ tasks.named('jar', Jar) {
     enabled = false
 }
 
-def serializationJarTask = tasks.getByPath(':serialization:jar')
-def originalJar = serializationJarTask.outputs.files.singleFile
+def serializationJarTask = project(':serialization').tasks.named('jar', Jar)
+def originalJar = serializationJarTask.map { it.outputs.files.singleFile }
 
 def patchSerialization = tasks.register('patchSerialization', Zip) {
     dependsOn serializationJarTask
@@ -77,7 +77,7 @@ def patchSerialization = tasks.register('patchSerialization', Zip) {
 }
 
 def predeterminise = tasks.register('predeterminise', ProGuardTask) {
-    dependsOn project(':core-deterministic').assemble
+    dependsOn project(':core-deterministic').tasks.named('assemble')
     injars patchSerialization
     outjars file("$buildDir/proguard/pre-deterministic-${project.version}.jar")
 
@@ -125,7 +125,7 @@ def jarFilter = tasks.register('jarFilter', JarFilterTask) {
     }
 }
 
-task determinise(type: ProGuardTask) {
+def determinise = tasks.register('determinise', ProGuardTask) {
     injars jarFilter
     outjars file("$buildDir/proguard/$jarBaseName-${project.version}.jar")
 
@@ -154,16 +154,19 @@ task determinise(type: ProGuardTask) {
     keepclassmembers 'class net.corda.serialization.** { public synthetic <methods>; }'
 }
 
-task metafix(type: MetaFixerTask) {
+def checkDeterminism = tasks.register('checkDeterminism', ProGuardTask)
+
+def metafix = tasks.register('metafix', MetaFixerTask) {
     outputDir file("$buildDir/libs")
     jars determinise
     suffix ""
 
     // Strip timestamps from the JAR to make it reproducible.
     preserveTimestamps = false
+    finalizedBy checkDeterminism
 }
 
-def checkDeterminism = tasks.register('checkDeterminism', ProGuardTask) {
+checkDeterminism.configure {
     dependsOn jdkTask
     injars metafix
 
@@ -183,14 +186,17 @@ def checkDeterminism = tasks.register('checkDeterminism', ProGuardTask) {
 }
 
 defaultTasks "determinise"
-determinise.finalizedBy metafix
-metafix.finalizedBy checkDeterminism
-assemble.dependsOn checkDeterminism
+determinise.configure {
+    finalizedBy metafix
+}
+tasks.named('assemble') {
+    dependsOn checkDeterminism
+}
 
-def deterministicJar = metafix.outputs.files.singleFile
+def deterministicJar = metafix.map { it.outputs.files.singleFile }
 artifacts {
-    deterministicArtifacts file: deterministicJar, name: jarBaseName, type: 'jar', extension: 'jar', builtBy: metafix
-    publish file: deterministicJar, name: jarBaseName, type: 'jar', extension: 'jar', builtBy: metafix
+    deterministicArtifacts deterministicJar
+    publish deterministicJar
 }
 
 tasks.named('sourceJar', Jar) {


### PR DESCRIPTION
Replace more eager `Task` objects with lazy `TaskProvider` objects.