### PR TITLE
CORDA-3909: Upgrade to Corda Gradle plugins 5.0.11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,6 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath "net.corda.plugins:publish-utils:$gradle_plugins_version"
         classpath "net.corda.plugins:quasar-utils:$gradle_plugins_version"
         classpath "net.corda.plugins:cordformation:$gradle_plugins_version"
@@ -204,7 +203,6 @@ plugins {
 apply plugin: 'project-report'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'net.corda.plugins.publish-utils'
-apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: "com.bmuschko.docker-remote-api"
 apply plugin: "com.r3.dependx.dependxies"
@@ -626,7 +624,7 @@ dependxiesModule {
     skipTasks = "test,integrationTest,smokeTest,slowIntegrationTest"
 }
 
-tasks.register('generateApi', net.corda.plugins.GenerateApi) {
+tasks.register('generateApi', net.corda.plugins.apiscanner.GenerateApi) {
     baseName = "api-corda"
 }
 

--- a/constants.properties
+++ b/constants.properties
@@ -4,7 +4,7 @@
 
 cordaVersion=4.6
 versionSuffix=SNAPSHOT
-gradlePluginsVersion=5.0.9
+gradlePluginsVersion=5.0.11
 kotlinVersion=1.2.71
 java8MinUpdateVersion=171
 # ***************************************************************#
@@ -25,7 +25,7 @@ classgraphVersion=4.8.78
 disruptorVersion=3.4.2
 typesafeConfigVersion=1.3.4
 jsr305Version=3.0.2
-artifactoryPluginVersion=4.7.3
+artifactoryPluginVersion=4.16.1
 snakeYamlVersion=1.19
 caffeineVersion=2.7.0
 metricsVersion=4.1.0


### PR DESCRIPTION
This also upgrades the following plugins:
- Artifactory: 4.7.3 -> 4.16.1
- Bintray: 1.4 -> 1.8.5