### PR TITLE
CORDA-3916 Update to BouncyCastle 1.61

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -22,7 +22,7 @@ quasarVersion11=0.8.0
 # Specify a classifier for Java 11 built artifacts
 jdkClassifier11=jdk11
 proguardVersion=6.1.1
-bouncycastleVersion=1.60
+bouncycastleVersion=1.61
 classgraphVersion=4.8.41
 disruptorVersion=3.4.2
 typesafeConfigVersion=1.3.4


### PR DESCRIPTION
Update to BouncyCastle 1.61. Updating one version at a time to mitigate risk of a complex breaking change being introduced.