### PR TITLE
NOTICK Add more detail on signature build failures

### DIFF
--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilderTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilderTest.kt
@@ -10,7 +10,7 @@ class ContentSignerBuilderTest {
         private const val entropy = "20200723"
     }
 
-    @Test
+    @Test(timeout = 300_000)
     fun `should build content signer for valid eddsa key`() {
         val signatureScheme = Crypto.EDDSA_ED25519_SHA512
         val provider = Crypto.findProvider(signatureScheme.providerName)
@@ -18,7 +18,7 @@ class ContentSignerBuilderTest {
         ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
     }
 
-    @Test(expected = InvalidKeyException::class)
+    @Test(expected = InvalidKeyException::class, timeout = 300_000)
     fun `should fail to build content signer for incorrect key type`() {
         val signatureScheme = Crypto.EDDSA_ED25519_SHA512
         val provider = Crypto.findProvider(signatureScheme.providerName)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilderTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilderTest.kt
@@ -1,6 +1,7 @@
 package net.corda.nodeapi.internal.crypto
 
 import net.corda.core.crypto.Crypto
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
 import java.math.BigInteger
 import java.security.InvalidKeyException
@@ -18,11 +19,15 @@ class ContentSignerBuilderTest {
         ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
     }
 
-    @Test(expected = InvalidKeyException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `should fail to build content signer for incorrect key type`() {
         val signatureScheme = Crypto.EDDSA_ED25519_SHA512
         val provider = Crypto.findProvider(signatureScheme.providerName)
         val issuerKeyPair = Crypto.deriveKeyPairFromEntropy(Crypto.ECDSA_SECP256R1_SHA256, BigInteger(entropy))
-        ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
+        assertThatExceptionOfType(InvalidKeyException::class.java)
+                .isThrownBy {
+                    ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
+                }
+                .withMessage("Incorrect key type EC for signature scheme NONEwithEdDSA")
     }
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilderTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilderTest.kt
@@ -1,0 +1,28 @@
+package net.corda.nodeapi.internal.crypto
+
+import net.corda.core.crypto.Crypto
+import org.junit.Test
+import java.math.BigInteger
+import java.security.InvalidKeyException
+
+class ContentSignerBuilderTest {
+    companion object {
+        private const val entropy = "20200723"
+    }
+
+    @Test
+    fun `should build content signer for valid eddsa key`() {
+        val signatureScheme = Crypto.EDDSA_ED25519_SHA512
+        val provider = Crypto.findProvider(signatureScheme.providerName)
+        val issuerKeyPair = Crypto.deriveKeyPairFromEntropy(signatureScheme, BigInteger(entropy))
+        ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
+    }
+
+    @Test(expected = InvalidKeyException::class)
+    fun `should fail to build content signer for incorrect key type`() {
+        val signatureScheme = Crypto.EDDSA_ED25519_SHA512
+        val provider = Crypto.findProvider(signatureScheme.providerName)
+        val issuerKeyPair = Crypto.deriveKeyPairFromEntropy(Crypto.ECDSA_SECP256R1_SHA256, BigInteger(entropy))
+        ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
+    }
+}


### PR DESCRIPTION
Add details of the signature provider and key algorithm if `InvalidKeyException` is thrown when constructing a `ContentSigner`, in order to be able to usefully diagnose incorrect signature providers or similar errors.
