### PR TITLE
CORDA-3917 Update to Jackson 2.9.8

### DIFF
--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -1,0 +1,76 @@
+@Library('corda-shared-build-pipeline-steps')
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+pipeline {
+    agent { label 'k8s' }
+    options {
+        timestamps()
+        timeout(time: 3, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
+    }
+
+    environment {
+        PR_CONTEXT_STRING = "PR Code Checks"
+    }
+
+    stages {
+        stage('Detekt check') {
+            steps {
+                script {
+                    pullRequest.createStatus(
+                            status: 'pending',
+                            context: "${PR_CONTEXT_STRING}",
+                            description: "Running code checks",
+                            targetUrl: "${env.BUILD_URL}")
+                }
+                sh "./gradlew --no-daemon clean detekt"
+            }
+        }
+
+        stage('Compilation warnings check') {
+            steps {
+                sh "./gradlew --no-daemon -Pcompilation.warningsAsErrors=true compileAll"
+            }
+        }
+
+        stage('No API change check') {
+            steps {
+                sh "./gradlew --no-daemon generateApi"
+                sh ".ci/check-api-changes.sh"
+            }
+        }
+
+        stage('Deploy Nodes') {
+            steps {
+                sh "./gradlew --no-daemon jar deployNodes"
+            }
+        }
+    }
+
+    post {
+        success {
+            script {
+                pullRequest.createStatus(
+                        status: 'success',
+                        context: "${PR_CONTEXT_STRING}",
+                        description: 'Code checks passed',
+                        targetUrl: "${env.BUILD_URL}")
+            }
+        }
+
+        failure {
+            script {
+                pullRequest.createStatus(
+                        status: 'failure',
+                        context: "${PR_CONTEXT_STRING}",
+                        description: 'Code checks failed',
+                        targetUrl: "${env.BUILD_URL}")
+            }
+        }
+        cleanup {
+            deleteDir() /* clean up our workspace */
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,8 @@ buildscript {
 
     ext.asm_version = '7.1'
     ext.artemis_version = '2.6.2'
-    // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.9.7'
+    // TODO Upgrade to Jackson 2.10+ only when corda is using kotlin 1.3.10
+    ext.jackson_version = '2.9.8'
     ext.jetty_version = '9.4.19.v20190610'
     ext.jersey_version = '2.25'
     ext.servlet_version = '4.0.1'


### PR DESCRIPTION
Update to Jackson 2.9.8 to address multiple security issues, and update warning note about updates to clarify that it refers to 2.10+. When the note was added 2.9.7 as the highest available version in the 2.9.x series.