### PR TITLE
CORDA-3692 - Store result information in checkpoint results table

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/WithFinality.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/WithFinality.kt
@@ -6,7 +6,7 @@ import com.natpryce.hamkrest.Matcher
 import com.natpryce.hamkrest.equalTo
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.startFlow
@@ -16,7 +16,7 @@ import net.corda.testing.node.internal.TestStartedNode
 
 interface WithFinality : WithMockNet {
     //region Operations
-    fun TestStartedNode.finalise(stx: SignedTransaction, vararg recipients: Party): FlowStateMachine<SignedTransaction> {
+    fun TestStartedNode.finalise(stx: SignedTransaction, vararg recipients: Party): FlowStateMachineHandle<SignedTransaction> {
         return startFlowAndRunNetwork(FinalityInvoker(stx, recipients.toSet(), emptySet()))
     }
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/WithMockNet.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/WithMockNet.kt
@@ -6,7 +6,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.testing.core.makeUnique
@@ -48,12 +48,12 @@ interface WithMockNet {
     /**
      * Start a flow
      */
-    fun <T> TestStartedNode.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = services.startFlow(logic)
+    fun <T> TestStartedNode.startFlow(logic: FlowLogic<T>): FlowStateMachineHandle<T> = services.startFlow(logic)
 
     /**
      * Start a flow and run the network immediately afterwards
      */
-    fun <T> TestStartedNode.startFlowAndRunNetwork(logic: FlowLogic<T>): FlowStateMachine<T> =
+    fun <T> TestStartedNode.startFlowAndRunNetwork(logic: FlowLogic<T>): FlowStateMachineHandle<T> =
             startFlow(logic).andRunNetwork()
 
     fun TestStartedNode.createConfidentialIdentity(party: Party) =

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -24,8 +24,8 @@ data class InvocationContext(
     val actor: Actor?,
     val externalTrace: Trace? = null,
     val impersonatedActor: Actor? = null,
-    val clientId: String? = null,
-    val arguments: List<Any?> = emptyList()
+    val arguments: List<Any?> = emptyList(),
+    val clientId: String? = null
 ) {
 
     constructor(
@@ -34,7 +34,7 @@ data class InvocationContext(
         actor: Actor?,
         externalTrace: Trace? = null,
         impersonatedActor: Actor? = null
-    ) : this(origin, trace, actor, externalTrace, impersonatedActor, null, emptyList())
+    ) : this(origin, trace, actor, externalTrace, impersonatedActor, emptyList())
 
     companion object {
         /**
@@ -50,9 +50,9 @@ data class InvocationContext(
             actor: Actor? = null,
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
-            clientId: String? = null,
-            arguments: List<Any?> = emptyList()
-        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, clientId, arguments)
+            arguments: List<Any?> = emptyList(),
+            clientId: String? = null
+        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, arguments, clientId)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.RPC] origin.
@@ -66,7 +66,7 @@ data class InvocationContext(
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
             arguments: List<Any?> = emptyList()
-        ): InvocationContext = newInstance(InvocationOrigin.RPC(actor), trace, actor, externalTrace, impersonatedActor, null, arguments)
+        ): InvocationContext = newInstance(InvocationOrigin.RPC(actor), trace, actor, externalTrace, impersonatedActor, arguments)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.Peer] origin.

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -24,7 +24,7 @@ data class InvocationContext(
     val actor: Actor?,
     val externalTrace: Trace? = null,
     val impersonatedActor: Actor? = null,
-    val clientID: String? = null,
+    val clientId: String? = null,
     val arguments: List<Any?> = emptyList()
 ) {
 
@@ -50,9 +50,9 @@ data class InvocationContext(
             actor: Actor? = null,
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
-            clientID: String? = null,
+            clientId: String? = null,
             arguments: List<Any?> = emptyList()
-        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, clientID, arguments)
+        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, clientId, arguments)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.RPC] origin.
@@ -108,7 +108,7 @@ data class InvocationContext(
         actor: Actor? = this.actor,
         externalTrace: Trace? = this.externalTrace,
         impersonatedActor: Actor? = this.impersonatedActor,
-        clientID: String? = this.clientID
+        clientId: String? = this.clientId
     ): InvocationContext {
         return copy(
             origin = origin,
@@ -116,7 +116,7 @@ data class InvocationContext(
             actor = actor,
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
-            clientID = clientID,
+            clientId = clientId,
             arguments = arguments
         )
     }

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -117,7 +117,7 @@ data class InvocationContext(
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
             clientId = clientId,
-            arguments = this.arguments
+            arguments = arguments
         )
     }
 }

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -24,7 +24,7 @@ data class InvocationContext(
     val actor: Actor?,
     val externalTrace: Trace? = null,
     val impersonatedActor: Actor? = null,
-    val clientUUID: String? = null,
+    val clientID: String? = null,
     val arguments: List<Any?> = emptyList()
 ) {
 
@@ -50,9 +50,9 @@ data class InvocationContext(
             actor: Actor? = null,
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
-            clientUUID: String? = null,
+            clientID: String? = null,
             arguments: List<Any?> = emptyList()
-        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, clientUUID, arguments)
+        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, clientID, arguments)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.RPC] origin.
@@ -108,7 +108,7 @@ data class InvocationContext(
         actor: Actor? = this.actor,
         externalTrace: Trace? = this.externalTrace,
         impersonatedActor: Actor? = this.impersonatedActor,
-        clientUUID: String? = this.clientUUID
+        clientID: String? = this.clientID
     ): InvocationContext {
         return copy(
             origin = origin,
@@ -116,7 +116,7 @@ data class InvocationContext(
             actor = actor,
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
-            clientUUID = clientUUID,
+            clientID = clientID,
             arguments = arguments
         )
     }

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -24,7 +24,7 @@ data class InvocationContext(
     val actor: Actor?,
     val externalTrace: Trace? = null,
     val impersonatedActor: Actor? = null,
-    val arguments: List<Any?> = emptyList(),
+    val arguments: List<Any?>? = emptyList(), // 'arguments' is nullable so that a - >= 4.6 version - RPC client can be backwards compatible against - < 4.6 version - nodes
     val clientId: String? = null
 ) {
 

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -24,6 +24,7 @@ data class InvocationContext(
     val actor: Actor?,
     val externalTrace: Trace? = null,
     val impersonatedActor: Actor? = null,
+    val clientUUID: String? = null,
     val arguments: List<Any?> = emptyList()
 ) {
 
@@ -33,7 +34,7 @@ data class InvocationContext(
         actor: Actor?,
         externalTrace: Trace? = null,
         impersonatedActor: Actor? = null
-    ) : this(origin, trace, actor, externalTrace, impersonatedActor, emptyList())
+    ) : this(origin, trace, actor, externalTrace, impersonatedActor, null, emptyList())
 
     companion object {
         /**
@@ -49,8 +50,9 @@ data class InvocationContext(
             actor: Actor? = null,
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
+            clientUUID: String? = null,
             arguments: List<Any?> = emptyList()
-        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, arguments)
+        ) = InvocationContext(origin, trace, actor, externalTrace, impersonatedActor, clientUUID, arguments)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.RPC] origin.
@@ -64,7 +66,7 @@ data class InvocationContext(
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
             arguments: List<Any?> = emptyList()
-        ): InvocationContext = newInstance(InvocationOrigin.RPC(actor), trace, actor, externalTrace, impersonatedActor, arguments)
+        ): InvocationContext = newInstance(InvocationOrigin.RPC(actor), trace, actor, externalTrace, impersonatedActor, null, arguments)
 
         /**
          * Creates an [InvocationContext] with [InvocationOrigin.Peer] origin.
@@ -105,7 +107,8 @@ data class InvocationContext(
         trace: Trace = this.trace,
         actor: Actor? = this.actor,
         externalTrace: Trace? = this.externalTrace,
-        impersonatedActor: Actor? = this.impersonatedActor
+        impersonatedActor: Actor? = this.impersonatedActor,
+        clientUUID: String? = this.clientUUID
     ): InvocationContext {
         return copy(
             origin = origin,
@@ -113,6 +116,7 @@ data class InvocationContext(
             actor = actor,
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
+            clientUUID = clientUUID,
             arguments = arguments
         )
     }

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -117,7 +117,7 @@ data class InvocationContext(
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
             clientId = clientId,
-            arguments = arguments
+            arguments = this.arguments
         )
     }
 }

--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -107,8 +107,7 @@ data class InvocationContext(
         trace: Trace = this.trace,
         actor: Actor? = this.actor,
         externalTrace: Trace? = this.externalTrace,
-        impersonatedActor: Actor? = this.impersonatedActor,
-        clientId: String? = this.clientId
+        impersonatedActor: Actor? = this.impersonatedActor
     ): InvocationContext {
         return copy(
             origin = origin,
@@ -116,8 +115,8 @@ data class InvocationContext(
             actor = actor,
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
-            clientId = clientId,
-            arguments = arguments
+            arguments = arguments,
+            clientId = clientId
         )
     }
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -17,6 +17,7 @@ interface FlowStateMachineHandle<FLOWRETURN> {
     val logic: FlowLogic<FLOWRETURN>?
     val id: StateMachineRunId
     val resultFuture: CordaFuture<FLOWRETURN>
+    val clientID: String?
 }
 
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */
@@ -53,9 +54,4 @@ interface FlowStateMachine<FLOWRETURN>: FlowStateMachineHandle<FLOWRETURN> {
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
-    val clientID: String?
-}
-
-interface FlowStateMachineClientIdResult<FLOWRETURN>: FlowStateMachineHandle<FLOWRETURN> {
-    val clientID: String?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -48,4 +48,5 @@ interface FlowStateMachine<FLOWRETURN> {
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
+    val clientUUID: String?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -49,5 +49,5 @@ interface FlowStateMachine<FLOWRETURN> {
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
-    val clientUUID: UUID?
+    val clientUUID: String?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -48,5 +48,5 @@ interface FlowStateMachine<FLOWRETURN> {
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
-    val clientUUID: String?
+    val clientID: String?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -11,7 +11,10 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SerializedBytes
 import org.slf4j.Logger
 
+@DeleteForDJVM
+@DoNotImplement
 interface FlowStateMachineHandle<FLOWRETURN> {
+    val logic: FlowLogic<FLOWRETURN>?
     val id: StateMachineRunId
     val resultFuture: CordaFuture<FLOWRETURN>
 }
@@ -43,7 +46,6 @@ interface FlowStateMachine<FLOWRETURN>: FlowStateMachineHandle<FLOWRETURN> {
 
     fun updateTimedFlowTimeout(timeoutSeconds: Long)
 
-    val logic: FlowLogic<FLOWRETURN>
     val serviceHub: ServiceHub
     val logger: Logger
     val context: InvocationContext

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -11,10 +11,15 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SerializedBytes
 import org.slf4j.Logger
 
+interface FlowStateMachineReturnable<FLOWRETURN> {
+    val id: StateMachineRunId
+    val resultFuture: CordaFuture<FLOWRETURN>
+}
+
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */
 @DeleteForDJVM
 @DoNotImplement
-interface FlowStateMachine<FLOWRETURN> {
+interface FlowStateMachine<FLOWRETURN>: FlowStateMachineReturnable<FLOWRETURN> {
     @Suspendable
     fun <SUSPENDRETURN : Any> suspend(ioRequest: FlowIORequest<SUSPENDRETURN>, maySkipCheckpoint: Boolean): SUSPENDRETURN
 
@@ -41,12 +46,14 @@ interface FlowStateMachine<FLOWRETURN> {
     val logic: FlowLogic<FLOWRETURN>
     val serviceHub: ServiceHub
     val logger: Logger
-    val id: StateMachineRunId
-    val resultFuture: CordaFuture<FLOWRETURN>
     val context: InvocationContext
     val ourIdentity: Party
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
+    val clientID: String?
+}
+
+interface FlowStateMachineClientIdResult<FLOWRETURN>: FlowStateMachineReturnable<FLOWRETURN> {
     val clientID: String?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -10,7 +10,6 @@ import net.corda.core.identity.Party
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SerializedBytes
 import org.slf4j.Logger
-import java.util.UUID
 
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */
 @DeleteForDJVM
@@ -49,5 +48,4 @@ interface FlowStateMachine<FLOWRETURN> {
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
-    val clientUUID: UUID?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -49,5 +49,5 @@ interface FlowStateMachine<FLOWRETURN> {
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
-    val clientUUID: String?
+    val clientUUID: UUID?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -11,7 +11,7 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SerializedBytes
 import org.slf4j.Logger
 
-interface FlowStateMachineReturnable<FLOWRETURN> {
+interface FlowStateMachineHandle<FLOWRETURN> {
     val id: StateMachineRunId
     val resultFuture: CordaFuture<FLOWRETURN>
 }
@@ -19,7 +19,7 @@ interface FlowStateMachineReturnable<FLOWRETURN> {
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */
 @DeleteForDJVM
 @DoNotImplement
-interface FlowStateMachine<FLOWRETURN>: FlowStateMachineReturnable<FLOWRETURN> {
+interface FlowStateMachine<FLOWRETURN>: FlowStateMachineHandle<FLOWRETURN> {
     @Suspendable
     fun <SUSPENDRETURN : Any> suspend(ioRequest: FlowIORequest<SUSPENDRETURN>, maySkipCheckpoint: Boolean): SUSPENDRETURN
 
@@ -54,6 +54,6 @@ interface FlowStateMachine<FLOWRETURN>: FlowStateMachineReturnable<FLOWRETURN> {
     val clientID: String?
 }
 
-interface FlowStateMachineClientIdResult<FLOWRETURN>: FlowStateMachineReturnable<FLOWRETURN> {
+interface FlowStateMachineClientIdResult<FLOWRETURN>: FlowStateMachineHandle<FLOWRETURN> {
     val clientID: String?
 }

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -23,7 +23,7 @@ interface FlowStateMachineHandle<FLOWRETURN> {
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */
 @DeleteForDJVM
 @DoNotImplement
-interface FlowStateMachine<FLOWRETURN>: FlowStateMachineHandle<FLOWRETURN> {
+interface FlowStateMachine<FLOWRETURN> : FlowStateMachineHandle<FLOWRETURN> {
     @Suspendable
     fun <SUSPENDRETURN : Any> suspend(ioRequest: FlowIORequest<SUSPENDRETURN>, maySkipCheckpoint: Boolean): SUSPENDRETURN
 

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -17,7 +17,7 @@ interface FlowStateMachineHandle<FLOWRETURN> {
     val logic: FlowLogic<FLOWRETURN>?
     val id: StateMachineRunId
     val resultFuture: CordaFuture<FLOWRETURN>
-    val clientID: String?
+    val clientId: String?
 }
 
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -10,6 +10,7 @@ import net.corda.core.identity.Party
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SerializedBytes
 import org.slf4j.Logger
+import java.util.UUID
 
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */
 @DeleteForDJVM
@@ -48,4 +49,5 @@ interface FlowStateMachine<FLOWRETURN> {
     val ourSenderUUID: String?
     val creationTime: Long
     val isKilled: Boolean
+    val clientUUID: UUID?
 }

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -281,6 +281,13 @@ interface CordaRPCOps : RPCOps {
      */
     fun killFlow(id: StateMachineRunId): Boolean
 
+    /**
+     * Removes a flow's [clientID] to result/ exception mapping.
+     *
+     * @return whether the mapping was removed.
+     */
+    fun removeClientId(clientID: String): Boolean
+
     /** Returns Node's NodeInfo, assuming this will not change while the node is running. */
     fun nodeInfo(): NodeInfo
 

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -265,7 +265,7 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandleWithClientId<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -264,6 +264,9 @@ interface CordaRPCOps : RPCOps {
     @RPCReturnsObservables
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
+    @RPCReturnsObservables
+    fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the
      * result of running the flow. [logicType] must be annotated with [net.corda.core.flows.StartableByRPC].

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -29,7 +29,6 @@ import java.io.IOException
 import java.io.InputStream
 import java.security.PublicKey
 import java.time.Instant
-import java.util.UUID
 
 /**
  * Represents information about a flow (the name "state machine" is legacy, Kotlin users can use the [FlowInfo] type
@@ -264,9 +263,6 @@ interface CordaRPCOps : RPCOps {
      */
     @RPCReturnsObservables
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
-
-    @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(logicType: Class<out FlowLogic<T>>, clientId: UUID, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -265,7 +265,7 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamicWithClientId(clientUUID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -266,7 +266,7 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamicWithClientId(logicType: Class<out FlowLogic<T>>, clientId: UUID, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -29,6 +29,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.security.PublicKey
 import java.time.Instant
+import java.util.UUID
 
 /**
  * Represents information about a flow (the name "state machine" is legacy, Kotlin users can use the [FlowInfo] type
@@ -265,7 +266,7 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -29,6 +29,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.security.PublicKey
 import java.time.Instant
+import java.util.UUID
 
 /**
  * Represents information about a flow (the name "state machine" is legacy, Kotlin users can use the [FlowInfo] type
@@ -263,6 +264,9 @@ interface CordaRPCOps : RPCOps {
      */
     @RPCReturnsObservables
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+
+    @RPCReturnsObservables
+    fun <T> startFlowDynamicWithClientId(logicType: Class<out FlowLogic<T>>, clientId: UUID, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -29,7 +29,6 @@ import java.io.IOException
 import java.io.InputStream
 import java.security.PublicKey
 import java.time.Instant
-import java.util.UUID
 
 /**
  * Represents information about a flow (the name "state machine" is legacy, Kotlin users can use the [FlowInfo] type
@@ -266,7 +265,7 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -265,7 +265,7 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(clientUUID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -264,6 +264,13 @@ interface CordaRPCOps : RPCOps {
     @RPCReturnsObservables
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
+    /**
+     * Start the given flow with the given arguments and a [clientID]. [logicType] must be annotated
+     * with [net.corda.core.flows.StartableByRPC]. The flow's result/ exception will be available for the client to
+     * re-connect and retrieve them even after the flow's lifetime, by re-calling [startFlowDynamicWithClientId] with the same
+     * [clientID]. Upon calling [removeClientId], the node's resources holding the result/ exception will be freed
+     * and the result/ exception will no longer be available.
+     */
     @RPCReturnsObservables
     fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandleWithClientId<T>
 
@@ -282,7 +289,9 @@ interface CordaRPCOps : RPCOps {
     fun killFlow(id: StateMachineRunId): Boolean
 
     /**
-     * Removes a flow's [clientID] to result/ exception mapping.
+     * Removes a flow's [clientID] to result/ exception mapping. If the mapping is of a running flow, then the mapping will not get removed.
+     *
+     * See [startFlowDynamicWithClientId] for more information.
      *
      * @return whether the mapping was removed.
      */

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -265,14 +265,14 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     /**
-     * Start the given flow with the given arguments and a [clientID]. [logicType] must be annotated
+     * Start the given flow with the given arguments and a [clientId]. [logicType] must be annotated
      * with [net.corda.core.flows.StartableByRPC]. The flow's result/ exception will be available for the client to
      * re-connect and retrieve them even after the flow's lifetime, by re-calling [startFlowDynamicWithClientId] with the same
-     * [clientID]. Upon calling [removeClientId], the node's resources holding the result/ exception will be freed
+     * [clientId]. Upon calling [removeClientId], the node's resources holding the result/ exception will be freed
      * and the result/ exception will no longer be available.
      */
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandleWithClientId<T>
+    fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandleWithClientId<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the
@@ -289,13 +289,13 @@ interface CordaRPCOps : RPCOps {
     fun killFlow(id: StateMachineRunId): Boolean
 
     /**
-     * Removes a flow's [clientID] to result/ exception mapping. If the mapping is of a running flow, then the mapping will not get removed.
+     * Removes a flow's [clientId] to result/ exception mapping. If the mapping is of a running flow, then the mapping will not get removed.
      *
      * See [startFlowDynamicWithClientId] for more information.
      *
      * @return whether the mapping was removed.
      */
-    fun removeClientId(clientID: String): Boolean
+    fun removeClientId(clientId: String): Boolean
 
     /** Returns Node's NodeInfo, assuming this will not change while the node is running. */
     fun nodeInfo(): NodeInfo

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -562,6 +562,79 @@ inline fun <T, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.startFlow
 ): FlowHandle<T> = startFlowDynamic(R::class.java, arg0, arg1, arg2, arg3, arg4, arg5)
 
 /**
+ * Extension function for type safe invocation of flows from Kotlin, with [clientId].
+ */
+@Suppress("unused")
+inline fun <T, reified R : FlowLogic<T>> CordaRPCOps.startFlowWithClientId(
+    clientId: String,
+    @Suppress("unused_parameter")
+    flowConstructor: () -> R
+): FlowHandleWithClientId<T> = startFlowDynamicWithClientId(clientId, R::class.java)
+
+@Suppress("unused")
+inline fun <T, A, reified R : FlowLogic<T>> CordaRPCOps.startFlowWithClientId(
+    clientId: String,
+    @Suppress("unused_parameter")
+    flowConstructor: (A) -> R,
+    arg0: A
+): FlowHandleWithClientId<T> = startFlowDynamicWithClientId(clientId, R::class.java, arg0)
+
+@Suppress("unused")
+inline fun <T, A, B, reified R : FlowLogic<T>> CordaRPCOps.startFlowWithClientId(
+    clientId: String,
+    @Suppress("unused_parameter")
+    flowConstructor: (A, B) -> R,
+    arg0: A,
+    arg1: B
+): FlowHandleWithClientId<T> = startFlowDynamicWithClientId(clientId, R::class.java, arg0, arg1)
+
+@Suppress("unused")
+inline fun <T, A, B, C, reified R : FlowLogic<T>> CordaRPCOps.startFlowWithClientId(
+    clientId: String,
+    @Suppress("unused_parameter")
+    flowConstructor: (A, B, C) -> R,
+    arg0: A,
+    arg1: B,
+    arg2: C
+): FlowHandleWithClientId<T> = startFlowDynamicWithClientId(clientId, R::class.java, arg0, arg1, arg2)
+
+@Suppress("unused")
+inline fun <T, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startFlowWithClientId(
+    clientId: String,
+    @Suppress("unused_parameter")
+    flowConstructor: (A, B, C, D) -> R,
+    arg0: A,
+    arg1: B,
+    arg2: C,
+    arg3: D
+): FlowHandleWithClientId<T> = startFlowDynamicWithClientId(clientId, R::class.java, arg0, arg1, arg2, arg3)
+
+@Suppress("unused")
+inline fun <T, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startFlowWithClientId(
+    clientId: String,
+    @Suppress("unused_parameter")
+    flowConstructor: (A, B, C, D, E) -> R,
+    arg0: A,
+    arg1: B,
+    arg2: C,
+    arg3: D,
+    arg4: E
+): FlowHandleWithClientId<T> = startFlowDynamicWithClientId(clientId, R::class.java, arg0, arg1, arg2, arg3, arg4)
+
+@Suppress("unused")
+inline fun <T, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.startFlowWithClientId(
+    clientId: String,
+    @Suppress("unused_parameter")
+    flowConstructor: (A, B, C, D, E, F) -> R,
+    arg0: A,
+    arg1: B,
+    arg2: C,
+    arg3: D,
+    arg4: E,
+    arg5: F
+): FlowHandleWithClientId<T> = startFlowDynamicWithClientId(clientId, R::class.java, arg0, arg1, arg2, arg3, arg4, arg5)
+
+/**
  * Extension function for type safe invocation of flows from Kotlin, with progress tracking enabled.
  */
 @Suppress("unused")

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -266,7 +266,7 @@ interface CordaRPCOps : RPCOps {
     fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     @RPCReturnsObservables
-    fun <T> startFlowDynamicWithClientId(logicType: Class<out FlowLogic<T>>, clientId: UUID, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the

--- a/core/src/main/kotlin/net/corda/core/messaging/FlowHandle.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/FlowHandle.kt
@@ -28,6 +28,14 @@ interface FlowHandle<A> : AutoCloseable {
     override fun close()
 }
 
+interface FlowHandleWithClientId<A> : FlowHandle<A> {
+
+    /**
+     * The [clientID] with which the client has started the flow.
+     */
+    val clientID: String
+}
+
 /**
  * [FlowProgressHandle] is a serialisable handle for the started flow, parameterised by the type of the flow's return value.
  */
@@ -59,6 +67,18 @@ interface FlowProgressHandle<A> : FlowHandle<A> {
 data class FlowHandleImpl<A>(
         override val id: StateMachineRunId,
         override val returnValue: CordaFuture<A>) : FlowHandle<A> {
+
+    // Remember to add @Throws to FlowHandle.close() if this throws an exception.
+    override fun close() {
+        returnValue.cancel(false)
+    }
+}
+
+@CordaSerializable
+data class FlowHandleWithClientIdImpl<A>(
+        override val id: StateMachineRunId,
+        override val returnValue: CordaFuture<A>,
+        override val clientID: String) : FlowHandleWithClientId<A> {
 
     // Remember to add @Throws to FlowHandle.close() if this throws an exception.
     override fun close() {

--- a/core/src/main/kotlin/net/corda/core/messaging/FlowHandle.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/FlowHandle.kt
@@ -31,9 +31,9 @@ interface FlowHandle<A> : AutoCloseable {
 interface FlowHandleWithClientId<A> : FlowHandle<A> {
 
     /**
-     * The [clientID] with which the client has started the flow.
+     * The [clientId] with which the client has started the flow.
      */
-    val clientID: String
+    val clientId: String
 }
 
 /**
@@ -78,7 +78,7 @@ data class FlowHandleImpl<A>(
 data class FlowHandleWithClientIdImpl<A>(
         override val id: StateMachineRunId,
         override val returnValue: CordaFuture<A>,
-        override val clientID: String) : FlowHandleWithClientId<A> {
+        override val clientId: String) : FlowHandleWithClientId<A> {
 
     // Remember to add @Throws to FlowHandle.close() if this throws an exception.
     override fun close() {

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -9,23 +9,11 @@
     <ID>ClassNaming:BuyerFlow.kt$BuyerFlow$STARTING_BUY : Step</ID>
     <ID>ClassNaming:CompositeMemberCompositeSchemaToClassCarpenterTests.kt$I_</ID>
     <ID>ClassNaming:CordaServiceTest.kt$CordaServiceTest.DummyServiceFlow.Companion$TEST_STEP : Step</ID>
-    <ID>ClassNaming:CustomVaultQuery.kt$TopupIssuerFlow.TopupIssuer.Companion$AWAITING_REQUEST : Step</ID>
-    <ID>ClassNaming:CustomVaultQuery.kt$TopupIssuerFlow.TopupIssuer.Companion$SENDING_TOP_UP_ISSUE_REQUEST : Step</ID>
     <ID>ClassNaming:DeserializeNeedingCarpentryTests.kt$DeserializeNeedingCarpentryTests$outer</ID>
     <ID>ClassNaming:FlowCheckpointCordapp.kt$SendMessageFlow.Companion$FINALISING_TRANSACTION : Step</ID>
     <ID>ClassNaming:FlowCheckpointCordapp.kt$SendMessageFlow.Companion$GENERATING_TRANSACTION : Step</ID>
     <ID>ClassNaming:FlowCheckpointCordapp.kt$SendMessageFlow.Companion$SIGNING_TRANSACTION : Step</ID>
     <ID>ClassNaming:FlowCheckpointCordapp.kt$SendMessageFlow.Companion$VERIFYING_TRANSACTION : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$EXTRACTING_VAULT_STATES : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$ID_OTHER_NODES : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$OTHER_TX_COMPONENTS : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$SENDING_AND_RECEIVING_DATA : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$SIGS_GATHERING : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$TX_BUILDING : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$TX_SIGNING : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$TX_VERIFICATION : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$InitiatorFlow.Companion$VERIFYING_SIGS : Step</ID>
-    <ID>ClassNaming:FlowCookbook.kt$ResponderFlow.Companion$RECEIVING_AND_SENDING_DATA : Step</ID>
     <ID>ClassNaming:FlowFrameworkTests.kt$ExceptionFlow$START_STEP : Step</ID>
     <ID>ClassNaming:FlowFrameworkTests.kt$InitiatedReceiveFlow$RECEIVED_STEP : Step</ID>
     <ID>ClassNaming:FlowFrameworkTests.kt$InitiatedReceiveFlow$START_STEP : Step</ID>
@@ -178,7 +166,6 @@
     <ID>ComplexMethod:RPCServer.kt$RPCServer$private fun clientArtemisMessageHandler(artemisMessage: ClientMessage)</ID>
     <ID>ComplexMethod:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ private tailrec fun establishConnectionWithRetry( retryInterval: Duration, roundRobinIndex: Int = 0, retries: Int = -1 ): CordaRPCConnection?</ID>
     <ID>ComplexMethod:RemoteTypeCarpenter.kt$SchemaBuildingRemoteTypeCarpenter$override fun carpent(typeInformation: RemoteTypeInformation): Type</ID>
-    <ID>ComplexMethod:RpcReconnectTests.kt$RpcReconnectTests$ @Test(timeout=300_000) fun `test that the RPC client is able to reconnect and proceed after node failure, restart, or connection reset`()</ID>
     <ID>ComplexMethod:SchemaMigration.kt$SchemaMigration$ private fun migrateOlderDatabaseToUseLiquibase(existingCheckpoints: Boolean): Boolean</ID>
     <ID>ComplexMethod:SchemaMigration.kt$SchemaMigration$private fun doRunMigration( run: Boolean, check: Boolean, existingCheckpoints: Boolean? = null )</ID>
     <ID>ComplexMethod:SendTransactionFlow.kt$DataVendingFlow$@Suspendable override fun call(): Void?</ID>
@@ -310,7 +297,6 @@
     <ID>ForbiddenComment:CordappProviderImplTests.kt$CordappProviderImplTests.Companion$// TODO: Cordapp name should differ from the JAR name</ID>
     <ID>ForbiddenComment:CoreFlowHandlers.kt$NotaryChangeHandler$// TODO: Right now all nodes will automatically approve the notary change. We need to figure out if stricter controls are necessary.</ID>
     <ID>ForbiddenComment:CrossCashTest.kt$CrossCashState$// TODO: Alternative: We may possibly reduce the complexity of the search even further using some form of</ID>
-    <ID>ForbiddenComment:Crypto.kt$Crypto$// TODO: Check if non-ECC keys satisfy params (i.e. approved/valid RSA modulus size).</ID>
     <ID>ForbiddenComment:Crypto.kt$Crypto$// TODO: We currently use SHA256(seed) when retrying, but BIP32 just skips a counter (i) that results to an invalid key.</ID>
     <ID>ForbiddenComment:Crypto.kt$Crypto$// TODO: change the val name to a more descriptive one as it's now confusing and looks like a Key type.</ID>
     <ID>ForbiddenComment:Crypto.kt$Crypto$// TODO: change val name to SPHINCS256_SHA512. This will break backwards compatibility.</ID>
@@ -435,7 +421,6 @@
     <ID>ForbiddenComment:RatesFixFlow.kt$RatesFixFlow.FixQueryFlow$// TODO: add deadline to receive</ID>
     <ID>ForbiddenComment:ResolveTransactionsFlow.kt$ResolveTransactionsFlow$// TODO: This could be done in parallel with other fetches for extra speed.</ID>
     <ID>ForbiddenComment:ResolveTransactionsFlowTest.kt$ResolveTransactionsFlowTest$// TODO: this operation should not require an explicit transaction</ID>
-    <ID>ForbiddenComment:RestrictedEntityManager.kt$RestrictedEntityManager$// TODO: Figure out which other methods on EntityManager need to be blocked?</ID>
     <ID>ForbiddenComment:ScheduledActivityObserver.kt$ScheduledActivityObserver.Companion$// TODO: Beware we are calling dynamically loaded contract code inside here.</ID>
     <ID>ForbiddenComment:ScheduledFlowIntegrationTests.kt$ScheduledFlowIntegrationTests$// TODO: the queries below are not atomic so we need to allow enough time for the scheduler to finish. Would be better to query scheduler.</ID>
     <ID>ForbiddenComment:SendTransactionFlow.kt$DataVendingFlow$// Security TODO: Check for abnormally large or malformed data requests</ID>
@@ -622,7 +607,6 @@
     <ID>FunctionNaming:VersionExtractorTest.kt$VersionExtractorTest$@Test(timeout=300_000) fun version_header_extraction_present()</ID>
     <ID>LargeClass:AbstractNode.kt$AbstractNode&lt;S&gt; : SingletonSerializeAsToken</ID>
     <ID>LargeClass:SingleThreadedStateMachineManager.kt$SingleThreadedStateMachineManager : StateMachineManagerStateMachineManagerInternal</ID>
-    <ID>LongMethod:FlowCookbook.kt$InitiatorFlow$@Suppress("RemoveExplicitTypeArguments") @Suspendable override fun call()</ID>
     <ID>LongMethod:HibernateQueryCriteriaParser.kt$HibernateQueryCriteriaParser$override fun parseCriteria(criteria: CommonQueryCriteria): Collection&lt;Predicate&gt;</ID>
     <ID>LongParameterList:AMQPSerializer.kt$AMQPSerializer$(obj: Any, data: Data, type: Type, output: SerializationOutput, context: SerializationContext, debugIndent: Int = 0)</ID>
     <ID>LongParameterList:AbstractCashSelection.kt$AbstractCashSelection$(connection: Connection, amount: Amount&lt;Currency&gt;, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set&lt;AbstractParty&gt;, withIssuerRefs: Set&lt;OpaqueBytes&gt;, withResultSet: (ResultSet) -&gt; Boolean)</ID>
@@ -657,6 +641,9 @@
     <ID>LongParameterList:CordaRPCOps.kt$( @Suppress("UNUSED_PARAMETER") flowConstructor: (A, B, C, D, E, F) -&gt; R, arg0: A, arg1: B, arg2: C, arg3: D, arg4: E, arg5: F )</ID>
     <ID>LongParameterList:CordaRPCOps.kt$( @Suppress("unused_parameter") flowConstructor: (A, B, C, D, E) -&gt; R, arg0: A, arg1: B, arg2: C, arg3: D, arg4: E )</ID>
     <ID>LongParameterList:CordaRPCOps.kt$( @Suppress("unused_parameter") flowConstructor: (A, B, C, D, E, F) -&gt; R, arg0: A, arg1: B, arg2: C, arg3: D, arg4: E, arg5: F )</ID>
+    <ID>LongParameterList:CordaRPCOps.kt$( clientId: String, @Suppress("unused_parameter") flowConstructor: (A, B, C, D) -&gt; R, arg0: A, arg1: B, arg2: C, arg3: D )</ID>
+    <ID>LongParameterList:CordaRPCOps.kt$( clientId: String, @Suppress("unused_parameter") flowConstructor: (A, B, C, D, E) -&gt; R, arg0: A, arg1: B, arg2: C, arg3: D, arg4: E )</ID>
+    <ID>LongParameterList:CordaRPCOps.kt$( clientId: String, @Suppress("unused_parameter") flowConstructor: (A, B, C, D, E, F) -&gt; R, arg0: A, arg1: B, arg2: C, arg3: D, arg4: E, arg5: F )</ID>
     <ID>LongParameterList:Driver.kt$DriverParameters$( isDebug: Boolean, driverDirectory: Path, portAllocation: PortAllocation, debugPortAllocation: PortAllocation, systemProperties: Map&lt;String, String&gt;, useTestClock: Boolean, startNodesInProcess: Boolean, waitForAllNodesToFinish: Boolean, notarySpecs: List&lt;NotarySpec&gt;, extraCordappPackagesToScan: List&lt;String&gt;, jmxPolicy: JmxPolicy, networkParameters: NetworkParameters )</ID>
     <ID>LongParameterList:Driver.kt$DriverParameters$( isDebug: Boolean, driverDirectory: Path, portAllocation: PortAllocation, debugPortAllocation: PortAllocation, systemProperties: Map&lt;String, String&gt;, useTestClock: Boolean, startNodesInProcess: Boolean, waitForAllNodesToFinish: Boolean, notarySpecs: List&lt;NotarySpec&gt;, extraCordappPackagesToScan: List&lt;String&gt;, jmxPolicy: JmxPolicy, networkParameters: NetworkParameters, cordappsForAllNodes: Set&lt;TestCordapp&gt;? )</ID>
     <ID>LongParameterList:DriverDSL.kt$DriverDSL$( defaultParameters: NodeParameters = NodeParameters(), providedName: CordaX500Name? = defaultParameters.providedName, rpcUsers: List&lt;User&gt; = defaultParameters.rpcUsers, verifierType: VerifierType = defaultParameters.verifierType, customOverrides: Map&lt;String, Any?&gt; = defaultParameters.customOverrides, startInSameProcess: Boolean? = defaultParameters.startInSameProcess, maximumHeapSize: String = defaultParameters.maximumHeapSize )</ID>
@@ -753,7 +740,6 @@
     <ID>MagicNumber:AttachmentDemo.kt$10009</ID>
     <ID>MagicNumber:AttachmentDemo.kt$10010</ID>
     <ID>MagicNumber:AttachmentTrustTable.kt$AttachmentTrustTable$3</ID>
-    <ID>MagicNumber:AttachmentsClassLoader.kt$AttachmentsClassLoader$4</ID>
     <ID>MagicNumber:AzureSmbVolume.kt$AzureSmbVolume$5000</ID>
     <ID>MagicNumber:BFTSmart.kt$BFTSmart.Client$100</ID>
     <ID>MagicNumber:BFTSmart.kt$BFTSmart.Replica.&lt;no name provided&gt;$20000</ID>
@@ -775,12 +761,6 @@
     <ID>MagicNumber:CashViewer.kt$CashViewer.StateRowGraphic$16</ID>
     <ID>MagicNumber:CashViewer.kt$CashViewer.StateRowGraphic$30.0</ID>
     <ID>MagicNumber:ClassCarpenter.kt$ClassCarpenterImpl$3</ID>
-    <ID>MagicNumber:ClientRpcExample.kt$ClientRpcExample$3</ID>
-    <ID>MagicNumber:ClientRpcTutorial.kt$0.7</ID>
-    <ID>MagicNumber:ClientRpcTutorial.kt$0.8</ID>
-    <ID>MagicNumber:ClientRpcTutorial.kt$1000</ID>
-    <ID>MagicNumber:ClientRpcTutorial.kt$10000</ID>
-    <ID>MagicNumber:ClientRpcTutorial.kt$2000</ID>
     <ID>MagicNumber:CommercialPaperIssueFlow.kt$CommercialPaperIssueFlow$10</ID>
     <ID>MagicNumber:CommercialPaperIssueFlow.kt$CommercialPaperIssueFlow$30</ID>
     <ID>MagicNumber:CompositeSignature.kt$CompositeSignature$1024</ID>
@@ -846,11 +826,6 @@
     <ID>MagicNumber:ExchangeRateModel.kt$1.18</ID>
     <ID>MagicNumber:ExchangeRateModel.kt$1.31</ID>
     <ID>MagicNumber:FixingFlow.kt$FixingFlow.Fixer.&lt;no name provided&gt;$30</ID>
-    <ID>MagicNumber:FlowCookbook.kt$InitiatorFlow$30</ID>
-    <ID>MagicNumber:FlowCookbook.kt$InitiatorFlow$45</ID>
-    <ID>MagicNumber:FlowCookbook.kt$InitiatorFlow$777</ID>
-    <ID>MagicNumber:FlowCookbook.kt$ResponderFlow$99</ID>
-    <ID>MagicNumber:FlowCookbook.kt$ResponderFlow.&lt;no name provided&gt;$777</ID>
     <ID>MagicNumber:FlowLogic.kt$FlowLogic$300</ID>
     <ID>MagicNumber:FlowLogic.kt$FlowLogic.Companion$5</ID>
     <ID>MagicNumber:FlowMonitor.kt$FlowMonitor$1000</ID>
@@ -864,7 +839,6 @@
     <ID>MagicNumber:HTTPNetworkRegistrationService.kt$HTTPNetworkRegistrationService$10</ID>
     <ID>MagicNumber:HttpUtils.kt$HttpUtils$5</ID>
     <ID>MagicNumber:HttpUtils.kt$HttpUtils$60</ID>
-    <ID>MagicNumber:IOUFlowResponder.kt$IOUFlowResponder.&lt;no name provided&gt;$100</ID>
     <ID>MagicNumber:IRS.kt$RatePaymentEvent$360.0</ID>
     <ID>MagicNumber:IRS.kt$RatePaymentEvent$4</ID>
     <ID>MagicNumber:IRS.kt$RatePaymentEvent$8</ID>
@@ -1026,7 +1000,6 @@
     <ID>MagicNumber:NodeWebServer.kt$NodeWebServer$100</ID>
     <ID>MagicNumber:NodeWebServer.kt$NodeWebServer$32768</ID>
     <ID>MagicNumber:NodeWebServer.kt$NodeWebServer$40</ID>
-    <ID>MagicNumber:NonValidatingNotaryFlow.kt$NonValidatingNotaryFlow$4</ID>
     <ID>MagicNumber:Notarise.kt$10</ID>
     <ID>MagicNumber:Notarise.kt$10003</ID>
     <ID>MagicNumber:NullKeys.kt$NullKeys$32</ID>
@@ -1143,7 +1116,6 @@
     <ID>MagicNumber:StandaloneShell.kt$StandaloneShell$7</ID>
     <ID>MagicNumber:StateRevisionFlow.kt$StateRevisionFlow.Requester$30</ID>
     <ID>MagicNumber:Structures.kt$PrivacySalt$32</ID>
-    <ID>MagicNumber:TargetVersionDependentRules.kt$StateContractValidationEnforcementRule$4</ID>
     <ID>MagicNumber:TestNodeInfoBuilder.kt$TestNodeInfoBuilder$1234</ID>
     <ID>MagicNumber:TestUtils.kt$10000</ID>
     <ID>MagicNumber:TestUtils.kt$30000</ID>
@@ -1154,7 +1126,6 @@
     <ID>MagicNumber:TraderDemoClientApi.kt$TraderDemoClientApi$3</ID>
     <ID>MagicNumber:TransactionBuilder.kt$TransactionBuilder$4</ID>
     <ID>MagicNumber:TransactionDSLInterpreter.kt$TransactionDSL$30</ID>
-    <ID>MagicNumber:TransactionUtils.kt$4</ID>
     <ID>MagicNumber:TransactionVerificationException.kt$TransactionVerificationException.ConstraintPropagationRejection$3</ID>
     <ID>MagicNumber:TransactionViewer.kt$TransactionViewer$15.0</ID>
     <ID>MagicNumber:TransactionViewer.kt$TransactionViewer$20.0</ID>
@@ -1179,8 +1150,6 @@
     <ID>MagicNumber:WebServer.kt$100.0</ID>
     <ID>MagicNumber:WebServer.kt$WebServer$500</ID>
     <ID>MagicNumber:WireTransaction.kt$WireTransaction$4</ID>
-    <ID>MagicNumber:WorkflowTransactionBuildTutorial.kt$SubmitCompletionFlow$60</ID>
-    <ID>MagicNumber:WorkflowTransactionBuildTutorial.kt$SubmitTradeApprovalFlow$60</ID>
     <ID>MagicNumber:X509Utilities.kt$X509Utilities$3650</ID>
     <ID>MagicNumber:errorAndTerminate.kt$10</ID>
     <ID>MatchingDeclarationName:AMQPSerializerFactories.kt$net.corda.serialization.internal.amqp.AMQPSerializerFactories.kt</ID>
@@ -1225,7 +1194,6 @@
     <ID>MatchingDeclarationName:TestConstants.kt$net.corda.testing.core.TestConstants.kt</ID>
     <ID>MatchingDeclarationName:TestUtils.kt$net.corda.testing.core.TestUtils.kt</ID>
     <ID>MatchingDeclarationName:TransactionTypes.kt$net.corda.explorer.model.TransactionTypes.kt</ID>
-    <ID>MatchingDeclarationName:TutorialFlowStateMachines.kt$net.corda.docs.kotlin.tutorial.flowstatemachines.TutorialFlowStateMachines.kt</ID>
     <ID>MatchingDeclarationName:Utils.kt$io.cryptoblk.core.Utils.kt</ID>
     <ID>MatchingDeclarationName:VirtualCordapps.kt$net.corda.node.internal.cordapp.VirtualCordapps.kt</ID>
     <ID>ModifierOrder:NodeNamedCache.kt$DefaultNamedCacheFactory$open protected</ID>
@@ -1298,7 +1266,6 @@
     <ID>SpreadOperator:ConfigUtilities.kt$(*pairs)</ID>
     <ID>SpreadOperator:Configuration.kt$Configuration.Validation.Error$(*(containingPath.toList() + this.containingPath).toTypedArray())</ID>
     <ID>SpreadOperator:ContractJarTestUtils.kt$ContractJarTestUtils$(jarName, *contractNames.map{ "${it.replace(".", "/")}.class" }.toTypedArray())</ID>
-    <ID>SpreadOperator:CordaRPCOpsImpl.kt$CordaRPCOpsImpl$(logicType, context(), *args)</ID>
     <ID>SpreadOperator:CordaX500Name.kt$CordaX500Name.Companion$(*Locale.getISOCountries(), unspecifiedCountry)</ID>
     <ID>SpreadOperator:CustomCordapp.kt$CustomCordapp$(*classes.map { it.name }.toTypedArray())</ID>
     <ID>SpreadOperator:CustomCordapp.kt$CustomCordapp$(*packages.map { it.replace('.', '/') }.toTypedArray())</ID>
@@ -1320,10 +1287,6 @@
     <ID>SpreadOperator:FlowOverrideTests.kt$FlowOverrideTests$(*nodeBClasses.toTypedArray())</ID>
     <ID>SpreadOperator:FlowTestsUtils.kt$(*allSessions)</ID>
     <ID>SpreadOperator:FlowTestsUtils.kt$(session, *sessions)</ID>
-    <ID>SpreadOperator:FxTransactionBuildTutorial.kt$ForeignExchangeFlow$(*ourInputStates.toTypedArray())</ID>
-    <ID>SpreadOperator:FxTransactionBuildTutorial.kt$ForeignExchangeFlow$(*ourOutputState.map { StateAndContract(it, Cash.PROGRAM_ID) }.toTypedArray())</ID>
-    <ID>SpreadOperator:FxTransactionBuildTutorial.kt$ForeignExchangeFlow$(*theirInputStates.toTypedArray())</ID>
-    <ID>SpreadOperator:FxTransactionBuildTutorial.kt$ForeignExchangeFlow$(*theirOutputState.map { StateAndContract(it, Cash.PROGRAM_ID) }.toTypedArray())</ID>
     <ID>SpreadOperator:HTTPNetworkRegistrationService.kt$HTTPNetworkRegistrationService$(OpaqueBytes(request.encoded), "Platform-Version" to "${versionInfo.platformVersion}", "Client-Version" to versionInfo.releaseVersion, "Private-Network-Map" to (config.pnm?.toString() ?: ""), *(config.csrToken?.let { arrayOf(CENM_SUBMISSION_TOKEN to it) } ?: arrayOf()))</ID>
     <ID>SpreadOperator:HibernateQueryCriteriaParser.kt$AbstractQueryCriteriaParser$(*leftPredicates.toTypedArray())</ID>
     <ID>SpreadOperator:HibernateQueryCriteriaParser.kt$AbstractQueryCriteriaParser$(*leftPredicates.toTypedArray(), *rightPredicates.toTypedArray())</ID>
@@ -1574,7 +1537,6 @@
     <ID>TooGenericExceptionCaught:NotaryUtils.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ObjectDiffer.kt$ObjectDiffer$throwable: Exception</ID>
     <ID>TooGenericExceptionCaught:P2PMessagingClient.kt$P2PMessagingClient$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:PersistentIdentityMigrationNewTableTest.kt$PersistentIdentityMigrationNewTableTest$e: Exception</ID>
     <ID>TooGenericExceptionCaught:PersistentUniquenessProvider.kt$PersistentUniquenessProvider$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ProfileController.kt$ProfileController$e: Exception</ID>
     <ID>TooGenericExceptionCaught:PropertyValidationTest.kt$PropertyValidationTest$e: Exception</ID>
@@ -1742,8 +1704,6 @@
     <ID>UnusedImports:Amount.kt$import net.corda.core.crypto.CompositeKey</ID>
     <ID>UnusedImports:Amount.kt$import net.corda.core.identity.Party</ID>
     <ID>UnusedImports:DummyLinearStateSchemaV1.kt$import net.corda.core.contracts.ContractState</ID>
-    <ID>UnusedImports:FlowsExecutionModeRpcTest.kt$import net.corda.core.internal.packageName</ID>
-    <ID>UnusedImports:FlowsExecutionModeRpcTest.kt$import net.corda.finance.schemas.CashSchemaV1</ID>
     <ID>UnusedImports:InternalTestUtils.kt$import java.nio.file.Files</ID>
     <ID>UnusedImports:InternalTestUtils.kt$import net.corda.nodeapi.internal.loadDevCaTrustStore</ID>
     <ID>UnusedImports:NetworkMap.kt$import net.corda.core.node.NodeInfo</ID>
@@ -2012,8 +1972,6 @@
     <ID>WildcardImport:CordaModule.kt$import net.corda.core.identity.*</ID>
     <ID>WildcardImport:CordaModule.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:CordaRPCOps.kt$import net.corda.core.node.services.vault.*</ID>
-    <ID>WildcardImport:CordaRPCOpsImplTest.kt$import net.corda.core.messaging.*</ID>
-    <ID>WildcardImport:CordaRPCOpsImplTest.kt$import org.assertj.core.api.Assertions.*</ID>
     <ID>WildcardImport:CordaServiceTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:CordaViewModel.kt$import tornadofx.*</ID>
     <ID>WildcardImport:Cordapp.kt$import net.corda.core.cordapp.Cordapp.Info.*</ID>
@@ -2031,10 +1989,6 @@
     <ID>WildcardImport:CryptoSignUtils.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:CryptoUtilsTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:CustomCordapp.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:CustomVaultQuery.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:CustomVaultQuery.kt$import net.corda.core.utilities.*</ID>
-    <ID>WildcardImport:CustomVaultQueryTest.kt$import net.corda.core.node.services.vault.*</ID>
-    <ID>WildcardImport:CustomVaultQueryTest.kt$import net.corda.finance.*</ID>
     <ID>WildcardImport:DBNetworkParametersStorage.kt$import javax.persistence.*</ID>
     <ID>WildcardImport:DBRunnerExtension.kt$import org.junit.jupiter.api.extension.*</ID>
     <ID>WildcardImport:DBTransactionStorage.kt$import javax.persistence.*</ID>
@@ -2057,7 +2011,6 @@
     <ID>WildcardImport:DeserializeSimpleTypesTests.kt$import net.corda.serialization.internal.amqp.testutils.*</ID>
     <ID>WildcardImport:DigitalSignatureWithCert.kt$import java.security.cert.*</ID>
     <ID>WildcardImport:DistributedServiceTests.kt$import net.corda.testing.core.*</ID>
-    <ID>WildcardImport:DoRemainingWorkTransition.kt$import net.corda.node.services.statemachine.*</ID>
     <ID>WildcardImport:DockerInstantiator.kt$import com.github.dockerjava.api.model.*</ID>
     <ID>WildcardImport:DriverDSLImpl.kt$import net.corda.testing.driver.*</ID>
     <ID>WildcardImport:DummyContract.kt$import net.corda.core.contracts.*</ID>
@@ -2076,8 +2029,6 @@
     <ID>WildcardImport:EvolutionSerializerFactoryTests.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:EvolutionSerializerFactoryTests.kt$import net.corda.serialization.internal.amqp.testutils.*</ID>
     <ID>WildcardImport:Explorer.kt$import tornadofx.*</ID>
-    <ID>WildcardImport:FiberDeserializationCheckingInterceptor.kt$import net.corda.node.services.statemachine.*</ID>
-    <ID>WildcardImport:FinalityFlowMigration.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:FinalityFlowTests.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:FinalityFlowTests.kt$import net.corda.testing.node.internal.*</ID>
     <ID>WildcardImport:FinalityHandlerTest.kt$import net.corda.node.services.statemachine.StaffedFlowHospital.*</ID>
@@ -2089,11 +2040,7 @@
     <ID>WildcardImport:FlowCheckpointCordapp.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:FlowCheckpointVersionNodeStartupCheckTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:FlowCheckpointVersionNodeStartupCheckTest.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:FlowCookbook.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:FlowCookbook.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:FlowFrameworkPersistenceTests.kt$import net.corda.testing.node.internal.*</ID>
-    <ID>WildcardImport:FlowFrameworkTests.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:FlowFrameworkTests.kt$import net.corda.testing.node.internal.*</ID>
     <ID>WildcardImport:FlowFrameworkTripartyTests.kt$import net.corda.testing.node.internal.*</ID>
     <ID>WildcardImport:FlowLogicRefFactoryImpl.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:FlowMatchers.kt$import net.corda.coretesting.internal.matchers.*</ID>
@@ -2101,10 +2048,7 @@
     <ID>WildcardImport:FlowRetryTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:FlowStackSnapshotTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:FlowStateMachine.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:FlowStateMachineImpl.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:FlowStateMachineImpl.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:FlowsDrainingModeContentionTest.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:FxTransactionBuildTutorialTest.kt$import net.corda.finance.*</ID>
     <ID>WildcardImport:GenericsTests.kt$import net.corda.serialization.internal.amqp.testutils.*</ID>
     <ID>WildcardImport:Gui.kt$import tornadofx.*</ID>
     <ID>WildcardImport:GuiUtilities.kt$import tornadofx.*</ID>
@@ -2121,8 +2065,6 @@
     <ID>WildcardImport:HibernateQueryCriteriaParser.kt$import net.corda.core.node.services.vault.EqualityComparisonOperator.*</ID>
     <ID>WildcardImport:HibernateQueryCriteriaParser.kt$import net.corda.core.node.services.vault.LikenessOperator.*</ID>
     <ID>WildcardImport:HibernateStatistics.kt$import org.hibernate.stat.*</ID>
-    <ID>WildcardImport:IOUContract.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:IOUFlowResponder.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:IRS.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:IRS.kt$import net.corda.finance.contracts.*</ID>
     <ID>WildcardImport:IRSState.kt$import net.corda.core.contracts.*</ID>
@@ -2169,7 +2111,6 @@
     <ID>WildcardImport:JarSignatureCollectorTest.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:KeyStoreUtilities.kt$import java.security.*</ID>
     <ID>WildcardImport:KeyStoreUtilities.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:KotlinIntegrationTestingTutorial.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:Kryo.kt$import com.esotericsoftware.kryo.*</ID>
     <ID>WildcardImport:Kryo.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:KryoStreamsTest.kt$import java.io.*</ID>
@@ -2420,8 +2361,6 @@
     <ID>WildcardImport:SignedTransaction.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:SignedTransaction.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:SimpleMQClient.kt$import org.apache.activemq.artemis.api.core.client.*</ID>
-    <ID>WildcardImport:SingleThreadedStateMachineManager.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:SingleThreadedStateMachineManager.kt$import net.corda.node.services.statemachine.interceptors.*</ID>
     <ID>WildcardImport:SpringDriver.kt$import net.corda.testing.node.internal.*</ID>
     <ID>WildcardImport:StandaloneCordaRPClientTest.kt$import net.corda.core.messaging.*</ID>
     <ID>WildcardImport:StandaloneCordaRPClientTest.kt$import net.corda.core.node.services.vault.*</ID>
@@ -2473,8 +2412,6 @@
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.client.jfx.utils.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import tornadofx.*</ID>
-    <ID>WildcardImport:TutorialContract.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:TutorialTestDSL.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:TwoPartyDealFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:TwoPartyTradeFlow.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TwoPartyTradeFlow.kt$import net.corda.core.flows.*</ID>
@@ -2502,7 +2439,6 @@
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.testing.node.internal.*</ID>
     <ID>WildcardImport:VaultFiller.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:VaultFlowTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.vault.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.vault.QueryCriteria.*</ID>

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
@@ -1,0 +1,76 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import org.junit.Before
+import org.junit.Test
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class FlowWithClientIdTest {
+
+    @Before
+    fun reset() {
+        ResultFlow.hook = null
+    }
+
+    @Test(timeout=300_000)
+    fun `start flow with client id`() {
+        val clientID = UUID.randomUUID().toString()
+        driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = emptySet())) {
+            val nodeA = startNode().getOrThrow()
+            val flowHandle = nodeA.rpc.startFlowDynamicWithClientId(clientID, ResultFlow::class.java, 5)
+
+            assertEquals(5, flowHandle.returnValue.getOrThrow(20.seconds))
+            // TODO assert clientID returned also once define FlowHandleWithClientId
+        }
+    }
+
+    @Test(timeout=300_000)
+    fun `remove client id`() {
+        val clientID = UUID.randomUUID().toString()
+        var counter = 0
+        ResultFlow.hook = { counter++ }
+        driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = emptySet())) {
+            val nodeA = startNode().getOrThrow()
+
+            val flowHandle0 = nodeA.rpc.startFlowDynamicWithClientId(clientID, ResultFlow::class.java, 5)
+            flowHandle0.returnValue.getOrThrow(20.seconds)
+
+            val removed = nodeA.rpc.removeClientId(clientID)
+
+            val flowHandle1 = nodeA.rpc.startFlowDynamicWithClientId(clientID, ResultFlow::class.java, 5)
+            flowHandle1.returnValue.getOrThrow(20.seconds)
+
+            assertTrue(removed)
+            assertNotEquals(flowHandle0.id, flowHandle1.id)
+            assertEquals(2, counter) // this asserts that 2 different flows were spawned indeed
+            // TODO assert clientID returned also once define FlowHandleWithClientId
+        }
+
+    }
+
+}
+
+@StartableByRPC
+internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {
+    companion object {
+        var hook: (() -> Unit)? = null
+        var suspendableHook: FlowLogic<Unit>? = null
+    }
+
+    @Suspendable
+    override fun call(): A {
+        hook?.invoke()
+        suspendableHook?.let { subFlow(it) }
+        return result
+    }
+}
+

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
@@ -29,7 +29,7 @@ class FlowWithClientIdTest {
             val flowHandle = nodeA.rpc.startFlowDynamicWithClientId(clientID, ResultFlow::class.java, 5)
 
             assertEquals(5, flowHandle.returnValue.getOrThrow(20.seconds))
-            // TODO assert clientID returned also once define FlowHandleWithClientId
+            assertEquals(clientID, flowHandle.clientID)
         }
     }
 
@@ -51,8 +51,8 @@ class FlowWithClientIdTest {
 
             assertTrue(removed)
             assertNotEquals(flowHandle0.id, flowHandle1.id)
+            assertEquals(flowHandle0.clientID, flowHandle1.clientID)
             assertEquals(2, counter) // this asserts that 2 different flows were spawned indeed
-            // TODO assert clientID returned also once define FlowHandleWithClientId
         }
 
     }

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
@@ -23,35 +23,35 @@ class FlowWithClientIdTest {
 
     @Test(timeout=300_000)
     fun `start flow with client id`() {
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
         driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = emptySet())) {
             val nodeA = startNode().getOrThrow()
-            val flowHandle = nodeA.rpc.startFlowDynamicWithClientId(clientID, ResultFlow::class.java, 5)
+            val flowHandle = nodeA.rpc.startFlowDynamicWithClientId(clientId, ResultFlow::class.java, 5)
 
             assertEquals(5, flowHandle.returnValue.getOrThrow(20.seconds))
-            assertEquals(clientID, flowHandle.clientID)
+            assertEquals(clientId, flowHandle.clientId)
         }
     }
 
     @Test(timeout=300_000)
     fun `remove client id`() {
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
         var counter = 0
         ResultFlow.hook = { counter++ }
         driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = emptySet())) {
             val nodeA = startNode().getOrThrow()
 
-            val flowHandle0 = nodeA.rpc.startFlowDynamicWithClientId(clientID, ResultFlow::class.java, 5)
+            val flowHandle0 = nodeA.rpc.startFlowDynamicWithClientId(clientId, ResultFlow::class.java, 5)
             flowHandle0.returnValue.getOrThrow(20.seconds)
 
-            val removed = nodeA.rpc.removeClientId(clientID)
+            val removed = nodeA.rpc.removeClientId(clientId)
 
-            val flowHandle1 = nodeA.rpc.startFlowDynamicWithClientId(clientID, ResultFlow::class.java, 5)
+            val flowHandle1 = nodeA.rpc.startFlowDynamicWithClientId(clientId, ResultFlow::class.java, 5)
             flowHandle1.returnValue.getOrThrow(20.seconds)
 
             assertTrue(removed)
             assertNotEquals(flowHandle0.id, flowHandle1.id)
-            assertEquals(flowHandle0.clientID, flowHandle1.clientID)
+            assertEquals(flowHandle0.clientId, flowHandle1.clientId)
             assertEquals(2, counter) // this asserts that 2 different flows were spawned indeed
         }
 

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
@@ -3,6 +3,7 @@ package net.corda.node.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
+import net.corda.core.messaging.startFlowWithClientId
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
 import net.corda.testing.driver.DriverParameters
@@ -26,7 +27,7 @@ class FlowWithClientIdTest {
         val clientId = UUID.randomUUID().toString()
         driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = emptySet())) {
             val nodeA = startNode().getOrThrow()
-            val flowHandle = nodeA.rpc.startFlowDynamicWithClientId(clientId, ResultFlow::class.java, 5)
+            val flowHandle = nodeA.rpc.startFlowWithClientId(clientId, ::ResultFlow, 5)
 
             assertEquals(5, flowHandle.returnValue.getOrThrow(20.seconds))
             assertEquals(clientId, flowHandle.clientId)
@@ -41,12 +42,12 @@ class FlowWithClientIdTest {
         driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = emptySet())) {
             val nodeA = startNode().getOrThrow()
 
-            val flowHandle0 = nodeA.rpc.startFlowDynamicWithClientId(clientId, ResultFlow::class.java, 5)
+            val flowHandle0 = nodeA.rpc.startFlowWithClientId(clientId, ::ResultFlow, 5)
             flowHandle0.returnValue.getOrThrow(20.seconds)
 
             val removed = nodeA.rpc.removeClientId(clientId)
 
-            val flowHandle1 = nodeA.rpc.startFlowDynamicWithClientId(clientId, ResultFlow::class.java, 5)
+            val flowHandle1 = nodeA.rpc.startFlowWithClientId(clientId, ::ResultFlow, 5)
             flowHandle1.returnValue.getOrThrow(20.seconds)
 
             assertTrue(removed)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1274,14 +1274,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         // check clientID early, so that we don't get further down if it can't be saved in the database
         val clientID = event.context.clientID
         if (clientID != null && clientID.length > maxClientIdLength) {
-            event.wireUpFuture(doneFuture(object : FlowStateMachineHandle<T> {
-                override val logic: Nothing? = null
-                override val id: StateMachineRunId = event.flowId
-                override val resultFuture = openFuture<T>().also {
-                    it.setException(IllegalArgumentException("clientID cannot be longer than $maxClientIdLength characters"))
-                }
-                override val clientID: String? = clientID
-            }))
+            throw IllegalArgumentException("clientID cannot be longer than $maxClientIdLength characters")
         } else {
             smm.deliverExternalEvent(event)
         }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -33,7 +33,6 @@ import net.corda.core.internal.NODE_INFO_DIRECTORY
 import net.corda.core.internal.NamedCacheFactory
 import net.corda.core.internal.NetworkParametersStorage
 import net.corda.core.internal.VisibleForTesting
-import net.corda.core.internal.concurrent.doneFuture
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.concurrent.openFuture
@@ -1275,9 +1274,9 @@ class FlowStarterImpl(
     private val maxClientIdLength: Int
 ) : FlowStarter {
     override fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<out FlowStateMachineHandle<T>> {
-        val clientID = event.context.clientID
-        if (clientID != null && clientID.length > maxClientIdLength) {
-            throw IllegalArgumentException("clientID cannot be longer than $maxClientIdLength characters")
+        val clientId = event.context.clientId
+        if (clientId != null && clientId.length > maxClientIdLength) {
+            throw IllegalArgumentException("clientId cannot be longer than $maxClientIdLength characters")
         } else {
             smm.deliverExternalEvent(event)
         }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1276,7 +1276,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         return event.future
     }
 
-    override fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+    override fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
         val startFlowEvent = object : ExternalEvent.ExternalStartFlowEvent<T>, DeduplicationHandler {
             override fun insideDatabaseTransaction() {}
 
@@ -1287,11 +1287,11 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
             override val deduplicationHandler: DeduplicationHandler
                 get() = this
 
+            override val clientId: UUID?
+                get() = clientId
             override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
             override val flowLogic: FlowLogic<T>
                 get() = logic
-            override val clientId: UUID?
-                get() = clientId
             override val context: InvocationContext
                 get() = context
 
@@ -1307,13 +1307,13 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
     }
 
     override fun <T> invokeFlowAsync(
-            logicType: Class<out FlowLogic<T>>,
             clientId: UUID?,
+            logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>> {
         val logicRef = flowLogicRefFactory.createForRPC(logicType, *args)
         val logic: FlowLogic<T> = uncheckedCast(flowLogicRefFactory.toFlowLogic(logicRef))
-        return startFlow(logic, clientId, context)
+        return startFlow(clientId, logic, context)
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -28,7 +28,6 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.AttachmentTrustCalculator
-import net.corda.core.internal.FlowStateMachineClientIdResult
 import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.internal.NODE_INFO_DIRECTORY
 import net.corda.core.internal.NamedCacheFactory
@@ -1275,7 +1274,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         // check clientID early, so that we don't get further down if it can't be saved in the database
         val clientID = event.context.clientID
         if (clientID != null && clientID.length > maxClientIdLength) {
-            event.wireUpFuture(doneFuture(object : FlowStateMachineClientIdResult<T> {
+            event.wireUpFuture(doneFuture(object : FlowStateMachineHandle<T> {
                 override val logic: Nothing? = null
                 override val id: StateMachineRunId = event.flowId
                 override val resultFuture = openFuture<T>().also {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1276,7 +1276,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         return event.future
     }
 
-    override fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+    override fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
         val startFlowEvent = object : ExternalEvent.ExternalStartFlowEvent<T>, DeduplicationHandler {
             override fun insideDatabaseTransaction() {}
 
@@ -1287,11 +1287,11 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
             override val deduplicationHandler: DeduplicationHandler
                 get() = this
 
-            override val clientId: UUID?
-                get() = clientId
             override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
             override val flowLogic: FlowLogic<T>
                 get() = logic
+            override val clientId: UUID?
+                get() = clientId
             override val context: InvocationContext
                 get() = context
 
@@ -1307,13 +1307,13 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
     }
 
     override fun <T> invokeFlowAsync(
-            clientId: UUID?,
             logicType: Class<out FlowLogic<T>>,
+            clientId: UUID?,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>> {
         val logicRef = flowLogicRefFactory.createForRPC(logicType, *args)
         val logic: FlowLogic<T> = uncheckedCast(flowLogicRefFactory.toFlowLogic(logicRef))
-        return startFlow(clientId, logic, context)
+        return startFlow(logic, clientId, context)
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -185,7 +185,6 @@ import java.time.Clock
 import java.time.Duration
 import java.time.format.DateTimeParseException
 import java.util.Properties
-import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -195,7 +194,6 @@ import java.util.concurrent.TimeUnit.MINUTES
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.function.Consumer
 import javax.persistence.EntityManager
-import kotlin.collections.ArrayList
 
 /**
  * A base node implementation that can be customised either for production (with real implementations that do real
@@ -1276,7 +1274,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         return event.future
     }
 
-    override fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+    override fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
         val startFlowEvent = object : ExternalEvent.ExternalStartFlowEvent<T>, DeduplicationHandler {
             override fun insideDatabaseTransaction() {}
 
@@ -1290,8 +1288,6 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
             override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
             override val flowLogic: FlowLogic<T>
                 get() = logic
-            override val clientId: UUID?
-                get() = clientId
             override val context: InvocationContext
                 get() = context
 
@@ -1308,12 +1304,11 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
 
     override fun <T> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
-            clientId: UUID?,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>> {
         val logicRef = flowLogicRefFactory.createForRPC(logicType, *args)
         val logic: FlowLogic<T> = uncheckedCast(flowLogicRefFactory.toFlowLogic(logicRef))
-        return startFlow(logic, clientId, context)
+        return startFlow(logic, context)
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -185,6 +185,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.format.DateTimeParseException
 import java.util.Properties
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -1275,7 +1276,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         return event.future
     }
 
-    override fun <T> startFlow(clientId: String?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+    override fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
         val startFlowEvent = object : ExternalEvent.ExternalStartFlowEvent<T>, DeduplicationHandler {
             override fun insideDatabaseTransaction() {}
 
@@ -1286,7 +1287,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
             override val deduplicationHandler: DeduplicationHandler
                 get() = this
 
-            override val clientId: String?
+            override val clientId: UUID?
                 get() = clientId
             override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
             override val flowLogic: FlowLogic<T>
@@ -1306,7 +1307,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
     }
 
     override fun <T> invokeFlowAsync(
-            clientId: String?,
+            clientId: UUID?,
             logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>> {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1269,7 +1269,11 @@ internal fun logVendorString(database: CordaPersistence, log: Logger) {
 }
 
 // TODO Move this into its own file
-class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogicRefFactory: FlowLogicRefFactory, private val maxClientIdLength: Int) : FlowStarter {
+class FlowStarterImpl(
+    private val smm: StateMachineManager,
+    private val flowLogicRefFactory: FlowLogicRefFactory,
+    private val maxClientIdLength: Int
+) : FlowStarter {
     override fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<out FlowStateMachineHandle<T>> {
         val clientID = event.context.clientID
         if (clientID != null && clientID.length > maxClientIdLength) {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -185,7 +185,6 @@ import java.time.Clock
 import java.time.Duration
 import java.time.format.DateTimeParseException
 import java.util.Properties
-import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -1276,7 +1275,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         return event.future
     }
 
-    override fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+    override fun <T> startFlow(clientId: String?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
         val startFlowEvent = object : ExternalEvent.ExternalStartFlowEvent<T>, DeduplicationHandler {
             override fun insideDatabaseTransaction() {}
 
@@ -1287,7 +1286,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
             override val deduplicationHandler: DeduplicationHandler
                 get() = this
 
-            override val clientId: UUID?
+            override val clientId: String?
                 get() = clientId
             override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
             override val flowLogic: FlowLogic<T>
@@ -1307,7 +1306,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
     }
 
     override fun <T> invokeFlowAsync(
-            clientId: UUID?,
+            clientId: String?,
             logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>> {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1276,6 +1276,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         val clientID = event.context.clientID
         if (clientID != null && clientID.length > maxClientIdLength) {
             event.wireUpFuture(doneFuture(object : FlowStateMachineClientIdResult<T> {
+                override val logic: Nothing? = null
                 override val id: StateMachineRunId = event.flowId
                 override val resultFuture = openFuture<T>().also {
                     it.setException(IllegalArgumentException("clientID cannot be longer than $maxClientIdLength characters"))

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -185,6 +185,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.format.DateTimeParseException
 import java.util.Properties
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -194,6 +195,7 @@ import java.util.concurrent.TimeUnit.MINUTES
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.function.Consumer
 import javax.persistence.EntityManager
+import kotlin.collections.ArrayList
 
 /**
  * A base node implementation that can be customised either for production (with real implementations that do real
@@ -1274,7 +1276,7 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
         return event.future
     }
 
-    override fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
+    override fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>> {
         val startFlowEvent = object : ExternalEvent.ExternalStartFlowEvent<T>, DeduplicationHandler {
             override fun insideDatabaseTransaction() {}
 
@@ -1288,6 +1290,8 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
             override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
             override val flowLogic: FlowLogic<T>
                 get() = logic
+            override val clientId: UUID?
+                get() = clientId
             override val context: InvocationContext
                 get() = context
 
@@ -1304,11 +1308,12 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
 
     override fun <T> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
+            clientId: UUID?,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>> {
         val logicRef = flowLogicRefFactory.createForRPC(logicType, *args)
         val logic: FlowLogic<T> = uncheckedCast(flowLogicRefFactory.toFlowLogic(logicRef))
-        return startFlow(logic, context)
+        return startFlow(logic, clientId, context)
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1271,7 +1271,6 @@ internal fun logVendorString(database: CordaPersistence, log: Logger) {
 // TODO Move this into its own file
 class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogicRefFactory: FlowLogicRefFactory, private val maxClientIdLength: Int) : FlowStarter {
     override fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<out FlowStateMachineHandle<T>> {
-        // check clientID early, so that we don't get further down if it can't be saved in the database
         val clientID = event.context.clientID
         if (clientID != null && clientID.length > maxClientIdLength) {
             throw IllegalArgumentException("clientID cannot be longer than $maxClientIdLength characters")

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -78,7 +78,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
-                progress = stateMachine.logic?.let { it.track()?.updates } ?: Observable.empty()
+                progress = stateMachine.logic?.track()?.updates ?: Observable.empty()
         )
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -78,8 +78,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
-                progress = stateMachine.logic?.let { it.track()?.updates ?: Observable.empty() }
-                    ?: throw IllegalStateException("logic cannot be null")
+                progress = stateMachine.logic?.let { it.track()?.updates } ?: Observable.empty()
         )
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -105,7 +105,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
                     "Please consider registering your service to node's lifecycle event: `STATE_MACHINE_STARTED`")
         }
         val context = InvocationContext.service(serviceInstance.javaClass.name, myInfo.legalIdentities[0].name)
-        return flowStarter.startFlow(flow, null, context).getOrThrow()
+        return flowStarter.startFlow(flow, context).getOrThrow()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -105,7 +105,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
                     "Please consider registering your service to node's lifecycle event: `STATE_MACHINE_STARTED`")
         }
         val context = InvocationContext.service(serviceInstance.javaClass.name, myInfo.legalIdentities[0].name)
-        return flowStarter.startFlow(flow, null, context).getOrThrow()
+        return flowStarter.startFlow(null, flow,  context).getOrThrow()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -105,7 +105,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
                     "Please consider registering your service to node's lifecycle event: `STATE_MACHINE_STARTED`")
         }
         val context = InvocationContext.service(serviceInstance.javaClass.name, myInfo.legalIdentities[0].name)
-        return flowStarter.startFlow(flow, context).getOrThrow()
+        return flowStarter.startFlow(flow, null, context).getOrThrow()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -105,7 +105,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
                     "Please consider registering your service to node's lifecycle event: `STATE_MACHINE_STARTED`")
         }
         val context = InvocationContext.service(serviceInstance.javaClass.name, myInfo.legalIdentities[0].name)
-        return flowStarter.startFlow(flow, context).getOrThrow()
+        return flowStarter.startFlow(flow, context).getOrThrow() as FlowStateMachine
     }
 
     override fun equals(other: Any?): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -105,7 +105,7 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
                     "Please consider registering your service to node's lifecycle event: `STATE_MACHINE_STARTED`")
         }
         val context = InvocationContext.service(serviceInstance.javaClass.name, myInfo.legalIdentities[0].name)
-        return flowStarter.startFlow(null, flow,  context).getOrThrow()
+        return flowStarter.startFlow(flow, null, context).getOrThrow()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -63,7 +63,6 @@ import java.io.InputStream
 import java.net.ConnectException
 import java.security.PublicKey
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -237,7 +236,7 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
-        val stateMachine = startFlow(logicType, null, args)
+        val stateMachine = startFlow(logicType, args)
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
@@ -248,21 +247,16 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
-        val stateMachine = startFlow(logicType, null, args)
+        val stateMachine = startFlow(logicType, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(logicType: Class<out FlowLogic<T>>, clientId: UUID, vararg args: Any?): FlowHandle<T> {
-        val stateMachine = startFlow(logicType, clientId, args)
-        return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
-    }
-
-    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, clientId: UUID?, args: Array<out Any?>): FlowStateMachine<T> {
+    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachine<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
         }
-        return flowStarter.invokeFlowAsync(logicType, clientId, context(), *args).getOrThrow()
+        return flowStarter.invokeFlowAsync(logicType, context(), *args).getOrThrow()
     }
 
     override fun attachmentExists(id: SecureHash): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -63,6 +63,7 @@ import java.io.InputStream
 import java.net.ConnectException
 import java.security.PublicKey
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -251,12 +252,12 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
+    override fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
         val stateMachine = startFlow(clientId, logicType, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    private fun <T> startFlow(clientId: String?, logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachine<T> {
+    private fun <T> startFlow(clientId: UUID?, logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachine<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -20,6 +20,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.AttachmentTrustInfo
 import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.FlowStateMachineReturnable
 import net.corda.core.internal.RPC_UPLOADER
 import net.corda.core.internal.STRUCTURAL_STEP_PREFIX
 import net.corda.core.internal.messaging.InternalCordaRPCOps
@@ -236,7 +237,7 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
-        val stateMachine = startFlow(logicType, context(), args)
+        val stateMachine = startFlow(logicType, context(), args) as FlowStateMachine
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
@@ -256,7 +257,7 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachine<T> {
+    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineReturnable<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -237,7 +237,7 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
-        val stateMachine = startFlow(logicType, null, args)
+        val stateMachine = startFlow(null, logicType, args)
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
@@ -248,21 +248,21 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
-        val stateMachine = startFlow(logicType, null, args)
+        val stateMachine = startFlow(null, logicType, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(logicType: Class<out FlowLogic<T>>, clientId: UUID, vararg args: Any?): FlowHandle<T> {
-        val stateMachine = startFlow(logicType, clientId, args)
+    override fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
+        val stateMachine = startFlow(clientId, logicType, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, clientId: UUID?, args: Array<out Any?>): FlowStateMachine<T> {
+    private fun <T> startFlow(clientId: UUID?, logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachine<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
         }
-        return flowStarter.invokeFlowAsync(logicType, clientId, context(), *args).getOrThrow()
+        return flowStarter.invokeFlowAsync(clientId, logicType, context(), *args).getOrThrow()
     }
 
     override fun attachmentExists(id: SecureHash): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -19,7 +19,6 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.AttachmentTrustInfo
-import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.internal.RPC_UPLOADER
 import net.corda.core.internal.STRUCTURAL_STEP_PREFIX
@@ -173,7 +172,7 @@ internal class CordaRPCOpsImpl(
 
     override fun killFlow(id: StateMachineRunId): Boolean = smm.killFlow(id)
 
-    override fun removeClientId(clientID: String): Boolean = smm.removeClientId(clientID)
+    override fun removeClientId(clientId: String): Boolean = smm.removeClientId(clientId)
 
     override fun stateMachinesFeed(): DataFeed<List<StateMachineInfo>, StateMachineUpdate> {
 
@@ -256,9 +255,9 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandleWithClientId<T> {
-        val stateMachine = startFlow(logicType, context().withClientId(clientID), args)
-        return FlowHandleWithClientIdImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture, clientID = stateMachine.clientID!!)
+    override fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandleWithClientId<T> {
+        val stateMachine = startFlow(logicType, context().withClientId(clientId), args)
+        return FlowHandleWithClientIdImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture, clientId = stateMachine.clientId!!)
     }
 
     private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineHandle<T> {
@@ -475,5 +474,5 @@ internal class CordaRPCOpsImpl(
         require(TARGET::class.java.isAssignableFrom(this)) { "$name is not a ${TARGET::class.java.name}" }
     }
 
-    private fun InvocationContext.withClientId(clientID: String) = copy(clientID = clientID)
+    private fun InvocationContext.withClientId(clientId: String) = copy(clientId = clientId)
 }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -28,6 +28,8 @@ import net.corda.core.internal.sign
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.FlowHandleImpl
+import net.corda.core.messaging.FlowHandleWithClientId
+import net.corda.core.messaging.FlowHandleWithClientIdImpl
 import net.corda.core.messaging.FlowProgressHandle
 import net.corda.core.messaging.FlowProgressHandleImpl
 import net.corda.core.messaging.ParametersUpdateInfo
@@ -254,9 +256,9 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
+    override fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandleWithClientId<T> {
         val stateMachine = startFlow(logicType, context().withClientId(clientID), args)
-        return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
+        return FlowHandleWithClientIdImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture, clientID = stateMachine.clientID!!)
     }
 
     private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineHandle<T> {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -260,6 +260,7 @@ internal class CordaRPCOpsImpl(
         return FlowHandleWithClientIdImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture, clientId = stateMachine.clientId!!)
     }
 
+    @Suppress("SpreadOperator")
     private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineHandle<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -238,16 +238,13 @@ internal class CordaRPCOpsImpl(
 
     override fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
         val stateMachine = startFlow(logicType, context(), args)
-
-        return stateMachine.logic?.let { logic ->
-            FlowProgressHandleImpl(
+        return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
-                progress = logic.track()?.updates?.filter { !it.startsWith(STRUCTURAL_STEP_PREFIX) } ?: Observable.empty(),
-                stepsTreeIndexFeed = logic.trackStepsTreeIndex(),
-                stepsTreeFeed = logic.trackStepsTree()
-            )
-        } ?: throw IllegalStateException("logic cannot be null")
+                progress = stateMachine.logic?.track()?.updates?.filter { !it.startsWith(STRUCTURAL_STEP_PREFIX) } ?: Observable.empty(),
+                stepsTreeIndexFeed = stateMachine.logic?.trackStepsTreeIndex(),
+                stepsTreeFeed = stateMachine.logic?.trackStepsTree()
+        )
     }
 
     override fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -171,6 +171,8 @@ internal class CordaRPCOpsImpl(
 
     override fun killFlow(id: StateMachineRunId): Boolean = smm.killFlow(id)
 
+    override fun removeClientId(clientID: String): Boolean = smm.removeClientId(clientID)
+
     override fun stateMachinesFeed(): DataFeed<List<StateMachineInfo>, StateMachineUpdate> {
 
         val (allStateMachines, changes) = smm.track()

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -252,9 +252,9 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
-        pushClientIdToLoggingContext(clientId)
-        val stateMachine = startFlow(logicType, context().withClientId(clientId), args)
+    override fun <T> startFlowDynamicWithClientId(clientUUID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
+        pushClientIdToLoggingContext(clientUUID)
+        val stateMachine = startFlow(logicType, context().withClientId(clientUUID), args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -63,7 +63,6 @@ import java.io.InputStream
 import java.net.ConnectException
 import java.security.PublicKey
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -252,12 +251,12 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
+    override fun <T> startFlowDynamicWithClientId(clientId: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
         val stateMachine = startFlow(clientId, logicType, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    private fun <T> startFlow(clientId: UUID?, logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachine<T> {
+    private fun <T> startFlow(clientId: String?, logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachine<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -52,7 +52,6 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.api.FlowStarter
 import net.corda.node.services.api.ServiceHubInternal
-import net.corda.node.services.logging.pushClientIdToLoggingContext
 import net.corda.node.services.rpc.CheckpointDumperImpl
 import net.corda.node.services.rpc.context
 import net.corda.node.services.statemachine.StateMachineManager
@@ -253,7 +252,6 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startFlowDynamicWithClientId(clientUUID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
-        pushClientIdToLoggingContext(clientUUID)
         val stateMachine = startFlow(logicType, context().withClientId(clientUUID), args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -20,7 +20,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.AttachmentTrustInfo
 import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.FlowStateMachineReturnable
+import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.internal.RPC_UPLOADER
 import net.corda.core.internal.STRUCTURAL_STEP_PREFIX
 import net.corda.core.internal.messaging.InternalCordaRPCOps
@@ -257,7 +257,7 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineReturnable<T> {
+    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineHandle<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -237,14 +237,17 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
-        val stateMachine = startFlow(logicType, context(), args) as FlowStateMachine
-        return FlowProgressHandleImpl(
+        val stateMachine = startFlow(logicType, context(), args)
+
+        return stateMachine.logic?.let { logic ->
+            FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
-                progress = stateMachine.logic.track()?.updates?.filter { !it.startsWith(STRUCTURAL_STEP_PREFIX) } ?: Observable.empty(),
-                stepsTreeIndexFeed = stateMachine.logic.trackStepsTreeIndex(),
-                stepsTreeFeed = stateMachine.logic.trackStepsTree()
-        )
+                progress = logic.track()?.updates?.filter { !it.startsWith(STRUCTURAL_STEP_PREFIX) } ?: Observable.empty(),
+                stepsTreeIndexFeed = logic.trackStepsTreeIndex(),
+                stepsTreeFeed = logic.trackStepsTree()
+            )
+        } ?: throw IllegalStateException("logic cannot be null")
     }
 
     override fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -251,8 +251,8 @@ internal class CordaRPCOpsImpl(
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(clientUUID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
-        val stateMachine = startFlow(logicType, context().withClientId(clientUUID), args)
+    override fun <T> startFlowDynamicWithClientId(clientID: String, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
+        val stateMachine = startFlow(logicType, context().withClientId(clientID), args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
@@ -470,5 +470,5 @@ internal class CordaRPCOpsImpl(
         require(TARGET::class.java.isAssignableFrom(this)) { "$name is not a ${TARGET::class.java.name}" }
     }
 
-    private fun InvocationContext.withClientId(clientUUID: String) = copy(clientUUID = clientUUID)
+    private fun InvocationContext.withClientId(clientID: String) = copy(clientID = clientID)
 }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -237,7 +237,7 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
-        val stateMachine = startFlow(null, logicType, args)
+        val stateMachine = startFlow(logicType, null, args)
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
@@ -248,21 +248,21 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
-        val stateMachine = startFlow(null, logicType, args)
+        val stateMachine = startFlow(logicType, null, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    override fun <T> startFlowDynamicWithClientId(clientId: UUID, logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
-        val stateMachine = startFlow(clientId, logicType, args)
+    override fun <T> startFlowDynamicWithClientId(logicType: Class<out FlowLogic<T>>, clientId: UUID, vararg args: Any?): FlowHandle<T> {
+        val stateMachine = startFlow(logicType, clientId, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    private fun <T> startFlow(clientId: UUID?, logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachine<T> {
+    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, clientId: UUID?, args: Array<out Any?>): FlowStateMachine<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
         }
-        return flowStarter.invokeFlowAsync(clientId, logicType, context(), *args).getOrThrow()
+        return flowStarter.invokeFlowAsync(logicType, clientId, context(), *args).getOrThrow()
     }
 
     override fun attachmentExists(id: SecureHash): Boolean {

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -66,5 +66,7 @@ interface CheckpointStorage {
      */
     fun getPausedCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>>
 
+    fun getFlowResult(id: StateMachineRunId): SerializedBytes<Any>?
+
     fun updateStatus(runId: StateMachineRunId, flowStatus: Checkpoint.FlowStatus)
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,7 +215,7 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(clientId: String?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
@@ -232,7 +232,7 @@ interface FlowStarter {
      * [logicType] or [args].
      */
     fun <T> invokeFlowAsync(
-            clientId: UUID?,
+            clientId: String?,
             logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>>

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,13 +215,13 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<out FlowStateMachineReturnable<T>>
+    fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<out FlowStateMachineHandle<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
      * occurs during invocation, it will re-attempt to start the flow.
      */
-    fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<out FlowStateMachineReturnable<T>>
+    fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<out FlowStateMachineHandle<T>>
 
     /**
      * Will check [logicType] and [args] against a whitelist and if acceptable then construct and initiate the flow.
@@ -234,7 +234,7 @@ interface FlowStarter {
     fun <T> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
-            vararg args: Any?): CordaFuture<out FlowStateMachineReturnable<T>>
+            vararg args: Any?): CordaFuture<out FlowStateMachineHandle<T>>
 }
 
 interface StartedNodeServices : ServiceHubInternal, FlowStarter

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,7 +215,7 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
@@ -233,6 +233,7 @@ interface FlowStarter {
      */
     fun <T> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
+            clientId: UUID?,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>>
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,7 +215,7 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
@@ -232,8 +232,8 @@ interface FlowStarter {
      * [logicType] or [args].
      */
     fun <T> invokeFlowAsync(
-            logicType: Class<out FlowLogic<T>>,
             clientId: UUID?,
+            logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>>
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,13 +215,13 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<out FlowStateMachineReturnable<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
      * occurs during invocation, it will re-attempt to start the flow.
      */
-    fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(event: ExternalEvent.ExternalStartFlowEvent<T>): CordaFuture<out FlowStateMachineReturnable<T>>
 
     /**
      * Will check [logicType] and [args] against a whitelist and if acceptable then construct and initiate the flow.
@@ -234,7 +234,7 @@ interface FlowStarter {
     fun <T> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
-            vararg args: Any?): CordaFuture<FlowStateMachine<T>>
+            vararg args: Any?): CordaFuture<out FlowStateMachineReturnable<T>>
 }
 
 interface StartedNodeServices : ServiceHubInternal, FlowStarter

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,7 +215,7 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
@@ -233,7 +233,6 @@ interface FlowStarter {
      */
     fun <T> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
-            clientId: UUID?,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>>
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,7 +215,7 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(clientId: String?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
@@ -232,7 +232,7 @@ interface FlowStarter {
      * [logicType] or [args].
      */
     fun <T> invokeFlowAsync(
-            clientId: String?,
+            clientId: UUID?,
             logicType: Class<out FlowLogic<T>>,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>>

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -232,9 +232,10 @@ interface FlowStarter {
      * [logicType] or [args].
      */
     fun <T> invokeFlowAsync(
-            logicType: Class<out FlowLogic<T>>,
-            context: InvocationContext,
-            vararg args: Any?): CordaFuture<out FlowStateMachineHandle<T>>
+        logicType: Class<out FlowLogic<T>>,
+        context: InvocationContext,
+        vararg args: Any?
+    ): CordaFuture<out FlowStateMachineHandle<T>>
 }
 
 interface StartedNodeServices : ServiceHubInternal, FlowStarter

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -215,7 +215,7 @@ interface FlowStarter {
      * just synthesizes an [ExternalEvent.ExternalStartFlowEvent] and calls the method below.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(clientId: UUID?, logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
+    fun <T> startFlow(logic: FlowLogic<T>, clientId: UUID?, context: InvocationContext): CordaFuture<FlowStateMachine<T>>
 
     /**
      * Starts a flow as described by an [ExternalEvent.ExternalStartFlowEvent].  If a transient error
@@ -232,8 +232,8 @@ interface FlowStarter {
      * [logicType] or [args].
      */
     fun <T> invokeFlowAsync(
-            clientId: UUID?,
             logicType: Class<out FlowLogic<T>>,
+            clientId: UUID?,
             context: InvocationContext,
             vararg args: Any?): CordaFuture<FlowStateMachine<T>>
 }

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -258,7 +258,7 @@ class NodeSchedulerService(private val clock: CordaClock,
             return "${javaClass.simpleName}($scheduledState)"
         }
 
-        override fun wireUpFuture(flowFuture: CordaFuture<FlowStateMachine<Any?>>) {
+        override fun wireUpFuture(flowFuture: CordaFuture<out FlowStateMachineReturnable<Any?>>) {
             _future.captureLater(flowFuture)
             val future = _future.flatMap { it.resultFuture }
             future.then {
@@ -266,8 +266,8 @@ class NodeSchedulerService(private val clock: CordaClock,
             }
         }
 
-        private val _future = openFuture<FlowStateMachine<Any?>>()
-        override val future: CordaFuture<FlowStateMachine<Any?>>
+        private val _future = openFuture<FlowStateMachineReturnable<Any?>>()
+        override val future: CordaFuture<FlowStateMachineReturnable<Any?>>
             get() = _future
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -36,11 +36,13 @@ import org.apache.mina.util.ConcurrentHashSet
 import org.slf4j.Logger
 import java.time.Duration
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.*
 import javax.annotation.concurrent.ThreadSafe
 import javax.persistence.Column
 import javax.persistence.EmbeddedId
 import javax.persistence.Entity
+import kotlin.collections.HashSet
 import co.paralleluniverse.strands.SettableFuture as QuasarSettableFuture
 import com.google.common.util.concurrent.SettableFuture as GuavaSettableFuture
 
@@ -239,7 +241,12 @@ class NodeSchedulerService(private val clock: CordaClock,
         schedulerTimerExecutor.join()
     }
 
-    private inner class FlowStartDeduplicationHandler(val scheduledState: ScheduledStateRef, override val flowLogic: FlowLogic<Any?>, override val context: InvocationContext) : DeduplicationHandler, ExternalEvent.ExternalStartFlowEvent<Any?> {
+    private inner class FlowStartDeduplicationHandler(
+        val scheduledState: ScheduledStateRef,
+        override val flowLogic: FlowLogic<Any?>,
+        override val context: InvocationContext,
+        override val clientId: UUID? = null
+    ) : DeduplicationHandler, ExternalEvent.ExternalStartFlowEvent<Any?> {
         override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
         override val externalCause: ExternalEvent
             get() = this

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -36,7 +36,6 @@ import org.apache.mina.util.ConcurrentHashSet
 import org.slf4j.Logger
 import java.time.Duration
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.*
 import javax.annotation.concurrent.ThreadSafe
 import javax.persistence.Column
@@ -245,7 +244,7 @@ class NodeSchedulerService(private val clock: CordaClock,
         val scheduledState: ScheduledStateRef,
         override val flowLogic: FlowLogic<Any?>,
         override val context: InvocationContext,
-        override val clientId: UUID? = null
+        override val clientId: String? = null
     ) : DeduplicationHandler, ExternalEvent.ExternalStartFlowEvent<Any?> {
         override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
         override val externalCause: ExternalEvent

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -36,6 +36,7 @@ import org.apache.mina.util.ConcurrentHashSet
 import org.slf4j.Logger
 import java.time.Duration
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.*
 import javax.annotation.concurrent.ThreadSafe
 import javax.persistence.Column
@@ -244,7 +245,7 @@ class NodeSchedulerService(private val clock: CordaClock,
         val scheduledState: ScheduledStateRef,
         override val flowLogic: FlowLogic<Any?>,
         override val context: InvocationContext,
-        override val clientId: String? = null
+        override val clientId: UUID? = null
     ) : DeduplicationHandler, ExternalEvent.ExternalStartFlowEvent<Any?> {
         override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
         override val externalCause: ExternalEvent

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -258,7 +258,7 @@ class NodeSchedulerService(private val clock: CordaClock,
             return "${javaClass.simpleName}($scheduledState)"
         }
 
-        override fun wireUpFuture(flowFuture: CordaFuture<out FlowStateMachineReturnable<Any?>>) {
+        override fun wireUpFuture(flowFuture: CordaFuture<out FlowStateMachineHandle<Any?>>) {
             _future.captureLater(flowFuture)
             val future = _future.flatMap { it.resultFuture }
             future.then {
@@ -266,8 +266,8 @@ class NodeSchedulerService(private val clock: CordaClock,
             }
         }
 
-        private val _future = openFuture<FlowStateMachineReturnable<Any?>>()
-        override val future: CordaFuture<FlowStateMachineReturnable<Any?>>
+        private val _future = openFuture<FlowStateMachineHandle<Any?>>()
+        override val future: CordaFuture<FlowStateMachineHandle<Any?>>
             get() = _future
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -36,13 +36,11 @@ import org.apache.mina.util.ConcurrentHashSet
 import org.slf4j.Logger
 import java.time.Duration
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.*
 import javax.annotation.concurrent.ThreadSafe
 import javax.persistence.Column
 import javax.persistence.EmbeddedId
 import javax.persistence.Entity
-import kotlin.collections.HashSet
 import co.paralleluniverse.strands.SettableFuture as QuasarSettableFuture
 import com.google.common.util.concurrent.SettableFuture as GuavaSettableFuture
 
@@ -241,12 +239,7 @@ class NodeSchedulerService(private val clock: CordaClock,
         schedulerTimerExecutor.join()
     }
 
-    private inner class FlowStartDeduplicationHandler(
-        val scheduledState: ScheduledStateRef,
-        override val flowLogic: FlowLogic<Any?>,
-        override val context: InvocationContext,
-        override val clientId: UUID? = null
-    ) : DeduplicationHandler, ExternalEvent.ExternalStartFlowEvent<Any?> {
+    private inner class FlowStartDeduplicationHandler(val scheduledState: ScheduledStateRef, override val flowLogic: FlowLogic<Any?>, override val context: InvocationContext) : DeduplicationHandler, ExternalEvent.ExternalStartFlowEvent<Any?> {
         override val flowId: StateMachineRunId = StateMachineRunId.createRandom()
         override val externalCause: ExternalEvent
             get() = this

--- a/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
@@ -14,7 +14,7 @@ internal fun InvocationContext.pushToLoggingContext() {
     externalTrace?.pushToLoggingContext("external_")
     impersonatedActor?.pushToLoggingContext("impersonating_")
 
-    clientID?.let {
+    clientId?.let {
         MDC.getMDCAdapter().apply {
             put("client_id", it)
         }

--- a/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
@@ -13,6 +13,12 @@ internal fun InvocationContext.pushToLoggingContext() {
     origin.pushToLoggingContext()
     externalTrace?.pushToLoggingContext("external_")
     impersonatedActor?.pushToLoggingContext("impersonating_")
+
+    clientUUID?.let {
+        MDC.getMDCAdapter().apply {
+            put("client_id", it)
+        }
+    }
 }
 
 internal fun Trace.pushToLoggingContext(prefix: String = "") {
@@ -38,12 +44,5 @@ internal fun InvocationOrigin.pushToLoggingContext(prefix: String = "") {
 
     MDC.getMDCAdapter().apply {
         put("${prefix}origin", principal().name)
-    }
-}
-
-internal fun pushClientIdToLoggingContext(clientUUID: String) {
-
-    MDC.getMDCAdapter().apply {
-        put("client_id", clientUUID)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
@@ -40,3 +40,10 @@ internal fun InvocationOrigin.pushToLoggingContext(prefix: String = "") {
         put("${prefix}origin", principal().name)
     }
 }
+
+internal fun pushClientIdToLoggingContext(clientUUID: String) {
+
+    MDC.getMDCAdapter().apply {
+        put("client_id", clientUUID)
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt
@@ -14,7 +14,7 @@ internal fun InvocationContext.pushToLoggingContext() {
     externalTrace?.pushToLoggingContext("external_")
     impersonatedActor?.pushToLoggingContext("impersonating_")
 
-    clientUUID?.let {
+    clientID?.let {
         MDC.getMDCAdapter().apply {
             put("client_id", it)
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -453,7 +453,7 @@ class DBCheckpointStorage(
         deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
         deletedRows += deleteRow(DBFlowCheckpoint::class.java, DBFlowCheckpoint::flowId.name, flowId)
 //        exceptionId?.let { deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, it.toString()) }
-        return deletedRows == 3
+        return deletedRows >= 2
     }
 
     private fun <T> deleteRow(clazz: Class<T>, pk: String, value: String): Int {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -56,6 +56,7 @@ class DBCheckpointStorage(
         private const val MAX_EXC_TYPE_LENGTH = 256
         private const val MAX_FLOW_NAME_LENGTH = 128
         private const val MAX_PROGRESS_STEP_LENGTH = 256
+        const val MAX_CLIENT_ID_LENGTH = 512
 
         private val RUNNABLE_CHECKPOINTS = setOf(FlowStatus.RUNNABLE, FlowStatus.HOSPITALIZED)
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -22,7 +22,6 @@ import net.corda.nodeapi.internal.persistence.currentDBSession
 import org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.hibernate.annotations.Type
-import sun.plugin.dom.exception.InvalidStateException
 import java.sql.Connection
 import java.sql.SQLException
 import java.time.Clock
@@ -631,11 +630,7 @@ class DBCheckpointStorage(
     private fun InvocationContext.getFlowParameters(): List<Any?> {
         // Only RPC flows have parameters which are found in index 1
         return if (arguments.isNotEmpty()) {
-            when {
-                arguments.size == 2 -> uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()
-                arguments.size == 3 -> uncheckedCast<Any?, Array<Any?>>(arguments[2]).toList()
-                else -> throw InvalidStateException("Unexpected argument number provided in rpc call")
-            }
+            uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()
         } else {
             emptyList()
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -514,7 +514,7 @@ class DBCheckpointStorage(
             // Truncate the flow name to fit into the database column
             // Flow names are unlikely to be this long
             flowName = flowInfo.flowClass.name.take(MAX_FLOW_NAME_LENGTH),
-            userSuppliedIdentifier = context.clientID,
+            userSuppliedIdentifier = context.clientId,
             startType = context.getStartedType(),
             initialParameters = context.getFlowParameters().storageSerialize().bytes,
             launchingCordapp = (flowInfo.subFlowVersion as? SubFlowVersion.CorDappFlow)?.corDappName ?: "Core flow",

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -514,8 +514,7 @@ class DBCheckpointStorage(
             // Truncate the flow name to fit into the database column
             // Flow names are unlikely to be this long
             flowName = flowInfo.flowClass.name.take(MAX_FLOW_NAME_LENGTH),
-            // will come from the context
-            userSuppliedIdentifier = null,
+            userSuppliedIdentifier = context.clientUUID,
             startType = context.getStartedType(),
             initialParameters = context.getFlowParameters().storageSerialize().bytes,
             launchingCordapp = (flowInfo.subFlowVersion as? SubFlowVersion.CorDappFlow)?.corDappName ?: "Core flow",

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -630,10 +630,9 @@ class DBCheckpointStorage(
     private fun InvocationContext.getFlowParameters(): List<Any?> {
         // Only RPC flows have parameters which are found in index 1 or index 2 (if called with client id)
         return if (arguments.isNotEmpty()) {
-            when {
-                arguments.size == 2 -> uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()
-                arguments.size == 3 -> uncheckedCast<Any?, Array<Any?>>(arguments[2]).toList()
-                else -> throw IllegalStateException("Unexpected argument number provided in rpc call")
+            arguments.run {
+                check(size == 2 || size == 3) { "Unexpected argument number provided in rpc call" }
+                uncheckedCast<Any?, Array<Any?>>(last()).toList()
             }
         } else {
             emptyList()

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -22,7 +22,6 @@ import net.corda.nodeapi.internal.persistence.currentDBSession
 import org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.hibernate.annotations.Type
-import sun.plugin.dom.exception.InvalidStateException
 import java.sql.Connection
 import java.sql.SQLException
 import java.time.Clock
@@ -634,7 +633,7 @@ class DBCheckpointStorage(
             when {
                 arguments.size == 2 -> uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()
                 arguments.size == 3 -> uncheckedCast<Any?, Array<Any?>>(arguments[2]).toList()
-                else -> throw InvalidStateException("Unexpected argument number provided in rpc call")
+                else -> throw IllegalStateException("Unexpected argument number provided in rpc call")
             }
         } else {
             emptyList()

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -491,6 +491,10 @@ class DBCheckpointStorage(
         return currentDBSession().find(DBFlowCheckpoint::class.java, id.uuid.toString())
     }
 
+    private fun getDBFlowResult(id: StateMachineRunId): DBFlowResult? {
+        return currentDBSession().find(DBFlowResult::class.java, id.uuid.toString())
+    }
+
     override fun getPausedCheckpoints(): Stream<Pair<StateMachineRunId, Checkpoint.Serialized>> {
         val session = currentDBSession()
         val jpqlQuery = """select new ${DBPausedFields::class.java.name}(checkpoint.id, blob.checkpoint, checkpoint.status,
@@ -501,6 +505,10 @@ class DBCheckpointStorage(
         return query.resultList.stream().map {
             StateMachineRunId(UUID.fromString(it.id)) to it.toSerializedCheckpoint()
         }
+    }
+
+    override fun getFlowResult(id: StateMachineRunId): SerializedBytes<Any>? {
+        return getDBFlowResult(id)?.value?.let { SerializedBytes(it) }
     }
 
     override fun updateStatus(runId: StateMachineRunId, flowStatus: FlowStatus) {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -628,7 +628,7 @@ class DBCheckpointStorage(
     }
 
     private fun InvocationContext.getFlowParameters(): List<Any?> {
-        // Only RPC flows have parameters which are found in index 1
+        // Only RPC flows have parameters which are found in index 1 or index 2 (if called with client id)
         return if (arguments.isNotEmpty()) {
             when {
                 arguments.size == 2 -> uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -514,7 +514,7 @@ class DBCheckpointStorage(
             // Truncate the flow name to fit into the database column
             // Flow names are unlikely to be this long
             flowName = flowInfo.flowClass.name.take(MAX_FLOW_NAME_LENGTH),
-            userSuppliedIdentifier = context.clientUUID,
+            userSuppliedIdentifier = context.clientID,
             startType = context.getStartedType(),
             initialParameters = context.getFlowParameters().storageSerialize().bytes,
             launchingCordapp = (flowInfo.subFlowVersion as? SubFlowVersion.CorDappFlow)?.corDappName ?: "Core flow",

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -627,6 +627,7 @@ class DBCheckpointStorage(
         }
     }
 
+    @Suppress("MagicNumber")
     private fun InvocationContext.getFlowParameters(): List<Any?> {
         // Only RPC flows have parameters which are found in index 1 or index 2 (if called with client id)
         return if (arguments!!.isNotEmpty()) {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -22,6 +22,7 @@ import net.corda.nodeapi.internal.persistence.currentDBSession
 import org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.hibernate.annotations.Type
+import sun.plugin.dom.exception.InvalidStateException
 import java.sql.Connection
 import java.sql.SQLException
 import java.time.Clock
@@ -630,7 +631,11 @@ class DBCheckpointStorage(
     private fun InvocationContext.getFlowParameters(): List<Any?> {
         // Only RPC flows have parameters which are found in index 1
         return if (arguments.isNotEmpty()) {
-            uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()
+            when {
+                arguments.size == 2 -> uncheckedCast<Any?, Array<Any?>>(arguments[1]).toList()
+                arguments.size == 3 -> uncheckedCast<Any?, Array<Any?>>(arguments[2]).toList()
+                else -> throw InvalidStateException("Unexpected argument number provided in rpc call")
+            }
         } else {
             emptyList()
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -629,8 +629,8 @@ class DBCheckpointStorage(
 
     private fun InvocationContext.getFlowParameters(): List<Any?> {
         // Only RPC flows have parameters which are found in index 1 or index 2 (if called with client id)
-        return if (arguments.isNotEmpty()) {
-            arguments.run {
+        return if (arguments!!.isNotEmpty()) {
+            arguments!!.run {
                 check(size == 2 || size == 3) { "Unexpected argument number provided in rpc call" }
                 uncheckedCast<Any?, Array<Any?>>(last()).toList()
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -80,7 +80,7 @@ class FlowCreator(
 
     @Suppress("LongParameterList")
     fun <A> createFlowFromLogic(
-        clientUUID: String?,
+        clientUUID: UUID?,
         flowId: StateMachineRunId,
         invocationContext: InvocationContext,
         flowLogic: FlowLogic<A>,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -24,6 +24,7 @@ import net.corda.node.utilities.isEnabledTimedFlow
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import org.apache.activemq.artemis.utils.ReusableLatch
 import java.security.SecureRandom
+import java.util.UUID
 
 class Flow<A>(val fiber: FlowStateMachineImpl<A>, val resultFuture: OpenFuture<Any?>)
 
@@ -86,7 +87,8 @@ class FlowCreator(
         ourIdentity: Party,
         existingCheckpoint: Checkpoint?,
         deduplicationHandler: DeduplicationHandler?,
-        senderUUID: String?): Flow<A> {
+        senderUUID: String?,
+        clientUUID: UUID?): Flow<A> {
         // Before we construct the state machine state by freezing the FlowLogic we need to make sure that lazy properties
         // have access to the fiber (and thereby the service hub)
         val flowStateMachineImpl = FlowStateMachineImpl(flowId, flowLogic, scheduler)
@@ -104,7 +106,8 @@ class FlowCreator(
             frozenFlowLogic,
             ourIdentity,
             flowCorDappVersion,
-            flowLogic.isEnabledTimedFlow()
+            flowLogic.isEnabledTimedFlow(),
+            clientUUID
         ).getOrThrow()
 
         val state = createStateMachineState(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -24,7 +24,6 @@ import net.corda.node.utilities.isEnabledTimedFlow
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import org.apache.activemq.artemis.utils.ReusableLatch
 import java.security.SecureRandom
-import java.util.UUID
 
 class Flow<A>(val fiber: FlowStateMachineImpl<A>, val resultFuture: OpenFuture<Any?>)
 
@@ -87,8 +86,7 @@ class FlowCreator(
         ourIdentity: Party,
         existingCheckpoint: Checkpoint?,
         deduplicationHandler: DeduplicationHandler?,
-        senderUUID: String?,
-        clientUUID: UUID?): Flow<A> {
+        senderUUID: String?): Flow<A> {
         // Before we construct the state machine state by freezing the FlowLogic we need to make sure that lazy properties
         // have access to the fiber (and thereby the service hub)
         val flowStateMachineImpl = FlowStateMachineImpl(flowId, flowLogic, scheduler)
@@ -106,8 +104,7 @@ class FlowCreator(
             frozenFlowLogic,
             ourIdentity,
             flowCorDappVersion,
-            flowLogic.isEnabledTimedFlow(),
-            clientUUID
+            flowLogic.isEnabledTimedFlow()
         ).getOrThrow()
 
         val state = createStateMachineState(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -80,7 +80,7 @@ class FlowCreator(
 
     @Suppress("LongParameterList")
     fun <A> createFlowFromLogic(
-        clientUUID: UUID?,
+        clientUUID: String?,
         flowId: StateMachineRunId,
         invocationContext: InvocationContext,
         flowLogic: FlowLogic<A>,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -80,6 +80,7 @@ class FlowCreator(
 
     @Suppress("LongParameterList")
     fun <A> createFlowFromLogic(
+        clientUUID: UUID?,
         flowId: StateMachineRunId,
         invocationContext: InvocationContext,
         flowLogic: FlowLogic<A>,
@@ -87,8 +88,7 @@ class FlowCreator(
         ourIdentity: Party,
         existingCheckpoint: Checkpoint?,
         deduplicationHandler: DeduplicationHandler?,
-        senderUUID: String?,
-        clientUUID: UUID?): Flow<A> {
+        senderUUID: String?): Flow<A> {
         // Before we construct the state machine state by freezing the FlowLogic we need to make sure that lazy properties
         // have access to the fiber (and thereby the service hub)
         val flowStateMachineImpl = FlowStateMachineImpl(flowId, flowLogic, scheduler)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -80,7 +80,6 @@ class FlowCreator(
 
     @Suppress("LongParameterList")
     fun <A> createFlowFromLogic(
-        clientUUID: UUID?,
         flowId: StateMachineRunId,
         invocationContext: InvocationContext,
         flowLogic: FlowLogic<A>,
@@ -88,7 +87,8 @@ class FlowCreator(
         ourIdentity: Party,
         existingCheckpoint: Checkpoint?,
         deduplicationHandler: DeduplicationHandler?,
-        senderUUID: String?): Flow<A> {
+        senderUUID: String?,
+        clientUUID: UUID?): Flow<A> {
         // Before we construct the state machine state by freezing the FlowLogic we need to make sure that lazy properties
         // have access to the fiber (and thereby the service hub)
         val flowStateMachineImpl = FlowStateMachineImpl(flowId, flowLogic, scheduler)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -44,7 +44,6 @@ import net.corda.node.internal.cordapp.CordappProviderImpl
 import net.corda.node.services.api.FlowAppAuditEvent
 import net.corda.node.services.api.FlowPermissionAuditEvent
 import net.corda.node.services.api.ServiceHubInternal
-import net.corda.node.services.logging.pushClientIdToLoggingContext
 import net.corda.node.services.logging.pushToLoggingContext
 import net.corda.node.services.statemachine.transitions.FlowContinuation
 import net.corda.node.services.statemachine.transitions.StateMachine
@@ -270,7 +269,6 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
         MDC.put("flow-id", id.uuid.toString())
         MDC.put("fiber-id", this.getId().toString())
         MDC.put("thread-id", Thread.currentThread().id.toString())
-        clientUUID?.let { pushClientIdToLoggingContext(it) }
     }
 
     private fun openThreadLocalWormhole() {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -132,8 +132,8 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val context: InvocationContext get() = transientState!!.value.checkpoint.checkpointState.invocationContext
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
-    override val clientUUID: String?
-        get() = transientState?.value?.checkpoint!!.checkpointState.invocationContext.clientUUID
+    override val clientID: String?
+        get() = transientState?.value?.checkpoint!!.checkpointState.invocationContext.clientID
 
     internal val softLockedStates = mutableSetOf<StateRef>()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -133,7 +133,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val context: InvocationContext get() = transientState!!.value.checkpoint.checkpointState.invocationContext
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
-    override val clientUUID: UUID?
+    override val clientUUID: String?
         get() = transientState?.value?.checkpoint!!.checkpointState.clientUUID
 
     internal val softLockedStates = mutableSetOf<StateRef>()

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -132,6 +132,8 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val context: InvocationContext get() = transientState!!.value.checkpoint.checkpointState.invocationContext
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
+    override val clientUUID: String?
+        get() = transientState?.value?.checkpoint!!.checkpointState.invocationContext.clientUUID
 
     internal val softLockedStates = mutableSetOf<StateRef>()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -57,7 +57,6 @@ import org.apache.activemq.artemis.utils.ReusableLatch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KProperty1
 
@@ -133,8 +132,6 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val context: InvocationContext get() = transientState!!.value.checkpoint.checkpointState.invocationContext
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
-    override val clientUUID: UUID?
-        get() = transientState?.value?.checkpoint!!.checkpointState.clientUUID
 
     internal val softLockedStates = mutableSetOf<StateRef>()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -132,8 +132,8 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val context: InvocationContext get() = transientState!!.value.checkpoint.checkpointState.invocationContext
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
-    override val clientID: String?
-        get() = transientState!!.value.checkpoint.checkpointState.invocationContext.clientID
+    override val clientId: String?
+        get() = transientState!!.value.checkpoint.checkpointState.invocationContext.clientId
 
     internal val softLockedStates = mutableSetOf<StateRef>()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -133,7 +133,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
     override val clientID: String?
-        get() = transientState?.value?.checkpoint!!.checkpointState.invocationContext.clientID
+        get() = transientState!!.value.checkpoint.checkpointState.invocationContext.clientID
 
     internal val softLockedStates = mutableSetOf<StateRef>()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -133,7 +133,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val context: InvocationContext get() = transientState!!.value.checkpoint.checkpointState.invocationContext
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
-    override val clientUUID: String?
+    override val clientUUID: UUID?
         get() = transientState?.value?.checkpoint!!.checkpointState.clientUUID
 
     internal val softLockedStates = mutableSetOf<StateRef>()

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -57,6 +57,7 @@ import org.apache.activemq.artemis.utils.ReusableLatch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KProperty1
 
@@ -132,6 +133,8 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     override val context: InvocationContext get() = transientState!!.value.checkpoint.checkpointState.invocationContext
     override val ourIdentity: Party get() = transientState!!.value.checkpoint.checkpointState.ourIdentity
     override val isKilled: Boolean get() = transientState!!.value.isKilled
+    override val clientUUID: UUID?
+        get() = transientState?.value?.checkpoint!!.checkpointState.clientUUID
 
     internal val softLockedStates = mutableSetOf<StateRef>()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -44,6 +44,7 @@ import net.corda.node.internal.cordapp.CordappProviderImpl
 import net.corda.node.services.api.FlowAppAuditEvent
 import net.corda.node.services.api.FlowPermissionAuditEvent
 import net.corda.node.services.api.ServiceHubInternal
+import net.corda.node.services.logging.pushClientIdToLoggingContext
 import net.corda.node.services.logging.pushToLoggingContext
 import net.corda.node.services.statemachine.transitions.FlowContinuation
 import net.corda.node.services.statemachine.transitions.StateMachine
@@ -269,6 +270,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
         MDC.put("flow-id", id.uuid.toString())
         MDC.put("fiber-id", this.getId().toString())
         MDC.put("thread-id", Thread.currentThread().id.toString())
+        clientUUID?.let { pushClientIdToLoggingContext(it) }
     }
 
     private fun openThreadLocalWormhole() {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -294,7 +294,6 @@ internal class SingleThreadedStateMachineManager(
             }
             if (existingFuture != null) return uncheckedCast(existingFuture)
 
-            // (testing) client id exists but is not present in the map
             onClientIDNotFound?.invoke()
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -19,7 +19,6 @@ import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.castIfPossible
 import net.corda.core.internal.concurrent.OpenFuture
-import net.corda.core.internal.concurrent.doneFuture
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.concurrent.mapError
 import net.corda.core.internal.concurrent.openFuture

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -270,6 +270,8 @@ internal class SingleThreadedStateMachineManager(
     ): CordaFuture<out FlowStateMachineHandle<A>> {
         beforeClientIDCheck?.invoke()
 
+        var newFuture: CordaFuture<out FlowStateMachineHandle<out Any?>>? = null
+
         val clientID = context.clientID
         if (clientID != null) {
             var existingFuture: CordaFuture<out FlowStateMachineHandle<out Any?>>? = null
@@ -290,7 +292,7 @@ internal class SingleThreadedStateMachineManager(
                         }
                         existingStatus
                     } else {
-                        FlowWithClientIdStatus.Active(openFuture())
+                        FlowWithClientIdStatus.Active(openFuture()).also { newFuture = it.flowStateMachineFuture }
                     }
                 }
             }
@@ -309,9 +311,7 @@ internal class SingleThreadedStateMachineManager(
             deduplicationHandler = deduplicationHandler
         ).also {
             if (clientID != null) {
-                // wire up this future to the clientIDsToFlowIds[clientID] future
-                val active = mutex.content.clientIDsToFlowIds[clientID] as? FlowWithClientIdStatus.Active
-                (active?.flowStateMachineFuture as? OpenFuture<FlowStateMachine<*>>)?.captureLater(it)
+                (newFuture as? OpenFuture<FlowStateMachine<*>>)?.captureLater(it)
                     ?: throw java.lang.IllegalStateException("Flow's $flowId client id mapping is in an inconsistent state")
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -257,9 +257,10 @@ internal class SingleThreadedStateMachineManager(
                         override val resultFuture: CordaFuture<A> = future as OpenFuture<A>
                         override val clientID: String? = clientID
                     })
-                } ?:
-                onClientIDNotFound?.invoke()
-                null
+                } ?: {
+                    onClientIDNotFound?.invoke()
+                    null
+                }.invoke()
             }
         } ?: startFlowInternal(
             flowId,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -171,7 +171,6 @@ internal class SingleThreadedStateMachineManager(
         }
 
         // at the moment we have RUNNABLE, HOSPITALIZED and PAUSED -> TODO: RESULTED AND FAILED still need to be fetched
-        // populate [clientIDsToFlowIds] with done futures for -started from checkpoint- flows, as these flows have already started
         for (flow in fibers) {
             flow.fiber.clientID?.let {
                 mutex.content.clientIDsToFlowIds[it] = FlowWithClientIdStatus.Active(doneFuture(flow.fiber))

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -271,9 +271,7 @@ internal class SingleThreadedStateMachineManager(
         ).also {
             if (clientID != null) {
                 // wire up this future to the clientIDsToFlowIds[clientID] future
-                mutex.locked {
-                    clientIDsToFlowIds[clientID]!!.captureLater(it)
-                }
+                mutex.content.clientIDsToFlowIds[clientID]!!.captureLater(it) // TODO: take care of this not checked null
             }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -272,7 +272,7 @@ internal class SingleThreadedStateMachineManager(
     ): CordaFuture<out FlowStateMachineHandle<A>> {
         beforeClientIDCheck?.invoke()
 
-        var newFuture: OpenFuture<out FlowStateMachineHandle<A>>? = null
+        var newFuture: OpenFuture<FlowStateMachineHandle<A>>? = null
 
         val clientId = context.clientId
         if (clientId != null) {
@@ -886,7 +886,7 @@ internal class SingleThreadedStateMachineManager(
         id: StateMachineRunId,
         resultFuture: CordaFuture<Any?>,
         clientId: String
-    ): CordaFuture<out FlowStateMachineHandle<out Any?>> =
+    ): CordaFuture<FlowStateMachineHandle<Any?>> =
         doneFuture(object : FlowStateMachineHandle<Any?> {
             override val logic: Nothing? = null
             override val id: StateMachineRunId = id

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -280,7 +280,7 @@ internal class SingleThreadedStateMachineManager(
             innerState.withLock {
                 clientIdsToFlowIds.compute(clientId) { _, existingStatus ->
                     if (existingStatus != null) {
-                        existingFuture = activeOrRemovedFuture(existingStatus, clientId)
+                        existingFuture = activeOrRemovedClientIdFuture(existingStatus, clientId)
                         existingStatus
                     } else {
                         newFuture = openFuture()
@@ -871,7 +871,7 @@ internal class SingleThreadedStateMachineManager(
         }
     }
 
-    private fun activeOrRemovedFuture(existingStatus: FlowWithClientIdStatus, clientId: String) = when (existingStatus) {
+    private fun activeOrRemovedClientIdFuture(existingStatus: FlowWithClientIdStatus, clientId: String) = when (existingStatus) {
         is FlowWithClientIdStatus.Active -> existingStatus.flowStateMachineFuture
         is FlowWithClientIdStatus.Removed -> {
             val flowId = existingStatus.flowId

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -181,13 +181,8 @@ internal class SingleThreadedStateMachineManager(
         for (pausedFlow in pausedFlows) {
             pausedFlow.value.checkpoint.checkpointState.invocationContext.clientId?.let {
                 mutex.content.clientIdsToFlowIds[it] = FlowWithClientIdStatus.Active(
-                    doneFuture(object : FlowStateMachineHandle<Any?> {
-                        override val logic: Nothing? = null
-                        override val id: StateMachineRunId = pausedFlow.key
-                        override val resultFuture: CordaFuture<Any?> = pausedFlow.value.resultFuture
-                        override val clientId: String? = it
-                    }
-                ))
+                    doneClientIdFuture(pausedFlow.key, pausedFlow.value.resultFuture, it)
+                )
             }
         }
 
@@ -281,15 +276,7 @@ internal class SingleThreadedStateMachineManager(
                     if (existingStatus != null) {
                         existingFuture = when (existingStatus) {
                             is FlowWithClientIdStatus.Active -> existingStatus.flowStateMachineFuture
-                            is FlowWithClientIdStatus.Removed -> {
-                                doneFuture(object : FlowStateMachineHandle<Any> {
-                                    override val logic: Nothing? = null
-                                    override val id: StateMachineRunId = existingStatus.flowId
-                                    // The following future will be populated from DB upon implementing CORDA-3692 and CORDA-3681 - for now just return a dummy future
-                                    override val resultFuture: CordaFuture<Any> = doneFuture(5)
-                                    override val clientId: String? = clientId
-                                })
-                            }
+                            is FlowWithClientIdStatus.Removed -> doneClientIdFuture(existingStatus.flowId, doneFuture(5), clientId) // This dummy future ('doneFuture(5)') will be populated from DB upon implementing CORDA-3692 and CORDA-3681 - for now just return a dummy future
                         }
                         existingStatus
                     } else {
@@ -879,6 +866,23 @@ internal class SingleThreadedStateMachineManager(
             FlowWithClientIdStatus.Removed(id, nextStatus)
         }
     }
+
+    /**
+     * The flow out of which a [doneFuture] will be produced should be a started flow,
+     * i.e. it should not exist in [mutex.content.startedFutures].
+     */
+    private fun doneClientIdFuture(
+        id: StateMachineRunId,
+        resultFuture: CordaFuture<Any?>,
+        clientId: String
+    ): CordaFuture<out FlowStateMachineHandle<out Any?>> =
+        doneFuture(object : FlowStateMachineHandle<Any?> {
+            override val logic: Nothing? = null
+            override val id: StateMachineRunId = id
+            override val resultFuture: CordaFuture<Any?> = resultFuture
+            override val clientId: String? = clientId
+        }
+        )
 
     override fun removeClientId(clientId: String): Boolean {
         var removed = false

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -314,6 +314,8 @@ internal class SingleThreadedStateMachineManager(
                 clientIdsToFlowIds.remove(clientId)
                 newFuture?.setException(t)
             }
+            // Throwing the exception plain here is the same as to return an exceptionally completed future since the caller calls
+            // getOrThrow() on the returned future at [CordaRPCOpsImpl.startFlow].
             throw t
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -849,21 +849,21 @@ internal class SingleThreadedStateMachineManager(
     }
 
     private fun InnerState.setClientIdAsSucceeded(clientId: String, id: StateMachineRunId) {
-        setClientIdAsRemoved(clientId, id, FlowWithClientIdStatus.Removed.Status.SUCCEEDED)
+        setClientIdAsRemoved(clientId, id, true)
     }
 
     private fun InnerState.setClientIdAsFailed(clientId: String, id: StateMachineRunId) {
-        setClientIdAsRemoved(clientId, id, FlowWithClientIdStatus.Removed.Status.FAILED)
+        setClientIdAsRemoved(clientId, id, false)
     }
 
     private fun InnerState.setClientIdAsRemoved(
         clientId: String,
         id: StateMachineRunId,
-        nextStatus: FlowWithClientIdStatus.Removed.Status
+        succeeded: Boolean
     ) {
         clientIdsToFlowIds.compute(clientId) { _, existingStatus ->
             require(existingStatus != null && existingStatus is FlowWithClientIdStatus.Active)
-            FlowWithClientIdStatus.Removed(id, nextStatus)
+            FlowWithClientIdStatus.Removed(id, succeeded)
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -49,6 +49,7 @@ import rx.Observable
 import java.security.SecureRandom
 import java.time.Duration
 import java.util.HashSet
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -231,7 +232,7 @@ internal class SingleThreadedStateMachineManager(
     }
 
     private fun <A> startFlow(
-            clientUUID: String?,
+            clientUUID: UUID?,
             flowId: StateMachineRunId,
             flowLogic: FlowLogic<A>,
             context: InvocationContext,
@@ -589,7 +590,7 @@ internal class SingleThreadedStateMachineManager(
 
     @Suppress("LongParameterList")
     private fun <A> startFlowInternal(
-            clientUUID: String?,
+            clientUUID: UUID?,
             flowId: StateMachineRunId,
             invocationContext: InvocationContext,
             flowLogic: FlowLogic<A>,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -171,6 +171,7 @@ internal class SingleThreadedStateMachineManager(
         }
 
         // at the moment we have RUNNABLE, HOSPITALIZED and PAUSED -> TODO: RESULTED AND FAILED still need to be fetched
+        //  + Handle incompatible checkpoints upon implementing CORDA-3897
         for (flow in fibers) {
             flow.fiber.clientId?.let {
                 mutex.content.clientIdsToFlowIds[it] = FlowWithClientIdStatus.Active(doneFuture(flow.fiber))

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -52,7 +52,6 @@ import net.corda.serialization.internal.CheckpointSerializeAsTokenContextImpl
 import net.corda.serialization.internal.withTokenContext
 import org.apache.activemq.artemis.utils.ReusableLatch
 import rx.Observable
-import sun.plugin.dom.exception.InvalidStateException
 import java.security.SecureRandom
 import java.time.Duration
 import java.util.HashSet
@@ -288,7 +287,7 @@ internal class SingleThreadedStateMachineManager(
                             is FlowWithClientIdStatus.Removed -> {
                                 val serializedFlowResult = database.transaction { checkpointStorage.getFlowResult(existingStatus.flowId) }
                                 val flowResult = serializedFlowResult?.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
-                                    ?: throw InvalidStateException("serializedFlowResult was null or could not deserialize it")
+                                    ?: throw IllegalStateException("serializedFlowResult was null or could not deserialize it")
                                 doneClientIdFuture(existingStatus.flowId, doneFuture(flowResult), clientId)
                             }
                         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -299,10 +299,7 @@ internal class SingleThreadedStateMachineManager(
             ourIdentity = ourIdentity ?: ourFirstIdentity,
             deduplicationHandler = deduplicationHandler
         ).also {
-            if (clientId != null) {
-                (newFuture as? OpenFuture<FlowStateMachine<*>>)?.captureLater(it)
-                    ?: throw java.lang.IllegalStateException("Flow's $flowId client id mapping is in an inconsistent state")
-            }
+            newFuture?.captureLater(uncheckedCast(it))
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -865,7 +865,12 @@ internal class SingleThreadedStateMachineManager(
 
     override fun removeClientId(clientID: String): Boolean {
         return mutex.locked {
-            clientIDsToFlowIds.remove(clientID) != null
+            val existingStatus = clientIDsToFlowIds[clientID]
+            if (existingStatus != null && existingStatus is FlowWithClientIdStatus.Removed) {
+                clientIDsToFlowIds.remove(clientID) != null
+            } else {
+                false
+            }
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -172,19 +172,19 @@ internal class SingleThreadedStateMachineManager(
 
         // at the moment we have RUNNABLE, HOSPITALIZED and PAUSED -> TODO: RESULTED AND FAILED still need to be fetched
         for (flow in fibers) {
-            flow.fiber.clientID?.let {
-                mutex.content.clientIDsToFlowIds[it] = FlowWithClientIdStatus.Active(doneFuture(flow.fiber))
+            flow.fiber.clientId?.let {
+                mutex.content.clientIdsToFlowIds[it] = FlowWithClientIdStatus.Active(doneFuture(flow.fiber))
             }
         }
 
         for (pausedFlow in pausedFlows) {
-            pausedFlow.value.checkpoint.checkpointState.invocationContext.clientID?.let {
-                mutex.content.clientIDsToFlowIds[it] = FlowWithClientIdStatus.Active(
+            pausedFlow.value.checkpoint.checkpointState.invocationContext.clientId?.let {
+                mutex.content.clientIdsToFlowIds[it] = FlowWithClientIdStatus.Active(
                     doneFuture(object : FlowStateMachineHandle<Any?> {
                         override val logic: Nothing? = null
                         override val id: StateMachineRunId = pausedFlow.key
                         override val resultFuture: CordaFuture<Any?> = pausedFlow.value.resultFuture
-                        override val clientID: String? = it
+                        override val clientId: String? = it
                     }
                 ))
             }
@@ -272,11 +272,11 @@ internal class SingleThreadedStateMachineManager(
 
         var newFuture: CordaFuture<out FlowStateMachineHandle<out Any?>>? = null
 
-        val clientID = context.clientID
-        if (clientID != null) {
+        val clientId = context.clientId
+        if (clientId != null) {
             var existingFuture: CordaFuture<out FlowStateMachineHandle<out Any?>>? = null
             mutex.locked {
-                clientIDsToFlowIds.compute(clientID) { _, existingStatus ->
+                clientIdsToFlowIds.compute(clientId) { _, existingStatus ->
                     if (existingStatus != null) {
                         existingFuture = when (existingStatus) {
                             is FlowWithClientIdStatus.Active -> existingStatus.flowStateMachineFuture
@@ -286,7 +286,7 @@ internal class SingleThreadedStateMachineManager(
                                     override val id: StateMachineRunId = existingStatus.flowId
                                     // The following future will be populated from DB upon implementing CORDA-3692 and CORDA-3681 - for now just return a dummy future
                                     override val resultFuture: CordaFuture<Any> = doneFuture(5)
-                                    override val clientID: String? = clientID
+                                    override val clientId: String? = clientId
                                 })
                             }
                         }
@@ -310,7 +310,7 @@ internal class SingleThreadedStateMachineManager(
             ourIdentity = ourIdentity ?: ourFirstIdentity,
             deduplicationHandler = deduplicationHandler
         ).also {
-            if (clientID != null) {
+            if (clientId != null) {
                 (newFuture as? OpenFuture<FlowStateMachine<*>>)?.captureLater(it)
                     ?: throw java.lang.IllegalStateException("Flow's $flowId client id mapping is in an inconsistent state")
             }
@@ -807,7 +807,7 @@ internal class SingleThreadedStateMachineManager(
         require(lastState.isRemoved) { "Flow must be in removable state before removal" }
         require(lastState.checkpoint.checkpointState.subFlowStack.size == 1) { "Checkpointed stack must be empty" }
         require(flow.fiber.id !in sessionToFlow.values) { "Flow fibre must not be needed by an existing session" }
-        flow.fiber.clientID?.let { setClientIdAsSucceeded(it, flow.fiber.id) }
+        flow.fiber.clientId?.let { setClientIdAsSucceeded(it, flow.fiber.id) }
         flow.resultFuture.set(removalReason.flowReturnValue)
         lastState.flowLogic.progressTracker?.currentStep = ProgressTracker.DONE
         changesPublisher.onNext(StateMachineManager.Change.Removed(lastState.flowLogic, Try.Success(removalReason.flowReturnValue)))
@@ -819,7 +819,7 @@ internal class SingleThreadedStateMachineManager(
             lastState: StateMachineState
     ) {
         drainFlowEventQueue(flow)
-        flow.fiber.clientID?.let { setClientIdAsFailed(it, flow.fiber.id) }
+        flow.fiber.clientId?.let { setClientIdAsFailed(it, flow.fiber.id) }
         val flowError = removalReason.flowErrors[0] // TODO what to do with several?
         val exception = flowError.exception
         (exception as? FlowException)?.originalErrorId = flowError.errorId
@@ -860,29 +860,29 @@ internal class SingleThreadedStateMachineManager(
         }
     }
 
-    private fun InnerState.setClientIdAsSucceeded(clientID: String, id: StateMachineRunId) {
-        setClientIdAsRemoved(clientID, id, FlowWithClientIdStatus.Removed.Status.SUCCEEDED)
+    private fun InnerState.setClientIdAsSucceeded(clientId: String, id: StateMachineRunId) {
+        setClientIdAsRemoved(clientId, id, FlowWithClientIdStatus.Removed.Status.SUCCEEDED)
     }
 
-    private fun InnerState.setClientIdAsFailed(clientID: String, id: StateMachineRunId) {
-        setClientIdAsRemoved(clientID, id, FlowWithClientIdStatus.Removed.Status.FAILED)
+    private fun InnerState.setClientIdAsFailed(clientId: String, id: StateMachineRunId) {
+        setClientIdAsRemoved(clientId, id, FlowWithClientIdStatus.Removed.Status.FAILED)
     }
 
     private fun InnerState.setClientIdAsRemoved(
-        clientID: String,
+        clientId: String,
         id: StateMachineRunId,
         nextStatus: FlowWithClientIdStatus.Removed.Status
     ) {
-        clientIDsToFlowIds.compute(clientID) { _, existingStatus ->
+        clientIdsToFlowIds.compute(clientId) { _, existingStatus ->
             require(existingStatus != null && existingStatus is FlowWithClientIdStatus.Active)
             FlowWithClientIdStatus.Removed(id, nextStatus)
         }
     }
 
-    override fun removeClientId(clientID: String): Boolean {
+    override fun removeClientId(clientId: String): Boolean {
         var removed = false
         mutex.locked {
-            clientIDsToFlowIds.compute(clientID) { _, existingStatus ->
+            clientIdsToFlowIds.compute(clientId) { _, existingStatus ->
                 if (existingStatus != null && existingStatus is FlowWithClientIdStatus.Removed) {
                     removed = true
                     null

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -173,8 +173,10 @@ internal class SingleThreadedStateMachineManager(
             }
         }
 
-        // at the moment we have RUNNABLE, HOSPITALIZED and PAUSED -> TODO: RESULTED AND FAILED still need to be fetched
-        //  + Handle incompatible checkpoints upon implementing CORDA-3897
+        // at the moment we have RUNNABLE, HOSPITALIZED and PAUSED flows
+        // - RESULTED flows need to be fetched upon implementing https://r3-cev.atlassian.net/browse/CORDA-3692
+        // - FAILED flows need to be fetched upon implementing https://r3-cev.atlassian.net/browse/CORDA-3681
+        // - Incompatible checkpoints need to be handled upon implementing CORDA-3897
         for (flow in fibers) {
             flow.fiber.clientId?.let {
                 innerState.clientIdsToFlowIds[it] = FlowWithClientIdStatus.Active(doneFuture(flow.fiber))
@@ -279,7 +281,8 @@ internal class SingleThreadedStateMachineManager(
                     if (existingStatus != null) {
                         existingFuture = when (existingStatus) {
                             is FlowWithClientIdStatus.Active -> existingStatus.flowStateMachineFuture
-                            is FlowWithClientIdStatus.Removed -> doneClientIdFuture(existingStatus.flowId, doneFuture(5), clientId) // This dummy future ('doneFuture(5)') will be populated from DB upon implementing CORDA-3692 and CORDA-3681 - for now just return a dummy future
+                            // This below dummy future ('doneFuture(5)') will be populated from DB upon implementing CORDA-3692 and CORDA-3681 - for now just return a dummy future
+                            is FlowWithClientIdStatus.Removed -> doneClientIdFuture(existingStatus.flowId, doneFuture(@Suppress("MagicNumber")5), clientId)
                         }
                         existingStatus
                     } else {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -266,7 +266,7 @@ internal class SingleThreadedStateMachineManager(
     ): CordaFuture<out FlowStateMachineHandle<A>> {
         beforeClientIDCheck?.invoke()
 
-        var newFuture: CordaFuture<out FlowStateMachineHandle<out Any?>>? = null
+        var newFuture: OpenFuture<out FlowStateMachineHandle<out Any?>>? = null
 
         val clientId = context.clientId
         if (clientId != null) {
@@ -280,7 +280,8 @@ internal class SingleThreadedStateMachineManager(
                         }
                         existingStatus
                     } else {
-                        FlowWithClientIdStatus.Active(openFuture()).also { newFuture = it.flowStateMachineFuture }
+                        newFuture = openFuture()
+                        FlowWithClientIdStatus.Active(newFuture!!)
                     }
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -14,7 +14,6 @@ import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.FlowStateMachineHandle
-import net.corda.core.internal.ThreadBox
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.castIfPossible
@@ -661,7 +660,6 @@ internal class SingleThreadedStateMachineManager(
             ourIdentity: Party,
             deduplicationHandler: DeduplicationHandler?
     ): CordaFuture<FlowStateMachine<A>> {
-
         onCallingStartFlowInternal?.invoke()
 
         val existingFlow = innerState.withLock { flows[flowId] }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -820,14 +820,14 @@ internal class SingleThreadedStateMachineManager(
             lastState: StateMachineState
     ) {
         drainFlowEventQueue(flow)
+        // Complete the started future, needed when the flow fails during flow init (before completing an [UnstartedFlowTransition])
+        startedFutures.remove(flow.fiber.id)?.set(Unit)
         flow.fiber.clientId?.let { setClientIdAsFailed(it, flow.fiber.id) }
         val flowError = removalReason.flowErrors[0] // TODO what to do with several?
         val exception = flowError.exception
         (exception as? FlowException)?.originalErrorId = flowError.errorId
         flow.resultFuture.setException(exception)
         lastState.flowLogic.progressTracker?.endWithError(exception)
-        // Complete the started future, needed when the flow fails during flow init (before completing an [UnstartedFlowTransition])
-        startedFutures.remove(flow.fiber.id)?.set(Unit)
         changesPublisher.onNext(StateMachineManager.Change.Removed(lastState.flowLogic, Try.Failure<Nothing>(exception)))
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -262,6 +262,7 @@ internal class SingleThreadedStateMachineManager(
         }
     }
 
+    @Suppress("ComplexMethod")
     private fun <A> startFlow(
             flowId: StateMachineRunId,
             flowLogic: FlowLogic<A>,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -859,4 +859,10 @@ internal class SingleThreadedStateMachineManager(
             }
         }
     }
+
+    override fun removeClientId(clientID: String): Boolean {
+        return mutex.locked {
+            clientIDsToFlowIds.remove(clientID) != null
+        }
+    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -25,6 +25,7 @@ import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.mapNotNull
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.DataFeed
+import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.internal.CheckpointSerializationContext
 import net.corda.core.serialization.internal.CheckpointSerializationDefaults
@@ -51,6 +52,7 @@ import net.corda.serialization.internal.CheckpointSerializeAsTokenContextImpl
 import net.corda.serialization.internal.withTokenContext
 import org.apache.activemq.artemis.utils.ReusableLatch
 import rx.Observable
+import sun.plugin.dom.exception.InvalidStateException
 import java.security.SecureRandom
 import java.time.Duration
 import java.util.HashSet
@@ -283,7 +285,12 @@ internal class SingleThreadedStateMachineManager(
                         existingFuture = when (existingStatus) {
                             is FlowWithClientIdStatus.Active -> existingStatus.flowStateMachineFuture
                             // This below dummy future ('doneFuture(5)') will be populated from DB upon implementing CORDA-3692 and CORDA-3681 - for now just return a dummy future
-                            is FlowWithClientIdStatus.Removed -> doneClientIdFuture(existingStatus.flowId, doneFuture(@Suppress("MagicNumber")5), clientId)
+                            is FlowWithClientIdStatus.Removed -> {
+                                val serializedFlowResult = database.transaction { checkpointStorage.getFlowResult(existingStatus.flowId) }
+                                val flowResult = serializedFlowResult?.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+                                    ?: throw InvalidStateException("serializedFlowResult was null or could not deserialize it")
+                                doneClientIdFuture(existingStatus.flowId, doneFuture(flowResult), clientId)
+                            }
                         }
                         existingStatus
                     } else {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -178,19 +178,18 @@ internal class SingleThreadedStateMachineManager(
             }
         }
 
-        // paused flows do not have a flowStateMachineImpl yet...
-//        for (pausedFlow in pausedFlows) {
-//            pausedFlow.value.checkpoint.checkpointState.invocationContext.clientID?.let {
-//                mutex.content.clientIDsToFlowIds[it] = FlowWithClientIdStatus.Active(
-//                    doneFuture(object : FlowStateMachineHandle<Any> {
-//                        override val logic: Nothing? = null
-//                        override val id: StateMachineRunId = pausedFlow.key
-//                        override val resultFuture: CordaFuture<Any> = openFuture()
-//                        override val clientID: String? = it
-//                    }
-//                ))
-//            }
-//        }
+        for (pausedFlow in pausedFlows) {
+            pausedFlow.value.checkpoint.checkpointState.invocationContext.clientID?.let {
+                mutex.content.clientIDsToFlowIds[it] = FlowWithClientIdStatus.Active(
+                    doneFuture(object : FlowStateMachineHandle<Any?> {
+                        override val logic: Nothing? = null
+                        override val id: StateMachineRunId = pausedFlow.key
+                        override val resultFuture: CordaFuture<Any?> = pausedFlow.value.resultFuture
+                        override val clientID: String? = it
+                    }
+                ))
+            }
+        }
 
         return serviceHub.networkMapCache.nodeReady.map {
             logger.info("Node ready, info: ${serviceHub.myInfo}")

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -49,7 +49,6 @@ import rx.Observable
 import java.security.SecureRandom
 import java.time.Duration
 import java.util.HashSet
-import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -232,7 +231,7 @@ internal class SingleThreadedStateMachineManager(
     }
 
     private fun <A> startFlow(
-            clientUUID: UUID?,
+            clientUUID: String?,
             flowId: StateMachineRunId,
             flowLogic: FlowLogic<A>,
             context: InvocationContext,
@@ -590,7 +589,7 @@ internal class SingleThreadedStateMachineManager(
 
     @Suppress("LongParameterList")
     private fun <A> startFlowInternal(
-            clientUUID: UUID?,
+            clientUUID: String?,
             flowId: StateMachineRunId,
             invocationContext: InvocationContext,
             flowLogic: FlowLogic<A>,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineInnerState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineInnerState.kt
@@ -17,6 +17,7 @@ internal interface StateMachineInnerState {
     val changesPublisher: PublishSubject<Change>
     /** Flows scheduled to be retried if not finished within the specified timeout period. */
     val timedFlows: MutableMap<StateMachineRunId, ScheduledTimeout>
+    val clientIdsToFlowIds: MutableMap<String, FlowWithClientIdStatus>
 
     fun <R> withMutex(block: StateMachineInnerState.() -> R): R
 }
@@ -30,6 +31,7 @@ internal class StateMachineInnerStateImpl : StateMachineInnerState {
     override val pausedFlows = HashMap<StateMachineRunId, NonResidentFlow>()
     override val startedFutures = HashMap<StateMachineRunId, OpenFuture<Unit>>()
     override val timedFlows = HashMap<StateMachineRunId, ScheduledTimeout>()
+    override val clientIdsToFlowIds = HashMap<String, FlowWithClientIdStatus>()
 
     override fun <R> withMutex(block: StateMachineInnerState.() -> R): R = lock.withLock { block(this) }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -99,6 +99,13 @@ interface StateMachineManager {
      * Returns a snapshot of all [FlowStateMachineImpl]s currently managed.
      */
     fun snapshot(): Set<FlowStateMachineImpl<*>>
+
+    /**
+     * Removes a flow's [clientID] to result/ exception mapping.
+     *
+     * @return whether the mapping was removed.
+     */
+    fun removeClientId(clientID: String): Boolean
 }
 
 // These must be idempotent! A later failure in the state transition may error the flow state, and a replay may call

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -5,7 +5,7 @@ import net.corda.core.context.InvocationContext
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.FlowStateMachineReturnable
+import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.messaging.DataFeed
 import net.corda.core.utilities.Try
 import net.corda.node.services.messaging.DeduplicationHandler
@@ -140,11 +140,11 @@ interface ExternalEvent {
         /**
          * A callback for the state machine to pass back the [CordaFuture] associated with the flow start to the submitter.
          */
-        fun wireUpFuture(flowFuture: CordaFuture<out FlowStateMachineReturnable<T>>)
+        fun wireUpFuture(flowFuture: CordaFuture<out FlowStateMachineHandle<T>>)
 
         /**
          * The future representing the flow start, passed back from the state machine to the submitter of this event.
          */
-        val future: CordaFuture<out FlowStateMachineReturnable<T>>
+        val future: CordaFuture<out FlowStateMachineHandle<T>>
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -101,11 +101,11 @@ interface StateMachineManager {
     fun snapshot(): Set<FlowStateMachineImpl<*>>
 
     /**
-     * Removes a flow's [clientID] to result/ exception mapping.
+     * Removes a flow's [clientId] to result/ exception mapping.
      *
      * @return whether the mapping was removed.
      */
-    fun removeClientId(clientID: String): Boolean
+    fun removeClientId(clientId: String): Boolean
 }
 
 // These must be idempotent! A later failure in the state transition may error the flow state, and a replay may call

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -11,7 +11,6 @@ import net.corda.node.services.messaging.DeduplicationHandler
 import net.corda.node.services.messaging.ReceivedMessage
 import rx.Observable
 import java.time.Duration
-import java.util.UUID
 
 /**
  * A StateMachineManager is responsible for coordination and persistence of multiple [FlowStateMachine] objects.
@@ -136,7 +135,6 @@ interface ExternalEvent {
         val flowId: StateMachineRunId
         val flowLogic: FlowLogic<T>
         val context: InvocationContext
-        val clientId: UUID?
 
         /**
          * A callback for the state machine to pass back the [CordaFuture] associated with the flow start to the submitter.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -133,10 +133,10 @@ interface ExternalEvent {
      * An external request to start a flow, from the scheduler for example.
      */
     interface ExternalStartFlowEvent<T> : ExternalEvent {
-        val clientId: UUID?
         val flowId: StateMachineRunId
         val flowLogic: FlowLogic<T>
         val context: InvocationContext
+        val clientId: UUID?
 
         /**
          * A callback for the state machine to pass back the [CordaFuture] associated with the flow start to the submitter.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -11,6 +11,7 @@ import net.corda.node.services.messaging.DeduplicationHandler
 import net.corda.node.services.messaging.ReceivedMessage
 import rx.Observable
 import java.time.Duration
+import java.util.UUID
 
 /**
  * A StateMachineManager is responsible for coordination and persistence of multiple [FlowStateMachine] objects.
@@ -135,6 +136,7 @@ interface ExternalEvent {
         val flowId: StateMachineRunId
         val flowLogic: FlowLogic<T>
         val context: InvocationContext
+        val clientId: UUID?
 
         /**
          * A callback for the state machine to pass back the [CordaFuture] associated with the flow start to the submitter.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -5,6 +5,7 @@ import net.corda.core.context.InvocationContext
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.FlowStateMachineReturnable
 import net.corda.core.messaging.DataFeed
 import net.corda.core.utilities.Try
 import net.corda.node.services.messaging.DeduplicationHandler
@@ -139,11 +140,11 @@ interface ExternalEvent {
         /**
          * A callback for the state machine to pass back the [CordaFuture] associated with the flow start to the submitter.
          */
-        fun wireUpFuture(flowFuture: CordaFuture<FlowStateMachine<T>>)
+        fun wireUpFuture(flowFuture: CordaFuture<out FlowStateMachineReturnable<T>>)
 
         /**
          * The future representing the flow start, passed back from the state machine to the submitter of this event.
          */
-        val future: CordaFuture<FlowStateMachine<T>>
+        val future: CordaFuture<out FlowStateMachineReturnable<T>>
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -133,7 +133,7 @@ interface ExternalEvent {
      * An external request to start a flow, from the scheduler for example.
      */
     interface ExternalStartFlowEvent<T> : ExternalEvent {
-        val clientId: UUID?
+        val clientId: String?
         val flowId: StateMachineRunId
         val flowLogic: FlowLogic<T>
         val context: InvocationContext

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -133,10 +133,10 @@ interface ExternalEvent {
      * An external request to start a flow, from the scheduler for example.
      */
     interface ExternalStartFlowEvent<T> : ExternalEvent {
+        val clientId: UUID?
         val flowId: StateMachineRunId
         val flowLogic: FlowLogic<T>
         val context: InvocationContext
-        val clientId: UUID?
 
         /**
          * A callback for the state machine to pass back the [CordaFuture] associated with the flow start to the submitter.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -133,7 +133,7 @@ interface ExternalEvent {
      * An external request to start a flow, from the scheduler for example.
      */
     interface ExternalStartFlowEvent<T> : ExternalEvent {
-        val clientId: String?
+        val clientId: UUID?
         val flowId: StateMachineRunId
         val flowLogic: FlowLogic<T>
         val context: InvocationContext

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -112,8 +112,8 @@ data class Checkpoint(
                         numberOfSuspends = 0,
                         clientUUID = clientUUID
                     ),
-                    errorState = ErrorState.Clean,
-                    flowState = FlowState.Unstarted(flowStart, frozenFlowLogic)
+                    flowState = FlowState.Unstarted(flowStart, frozenFlowLogic),
+                    errorState = ErrorState.Clean
                 )
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -100,7 +100,7 @@ data class Checkpoint(
                 ourIdentity: Party,
                 subFlowVersion: SubFlowVersion,
                 isEnabledTimedFlow: Boolean,
-                clientUUID: String? = null
+                clientUUID: UUID? = null
         ): Try<Checkpoint> {
             return SubFlow.create(flowLogicClass, subFlowVersion, isEnabledTimedFlow).map { topLevelSubFlow ->
                 Checkpoint(
@@ -206,7 +206,7 @@ data class CheckpointState(
     val sessions: SessionMap, // This must preserve the insertion order!
     val subFlowStack: List<SubFlow>,
     val numberOfSuspends: Int,
-    val clientUUID: String?
+    val clientUUID: UUID?
 )
 
 /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -16,6 +16,7 @@ import net.corda.core.serialization.internal.checkpointDeserialize
 import net.corda.core.utilities.Try
 import net.corda.node.services.messaging.DeduplicationHandler
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.Future
 
 /**
@@ -98,7 +99,8 @@ data class Checkpoint(
                 frozenFlowLogic: SerializedBytes<FlowLogic<*>>,
                 ourIdentity: Party,
                 subFlowVersion: SubFlowVersion,
-                isEnabledTimedFlow: Boolean
+                isEnabledTimedFlow: Boolean,
+                clientUUID: UUID? = null
         ): Try<Checkpoint> {
             return SubFlow.create(flowLogicClass, subFlowVersion, isEnabledTimedFlow).map { topLevelSubFlow ->
                 Checkpoint(
@@ -107,7 +109,8 @@ data class Checkpoint(
                         ourIdentity,
                         emptyMap(),
                         listOf(topLevelSubFlow),
-                        numberOfSuspends = 0
+                        numberOfSuspends = 0,
+                        clientUUID = clientUUID
                     ),
                     errorState = ErrorState.Clean,
                     flowState = FlowState.Unstarted(flowStart, frozenFlowLogic)
@@ -202,7 +205,8 @@ data class CheckpointState(
     val ourIdentity: Party,
     val sessions: SessionMap, // This must preserve the insertion order!
     val subFlowStack: List<SubFlow>,
-    val numberOfSuspends: Int
+    val numberOfSuspends: Int,
+    val clientUUID: UUID?
 )
 
 /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -100,7 +100,7 @@ data class Checkpoint(
                 ourIdentity: Party,
                 subFlowVersion: SubFlowVersion,
                 isEnabledTimedFlow: Boolean,
-                clientUUID: UUID? = null
+                clientUUID: String? = null
         ): Try<Checkpoint> {
             return SubFlow.create(flowLogicClass, subFlowVersion, isEnabledTimedFlow).map { topLevelSubFlow ->
                 Checkpoint(
@@ -206,7 +206,7 @@ data class CheckpointState(
     val sessions: SessionMap, // This must preserve the insertion order!
     val subFlowStack: List<SubFlow>,
     val numberOfSuspends: Int,
-    val clientUUID: UUID?
+    val clientUUID: String?
 )
 
 /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -16,7 +16,6 @@ import net.corda.core.serialization.internal.checkpointDeserialize
 import net.corda.core.utilities.Try
 import net.corda.node.services.messaging.DeduplicationHandler
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.Future
 
 /**
@@ -99,8 +98,7 @@ data class Checkpoint(
                 frozenFlowLogic: SerializedBytes<FlowLogic<*>>,
                 ourIdentity: Party,
                 subFlowVersion: SubFlowVersion,
-                isEnabledTimedFlow: Boolean,
-                clientUUID: UUID? = null
+                isEnabledTimedFlow: Boolean
         ): Try<Checkpoint> {
             return SubFlow.create(flowLogicClass, subFlowVersion, isEnabledTimedFlow).map { topLevelSubFlow ->
                 Checkpoint(
@@ -109,8 +107,7 @@ data class Checkpoint(
                         ourIdentity,
                         emptyMap(),
                         listOf(topLevelSubFlow),
-                        numberOfSuspends = 0,
-                        clientUUID = clientUUID
+                        numberOfSuspends = 0
                     ),
                     flowState = FlowState.Unstarted(flowStart, frozenFlowLogic),
                     errorState = ErrorState.Clean
@@ -205,8 +202,7 @@ data class CheckpointState(
     val ourIdentity: Party,
     val sessions: SessionMap, // This must preserve the insertion order!
     val subFlowStack: List<SubFlow>,
-    val numberOfSuspends: Int,
-    val clientUUID: UUID?
+    val numberOfSuspends: Int
 )
 
 /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -386,7 +386,5 @@ sealed class SubFlowVersion {
 
 sealed class FlowWithClientIdStatus {
     data class Active(val flowStateMachineFuture: CordaFuture<out FlowStateMachineHandle<out Any?>>) : FlowWithClientIdStatus()
-    data class Removed(val flowId: StateMachineRunId, val removedStatus: Status) : FlowWithClientIdStatus() {
-        enum class Status { SUCCEEDED, FAILED }
-    }
+    data class Removed(val flowId: StateMachineRunId, val succeeded: Boolean) : FlowWithClientIdStatus()
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.statemachine
 
+import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.Destination
@@ -8,8 +9,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowIORequest
-import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.concurrent.OpenFuture
+import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
@@ -385,7 +385,7 @@ sealed class SubFlowVersion {
 }
 
 sealed class FlowWithClientIdStatus {
-    data class Active(val flowStateMachineFuture: OpenFuture<FlowStateMachine<*>>) : FlowWithClientIdStatus()
+    data class Active(val flowStateMachineFuture: CordaFuture<out FlowStateMachineHandle<out Any?>>) : FlowWithClientIdStatus()
     data class Removed(val flowId: StateMachineRunId, val removedStatus: Status) : FlowWithClientIdStatus() {
         enum class Status { SUCCEEDED, FAILED }
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -5,8 +5,11 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.Destination
 import net.corda.core.flows.FlowInfo
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowIORequest
+import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.concurrent.OpenFuture
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
@@ -379,4 +382,11 @@ sealed class SubFlowVersion {
     abstract val platformVersion: Int
     data class CoreFlow(override val platformVersion: Int) : SubFlowVersion()
     data class CorDappFlow(override val platformVersion: Int, val corDappName: String, val corDappHash: SecureHash) : SubFlowVersion()
+}
+
+sealed class FlowWithClientIdStatus {
+    data class Active(val flowStateMachineFuture: OpenFuture<FlowStateMachine<*>>) : FlowWithClientIdStatus()
+    data class Removed(val flowId: StateMachineRunId, val removedStatus: Status) : FlowWithClientIdStatus() {
+        enum class Status { SUCCEEDED, FAILED }
+    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -240,7 +240,6 @@ class TopLevelTransition(
                             isFlowResumed = false,
                             isRemoved = true
                     )
-                    val allSourceSessionIds = checkpoint.checkpointState.sessions.keys
 
                     if (currentState.isAnyCheckpointPersisted) {
                         if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
@@ -254,6 +253,8 @@ class TopLevelTransition(
                             )
                         }
                     }
+
+                    val allSourceSessionIds = checkpoint.checkpointState.sessions.keys
                     actions.addAll(arrayOf(
                         Action.PersistDeduplicationFacts(pendingDeduplicationHandlers),
                             Action.ReleaseSoftLocks(event.softLocksId),

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -241,8 +241,18 @@ class TopLevelTransition(
                             isRemoved = true
                     )
                     val allSourceSessionIds = checkpoint.checkpointState.sessions.keys
+
                     if (currentState.isAnyCheckpointPersisted) {
-                        actions.add(Action.RemoveCheckpoint(context.id))
+                        if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
+                            actions.add(Action.RemoveCheckpoint(context.id))
+                        } else {
+                            actions.add(
+                                Action.PersistCheckpoint(
+                                    context.id, currentState.checkpoint,
+                                    isCheckpointUpdate = currentState.isAnyCheckpointPersisted
+                                )
+                            )
+                        }
                     }
                     actions.addAll(arrayOf(
                         Action.PersistDeduplicationFacts(pendingDeduplicationHandlers),

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -178,7 +178,7 @@ class TopLevelTransition(
     private fun suspendTransition(event: Event.Suspend): TransitionResult {
         return builder {
             val newCheckpoint = currentState.checkpoint.run {
-                val newCheckpointState = if (checkpointState.invocationContext.arguments.isNotEmpty()) {
+                val newCheckpointState = if (checkpointState.invocationContext.arguments!!.isNotEmpty()) {
                     checkpointState.copy(
                         invocationContext = checkpointState.invocationContext.copy(arguments = emptyList()),
                         numberOfSuspends = checkpointState.numberOfSuspends + 1

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -254,7 +254,7 @@ class TopLevelTransition(
                         }
                     }
 
-                    val allSourceSessionIds = checkpoint.checkpointState.sessions.keys
+                    val allSourceSessionIds = currentState.checkpoint.checkpointState.sessions.keys
                     actions.addAll(arrayOf(
                         Action.PersistDeduplicationFacts(pendingDeduplicationHandlers),
                             Action.ReleaseSoftLocks(event.softLocksId),

--- a/node/src/main/resources/migration/node-core.changelog-v19-keys.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19-keys.xml
@@ -12,10 +12,13 @@
         <addPrimaryKey columnNames="flow_id" constraintName="node_checkpoints_pk" tableName="node_checkpoints"/>
     </changeSet>
 
-    <!-- TODO: add indexes for the rest of the tables as well (Results + Exceptions)   -->
+    <!-- TODO: add indexes for Exceptions table as well -->
     <!-- TODO: the following only add indexes so maybe also align name of file?   -->
     <changeSet author="R3.Corda" id="add_new_checkpoint_schema_indexes">
         <createIndex indexName="node_checkpoint_blobs_idx" tableName="node_checkpoint_blobs" clustered="false" unique="true">
+            <column name="flow_id"/>
+        </createIndex>
+        <createIndex indexName="node_flow_results_idx" tableName="node_flow_results" clustered="false" unique="true">
             <column name="flow_id"/>
         </createIndex>
         <createIndex indexName="node_flow_metadata_idx" tableName="node_flow_metadata" clustered="false" unique="true">

--- a/node/src/main/resources/migration/node-core.changelog-v19-postgres.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19-postgres.xml
@@ -49,7 +49,6 @@
         </createTable>
     </changeSet>
 
-
     <changeSet author="R3.Corda" id="add_new_flow_result_table-postgres" dbms="postgresql">
         <createTable tableName="node_flow_results">
             <column name="flow_id" type="NVARCHAR(64)">

--- a/node/src/main/resources/migration/node-core.changelog-v19.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19.xml
@@ -49,7 +49,6 @@
         </createTable>
     </changeSet>
 
-
     <changeSet author="R3.Corda" id="add_new_flow_result_table" dbms="!postgresql">
         <createTable tableName="node_flow_results">
             <column name="flow_id" type="NVARCHAR(64)">

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -210,17 +210,17 @@ class FlowClientIdTests {
             }
         }
 
+        val beforeCount = AtomicInteger(0)
+        SingleThreadedStateMachineManager.beforeClientIDCheck = {
+            beforeCount.incrementAndGet()
+        }
+
         val semaphore = Semaphore(0)
         val allThreadsBlocked = Semaphore(0)
         SingleThreadedStateMachineManager.onClientIDNotFound = {
             // Make all threads wait after client id not found on clientIdsToFlowIds
             allThreadsBlocked.release()
             semaphore.acquire()
-        }
-
-        val beforeCount = AtomicInteger(0)
-        SingleThreadedStateMachineManager.beforeClientIDCheck = {
-            beforeCount.incrementAndGet()
         }
 
         for (i in 0 until requests) {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -366,7 +366,7 @@ class FlowClientIdTests {
     }
 
 //    @Test
-//    fun `On 'startFlowInternal' throwing subsequent request with same client hits the time window in which previous request was about to remove the client id mapping, will not start a new flow but will not hang either`() {
+//    fun `On 'startFlowInternal' throwing subsequent request with same client hits the time window in which the previous request was about to remove the client id mapping`() {
 //        val clientId = UUID.randomUUID().toString()
 //        var firstRequest = true
 //        SingleThreadedStateMachineManager.onCallingStartFlowInternal = {
@@ -395,6 +395,7 @@ class FlowClientIdTests {
 //        waitForFirstRequest.acquire()
 //        wait.release()
 //        assertFailsWith<IllegalStateException> {
+//            // the subsequent request will not hang on a never ending future, as the previous request upon failing, will complete the future exceptionally
 //            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
 //        }
 //

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -6,6 +6,7 @@ import co.paralleluniverse.strands.concurrent.Semaphore
 import net.corda.core.flows.FlowLogic
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
+import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
@@ -63,6 +64,16 @@ class FlowClientIdTests {
         aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         Assert.assertEquals(1, counter)
+    }
+
+    @Test
+    fun `flow's result gets persisted if the flow is started with a client id`() {
+        val clientId = UUID.randomUUID().toString()
+        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(10)).resultFuture.getOrThrow()
+
+        aliceNode.database.transaction {
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowResult>().size)
+        }
     }
 
     @Test(timeout=300_000)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -215,21 +215,21 @@ class FlowClientIdTests {
             beforeCount.incrementAndGet()
         }
 
-        val semaphore = Semaphore(0)
-        val allThreadsBlocked = Semaphore(0)
+        val clientIdNotFound = Semaphore(0)
+        val waitUntilClientIdNotFound = Semaphore(0)
         SingleThreadedStateMachineManager.onClientIDNotFound = {
-            // Make all threads wait after client id not found on clientIdsToFlowIds
-            allThreadsBlocked.release()
-            semaphore.acquire()
+            // Only the first request should reach this point
+            waitUntilClientIdNotFound.release()
+            clientIdNotFound.acquire()
         }
 
         for (i in 0 until requests) {
             threads[i]!!.start()
         }
 
-        allThreadsBlocked.acquire()
+        waitUntilClientIdNotFound.acquire()
         for (i in 0 until requests) {
-            semaphore.release()
+            clientIdNotFound.release()
         }
 
         for (thread in threads) {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -122,7 +122,7 @@ class FlowClientIdTests {
         }
 
         assertFailsWith<IllegalStateException> {
-            val handle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -341,7 +341,7 @@ class FlowClientIdTests {
 //    }
 
     @Test
-    fun `On 'startFlowInternal' throwing subsequent request with same client id does not get de-duplicated and starts a new flow`() {
+    fun `On 'startFlowInternal' throwing, subsequent request with same client id does not get de-duplicated and starts a new flow`() {
         val clientId = UUID.randomUUID().toString()
         var firstRequest = true
         SingleThreadedStateMachineManager.onCallingStartFlowInternal = {
@@ -365,7 +365,7 @@ class FlowClientIdTests {
     }
 
 //    @Test
-//    fun `On 'startFlowInternal' throwing subsequent request with same client hits the time window in which the previous request was about to remove the client id mapping`() {
+//    fun `On 'startFlowInternal' throwing, subsequent request with same client hits the time window in which the previous request was about to remove the client id mapping`() {
 //        val clientId = UUID.randomUUID().toString()
 //        var firstRequest = true
 //        SingleThreadedStateMachineManager.onCallingStartFlowInternal = {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -3,8 +3,6 @@ package net.corda.node.services.statemachine
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.concurrent.Semaphore
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.flows.FlowLogic
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
@@ -291,57 +289,57 @@ class FlowClientIdTests {
         Assert.assertEquals(1, noSecondFlowWasSpawned)
     }
 
-    @Test
-    fun `on node restart -paused- flows with client id are hook-able`() {
-        val clientId = UUID.randomUUID().toString()
-        var noSecondFlowWasSpawned = 0
-        var firstRun = true
-        var firstFiber: Fiber<out Any?>? = null
-        val flowIsRunning = Semaphore(0)
-        val waitUntilFlowIsRunning = Semaphore(0)
-
-        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
-            @Suspendable
-            override fun call() {
-                if (firstRun) {
-                    firstFiber = Fiber.currentFiber()
-                    firstRun = false
-                }
-
-                waitUntilFlowIsRunning.release()
-                try {
-                    flowIsRunning.acquire() // make flow wait here to impersonate a running flow
-                } catch (e: InterruptedException) {
-                    flowIsRunning.release()
-                    throw e
-                }
-
-                noSecondFlowWasSpawned++
-            }
-        }
-
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        waitUntilFlowIsRunning.acquire()
-        aliceNode.internals.acceptableLiveFiberCountOnStop = 1
-        // Pause the flow on node restart
-        val aliceNode = mockNet.restartNode(aliceNode,
-            InternalMockNodeParameters(
-                configOverrides = {
-                    doReturn(StateMachineManager.StartMode.Safe).whenever(it).smmStartMode
-                }
-            ))
-        // Blow up the first fiber running our flow as it is leaked here, on normal node shutdown that fiber should be gone
-        firstFiber!!.interrupt()
-
-        // Re-hook a paused flow
-        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-
-        Assert.assertEquals(flowHandle0.id, flowHandle1.id)
-        Assert.assertEquals(clientId, flowHandle1.clientId)
-        aliceNode.smm.unPauseFlow(flowHandle1.id)
-        Assert.assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
-        Assert.assertEquals(1, noSecondFlowWasSpawned)
-    }
+//    @Test
+//    fun `on node restart -paused- flows with client id are hook-able`() {
+//        val clientId = UUID.randomUUID().toString()
+//        var noSecondFlowWasSpawned = 0
+//        var firstRun = true
+//        var firstFiber: Fiber<out Any?>? = null
+//        val flowIsRunning = Semaphore(0)
+//        val waitUntilFlowIsRunning = Semaphore(0)
+//
+//        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
+//            @Suspendable
+//            override fun call() {
+//                if (firstRun) {
+//                    firstFiber = Fiber.currentFiber()
+//                    firstRun = false
+//                }
+//
+//                waitUntilFlowIsRunning.release()
+//                try {
+//                    flowIsRunning.acquire() // make flow wait here to impersonate a running flow
+//                } catch (e: InterruptedException) {
+//                    flowIsRunning.release()
+//                    throw e
+//                }
+//
+//                noSecondFlowWasSpawned++
+//            }
+//        }
+//
+//        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+//        waitUntilFlowIsRunning.acquire()
+//        aliceNode.internals.acceptableLiveFiberCountOnStop = 1
+//        // Pause the flow on node restart
+//        val aliceNode = mockNet.restartNode(aliceNode,
+//            InternalMockNodeParameters(
+//                configOverrides = {
+//                    doReturn(StateMachineManager.StartMode.Safe).whenever(it).smmStartMode
+//                }
+//            ))
+//        // Blow up the first fiber running our flow as it is leaked here, on normal node shutdown that fiber should be gone
+//        firstFiber!!.interrupt()
+//
+//        // Re-hook a paused flow
+//        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+//
+//        Assert.assertEquals(flowHandle0.id, flowHandle1.id)
+//        Assert.assertEquals(clientId, flowHandle1.clientId)
+//        aliceNode.smm.unPauseFlow(flowHandle1.id)
+//        Assert.assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
+//        Assert.assertEquals(1, noSecondFlowWasSpawned)
+//    }
 
     @Test
     fun `On 'startFlowInternal' throwing subsequent request with same client id does not get de-duplicated and starts a new flow`() {
@@ -367,41 +365,41 @@ class FlowClientIdTests {
         assertEquals(1, counter)
     }
 
-    @Test
-    fun `On 'startFlowInternal' throwing subsequent request with same client hits the time window in which previous request was about to remove the client id mapping, will not start a new flow but will not hang either`() {
-        val clientId = UUID.randomUUID().toString()
-        var firstRequest = true
-        SingleThreadedStateMachineManager.onCallingStartFlowInternal = {
-            if (firstRequest) {
-                firstRequest = false
-                throw IllegalStateException("Yet another one")
-            }
-        }
-
-        val wait = Semaphore(0)
-        val waitForFirstRequest = Semaphore(0)
-        SingleThreadedStateMachineManager.onStartFlowInternalThrewAndAboutToRemove = {
-            waitForFirstRequest.release()
-            wait.acquire()
-            Thread.sleep(10000)
-        }
-        var counter = 0
-        ResultFlow.hook = { counter++ }
-
-        thread {
-            assertFailsWith<IllegalStateException> {
-                aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-            }
-        }
-
-        waitForFirstRequest.acquire()
-        wait.release()
-        assertFailsWith<IllegalStateException> {
-            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        }
-
-        assertEquals(0, counter)
-    }
+//    @Test
+//    fun `On 'startFlowInternal' throwing subsequent request with same client hits the time window in which previous request was about to remove the client id mapping, will not start a new flow but will not hang either`() {
+//        val clientId = UUID.randomUUID().toString()
+//        var firstRequest = true
+//        SingleThreadedStateMachineManager.onCallingStartFlowInternal = {
+//            if (firstRequest) {
+//                firstRequest = false
+//                throw IllegalStateException("Yet another one")
+//            }
+//        }
+//
+//        val wait = Semaphore(0)
+//        val waitForFirstRequest = Semaphore(0)
+//        SingleThreadedStateMachineManager.onStartFlowInternalThrewAndAboutToRemove = {
+//            waitForFirstRequest.release()
+//            wait.acquire()
+//            Thread.sleep(10000)
+//        }
+//        var counter = 0
+//        ResultFlow.hook = { counter++ }
+//
+//        thread {
+//            assertFailsWith<IllegalStateException> {
+//                aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+//            }
+//        }
+//
+//        waitForFirstRequest.acquire()
+//        wait.release()
+//        assertFailsWith<IllegalStateException> {
+//            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+//        }
+//
+//        assertEquals(0, counter)
+//    }
 }
 
 internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -55,7 +55,7 @@ class FlowClientIdTests {
         SingleThreadedStateMachineManager.onStartFlowInternalThrewAndAboutToRemove = null
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `no new flow starts if the client id provided pre exists`() {
         var counter = 0
         ResultFlow.hook = { counter++ }
@@ -65,7 +65,7 @@ class FlowClientIdTests {
         Assert.assertEquals(1, counter)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow's result is retrievable after flow's lifetime, when flow is started with a client id - different parameters are ignored`() {
         val clientId = UUID.randomUUID().toString()
         val handle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
@@ -83,7 +83,7 @@ class FlowClientIdTests {
         Assert.assertEquals(result0, result1)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow's result is available if reconnect after flow had retried from previous checkpoint, when flow is started with a client id`() {
         var firstRun = true
         ResultFlow.hook = {
@@ -99,7 +99,7 @@ class FlowClientIdTests {
         Assert.assertEquals(result0, result1)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow's result is available if reconnect during flow's retrying from previous checkpoint, when flow is started with a client id`() {
         var firstRun = true
         val waitForSecondRequest = Semaphore(0)
@@ -131,7 +131,7 @@ class FlowClientIdTests {
     }
 
     @Ignore // this is to be unignored upon implementing CORDA-3681
-    @Test
+    @Test(timeout=300_000)
     fun `flow's exception is available after flow's lifetime if flow is started with a client id`() {
         ResultFlow.hook = { throw IllegalStateException() }
         val clientId = UUID.randomUUID().toString()
@@ -145,7 +145,7 @@ class FlowClientIdTests {
         }
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow's client id mapping gets removed upon request`() {
         val clientId = UUID.randomUUID().toString()
         var counter = 0
@@ -163,7 +163,7 @@ class FlowClientIdTests {
         Assert.assertEquals(2, counter)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow's client id mapping can only get removed once the flow gets removed`() {
         val clientId = UUID.randomUUID().toString()
         var tries = 0
@@ -193,7 +193,7 @@ class FlowClientIdTests {
         Assert.assertEquals(maxTries, failedRemovals)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `only one flow starts upon concurrent requests with the same client id`() {
         val requests = 2
         val counter = AtomicInteger(0)
@@ -241,7 +241,7 @@ class FlowClientIdTests {
     }
 
 
-    @Test
+    @Test(timeout=300_000)
     fun `on node start -running- flows with client id are hook-able`() {
         val clientId = UUID.randomUUID().toString()
         var noSecondFlowWasSpawned = 0
@@ -288,7 +288,7 @@ class FlowClientIdTests {
         Assert.assertEquals(1, noSecondFlowWasSpawned)
     }
 
-//    @Test
+//    @Test(timeout=300_000)
 //    fun `on node restart -paused- flows with client id are hook-able`() {
 //        val clientId = UUID.randomUUID().toString()
 //        var noSecondFlowWasSpawned = 0
@@ -340,7 +340,7 @@ class FlowClientIdTests {
 //        Assert.assertEquals(1, noSecondFlowWasSpawned)
 //    }
 
-    @Test
+    @Test(timeout=300_000)
     fun `On 'startFlowInternal' throwing, subsequent request with same client id does not get de-duplicated and starts a new flow`() {
         val clientId = UUID.randomUUID().toString()
         var firstRequest = true
@@ -364,7 +364,7 @@ class FlowClientIdTests {
         assertEquals(1, counter)
     }
 
-//    @Test
+//    @Test(timeout=300_000)
 //    fun `On 'startFlowInternal' throwing, subsequent request with same client hits the time window in which the previous request was about to remove the client id mapping`() {
 //        val clientId = UUID.randomUUID().toString()
 //        var firstRequest = true

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -1,0 +1,354 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Fiber
+import co.paralleluniverse.fibers.Suspendable
+import co.paralleluniverse.strands.concurrent.Semaphore
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
+import net.corda.core.flows.FlowLogic
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.node.InMemoryMessagingNetwork
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.FINANCE_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.InternalMockNetwork
+import net.corda.testing.node.internal.InternalMockNodeParameters
+import net.corda.testing.node.internal.TestStartedNode
+import net.corda.testing.node.internal.startFlowWithClientId
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import java.lang.IllegalStateException
+import java.sql.SQLTransientConnectionException
+import java.util.*
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class FlowClientIdTests {
+
+    private lateinit var mockNet: InternalMockNetwork
+    private lateinit var aliceNode: TestStartedNode
+
+    @Before
+    fun setUpMockNet() {
+        mockNet = InternalMockNetwork(
+            cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, FINANCE_CONTRACTS_CORDAPP),
+            servicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin()
+        )
+
+        aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
+
+    }
+
+    @After
+    fun cleanUp() {
+        mockNet.stopNodes()
+        ResultFlow.hook = null
+        ResultFlow.suspendableHook = null
+        SingleThreadedStateMachineManager.beforeClientIDCheck = null
+        SingleThreadedStateMachineManager.onClientIDNotFound = null
+    }
+
+    @Test
+    fun `no new flow starts if the client id provided pre exists`() {
+        var counter = 0
+        ResultFlow.hook = { counter++ }
+        val clientId = UUID.randomUUID().toString()
+        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        Assert.assertEquals(1, counter)
+    }
+
+    @Test
+    fun `flow's result is retrievable after flow's lifetime, when flow is started with a client id - different parameters are ignored`() {
+        val clientId = UUID.randomUUID().toString()
+        val handle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        val clientId0 = handle0.clientId
+        val flowId0 = handle0.id
+        val result0 = handle0.resultFuture.getOrThrow()
+
+        val handle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(10))
+        val clientId1 = handle1.clientId
+        val flowId1 = handle1.id
+        val result1 = handle1.resultFuture.getOrThrow()
+
+        Assert.assertEquals(clientId0, clientId1)
+        Assert.assertEquals(flowId0, flowId1)
+        Assert.assertEquals(result0, result1)
+    }
+
+    @Test
+    fun `flow's result is available if reconnect after flow had retried from previous checkpoint, when flow is started with a client id`() {
+        var firstRun = true
+        ResultFlow.hook = {
+            if (firstRun) {
+                firstRun = false
+                throw SQLTransientConnectionException("connection is not available")
+            }
+        }
+
+        val clientId = UUID.randomUUID().toString()
+        val result0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        val result1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        Assert.assertEquals(result0, result1)
+    }
+
+    @Test // TODO: this test needs change -> what makes sense is to test this scenario: flow has retried, AND THEN the second request comes in
+    // and gets a [FlowStateMachineHandle] whose future is the old one
+    fun `flow's result is available if reconnect during flow's retrying from previous checkpoint, when flow is started with a client id`() {
+        var firstRun = true
+        val semaphore = Semaphore(0)
+        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
+            @Suspendable
+            override fun call() {
+                if (firstRun) {
+                    firstRun = false
+                    throw SQLTransientConnectionException("connection is not available")
+                } else {
+                    semaphore.acquire()
+                }
+            }
+        }
+
+        var result1 = 0
+        val clientId = UUID.randomUUID().toString()
+        val handle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        val t = thread { result1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow() }
+
+        Thread.sleep(1000)
+        semaphore.release()
+        val result0 = handle0.resultFuture.getOrThrow()
+        t.join()
+        Assert.assertEquals(result0, result1)
+    }
+
+    @Ignore // this is to be unignored upon implementing CORDA-3681
+    @Test
+    fun `flow's exception is available after flow's lifetime if flow is started with a client id`() {
+        ResultFlow.hook = { throw IllegalStateException() }
+        val clientId = UUID.randomUUID().toString()
+
+        assertFailsWith<IllegalStateException> {
+            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        }
+
+        assertFailsWith<IllegalStateException> {
+            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        }
+    }
+
+    @Test
+    fun `flow's client id mapping gets removed upon request`() {
+        val clientId = UUID.randomUUID().toString()
+        var counter = 0
+        ResultFlow.hook = { counter++ }
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        flowHandle0.resultFuture.getOrThrow(20.seconds)
+        val removed = aliceNode.smm.removeClientId(clientId)
+        // On new request with clientId, after the same clientId was removed, a brand new flow will start with that clientId
+        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        flowHandle1.resultFuture.getOrThrow(20.seconds)
+
+        assertTrue(removed)
+        Assert.assertNotEquals(flowHandle0.id, flowHandle1.id)
+        Assert.assertEquals(flowHandle0.clientId, flowHandle1.clientId)
+        Assert.assertEquals(2, counter)
+    }
+
+    @Test
+    fun `flow's client id mapping can only get removed once the flow gets removed`() {
+        val clientId = UUID.randomUUID().toString()
+        var tries = 0
+        val maxTries = 10
+        var failedRemovals = 0
+        val semaphore = Semaphore(0)
+        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
+            @Suspendable
+            override fun call() {
+                semaphore.acquire()
+            }
+        }
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+
+        var removed = false
+        while (!removed) {
+            removed = aliceNode.smm.removeClientId(clientId)
+            if (!removed) ++failedRemovals
+            ++tries
+            if (tries >= maxTries) {
+                semaphore.release()
+                flowHandle0.resultFuture.getOrThrow(20.seconds)
+            }
+        }
+
+        assertTrue(removed)
+        Assert.assertEquals(maxTries, failedRemovals)
+    }
+
+    @Test
+    fun `only one flow starts upon concurrent requests with the same client id`() {
+        val requests = 2
+        val counter = AtomicInteger(0)
+        val resultsCounter = AtomicInteger(0)
+        ResultFlow.hook = { counter.incrementAndGet() }
+        //(aliceNode.smm as SingleThreadedStateMachineManager).concurrentRequests = true
+
+        val clientId = UUID.randomUUID().toString()
+        val threads = arrayOfNulls<Thread>(requests)
+        for (i in 0 until requests) {
+            threads[i] = Thread {
+                val result = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+                resultsCounter.addAndGet(result)
+            }
+        }
+
+        val semaphore = Semaphore(0)
+        val allThreadsBlocked = Semaphore(0)
+        SingleThreadedStateMachineManager.onClientIDNotFound = {
+            // Make all threads wait after client id not found on clientIdsToFlowIds
+            allThreadsBlocked.release()
+            semaphore.acquire()
+        }
+
+        val beforeCount = AtomicInteger(0)
+        SingleThreadedStateMachineManager.beforeClientIDCheck = {
+            // Make all threads wait after client id not found on clientIdsToFlowIds
+            beforeCount.incrementAndGet()
+        }
+
+        for (i in 0 until requests) {
+            threads[i]!!.start()
+        }
+
+        allThreadsBlocked.acquire()
+        for (i in 0 until requests) {
+            semaphore.release()
+        }
+
+        for (thread in threads) {
+            thread!!.join()
+        }
+        Assert.assertEquals(1, counter.get())
+        Assert.assertEquals(2, beforeCount.get())
+        Assert.assertEquals(10, resultsCounter.get())
+    }
+
+
+    @Test
+    fun `on node start -running- flows with client id are hook-able`() {
+        val clientId = UUID.randomUUID().toString()
+        var noSecondFlowWasSpawned = 0
+        var firstRun = true
+        var firstFiber: Fiber<out Any?>? = null
+        val flowIsRunning = Semaphore(0)
+        val waitUntilFlowIsRunning = Semaphore(0)
+
+        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
+            @Suspendable
+            override fun call() {
+                if (firstRun) {
+                    firstFiber = Fiber.currentFiber()
+                    firstRun = false
+                }
+
+                waitUntilFlowIsRunning.release()
+                try {
+                    flowIsRunning.acquire() // make flow wait here to impersonate a running flow
+                } catch (e: InterruptedException) {
+                    flowIsRunning.release()
+                    throw e
+                }
+
+                noSecondFlowWasSpawned++
+            }
+        }
+
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        waitUntilFlowIsRunning.acquire()
+        aliceNode.internals.acceptableLiveFiberCountOnStop = 1
+        val aliceNode = mockNet.restartNode(aliceNode)
+        // Blow up the first fiber running our flow as it is leaked here, on normal node shutdown that fiber should be gone
+        firstFiber!!.interrupt()
+
+        waitUntilFlowIsRunning.acquire()
+        // Re-hook a running flow
+        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        flowIsRunning.release()
+
+        Assert.assertEquals(flowHandle0.id, flowHandle1.id)
+        Assert.assertEquals(clientId, flowHandle1.clientId)
+        Assert.assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
+        Assert.assertEquals(1, noSecondFlowWasSpawned)
+    }
+
+    @Test
+    fun `on node restart -paused- flows with client id are hook-able`() {
+        val clientId = UUID.randomUUID().toString()
+        var noSecondFlowWasSpawned = 0
+        var firstRun = true
+        var firstFiber: Fiber<out Any?>? = null
+        val flowIsRunning = Semaphore(0)
+        val waitUntilFlowIsRunning = Semaphore(0)
+
+        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
+            @Suspendable
+            override fun call() {
+                if (firstRun) {
+                    firstFiber = Fiber.currentFiber()
+                    firstRun = false
+                }
+
+                waitUntilFlowIsRunning.release()
+                try {
+                    flowIsRunning.acquire() // make flow wait here to impersonate a running flow
+                } catch (e: InterruptedException) {
+                    flowIsRunning.release()
+                    throw e
+                }
+
+                noSecondFlowWasSpawned++
+            }
+        }
+
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        waitUntilFlowIsRunning.acquire()
+        aliceNode.internals.acceptableLiveFiberCountOnStop = 1
+        // Pause the flow on node restart
+        val aliceNode = mockNet.restartNode(aliceNode,
+            InternalMockNodeParameters(
+                configOverrides = {
+                    doReturn(StateMachineManager.StartMode.Safe).whenever(it).smmStartMode
+                }
+            ))
+        // Blow up the first fiber running our flow as it is leaked here, on normal node shutdown that fiber should be gone
+        firstFiber!!.interrupt()
+
+        // Re-hook a paused flow
+        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+
+        Assert.assertEquals(flowHandle0.id, flowHandle1.id)
+        Assert.assertEquals(clientId, flowHandle1.clientId)
+        aliceNode.smm.unPauseFlow(flowHandle1.id)
+        Assert.assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
+        Assert.assertEquals(1, noSecondFlowWasSpawned)
+    }
+}
+
+internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {
+    companion object {
+        var hook: (() -> Unit)? = null
+        var suspendableHook: FlowLogic<Unit>? = null
+    }
+
+    @Suspendable
+    override fun call(): A {
+        hook?.invoke()
+        suspendableHook?.let { subFlow(it) }
+        return result
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -394,7 +394,7 @@ class FlowClientIdTests {
 //        waitForFirstRequest.acquire()
 //        wait.release()
 //        assertFailsWith<IllegalStateException> {
-//            // the subsequent request will not hang on a never ending future, as the previous request upon failing, will complete the future exceptionally
+//            // the subsequent request will not hang on a never ending future, because the previous request ,upon failing, will also complete the future exceptionally
 //            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
 //        }
 //

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -66,7 +66,7 @@ class FlowClientIdTests {
         Assert.assertEquals(1, counter)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow's result gets persisted if the flow is started with a client id`() {
         val clientId = UUID.randomUUID().toString()
         aliceNode.services.startFlowWithClientId(clientId, ResultFlow(10)).resultFuture.getOrThrow()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -220,7 +220,6 @@ class FlowClientIdTests {
 
         val beforeCount = AtomicInteger(0)
         SingleThreadedStateMachineManager.beforeClientIDCheck = {
-            // Make all threads wait after client id not found on clientIdsToFlowIds
             beforeCount.incrementAndGet()
         }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -1054,7 +1054,6 @@ class FlowFrameworkTests {
 
         assertEquals(flowHandle0.id, flowHandle1.id)
         assertEquals(clientID, flowHandle1.clientID)
-        // Unpause the flow
         aliceNode.smm.unPauseFlow(flowHandle1.id)
         assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
         assertEquals(1, noSecondFlowWasSpawned)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -843,8 +843,6 @@ class FlowFrameworkTests {
         assertEquals(null, persistedException)
     }
 
-    // TODO: We set a new clientId (in StateMachineManager.addAndStartFlow) much later than we check if it exists; What will happen
-    //  if two concurrent requests come in with the same client id (these two actions need to be done in one place).
     @Test
     fun `no new flow starts if the client id provided pre exists`() {
         var counter = 0

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -986,6 +986,7 @@ class FlowFrameworkTests {
         val clientID = UUID.randomUUID().toString()
 
         var run = 0
+        var noSecondFlowWasSpawned = 0
         val semaphore = Semaphore(0)
         ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
             @Suspendable
@@ -994,6 +995,8 @@ class FlowFrameworkTests {
                     run++
                     semaphore.acquire() // make flow wait on first run so it remains in the system on shutdown
                 }
+
+                noSecondFlowWasSpawned++
             }
         }
 
@@ -1013,6 +1016,7 @@ class FlowFrameworkTests {
         assertEquals(flowHandle0.id, flowHandle1.id)
         assertEquals(clientID, flowHandle1.clientID)
         assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
+        assertEquals(1, noSecondFlowWasSpawned)
     }
 
     @Test

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -944,15 +944,10 @@ class FlowFrameworkTests {
             }
         }
 
-        val semaphores = mutableMapOf<Long, Semaphore>()
-        for (i in 0 until requests) {
-            semaphores[threads[i]!!.id] = Semaphore(0)
-        }
-
+        val semaphore = Semaphore(0)
         SingleThreadedStateMachineManager.onClientIDNotFound = {
-            val tid = Thread.currentThread().id
             // Make all threads wait after client id not found on clientIDsToFlowIds
-            semaphores[tid]!!.acquire()
+            semaphore.acquire()
         }
 
         for (i in 0 until requests) {
@@ -961,7 +956,7 @@ class FlowFrameworkTests {
 
         Thread.sleep(1000)
         for (i in 0 until requests) {
-            semaphores[threads[i]!!.id]!!.release()
+            semaphore.release()
         }
 
         for (thread in threads) {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -849,26 +849,26 @@ class FlowFrameworkTests {
     fun `no new flow starts if the client id provided pre exists`() {
         var counter = 0
         ResultFlow.hook = { counter++ }
-        val clientID = UUID.randomUUID().toString()
-        aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow()
-        aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow()
+        val clientId = UUID.randomUUID().toString()
+        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         assertEquals(1, counter)
     }
 
     @Test
     fun `flow's result is retrievable after flow's lifetime, when flow is started with a client id - different parameters are ignored`() {
-        val clientID = UUID.randomUUID().toString()
-        val handle0 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
-        val clientID0 = handle0.clientID
+        val clientId = UUID.randomUUID().toString()
+        val handle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        val clientId0 = handle0.clientId
         val flowId0 = handle0.id
         val result0 = handle0.resultFuture.getOrThrow()
 
-        val handle1 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(10))
-        val clientID1 = handle1.clientID
+        val handle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(10))
+        val clientId1 = handle1.clientId
         val flowId1 = handle1.id
         val result1 = handle1.resultFuture.getOrThrow()
 
-        assertEquals(clientID0, clientID1)
+        assertEquals(clientId0, clientId1)
         assertEquals(flowId0, flowId1)
         assertEquals(result0, result1)
     }
@@ -883,9 +883,9 @@ class FlowFrameworkTests {
             }
         }
 
-        val clientID = UUID.randomUUID().toString()
-        val result0 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow()
-        val result1 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow()
+        val clientId = UUID.randomUUID().toString()
+        val result0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        val result1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         assertEquals(result0, result1)
     }
 
@@ -907,9 +907,9 @@ class FlowFrameworkTests {
         }
 
         var result1 = 0
-        val clientID = UUID.randomUUID().toString()
-        val handle0 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
-        val t = thread { result1 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow() }
+        val clientId = UUID.randomUUID().toString()
+        val handle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        val t = thread { result1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow() }
 
         Thread.sleep(1000)
         semaphore.release()
@@ -922,38 +922,38 @@ class FlowFrameworkTests {
     @Test
     fun `flow's exception is available after flow's lifetime if flow is started with a client id`() {
         ResultFlow.hook = { throw IllegalStateException() }
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
 
         assertFailsWith<IllegalStateException> {
-            aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow()
+            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         }
 
         assertFailsWith<IllegalStateException> {
-            aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow()
+            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         }
     }
 
     @Test
     fun `flow's client id mapping gets removed upon request`() {
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
         var counter = 0
         ResultFlow.hook = { counter++ }
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         flowHandle0.resultFuture.getOrThrow(20.seconds)
-        val removed = aliceNode.smm.removeClientId(clientID)
-        // On new request with clientID, after the same clientID was removed, a brand new flow will start with that clientID
-        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
+        val removed = aliceNode.smm.removeClientId(clientId)
+        // On new request with clientId, after the same clientId was removed, a brand new flow will start with that clientId
+        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         flowHandle1.resultFuture.getOrThrow(20.seconds)
 
         assertTrue(removed)
         assertNotEquals(flowHandle0.id, flowHandle1.id)
-        assertEquals(flowHandle0.clientID, flowHandle1.clientID)
+        assertEquals(flowHandle0.clientId, flowHandle1.clientId)
         assertEquals(2, counter)
     }
 
     @Test
     fun `flow's client id mapping can only get removed once the flow gets removed`() {
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
         var tries = 0
         val maxTries = 10
         var failedRemovals = 0
@@ -964,11 +964,11 @@ class FlowFrameworkTests {
                 semaphore.acquire()
             }
         }
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
 
         var removed = false
         while (!removed) {
-            removed = aliceNode.smm.removeClientId(clientID)
+            removed = aliceNode.smm.removeClientId(clientId)
             if (!removed) ++failedRemovals
             ++tries
             if (tries >= maxTries) {
@@ -989,11 +989,11 @@ class FlowFrameworkTests {
         ResultFlow.hook = { counter.incrementAndGet() }
         //(aliceNode.smm as SingleThreadedStateMachineManager).concurrentRequests = true
 
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
         val threads = arrayOfNulls<Thread>(requests)
         for (i in 0 until requests) {
             threads[i] = Thread {
-                val result = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5)).resultFuture.getOrThrow()
+                val result = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
                 resultsCounter.addAndGet(result)
             }
         }
@@ -1001,14 +1001,14 @@ class FlowFrameworkTests {
         val semaphore = Semaphore(0)
         val allThreadsBlocked = Semaphore(0)
         SingleThreadedStateMachineManager.onClientIDNotFound = {
-            // Make all threads wait after client id not found on clientIDsToFlowIds
+            // Make all threads wait after client id not found on clientIdsToFlowIds
             allThreadsBlocked.release()
             semaphore.acquire()
         }
 
         val beforeCount = AtomicInteger(0)
         SingleThreadedStateMachineManager.beforeClientIDCheck = {
-            // Make all threads wait after client id not found on clientIDsToFlowIds
+            // Make all threads wait after client id not found on clientIdsToFlowIds
             beforeCount.incrementAndGet()
         }
 
@@ -1032,7 +1032,7 @@ class FlowFrameworkTests {
 
     @Test
     fun `on node start -running- flows with client id are hook-able`() {
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
         var noSecondFlowWasSpawned = 0
         var firstRun = true
         var firstFiber: Fiber<out Any?>? = null
@@ -1059,7 +1059,7 @@ class FlowFrameworkTests {
             }
         }
 
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         waitUntilFlowIsRunning.acquire()
         aliceNode.internals.acceptableLiveFiberCountOnStop = 1
         val aliceNode = mockNet.restartNode(aliceNode)
@@ -1068,18 +1068,18 @@ class FlowFrameworkTests {
 
         waitUntilFlowIsRunning.acquire()
         // Re-hook a running flow
-        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
+        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         flowIsRunning.release()
 
         assertEquals(flowHandle0.id, flowHandle1.id)
-        assertEquals(clientID, flowHandle1.clientID)
+        assertEquals(clientId, flowHandle1.clientId)
         assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
         assertEquals(1, noSecondFlowWasSpawned)
     }
 
     @Test
     fun `on node restart -paused- flows with client id are hook-able`() {
-        val clientID = UUID.randomUUID().toString()
+        val clientId = UUID.randomUUID().toString()
         var noSecondFlowWasSpawned = 0
         var firstRun = true
         var firstFiber: Fiber<out Any?>? = null
@@ -1106,7 +1106,7 @@ class FlowFrameworkTests {
             }
         }
 
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
+        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         waitUntilFlowIsRunning.acquire()
         aliceNode.internals.acceptableLiveFiberCountOnStop = 1
         // Pause the flow on node restart
@@ -1120,10 +1120,10 @@ class FlowFrameworkTests {
         firstFiber!!.interrupt()
 
         // Re-hook a paused flow
-        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientID, ResultFlow(5))
+        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
 
         assertEquals(flowHandle0.id, flowHandle1.id)
-        assertEquals(clientID, flowHandle1.clientID)
+        assertEquals(clientId, flowHandle1.clientId)
         aliceNode.smm.unPauseFlow(flowHandle1.id)
         assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
         assertEquals(1, noSecondFlowWasSpawned)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -911,6 +911,7 @@ class FlowFrameworkTests {
         assertEquals(result0, result1)
     }
 
+    @Ignore // this is to be unignored upon implementing CORDA-3681
     @Test
     fun `flow's exception is available after flow's lifetime if flow is started with a client id`() {
         ResultFlow.hook = { throw IllegalStateException() }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -154,6 +154,8 @@ class FlowFrameworkTests {
         SuspendingFlow.hookAfterCheckpoint = {}
         ResultFlow.hook = null
         ResultFlow.suspendableHook = null
+        SingleThreadedStateMachineManager.beforeClientIDCheck = null
+        SingleThreadedStateMachineManager.onClientIDNotFound = null
     }
 
     @Test(timeout=300_000)
@@ -887,7 +889,6 @@ class FlowFrameworkTests {
         assertEquals(result0, result1)
     }
 
-    @Ignore
     @Test // TODO: this test needs change -> what makes sense is to test this scenario: flow has retried, AND THEN the second request comes in
             // and gets a [FlowStateMachineHandle] whose future is the old one
     fun `flow's result is available if reconnect during flow's retrying from previous checkpoint, when flow is started with a client id`() {
@@ -980,7 +981,6 @@ class FlowFrameworkTests {
         assertEquals(maxTries, failedRemovals)
     }
 
-    @Ignore
     @Test
     fun `only one flow starts upon concurrent requests with the same client id`() {
         val requests = 2

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -832,12 +832,6 @@ class FlowFrameworkTests {
         assertEquals(null, persistedException)
     }
 
-    private inline fun <reified T> DatabaseTransaction.findRecordsFromDatabase(): List<T> {
-        val criteria = session.criteriaBuilder.createQuery(T::class.java)
-        criteria.select(criteria.from(T::class.java))
-        return session.createQuery(criteria).resultList
-    }
-
     //region Helpers
 
     private val normalEnd = ExistingSessionMessage(SessionId(0), EndSessionMessage) // NormalSessionEnd(0)
@@ -1020,6 +1014,12 @@ internal fun TestStartedNode.sendSessionMessage(message: SessionMessage, destina
         val address = getAddressOfParty(PartyInfo.SingleNode(destination, emptyList()))
         send(createMessage(FlowMessagingImpl.sessionTopic, message.serialize().bytes), address)
     }
+}
+
+inline fun <reified T> DatabaseTransaction.findRecordsFromDatabase(): List<T> {
+    val criteria = session.criteriaBuilder.createQuery(T::class.java)
+    criteria.select(criteria.from(T::class.java))
+    return session.createQuery(criteria).resultList
 }
 
 internal fun errorMessage(errorResponse: FlowException? = null) =

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -911,7 +911,7 @@ class FlowFrameworkTests {
     }
 
     @Test
-    fun `assert that the flow exception is available after flow's lifetime if flow is started with a client id`() {
+    fun `flow's exception is available after flow's lifetime if flow is started with a client id`() {
         ResultFlow.hook = { throw IllegalStateException() }
         val clientID = UUID.randomUUID().toString()
 
@@ -925,7 +925,7 @@ class FlowFrameworkTests {
     }
 
     @Test
-    fun `assert that the flow result is freed upon acknowledgement`() {
+    fun `flow's result is freed upon acknowledgement`() {
         // TODO upon implementing API
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -1312,11 +1312,6 @@ internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {
 
     @Suspendable
     override fun call(): A {
-        // 1. checkpoint
-        // 2. throw exception
-        // 3. retry and wait
-        // 4. re call start with ClientID
-        // 5. let it continue
         hook?.invoke()
         suspendableHook?.let { subFlow(it) }
         return result

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -955,6 +955,12 @@ class FlowFrameworkTests {
             semaphore.acquire()
         }
 
+        val beforeCount = AtomicInteger(0)
+        SingleThreadedStateMachineManager.beforeClientIDCheck = {
+            // Make all threads wait after client id not found on clientIDsToFlowIds
+            beforeCount.incrementAndGet()
+        }
+
         for (i in 0 until requests) {
             threads[i]!!.start()
         }
@@ -968,6 +974,7 @@ class FlowFrameworkTests {
             thread!!.join()
         }
         assertEquals(1, counter.get())
+        assertEquals(2, beforeCount.get())
         assertEquals(10, resultsCounter.get())
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -4,8 +4,6 @@ import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.concurrent.Semaphore
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.whenever
 import net.corda.client.rpc.notUsed
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.ContractState
@@ -64,7 +62,6 @@ import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.getMessage
 import net.corda.testing.node.internal.startFlow
-import net.corda.testing.node.internal.startFlowWithClientId
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
@@ -80,17 +77,13 @@ import org.junit.Ignore
 import org.junit.Test
 import rx.Notification
 import rx.Observable
-import java.lang.IllegalStateException
 import java.sql.SQLTransientConnectionException
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.ArrayList
-import java.util.UUID
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Predicate
-import kotlin.concurrent.thread
 import kotlin.reflect.KClass
 import kotlin.streams.toList
 import kotlin.test.assertFailsWith
@@ -152,10 +145,6 @@ class FlowFrameworkTests {
 
         SuspendingFlow.hookBeforeCheckpoint = {}
         SuspendingFlow.hookAfterCheckpoint = {}
-        ResultFlow.hook = null
-        ResultFlow.suspendableHook = null
-        SingleThreadedStateMachineManager.beforeClientIDCheck = null
-        SingleThreadedStateMachineManager.onClientIDNotFound = null
     }
 
     @Test(timeout=300_000)
@@ -843,290 +832,6 @@ class FlowFrameworkTests {
         assertEquals(null, persistedException)
     }
 
-    @Test
-    fun `no new flow starts if the client id provided pre exists`() {
-        var counter = 0
-        ResultFlow.hook = { counter++ }
-        val clientId = UUID.randomUUID().toString()
-        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
-        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
-        assertEquals(1, counter)
-    }
-
-    @Test
-    fun `flow's result is retrievable after flow's lifetime, when flow is started with a client id - different parameters are ignored`() {
-        val clientId = UUID.randomUUID().toString()
-        val handle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        val clientId0 = handle0.clientId
-        val flowId0 = handle0.id
-        val result0 = handle0.resultFuture.getOrThrow()
-
-        val handle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(10))
-        val clientId1 = handle1.clientId
-        val flowId1 = handle1.id
-        val result1 = handle1.resultFuture.getOrThrow()
-
-        assertEquals(clientId0, clientId1)
-        assertEquals(flowId0, flowId1)
-        assertEquals(result0, result1)
-    }
-
-    @Test
-    fun `flow's result is available if reconnect after flow had retried from previous checkpoint, when flow is started with a client id`() {
-        var firstRun = true
-        ResultFlow.hook = {
-            if (firstRun) {
-                firstRun = false
-                throw SQLTransientConnectionException("connection is not available")
-            }
-        }
-
-        val clientId = UUID.randomUUID().toString()
-        val result0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
-        val result1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
-        assertEquals(result0, result1)
-    }
-
-    @Test // TODO: this test needs change -> what makes sense is to test this scenario: flow has retried, AND THEN the second request comes in
-            // and gets a [FlowStateMachineHandle] whose future is the old one
-    fun `flow's result is available if reconnect during flow's retrying from previous checkpoint, when flow is started with a client id`() {
-        var firstRun = true
-        val semaphore = Semaphore(0)
-        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
-            @Suspendable
-            override fun call() {
-                if (firstRun) {
-                    firstRun = false
-                    throw SQLTransientConnectionException("connection is not available")
-                } else {
-                    semaphore.acquire()
-                }
-            }
-        }
-
-        var result1 = 0
-        val clientId = UUID.randomUUID().toString()
-        val handle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        val t = thread { result1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow() }
-
-        Thread.sleep(1000)
-        semaphore.release()
-        val result0 = handle0.resultFuture.getOrThrow()
-        t.join()
-        assertEquals(result0, result1)
-    }
-
-    @Ignore // this is to be unignored upon implementing CORDA-3681
-    @Test
-    fun `flow's exception is available after flow's lifetime if flow is started with a client id`() {
-        ResultFlow.hook = { throw IllegalStateException() }
-        val clientId = UUID.randomUUID().toString()
-
-        assertFailsWith<IllegalStateException> {
-            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
-        }
-
-        assertFailsWith<IllegalStateException> {
-            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
-        }
-    }
-
-    @Test
-    fun `flow's client id mapping gets removed upon request`() {
-        val clientId = UUID.randomUUID().toString()
-        var counter = 0
-        ResultFlow.hook = { counter++ }
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        flowHandle0.resultFuture.getOrThrow(20.seconds)
-        val removed = aliceNode.smm.removeClientId(clientId)
-        // On new request with clientId, after the same clientId was removed, a brand new flow will start with that clientId
-        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        flowHandle1.resultFuture.getOrThrow(20.seconds)
-
-        assertTrue(removed)
-        assertNotEquals(flowHandle0.id, flowHandle1.id)
-        assertEquals(flowHandle0.clientId, flowHandle1.clientId)
-        assertEquals(2, counter)
-    }
-
-    @Test
-    fun `flow's client id mapping can only get removed once the flow gets removed`() {
-        val clientId = UUID.randomUUID().toString()
-        var tries = 0
-        val maxTries = 10
-        var failedRemovals = 0
-        val semaphore = Semaphore(0)
-        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
-            @Suspendable
-            override fun call() {
-                semaphore.acquire()
-            }
-        }
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-
-        var removed = false
-        while (!removed) {
-            removed = aliceNode.smm.removeClientId(clientId)
-            if (!removed) ++failedRemovals
-            ++tries
-            if (tries >= maxTries) {
-                semaphore.release()
-                flowHandle0.resultFuture.getOrThrow(20.seconds)
-            }
-        }
-
-        assertTrue(removed)
-        assertEquals(maxTries, failedRemovals)
-    }
-
-    @Test
-    fun `only one flow starts upon concurrent requests with the same client id`() {
-        val requests = 2
-        val counter = AtomicInteger(0)
-        val resultsCounter = AtomicInteger(0)
-        ResultFlow.hook = { counter.incrementAndGet() }
-        //(aliceNode.smm as SingleThreadedStateMachineManager).concurrentRequests = true
-
-        val clientId = UUID.randomUUID().toString()
-        val threads = arrayOfNulls<Thread>(requests)
-        for (i in 0 until requests) {
-            threads[i] = Thread {
-                val result = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
-                resultsCounter.addAndGet(result)
-            }
-        }
-
-        val semaphore = Semaphore(0)
-        val allThreadsBlocked = Semaphore(0)
-        SingleThreadedStateMachineManager.onClientIDNotFound = {
-            // Make all threads wait after client id not found on clientIdsToFlowIds
-            allThreadsBlocked.release()
-            semaphore.acquire()
-        }
-
-        val beforeCount = AtomicInteger(0)
-        SingleThreadedStateMachineManager.beforeClientIDCheck = {
-            // Make all threads wait after client id not found on clientIdsToFlowIds
-            beforeCount.incrementAndGet()
-        }
-
-        for (i in 0 until requests) {
-            threads[i]!!.start()
-        }
-
-        allThreadsBlocked.acquire()
-        for (i in 0 until requests) {
-            semaphore.release()
-        }
-
-        for (thread in threads) {
-            thread!!.join()
-        }
-        assertEquals(1, counter.get())
-        assertEquals(2, beforeCount.get())
-        assertEquals(10, resultsCounter.get())
-    }
-
-
-    @Test
-    fun `on node start -running- flows with client id are hook-able`() {
-        val clientId = UUID.randomUUID().toString()
-        var noSecondFlowWasSpawned = 0
-        var firstRun = true
-        var firstFiber: Fiber<out Any?>? = null
-        val flowIsRunning = Semaphore(0)
-        val waitUntilFlowIsRunning = Semaphore(0)
-
-        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
-            @Suspendable
-            override fun call() {
-                if (firstRun) {
-                    firstFiber = Fiber.currentFiber()
-                    firstRun = false
-                }
-
-                waitUntilFlowIsRunning.release()
-                try {
-                    flowIsRunning.acquire() // make flow wait here to impersonate a running flow
-                } catch (e: InterruptedException) {
-                    flowIsRunning.release()
-                    throw e
-                }
-
-                noSecondFlowWasSpawned++
-            }
-        }
-
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        waitUntilFlowIsRunning.acquire()
-        aliceNode.internals.acceptableLiveFiberCountOnStop = 1
-        val aliceNode = mockNet.restartNode(aliceNode)
-        // Blow up the first fiber running our flow as it is leaked here, on normal node shutdown that fiber should be gone
-        firstFiber!!.interrupt()
-
-        waitUntilFlowIsRunning.acquire()
-        // Re-hook a running flow
-        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        flowIsRunning.release()
-
-        assertEquals(flowHandle0.id, flowHandle1.id)
-        assertEquals(clientId, flowHandle1.clientId)
-        assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
-        assertEquals(1, noSecondFlowWasSpawned)
-    }
-
-    @Test
-    fun `on node restart -paused- flows with client id are hook-able`() {
-        val clientId = UUID.randomUUID().toString()
-        var noSecondFlowWasSpawned = 0
-        var firstRun = true
-        var firstFiber: Fiber<out Any?>? = null
-        val flowIsRunning = Semaphore(0)
-        val waitUntilFlowIsRunning = Semaphore(0)
-
-        ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
-            @Suspendable
-            override fun call() {
-                if (firstRun) {
-                    firstFiber = Fiber.currentFiber()
-                    firstRun = false
-                }
-
-                waitUntilFlowIsRunning.release()
-                try {
-                    flowIsRunning.acquire() // make flow wait here to impersonate a running flow
-                } catch (e: InterruptedException) {
-                    flowIsRunning.release()
-                    throw e
-                }
-
-                noSecondFlowWasSpawned++
-            }
-        }
-
-        val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        waitUntilFlowIsRunning.acquire()
-        aliceNode.internals.acceptableLiveFiberCountOnStop = 1
-        // Pause the flow on node restart
-        val aliceNode = mockNet.restartNode(aliceNode,
-            InternalMockNodeParameters(
-                configOverrides = {
-                    doReturn(StateMachineManager.StartMode.Safe).whenever(it).smmStartMode
-                }
-            ))
-        // Blow up the first fiber running our flow as it is leaked here, on normal node shutdown that fiber should be gone
-        firstFiber!!.interrupt()
-
-        // Re-hook a paused flow
-        val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-
-        assertEquals(flowHandle0.id, flowHandle1.id)
-        assertEquals(clientId, flowHandle1.clientId)
-        aliceNode.smm.unPauseFlow(flowHandle1.id)
-        assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
-        assertEquals(1, noSecondFlowWasSpawned)
-    }
-
     private inline fun <reified T> DatabaseTransaction.findRecordsFromDatabase(): List<T> {
         val criteria = session.criteriaBuilder.createQuery(T::class.java)
         criteria.select(criteria.from(T::class.java))
@@ -1499,19 +1204,5 @@ internal class SuspendingFlow : FlowLogic<Unit>() {
         stateMachine.hookBeforeCheckpoint()
         sleep(1.seconds) // flow checkpoints => checkpoint is in DB
         stateMachine.hookAfterCheckpoint()
-    }
-}
-
-internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {
-    companion object {
-        var hook: (() -> Unit)? = null
-        var suspendableHook: FlowLogic<Unit>? = null
-    }
-
-    @Suspendable
-    override fun call(): A {
-        hook?.invoke()
-        suspendableHook?.let { subFlow(it) }
-        return result
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -46,6 +46,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.Semaphore
@@ -87,9 +88,11 @@ class FlowMetadataRecordingTest {
                     metadata = metadataFromHook
                 }
 
+            val clientID = UUID.randomUUID().toString()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
-                it.proxy.startFlow(
-                    ::MyFlow,
+                it.proxy.startFlowDynamicWithClientId(
+                    clientID,
+                    MyFlow::class.java,
                     nodeBHandle.nodeInfo.singleIdentity(),
                     string,
                     someObject
@@ -101,7 +104,7 @@ class FlowMetadataRecordingTest {
                 assertEquals(flowId!!.uuid.toString(), it.flowId)
                 assertEquals(MyFlow::class.java.name, it.flowName)
                 // Should be changed when [userSuppliedIdentifier] gets filled in future changes
-                assertNull(it.userSuppliedIdentifier)
+                assertEquals(clientID, it.userSuppliedIdentifier)
                 assertEquals(DBCheckpointStorage.StartReason.RPC, it.startType)
                 assertEquals(
                     listOf(nodeBHandle.nodeInfo.singleIdentity(), string, someObject),

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -397,14 +397,14 @@ class FlowMetadataRecordingTest {
 
     @Test(timeout = 300_000)
     fun `client id gets stored into node_flow_metadata table`() {
-        val clientUUID = UUID.randomUUID().toString()
+        val clientID = UUID.randomUUID().toString()
         driver(DriverParameters(startNodesInProcess = true)) {
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
             val rpc = CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).proxy
 
-            val flowId = rpc.startFlowDynamicWithClientId(clientUUID, ClientId.EmptyFlow::class.java).id
-            val dbClientUUID = rpc.startFlow(ClientId::FetchClientIdFlow, flowId).returnValue.getOrThrow(20.seconds)
-            assertEquals(clientUUID, dbClientUUID)
+            val flowId = rpc.startFlowDynamicWithClientId(clientID, ClientId.EmptyFlow::class.java).id
+            val dbClientID = rpc.startFlow(ClientId::FetchClientIdFlow, flowId).returnValue.getOrThrow(20.seconds)
+            assertEquals(clientID, dbClientID)
         }
     }
 
@@ -584,11 +584,11 @@ class FlowMetadataRecordingTest {
         class FetchClientIdFlow(private val flowId: StateMachineRunId): FlowLogic<String?>() {
             @Suspendable
             override fun call(): String? {
-                val dbClientUUID = serviceHub.withEntityManager {
+                val dbClientID = serviceHub.withEntityManager {
                     find(DBCheckpointStorage.DBFlowMetadata::class.java, flowId.uuid.toString()).userSuppliedIdentifier
                 }
                 semaphore.release()
-                return dbClientUUID
+                return dbClientID
             }
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -32,6 +32,7 @@ import net.corda.core.serialization.deserialize
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.minutes
+import net.corda.core.utilities.seconds
 import net.corda.node.services.Permissions
 import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.testing.contracts.DummyContract
@@ -46,6 +47,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.Semaphore
@@ -393,6 +395,19 @@ class FlowMetadataRecordingTest {
         }
     }
 
+    @Test(timeout = 300_000)
+    fun `client id gets stored into node_flow_metadata table`() {
+        val clientUUID = UUID.randomUUID().toString()
+        driver(DriverParameters(startNodesInProcess = true)) {
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val rpc = CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).proxy
+
+            val flowId = rpc.startFlowDynamicWithClientId(clientUUID, ClientId.EmptyFlow::class.java).id
+            val dbClientUUID = rpc.startFlow(ClientId::FetchClientIdFlow, flowId).returnValue.getOrThrow(20.seconds)
+            assertEquals(clientUUID, dbClientUUID)
+        }
+    }
+
     @InitiatingFlow
     @StartableByRPC
     @StartableByService
@@ -551,6 +566,30 @@ class FlowMetadataRecordingTest {
         override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
             val logicRef = flowLogicRefFactory.create(MyFlow::class.jvmName, party, string, someObject)
             return ScheduledActivity(logicRef, Instant.now())
+        }
+    }
+
+    object ClientId {
+        val semaphore = co.paralleluniverse.strands.concurrent.Semaphore(0)
+
+        @StartableByRPC
+        class EmptyFlow: FlowLogic<Unit>() {
+            @Suspendable
+            override fun call() {
+                semaphore.acquire()
+            }
+        }
+
+        @StartableByRPC
+        class FetchClientIdFlow(private val flowId: StateMachineRunId): FlowLogic<String?>() {
+            @Suspendable
+            override fun call(): String? {
+                val dbClientUUID = serviceHub.withEntityManager {
+                    find(DBCheckpointStorage.DBFlowMetadata::class.java, flowId.uuid.toString()).userSuppliedIdentifier
+                }
+                semaphore.release()
+                return dbClientUUID
+            }
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -197,7 +197,7 @@ class FlowMetadataRecordingTest {
 
             assertEquals(
                 listOf(nodeBHandle.nodeInfo.singleIdentity(), string, someObject),
-                uncheckedCast<Any?, Array<Any?>>(context!!.arguments[1]).toList()
+                uncheckedCast<Any?, Array<Any?>>(context!!.arguments!![1]).toList()
             )
             assertEquals(
                 listOf(nodeBHandle.nodeInfo.singleIdentity(), string, someObject),

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -90,10 +90,10 @@ class FlowMetadataRecordingTest {
                     metadata = metadataFromHook
                 }
 
-            val clientID = UUID.randomUUID().toString()
+            val clientId = UUID.randomUUID().toString()
             CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlowDynamicWithClientId(
-                    clientID,
+                    clientId,
                     MyFlow::class.java,
                     nodeBHandle.nodeInfo.singleIdentity(),
                     string,
@@ -106,7 +106,7 @@ class FlowMetadataRecordingTest {
                 assertEquals(flowId!!.uuid.toString(), it.flowId)
                 assertEquals(MyFlow::class.java.name, it.flowName)
                 // Should be changed when [userSuppliedIdentifier] gets filled in future changes
-                assertEquals(clientID, it.userSuppliedIdentifier)
+                assertEquals(clientId, it.userSuppliedIdentifier)
                 assertEquals(DBCheckpointStorage.StartReason.RPC, it.startType)
                 assertEquals(
                     listOf(nodeBHandle.nodeInfo.singleIdentity(), string, someObject),
@@ -400,13 +400,13 @@ class FlowMetadataRecordingTest {
 
     @Test
     fun `assert that flow started with longer client id than MAX_CLIENT_ID_LENGTH fails`() {
-        val clientID = "1".repeat(513) // DBCheckpointStorage.MAX_CLIENT_ID_LENGTH == 512
+        val clientId = "1".repeat(513) // DBCheckpointStorage.MAX_CLIENT_ID_LENGTH == 512
         driver(DriverParameters(startNodesInProcess = true)) {
             val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
             val rpc = CordaRPCClient(nodeAHandle.rpcAddress).start(user.username, user.password).proxy
 
-            assertFailsWith<CordaRuntimeException>("clientID cannot be longer than ${DBCheckpointStorage.MAX_CLIENT_ID_LENGTH} characters") {
-                rpc.startFlowDynamicWithClientId(clientID, EmptyFlow::class.java).returnValue.getOrThrow()
+            assertFailsWith<CordaRuntimeException>("clientId cannot be longer than ${DBCheckpointStorage.MAX_CLIENT_ID_LENGTH} characters") {
+                rpc.startFlowDynamicWithClientId(clientId, EmptyFlow::class.java).returnValue.getOrThrow()
             }
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -398,7 +398,7 @@ class FlowMetadataRecordingTest {
         }
     }
 
-    @Test
+    @Test(timeout = 300_000)
     fun `assert that flow started with longer client id than MAX_CLIENT_ID_LENGTH fails`() {
         val clientId = "1".repeat(513) // DBCheckpointStorage.MAX_CLIENT_ID_LENGTH == 512
         driver(DriverParameters(startNodesInProcess = true)) {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -65,7 +65,7 @@ class RetryFlowMockTest {
     }
 
     private fun <T> TestStartedNode.startFlow(logic: FlowLogic<T>): CordaFuture<T> {
-        return this.services.startFlow(logic, null, this.services.newContext()).flatMap { it.resultFuture }
+        return this.services.startFlow(logic, this.services.newContext()).flatMap { it.resultFuture }
     }
 
     @After
@@ -183,7 +183,7 @@ class RetryFlowMockTest {
             override fun send(payload: Any) {
                 TODO("not implemented")
             }
-        }), null, nodeA.services.newContext()).get()
+        }), nodeA.services.newContext()).get()
         records.next()
         // Killing it should remove it.
         nodeA.smm.killFlow(flow.id)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -183,7 +183,7 @@ class RetryFlowMockTest {
             override fun send(payload: Any) {
                 TODO("not implemented")
             }
-        }), nodeA.services.newContext()).get()
+        }), nodeA.services.newContext()).get() as FlowStateMachine
         records.next()
         // Killing it should remove it.
         nodeA.smm.killFlow(flow.id)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -65,7 +65,7 @@ class RetryFlowMockTest {
     }
 
     private fun <T> TestStartedNode.startFlow(logic: FlowLogic<T>): CordaFuture<T> {
-        return this.services.startFlow(logic, null, this.services.newContext()).flatMap { it.resultFuture }
+        return this.services.startFlow(null, logic, this.services.newContext()).flatMap { it.resultFuture }
     }
 
     @After
@@ -148,7 +148,7 @@ class RetryFlowMockTest {
         // Make sure we have seen an update from the hospital, and thus the flow went there.
         val alice = TestIdentity(CordaX500Name.parse("L=London,O=Alice Ltd,OU=Trade,C=GB")).party
         val records = nodeA.smm.flowHospital.track().updates.toBlocking().toIterable().iterator()
-        val flow: FlowStateMachine<Unit> = nodeA.services.startFlow(FinalityHandler(object : FlowSession() {
+        val flow: FlowStateMachine<Unit> = nodeA.services.startFlow(null, FinalityHandler(object : FlowSession() {
             override val destination: Destination get() = alice
             override val counterparty: Party get() = alice
 
@@ -183,7 +183,7 @@ class RetryFlowMockTest {
             override fun send(payload: Any) {
                 TODO("not implemented")
             }
-        }), null, nodeA.services.newContext()).get()
+        }), nodeA.services.newContext()).get()
         records.next()
         // Killing it should remove it.
         nodeA.smm.killFlow(flow.id)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -11,7 +11,6 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.KilledFlowException
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
-import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.utilities.UntrustworthyData

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -65,7 +65,7 @@ class RetryFlowMockTest {
     }
 
     private fun <T> TestStartedNode.startFlow(logic: FlowLogic<T>): CordaFuture<T> {
-        return this.services.startFlow(logic, this.services.newContext()).flatMap { it.resultFuture }
+        return this.services.startFlow(logic, null, this.services.newContext()).flatMap { it.resultFuture }
     }
 
     @After
@@ -183,7 +183,7 @@ class RetryFlowMockTest {
             override fun send(payload: Any) {
                 TODO("not implemented")
             }
-        }), nodeA.services.newContext()).get()
+        }), null, nodeA.services.newContext()).get()
         records.next()
         // Killing it should remove it.
         nodeA.smm.killFlow(flow.id)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -65,7 +65,7 @@ class RetryFlowMockTest {
     }
 
     private fun <T> TestStartedNode.startFlow(logic: FlowLogic<T>): CordaFuture<T> {
-        return this.services.startFlow(null, logic, this.services.newContext()).flatMap { it.resultFuture }
+        return this.services.startFlow(logic, null, this.services.newContext()).flatMap { it.resultFuture }
     }
 
     @After
@@ -148,7 +148,7 @@ class RetryFlowMockTest {
         // Make sure we have seen an update from the hospital, and thus the flow went there.
         val alice = TestIdentity(CordaX500Name.parse("L=London,O=Alice Ltd,OU=Trade,C=GB")).party
         val records = nodeA.smm.flowHospital.track().updates.toBlocking().toIterable().iterator()
-        val flow: FlowStateMachine<Unit> = nodeA.services.startFlow(null, FinalityHandler(object : FlowSession() {
+        val flow: FlowStateMachine<Unit> = nodeA.services.startFlow(FinalityHandler(object : FlowSession() {
             override val destination: Destination get() = alice
             override val counterparty: Party get() = alice
 
@@ -183,7 +183,7 @@ class RetryFlowMockTest {
             override fun send(payload: Any) {
                 TODO("not implemented")
             }
-        }), nodeA.services.newContext()).get()
+        }), null, nodeA.services.newContext()).get()
         records.next()
         // Killing it should remove it.
         nodeA.smm.killFlow(flow.id)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -148,7 +148,7 @@ class RetryFlowMockTest {
         // Make sure we have seen an update from the hospital, and thus the flow went there.
         val alice = TestIdentity(CordaX500Name.parse("L=London,O=Alice Ltd,OU=Trade,C=GB")).party
         val records = nodeA.smm.flowHospital.track().updates.toBlocking().toIterable().iterator()
-        val flow: FlowStateMachine<Unit> = nodeA.services.startFlow(FinalityHandler(object : FlowSession() {
+        val flow = nodeA.services.startFlow(FinalityHandler(object : FlowSession() {
             override val destination: Destination get() = alice
             override val counterparty: Party get() = alice
 
@@ -183,7 +183,7 @@ class RetryFlowMockTest {
             override fun send(payload: Any) {
                 TODO("not implemented")
             }
-        }), nodeA.services.newContext()).get() as FlowStateMachine
+        }), nodeA.services.newContext()).get()
         records.next()
         // Killing it should remove it.
         nodeA.smm.killFlow(flow.id)

--- a/testing/core-test-utils/src/main/kotlin/net/corda/coretesting/internal/matchers/flow/FlowMatchers.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/coretesting/internal/matchers/flow/FlowMatchers.kt
@@ -2,15 +2,14 @@ package net.corda.coretesting.internal.matchers.flow
 
 import com.natpryce.hamkrest.Matcher
 import com.natpryce.hamkrest.equalTo
-import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.coretesting.internal.matchers.*
 
 /**
  * Matches a Flow that succeeds with a result matched by the given matcher
  */
-fun <T> willReturn(): Matcher<FlowStateMachine<T>> = net.corda.coretesting.internal.matchers.future.willReturn<T>()
-        .extrude(FlowStateMachine<T>::resultFuture)
+fun <T> willReturn(): Matcher<FlowStateMachineHandle<T>> = net.corda.coretesting.internal.matchers.future.willReturn<T>()
+        .extrude(FlowStateMachineHandle<T>::resultFuture)
         .redescribe { "is a flow that will return" }
 
 fun <T> willReturn(expected: T): Matcher<FlowStateMachineHandle<T>> = willReturn(equalTo(expected))

--- a/testing/core-test-utils/src/main/kotlin/net/corda/coretesting/internal/matchers/flow/FlowMatchers.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/coretesting/internal/matchers/flow/FlowMatchers.kt
@@ -3,6 +3,7 @@ package net.corda.coretesting.internal.matchers.flow
 import com.natpryce.hamkrest.Matcher
 import com.natpryce.hamkrest.equalTo
 import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.coretesting.internal.matchers.*
 
 /**
@@ -12,13 +13,13 @@ fun <T> willReturn(): Matcher<FlowStateMachine<T>> = net.corda.coretesting.inter
         .extrude(FlowStateMachine<T>::resultFuture)
         .redescribe { "is a flow that will return" }
 
-fun <T> willReturn(expected: T): Matcher<FlowStateMachine<T>> = willReturn(equalTo(expected))
+fun <T> willReturn(expected: T): Matcher<FlowStateMachineHandle<T>> = willReturn(equalTo(expected))
 
 /**
  * Matches a Flow that succeeds with a result matched by the given matcher
  */
 fun <T> willReturn(successMatcher: Matcher<T>) = net.corda.coretesting.internal.matchers.future.willReturn(successMatcher)
-        .extrude(FlowStateMachine<out T>::resultFuture)
+        .extrude(FlowStateMachineHandle<out T>::resultFuture)
         .redescribe { "is a flow that will return with a value that ${successMatcher.description}" }
 
 /**
@@ -26,7 +27,7 @@ fun <T> willReturn(successMatcher: Matcher<T>) = net.corda.coretesting.internal.
  */
 inline fun <reified E: Exception> willThrow(failureMatcher: Matcher<E>) =
         net.corda.coretesting.internal.matchers.future.willThrow(failureMatcher)
-            .extrude(FlowStateMachine<*>::resultFuture)
+            .extrude(FlowStateMachineHandle<*>::resultFuture)
             .redescribe { "is a flow that will fail, throwing an exception that ${failureMatcher.description}" }
 
 /**
@@ -34,5 +35,5 @@ inline fun <reified E: Exception> willThrow(failureMatcher: Matcher<E>) =
  */
 inline fun <reified E: Exception> willThrow() =
         net.corda.coretesting.internal.matchers.future.willThrow<E>()
-                .extrude(FlowStateMachine<*>::resultFuture)
+                .extrude(FlowStateMachineHandle<*>::resultFuture)
                 .redescribe { "is a flow that will fail with an exception of type ${E::class.java.simpleName}" }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -88,7 +88,7 @@ interface InProcess : NodeHandle {
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(null, logic, internalServices.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(logic, null, internalServices.newContext()).getOrThrow().resultFuture
 }
 
 /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -88,7 +88,7 @@ interface InProcess : NodeHandle {
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(logic, null, internalServices.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(null, logic, internalServices.newContext()).getOrThrow().resultFuture
 }
 
 /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -88,7 +88,7 @@ interface InProcess : NodeHandle {
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(logic, null, internalServices.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(logic, internalServices.newContext()).getOrThrow().resultFuture
 }
 
 /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -88,7 +88,7 @@ interface InProcess : NodeHandle {
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(logic, internalServices.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = internalServices.startFlow(logic, null, internalServices.newContext()).getOrThrow().resultFuture
 }
 
 /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -192,7 +192,7 @@ class StartedMockNode private constructor(private val node: TestStartedNode) {
     /**
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(logic, null, node.services.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(logic, node.services.newContext()).getOrThrow().resultFuture
 
     /**
      * Manually register an initiating-responder flow pair based on the [FlowLogic] annotations.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -192,7 +192,7 @@ class StartedMockNode private constructor(private val node: TestStartedNode) {
     /**
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(logic, null, node.services.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(null, logic, node.services.newContext()).getOrThrow().resultFuture
 
     /**
      * Manually register an initiating-responder flow pair based on the [FlowLogic] annotations.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -192,7 +192,7 @@ class StartedMockNode private constructor(private val node: TestStartedNode) {
     /**
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(null, logic, node.services.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(logic, null, node.services.newContext()).getOrThrow().resultFuture
 
     /**
      * Manually register an initiating-responder flow pair based on the [FlowLogic] annotations.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -192,7 +192,7 @@ class StartedMockNode private constructor(private val node: TestStartedNode) {
     /**
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      */
-    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(logic, node.services.newContext()).getOrThrow().resultFuture
+    fun <T> startFlow(logic: FlowLogic<T>): CordaFuture<T> = node.services.startFlow(logic, null, node.services.newContext()).getOrThrow().resultFuture
 
     /**
      * Manually register an initiating-responder flow pair based on the [FlowLogic] annotations.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -256,7 +256,7 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
         """.trimIndent()
     )
 
-fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, newContext()).getOrThrow()
+fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, newContext()).getOrThrow() as FlowStateMachine
 
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -258,6 +258,9 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
 
 fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachineHandle<T> = startFlow(logic, newContext()).getOrThrow()
 
+fun <T> StartedNodeServices.startFlowWithClientId(clientID: String, logic: FlowLogic<T>): FlowStateMachineHandle<T> =
+    startFlow(logic, newContext().copy(clientID = clientID)).getOrThrow()
+
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 
 fun InMemoryMessagingNetwork.MessageTransfer.getMessage(): Message = message

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -256,7 +256,7 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
         """.trimIndent()
     )
 
-fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(null, logic, newContext()).getOrThrow()
+fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, null, newContext()).getOrThrow()
 
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -256,7 +256,7 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
         """.trimIndent()
     )
 
-fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, null, newContext()).getOrThrow()
+fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(null, logic, newContext()).getOrThrow()
 
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -256,7 +256,7 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
         """.trimIndent()
     )
 
-fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, null, newContext()).getOrThrow()
+fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, newContext()).getOrThrow()
 
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -258,8 +258,8 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
 
 fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachineHandle<T> = startFlow(logic, newContext()).getOrThrow()
 
-fun <T> StartedNodeServices.startFlowWithClientId(clientID: String, logic: FlowLogic<T>): FlowStateMachineHandle<T> =
-    startFlow(logic, newContext().copy(clientID = clientID)).getOrThrow()
+fun <T> StartedNodeServices.startFlowWithClientId(clientId: String, logic: FlowLogic<T>): FlowStateMachineHandle<T> =
+    startFlow(logic, newContext().copy(clientId = clientId)).getOrThrow()
 
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -256,7 +256,7 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
         """.trimIndent()
     )
 
-fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, newContext()).getOrThrow()
+fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, null, newContext()).getOrThrow()
 
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -7,7 +7,7 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.div
@@ -256,7 +256,7 @@ class NodeListenProcessDeathException(hostAndPort: NetworkHostAndPort, listenPro
         """.trimIndent()
     )
 
-fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = startFlow(logic, newContext()).getOrThrow() as FlowStateMachine
+fun <T> StartedNodeServices.startFlow(logic: FlowLogic<T>): FlowStateMachineHandle<T> = startFlow(logic, newContext()).getOrThrow()
 
 fun StartedNodeServices.newContext(): InvocationContext = testContext(myInfo.chooseIdentity().name)
 


### PR DESCRIPTION
Integrate `DBFlowResult` with the rest of the checkpoint schema, so now we are saving the flow's result in the database. 

Making statemachine not to remove `COMPLETED` flows' checkpoints from the database if they are started with a `clientId`.

Also retrieve the `DBFlowResult` from the database to construct a `FlowStateMachineHandle` done future for requests (`startFlowDynamicWithClientId`) that pick flows , started with client id, of status `Removed`. 