### PR TITLE
CORDA-3879 - query with OR combinator returns too many results

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -614,7 +614,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             val joinPredicate = if(IndirectStatePersistable::class.java.isAssignableFrom(entityRoot.javaType)) {
                         criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<IndirectStatePersistable<*>>("compositeKey").get<PersistentStateRef>("stateRef"))
                     } else {
-                criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
+                        criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
             }
             predicateSet.add(joinPredicate)
 
@@ -661,9 +661,14 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
 
         rootEntities.values.forEach {
             if (it != vaultStates) {
-                returnSet.add(criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), it.get<PersistentStateRef>("stateRef")))
+                if(IndirectStatePersistable::class.java.isAssignableFrom(it.javaType)) {
+                    returnSet.add(criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), it.get<IndirectStatePersistable<*>>("compositeKey").get<PersistentStateRef>("stateRef")))
+                } else {
+                    returnSet.add(criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), it.get<PersistentStateRef>("stateRef")))
+                }
             }
         }
+
         return returnSet
     }
 
@@ -863,8 +868,6 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                         // scenario where sorting on attributes not parsed as criteria
                         val entityRoot = criteriaQuery.from(entityStateClass)
                         rootEntities[entityStateClass] = entityRoot
-                        val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
-                        joinPredicates.add(joinPredicate)
                         entityRoot
                     }
             when (direction) {
@@ -883,7 +886,6 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
         }
         if (orderCriteria.isNotEmpty()) {
             criteriaQuery.orderBy(orderCriteria)
-            criteriaQuery.where(*joinPredicates.toTypedArray())
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -632,6 +632,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
         return predicateSet
     }
 
+    @Suppress("SpreadOperator")
     override fun parse(criteria: QueryCriteria, sorting: Sort?): Collection<Predicate> {
         val predicateSet = criteria.visit(this)
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -278,6 +278,8 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
         private val log = contextLogger()
     }
 
+    // incrementally build list of join predicates
+    private val joinPredicates = mutableListOf<Predicate>()
     // incrementally build list of root entities (for later use in Sort parsing)
     private val rootEntities = mutableMapOf<Class<out StatePersistable>, Root<*>>(Pair(VaultSchemaV1.VaultStates::class.java, vaultStates))
     private val aggregateExpressions = mutableListOf<Expression<*>>()
@@ -476,6 +478,9 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
 
         // ensure we re-use any existing instance of the same root entity
         val vaultFungibleStatesRoot = getVaultFungibleStateRoot()
+        val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"),
+                vaultFungibleStatesRoot.get<PersistentStateRef>("stateRef"))
+        predicateSet.add(joinPredicate)
 
         // owner
         criteria.owner?.let {
@@ -544,6 +549,9 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
 
         // ensure we re-use any existing instance of the same root entity
         val vaultLinearStatesRoot = getVaultLinearStatesRoot()
+        val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"),
+                vaultLinearStatesRoot.get<PersistentStateRef>("stateRef"))
+        predicateSet.add(joinPredicate)
 
         // linear ids UUID
         criteria.uuid?.let {
@@ -602,6 +610,13 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                         entityRoot
                     }
 
+            val joinPredicate = if(IndirectStatePersistable::class.java.isAssignableFrom(entityRoot.javaType)) {
+                criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<IndirectStatePersistable<*>>("compositeKey").get<PersistentStateRef>("stateRef"))
+            } else {
+                criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
+            }
+            predicateSet.add(joinPredicate)
+
             // resolve general criteria expressions
             @Suppress("UNCHECKED_CAST")
             parseExpression(entityRoot as Root<L>, criteria.expression, predicateSet)
@@ -633,8 +648,15 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
         criteriaQuery.multiselect(selections)
         val combinedPredicates = commonPredicates.values.plus(predicateSet)
                 .plus(constraintPredicates)
+                .plus(joinPredicates)
 
-        criteriaQuery.where(*combinedPredicates.toTypedArray(), *joinStateRefPredicate().toTypedArray())
+        val forceJoinPredicates = joinStateRefPredicate()
+
+        if(forceJoinPredicates.isEmpty()) {
+            criteriaQuery.where(*combinedPredicates.toTypedArray())
+        } else {
+            criteriaQuery.where(*combinedPredicates.toTypedArray(), criteriaBuilder.or(*forceJoinPredicates.toTypedArray()))
+        }
 
         return predicateSet
     }

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -276,6 +276,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                                    val vaultStates: Root<VaultSchemaV1.VaultStates>) : AbstractQueryCriteriaParser<QueryCriteria, IQueryCriteriaParser, Sort>(), IQueryCriteriaParser {
     private companion object {
         private val log = contextLogger()
+        private val disableCorda3879 = System.getProperty("net.corda.vault.query.disable.corda3879")?.toBoolean() ?: false
     }
 
     // incrementally build list of join predicates
@@ -652,7 +653,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
 
         val forceJoinPredicates = joinStateRefPredicate()
 
-        if(forceJoinPredicates.isEmpty()) {
+        if(forceJoinPredicates.isEmpty() || disableCorda3879) {
             criteriaQuery.where(*combinedPredicates.toTypedArray())
         } else {
             criteriaQuery.where(*combinedPredicates.toTypedArray(), criteriaBuilder.or(*forceJoinPredicates.toTypedArray()))

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryJoinTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryJoinTest.kt
@@ -1,0 +1,131 @@
+package net.corda.node.services.vault
+
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateRef
+import net.corda.core.identity.AbstractParty
+import net.corda.core.node.services.Vault
+import net.corda.core.node.services.queryBy
+import net.corda.core.node.services.vault.DEFAULT_PAGE_SIZE
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.node.services.vault.builder
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import net.corda.core.schemas.QueryableState
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
+import net.corda.testing.node.internal.cordappsForPackages
+import org.junit.BeforeClass
+import org.junit.Test
+import java.lang.IllegalArgumentException
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Index
+import javax.persistence.Table
+import kotlin.test.assertEquals
+
+class VaultQueryJoinTest {
+    companion object {
+        private val mockNetwork = MockNetwork(
+                MockNetworkParameters(
+                        cordappsForAllNodes = cordappsForPackages(
+                                listOf(
+                                        "net.corda.node.services.vault"
+                                )
+                        )
+                )
+        )
+        private val aliceNode = mockNetwork.createPartyNode(ALICE_NAME)
+        private val notaryNode = mockNetwork.defaultNotaryNode
+        private val serviceHubHandle = aliceNode.services
+        private val createdStateRefs = mutableListOf<StateRef>()
+        private const val numObjectsInLedger = DEFAULT_PAGE_SIZE + 1
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            repeat(numObjectsInLedger) { index ->
+                createdStateRefs.add(addSimpleObjectToLedger(DummyData(index)))
+            }
+        }
+
+        private fun addSimpleObjectToLedger(dummyObject: DummyData): StateRef {
+            val tx = TransactionBuilder(notaryNode.info.legalIdentities.first())
+            tx.addOutputState(
+                    DummyState(dummyObject, listOf(aliceNode.info.identityFromX500Name(ALICE_NAME)))
+            )
+            tx.addCommand(DummyContract.Commands.AddDummy(), aliceNode.info.legalIdentitiesAndCerts.first().owningKey)
+            tx.verify(serviceHubHandle)
+            val stx = serviceHubHandle.signInitialTransaction(tx)
+            serviceHubHandle.recordTransactions(listOf(stx))
+            return StateRef(stx.id, 0)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `filter query with OR operator that returns only one tuple with pagination defined`() {
+        val queryToCheckId = builder {
+            val conditionToCheckId =
+                    DummySchema.DummyState::id
+                            .equal(0)
+            QueryCriteria.VaultCustomQueryCriteria(conditionToCheckId, Vault.StateStatus.UNCONSUMED)
+        }
+
+        val queryToCheckStateRef =
+                QueryCriteria.VaultQueryCriteria(Vault.StateStatus.UNCONSUMED, stateRefs = listOf(createdStateRefs[numObjectsInLedger-1]))
+
+
+        val results = serviceHubHandle.vaultService.queryBy<DummyState>(
+                queryToCheckId.or(queryToCheckStateRef)
+        )
+        assertEquals(2, results.states.size)
+        assertEquals(2, results.statesMetadata.size)
+    }
+}
+
+object DummyStatesV
+
+@Suppress("MagicNumber") // SQL column length
+@CordaSerializable
+object DummySchema : MappedSchema(schemaFamily = DummyStatesV.javaClass, version = 1, mappedTypes = listOf(DummyState::class.java)){
+
+    @Entity
+    @Table(name = "dummy_states", indexes = [Index(name = "dummy_id_index", columnList = "id")])
+    class DummyState (
+            @Column(name = "id", length = 4, nullable = false)
+            var id: Int
+    ) : PersistentState()
+}
+
+@CordaSerializable
+data class DummyData(
+        val id: Int
+)
+
+@BelongsToContract(DummyContract::class)
+data class DummyState(val dummyData: DummyData, override val participants: List<AbstractParty>) :
+        ContractState, QueryableState {
+    override fun supportedSchemas(): Iterable<MappedSchema> = listOf(DummySchema)
+
+
+    override fun generateMappedObject(schema: MappedSchema) =
+            when (schema) {
+                is DummySchema -> DummySchema.DummyState(
+                        dummyData.id
+                )
+                else -> throw IllegalArgumentException("Unsupported Schema")
+            }
+}
+
+class DummyContract : Contract {
+    override fun verify(tx: LedgerTransaction) { }
+    interface Commands : CommandData {
+        class AddDummy : Commands
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryJoinTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryJoinTest.kt
@@ -54,6 +54,8 @@ class VaultQueryJoinTest {
             repeat(numObjectsInLedger) { index ->
                 createdStateRefs.add(addSimpleObjectToLedger(DummyData(index)))
             }
+
+            System.setProperty("net.corda.vault.query.disable.corda3879", "false");
         }
 
         private fun addSimpleObjectToLedger(dummyObject: DummyData): StateRef {

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryJoinTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryJoinTest.kt
@@ -102,10 +102,10 @@ class VaultQueryJoinTest {
 
     @Test(timeout = 300_000)
     fun `filter query with OR operator and sorting`() {
-        val SORTING = Sort(listOf(Sort.SortColumn(SortAttribute.Custom(DummySchema.DummyState::class.java, "stateRef"), Sort.Direction.DESC)))
+        val sorting = Sort(listOf(Sort.SortColumn(SortAttribute.Custom(DummySchema.DummyState::class.java, "stateRef"), Sort.Direction.DESC)))
 
         val results = serviceHubHandle.vaultService.queryBy<DummyState>(
-                queryToCheckId.or(queryToCheckStateRef), sorting = SORTING
+                queryToCheckId.or(queryToCheckStateRef), sorting = sorting
         )
 
         assertEquals(2, results.states.size)


### PR DESCRIPTION
Fix candidate for:
https://r3-cev.atlassian.net/browse/CORDA-3874

Generated query:
`select vs, ds from VAULT_STATES as vs, DUMMY_STATE as ds where ( vs.stateStatus=0 ) and ( vs.contractStateClassName in (‘net.corda.node.services.vault.DummyState’) ) and ( ( ( vs.stateRef=ds.stateRef ) and ( generatedAlias1.id=0 ) ) or ( vs.stateRef in (param) ) ) and ( vs.stateRef=ds.stateRef )`

Another example:
Before:
`select generatedAlias0, generatedAlias1, generatedAlias2 from VaultSchemaV1$VaultStates as generatedAlias0, VaultSchemaV1$VaultFungibleStates as generatedAlias1, VaultSchemaV1$VaultLinearStates as generatedAlias2 where ( generatedAlias0.stateStatus=:param0 ) and ( ( generatedAlias0.stateRef=generatedAlias1.stateRef ) or ( generatedAlias0.stateRef=generatedAlias2.stateRef ) ) `

After:
`select generatedAlias0, generatedAlias1, generatedAlias2 from VaultSchemaV1$VaultStates as generatedAlias0, VaultSchemaV1$VaultFungibleStates as generatedAlias1, VaultSchemaV1$VaultLinearStates as generatedAlias2 where ( generatedAlias0.stateStatus=:param0 ) and ( ( generatedAlias0.stateRef=generatedAlias1.stateRef ) or ( generatedAlias0.stateRef=generatedAlias2.stateRef ) ) and ( ( generatedAlias0.stateRef=generatedAlias1.stateRef ) or ( generatedAlias0.stateRef=generatedAlias2.stateRef ) )`