### PR TITLE
NOTICK - Decrease the ring buffer size

### DIFF
--- a/node/src/main/resources/log4j2.component.properties
+++ b/node/src/main/resources/log4j2.component.properties
@@ -1,2 +1,2 @@
 Log4jContextSelector=net.corda.node.utilities.logging.AsyncLoggerContextSelectorNoThreadLocal
-AsyncLogger.RingBufferSize=262144
+AsyncLogger.RingBufferSize=16384


### PR DESCRIPTION
This PR decreases the size of the ring buffer so it uses less memory and is equal to the size set in Corda Enterprise.