### PR TITLE
CORDA-3918: Port of ENT-5417: Allow exceptions to propagate when shutdown commands are called

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -111,6 +111,8 @@ object InteractiveShell {
         YAML
     }
 
+    private fun isShutdownCmd(cmd: String) = cmd == "shutdown" || cmd == "gracefulShutdown" || cmd == "terminate"
+
     fun startShell(configuration: ShellConfiguration, classLoader: ClassLoader? = null, standalone: Boolean = false) {
         makeRPCConnection = { username: String, password: String ->
             val connection = if (standalone) {
@@ -623,6 +625,10 @@ object InteractiveShell {
                     throw e.rootCause
                 }
             }
+            if (isShutdownCmd(cmd)) {
+                out.println("Called 'shutdown' on the node.\nQuitting the shell now.").also { out.flush() }
+                onExit.invoke()
+            }
         } catch (e: StringToMethodCallParser.UnparseableCallException) {
             out.println(e.message, Decoration.bold, Color.red)
             if (e !is StringToMethodCallParser.UnparseableCallException.NoSuchFile) {
@@ -633,10 +639,6 @@ object InteractiveShell {
         } finally {
             InputStreamSerializer.invokeContext = null
             InputStreamDeserializer.closeAll()
-        }
-        if (cmd == "shutdown") {
-            out.println("Called 'shutdown' on the node.\nQuitting the shell now.").also { out.flush() }
-            onExit.invoke()
         }
         return result
     }


### PR DESCRIPTION
Port from ENT.  Should have started in OS