### PR TITLE
NOTICK: Remove `relaxedThoroughness` variable

### DIFF
--- a/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt
@@ -6,7 +6,6 @@ import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.getOrThrow
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
-import net.corda.testing.common.internal.relaxedThoroughness
 import net.corda.testing.internal.configureDatabase
 import net.corda.testing.node.internal.ProcessUtilities.startJavaProcess
 import org.junit.Rule
@@ -43,8 +42,7 @@ class AbstractNodeTests {
     @Test(timeout=300_000)
 	fun `H2 fix is applied`() {
         val pool = Executors.newFixedThreadPool(5)
-        val runs = if (relaxedThoroughness) 1 else 100
-        (0 until runs).map {
+        (0 until 5).map {
             // Four "nodes" seems to be the magic number to reproduce the problem on CI:
             val urls = (0 until 4).map { freshURL() }
             // Haven't been able to reproduce in a warm JVM:

--- a/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/Thoroughness.kt
+++ b/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/Thoroughness.kt
@@ -1,3 +1,0 @@
-package net.corda.testing.common.internal
-
-val relaxedThoroughness = System.getenv("TEAMCITY_PROJECT_NAME") == "Pull Requests"


### PR DESCRIPTION
It is:
a. No longer works in Jenkins
b. May result spawning 100s of process that kill Windows build. Evidence: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda-Enterprise%2FCorda-ENT-MS-Win-Compatibility%2Fenterprise/detail/PR-3553/25/pipeline/

This has been introduced long time ago as part of https://github.com/corda/corda/pull/2349
