### PR TITLE
CORDA-3663 MockServices crashes when two of the provided packages to …

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -96,5 +96,5 @@ class FinalityFlowTests : WithFinality {
     }
 
     /** "Old" CorDapp which will force its node to keep its FinalityHandler enabled */
-    private fun tokenOldCordapp() = cordappWithPackages("com.template").copy(targetPlatformVersion = 3)
+    private fun tokenOldCordapp() = cordappWithPackages("net.corda.finance.POUNDS").copy(targetPlatformVersion = 3)
 }

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -96,5 +96,5 @@ class FinalityFlowTests : WithFinality {
     }
 
     /** "Old" CorDapp which will force its node to keep its FinalityHandler enabled */
-    private fun tokenOldCordapp() = cordappWithPackages("net.corda.finance.POUNDS").copy(targetPlatformVersion = 3)
+    private fun tokenOldCordapp() = cordappWithPackages().copy(targetPlatformVersion = 3)
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
@@ -49,13 +49,11 @@ data class CustomCordapp(
 
     @VisibleForTesting
     internal fun packageAsJar(file: Path) {
-        if(packages.isEmpty() && classes.isEmpty() && fixups.isEmpty()){
+        if(packages.isEmpty()){
             return
         }
         val classGraph = ClassGraph()
-        if (packages.isNotEmpty()) {
-            classGraph.whitelistPaths(*packages.map { it.replace('.', '/') }.toTypedArray())
-        }
+        classGraph.whitelistPaths(*packages.map { it.replace('.', '/') }.toTypedArray())
         if (classes.isNotEmpty()) {
             classes.forEach { classGraph.addClassLoader(it.classLoader) }
             classGraph.whitelistClasses(*classes.map { it.name }.toTypedArray())
@@ -81,10 +79,8 @@ data class CustomCordapp(
                 if (scanResult.allResources.isEmpty()){
                     throw ClassNotFoundException("Could not create jar file as the given package is not found on the classpath: ${packages.toList()[0]}")
                 }
-                if(packages.isNotEmpty() || classes.isNotEmpty() || fixups.isNotEmpty()){
-                    scanResult.allResources.asMap().forEach { path, resourceList ->
-                        jos.addEntry(testEntry(path), resourceList[0].open())
-                    }
+                scanResult.allResources.asMap().forEach { path, resourceList ->
+                    jos.addEntry(testEntry(path), resourceList[0].open())
                 }
             }
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
@@ -73,12 +73,12 @@ data class CustomCordapp(
                     }
                 }
 
-                // The same resource may be found in different locations (this will happen when running from gradle) so just
-                // pick the first one found.
                 if (scanResult.allResources.isEmpty()){
                     throw ClassNotFoundException("Could not create jar file as the given package is not found on the classpath: ${packages.toList()[0]}")
                 }
 
+                // The same resource may be found in different locations (this will happen when running from gradle) so just
+                // pick the first one found.
                 scanResult.allResources.asMap().forEach { path, resourceList ->
                     jos.addEntry(testEntry(path), resourceList[0].open())
                 }
@@ -177,10 +177,8 @@ data class CustomCordapp(
                 val jarFile = cordappsDirectory.createDirectories() / filename
                 if (it.fixups.isNotEmpty()) {
                     it.createFixupJar(jarFile)
-                } else {
-                    if(it.packages.isNotEmpty() || it.classes.isNotEmpty() || it.fixups.isNotEmpty()) {
+                } else if(it.packages.isNotEmpty() || it.classes.isNotEmpty() || it.fixups.isNotEmpty()) {
                         it.packageAsJar(jarFile)
-                    }
                 }
                 it.signJar(jarFile)
                 logger.debug { "$it packaged into $jarFile" }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
@@ -78,10 +78,9 @@ data class CustomCordapp(
                 if (scanResult.allResources.isEmpty()){
                     throw ClassNotFoundException("Could not create jar file as the given package is not found on the classpath: ${packages.toList()[0]}")
                 }
-                if(packages.isNotEmpty() || classes.isNotEmpty() || fixups.isEmpty()){
-                    scanResult.allResources.asMap().forEach { path, resourceList ->
-                        jos.addEntry(testEntry(path), resourceList[0].open())
-                    }
+
+                scanResult.allResources.asMap().forEach { path, resourceList ->
+                    jos.addEntry(testEntry(path), resourceList[0].open())
                 }
             }
         }
@@ -179,7 +178,9 @@ data class CustomCordapp(
                 if (it.fixups.isNotEmpty()) {
                     it.createFixupJar(jarFile)
                 } else {
-                    it.packageAsJar(jarFile)
+                    if(it.packages.isNotEmpty() || it.classes.isNotEmpty() || it.fixups.isNotEmpty()) {
+                        it.packageAsJar(jarFile)
+                    }
                 }
                 it.signJar(jarFile)
                 logger.debug { "$it packaged into $jarFile" }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
@@ -49,11 +49,10 @@ data class CustomCordapp(
 
     @VisibleForTesting
     internal fun packageAsJar(file: Path) {
-        if(packages.isEmpty()){
-            return
-        }
         val classGraph = ClassGraph()
-        classGraph.whitelistPaths(*packages.map { it.replace('.', '/') }.toTypedArray())
+        if(packages.isNotEmpty()){
+            classGraph.whitelistPaths(*packages.map { it.replace('.', '/') }.toTypedArray())
+        }
         if (classes.isNotEmpty()) {
             classes.forEach { classGraph.addClassLoader(it.classLoader) }
             classGraph.whitelistClasses(*classes.map { it.name }.toTypedArray())
@@ -79,8 +78,10 @@ data class CustomCordapp(
                 if (scanResult.allResources.isEmpty()){
                     throw ClassNotFoundException("Could not create jar file as the given package is not found on the classpath: ${packages.toList()[0]}")
                 }
-                scanResult.allResources.asMap().forEach { path, resourceList ->
-                    jos.addEntry(testEntry(path), resourceList[0].open())
+                if(packages.isNotEmpty() || classes.isNotEmpty() || fixups.isEmpty()){
+                    scanResult.allResources.asMap().forEach { path, resourceList ->
+                        jos.addEntry(testEntry(path), resourceList[0].open())
+                    }
                 }
             }
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
@@ -80,6 +80,9 @@ data class CustomCordapp(
 
                 // The same resource may be found in different locations (this will happen when running from gradle) so just
                 // pick the first one found.
+                if (scanResult.allResources.isEmpty()){
+                    throw ClassNotFoundException("Could not create jar file as the given package is not found on the classpath: ${packages.toList()[0]}")
+                }
                 scanResult.allResources.asMap().forEach { path, resourceList ->
                     jos.addEntry(testEntry(path), resourceList[0].open())
                 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
@@ -31,7 +31,7 @@ abstract class TestCordappInternal : TestCordapp() {
             val allCordapps = nodeSpecificCordapps + generalCordapps.filter { it.withOnlyJarContents() !in nodeSpecificCordappsWithoutMeta }
             // Ignore any duplicate jar files
             val jarToCordapp  = allCordapps.filter {
-                it !is CustomCordapp || it.packages.isNotEmpty() }.associateBy { it.jarFile }
+                it !is CustomCordapp || it.packages.isNotEmpty() || it.classes.isNotEmpty() || it.fixups.isNotEmpty() }.associateBy { it.jarFile }
 
             val cordappsDir = baseDirectory / "cordapps"
             val configDir = (cordappsDir / "config").createDirectories()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
@@ -6,7 +6,6 @@ import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.internal.writeText
 import net.corda.testing.node.TestCordapp
-import java.io.File
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Path
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
@@ -31,7 +31,7 @@ abstract class TestCordappInternal : TestCordapp() {
             val allCordapps = nodeSpecificCordapps + generalCordapps.filter { it.withOnlyJarContents() !in nodeSpecificCordappsWithoutMeta }
             // Ignore any duplicate jar files
             val jarToCordapp  = allCordapps.filter {
-                it !is CustomCordapp || it.classes.isNotEmpty() }.associateBy { it.jarFile }
+                it !is CustomCordapp || it.packages.isNotEmpty() }.associateBy { it.jarFile }
 
             val cordappsDir = baseDirectory / "cordapps"
             val configDir = (cordappsDir / "config").createDirectories()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappInternal.kt
@@ -30,8 +30,8 @@ abstract class TestCordappInternal : TestCordapp() {
             // Precedence is given to node-specific CorDapps
             val allCordapps = nodeSpecificCordapps + generalCordapps.filter { it.withOnlyJarContents() !in nodeSpecificCordappsWithoutMeta }
             // Ignore any duplicate jar files
-            val jarToCordapp  = allCordapps.filter { it !is CustomCordapp ||
-                    (it is CustomCordapp && it.classes.isNotEmpty()) }.associateBy { it.jarFile }
+            val jarToCordapp  = allCordapps.filter {
+                it !is CustomCordapp || it.classes.isNotEmpty() }.associateBy { it.jarFile }
 
             val cordappsDir = baseDirectory / "cordapps"
             val configDir = (cordappsDir / "config").createDirectories()

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
@@ -22,7 +22,7 @@ import org.junit.Test
  */
 class TestResponseFlowInIsolation {
 
-    private val network: MockNetwork = MockNetwork(MockNetworkParameters(cordappsForAllNodes = cordappsForPackages("com.template")))
+    private val network: MockNetwork = MockNetwork(MockNetworkParameters(cordappsForAllNodes = cordappsForPackages("net.corda.core.identity.Party")))
     private val a = network.createNode()
     private val b = network.createNode()
 

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
@@ -22,7 +22,7 @@ import org.junit.Test
  */
 class TestResponseFlowInIsolation {
 
-    private val network: MockNetwork = MockNetwork(MockNetworkParameters(cordappsForAllNodes = cordappsForPackages("net.corda.core.identity.Party")))
+    private val network: MockNetwork = MockNetwork(MockNetworkParameters(cordappsForAllNodes = cordappsForPackages()))
     private val a = network.createNode()
     private val b = network.createNode()
 

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolationInJava.java
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolationInJava.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class TestResponseFlowInIsolationInJava {
 
-    private final MockNetwork network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(cordappsForPackages("com.template")));
+    private final MockNetwork network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(cordappsForPackages("net.corda.core.identity.Party")));
     private final StartedMockNode a = network.createNode();
     private final StartedMockNode b = network.createNode();
 

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolationInJava.java
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolationInJava.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class TestResponseFlowInIsolationInJava {
 
-    private final MockNetwork network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(cordappsForPackages("net.corda.core.identity.Party")));
+    private final MockNetwork network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(cordappsForPackages()));
     private final StartedMockNode a = network.createNode();
     private final StartedMockNode b = network.createNode();
 


### PR DESCRIPTION
CORDA-3663 MockServices crashes when two of the provided packages to scan are deemed empty in 4.4 RC05

this happends when a given package is not found on the classpath. Now it is handled and an exception is thrown
