### PR TITLE
CORDA-3906: Allow usage of SchedulableState in deterministic CorDapps.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -89,6 +89,7 @@ interface OwnableState : ContractState {
 // DOCEND 3
 
 /** Something which is scheduled to happen at a point in time. */
+@KeepForDJVM
 interface Scheduled {
     val scheduledAt: Instant
 }
@@ -101,6 +102,7 @@ interface Scheduled {
  * lifecycle processing needs to take place.  e.g. a fixing or a late payment etc.
  */
 @CordaSerializable
+@KeepForDJVM
 data class ScheduledStateRef(val ref: StateRef, override val scheduledAt: Instant) : Scheduled
 
 /**
@@ -115,7 +117,7 @@ data class ScheduledStateRef(val ref: StateRef, override val scheduledAt: Instan
  * for a particular [ContractState] have been processed/fired etc.  If the activity is not "on ledger" then the
  * scheduled activity shouldn't be either.
  */
-@DeleteForDJVM
+@KeepForDJVM
 data class ScheduledActivity(val logicRef: FlowLogicRef, override val scheduledAt: Instant) : Scheduled
 
 // DOCSTART 2
@@ -134,7 +136,7 @@ interface LinearState : ContractState {
     val linearId: UniqueIdentifier
 }
 // DOCEND 2
-@DeleteForDJVM
+@KeepForDJVM
 interface SchedulableState : ContractState {
     /**
      * Indicate whether there is some activity to be performed at some future point in time with respect to this

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt
@@ -1,7 +1,9 @@
 package net.corda.core.flows
 
 import net.corda.core.CordaInternal
+import net.corda.core.DeleteForDJVM
 import net.corda.core.DoNotImplement
+import net.corda.core.KeepForDJVM
 import net.corda.core.serialization.CordaSerializable
 
 /**
@@ -11,11 +13,13 @@ import net.corda.core.serialization.CordaSerializable
  * the flow to run at the scheduled time.
  */
 @DoNotImplement
+@KeepForDJVM
 interface FlowLogicRefFactory {
     /**
      * Construct a FlowLogicRef. This is intended for cases where the calling code has the relevant class already
      * and can provide it directly.
      */
+    @DeleteForDJVM
     fun create(flowClass: Class<out FlowLogic<*>>, vararg args: Any?): FlowLogicRef
 
     /**
@@ -30,12 +34,14 @@ interface FlowLogicRefFactory {
      * [SchedulableFlow] annotation.
      */
     @CordaInternal
+    @DeleteForDJVM
     fun createForRPC(flowClass: Class<out FlowLogic<*>>, vararg args: Any?): FlowLogicRef
 
     /**
      * Converts a [FlowLogicRef] object that was obtained from the calls above into a [FlowLogic], after doing some
      * validation to ensure it points to a legitimate flow class.
      */
+    @DeleteForDJVM
     fun toFlowLogic(ref: FlowLogicRef): FlowLogic<*>
 }
 
@@ -59,4 +65,5 @@ class IllegalFlowLogicException(val type: String, msg: String) :
 // TODO: align this with the existing [FlowRef] in the bank-side API (probably replace some of the API classes)
 @CordaSerializable
 @DoNotImplement
+@KeepForDJVM
 interface FlowLogicRef


### PR DESCRIPTION
Allow deterministic CorDapps to create states that implement the `SchedulableState` interface. These states will only be able to invoke the following `FlowLogicRefFactory` method:
```kotlin
@DoNotImplement
interface FlowLogicRefFactory {
    fun create(flowClassName: String, vararg args: Any?): FlowLogicRef
}
```
It is highly probable that any `SchedulableState.nextScheduledActivity()` methods will still be unable to _run_ inside the DJVM sandbox. This PR only intends to allow such states to be created in the first place.