### PR TITLE
INFRA-530: Start notary node in process

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
@@ -41,7 +41,7 @@ class AddressBindingFailureTests {
 
             assertThatThrownBy {
                 driver(DriverParameters(startNodesInProcess = false,
-                    notarySpecs = listOf(NotarySpec(notaryName)),
+                    notarySpecs = listOf(NotarySpec(notaryName, startInProcess = false)),
                     notaryCustomOverrides = mapOf("p2pAddress" to address.toString()),
                     portAllocation = portAllocation,
                     cordappsForAllNodes = emptyList())

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -16,7 +16,9 @@ import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.http.HttpApi
+import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.addressMustBeBound
 import net.corda.testing.node.internal.addressMustNotBeBound
 import org.assertj.core.api.Assertions.assertThat
@@ -118,7 +120,7 @@ class DriverTests {
 	fun `started node, which is not waited for in the driver, is shutdown when the driver exits`() {
         // First check that the process-id file is created by the node on startup, so that we can be sure our check that
         // it's deleted on shutdown isn't a false-positive.
-        val baseDirectory = driver {
+        val baseDirectory = driver(DriverParameters(notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = false)))) {
             val baseDirectory = defaultNotaryNode.getOrThrow().baseDirectory
             assertThat(baseDirectory / "process-id").exists()
             baseDirectory

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -279,7 +279,6 @@ data class DriverParameters(
             systemProperties: Map<String, String> = emptyMap(),
             useTestClock: Boolean = false,
             startNodesInProcess: Boolean = false,
-            startNoteryInProcess: Boolean = false,
             waitForAllNodesToFinish: Boolean = false,
             notarySpecs: List<NotarySpec> = listOf(NotarySpec(DUMMY_NOTARY_NAME)),
             extraCordappPackagesToScan: List<String> = emptyList(),

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -279,6 +279,7 @@ data class DriverParameters(
             systemProperties: Map<String, String> = emptyMap(),
             useTestClock: Boolean = false,
             startNodesInProcess: Boolean = false,
+            startNoteryInProcess: Boolean = false,
             waitForAllNodesToFinish: Boolean = false,
             notarySpecs: List<NotarySpec> = listOf(NotarySpec(DUMMY_NOTARY_NAME)),
             extraCordappPackagesToScan: List<String> = emptyList(),

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
@@ -23,6 +23,19 @@ data class NotarySpec(
         val cluster: ClusterSpec? = null,
         val startInProcess: Boolean = true
 ) {
+    constructor(name: CordaX500Name,
+                validating: Boolean = true,
+                rpcUsers: List<User> = emptyList(),
+                verifierType: VerifierType = VerifierType.InMemory,
+                cluster: ClusterSpec? = null): this(name, validating, rpcUsers, verifierType, cluster, "512m", true)
+
+    constructor(name: CordaX500Name,
+                validating: Boolean = true,
+                rpcUsers: List<User> = emptyList(),
+                verifierType: VerifierType = VerifierType.InMemory,
+                cluster: ClusterSpec? = null,
+                maximumHeapSize: String): this(name, validating, rpcUsers, verifierType, cluster, maximumHeapSize, true)
+
     // These extra fields are handled this way to preserve Kotlin wire compatibility wrt additional parameters with default values.
     constructor(name: CordaX500Name,
                 validating: Boolean = true,
@@ -33,6 +46,21 @@ data class NotarySpec(
                 startInProcess: Boolean = true): this(name, validating, rpcUsers, verifierType, cluster, startInProcess) {
         this.maximumHeapSize = maximumHeapSize
     }
+
+    fun copy(
+            name: CordaX500Name,
+            validating: Boolean = true,
+            rpcUsers: List<User> = emptyList(),
+            verifierType: VerifierType = VerifierType.InMemory,
+            cluster: ClusterSpec? = null
+    ) = this.copy(
+            name = name,
+            validating = validating,
+            rpcUsers = rpcUsers,
+            verifierType = verifierType,
+            cluster = cluster,
+            startInProcess = true
+    )
 
     var maximumHeapSize: String = "512m"
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
@@ -29,8 +29,8 @@ data class NotarySpec(
                 rpcUsers: List<User> = emptyList(),
                 verifierType: VerifierType = VerifierType.InMemory,
                 cluster: ClusterSpec? = null,
-                startInProcess: Boolean = true,
-                maximumHeapSize: String = "512m"): this(name, validating, rpcUsers, verifierType, cluster, startInProcess) {
+                maximumHeapSize: String = "512m",
+                startInProcess: Boolean = true): this(name, validating, rpcUsers, verifierType, cluster, startInProcess) {
         this.maximumHeapSize = maximumHeapSize
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
@@ -13,13 +13,15 @@ import net.corda.testing.driver.VerifierType
  * @property rpcUsers A list of users able to instigate RPC for this node or cluster of nodes.
  * @property verifierType How the notary will verify transactions.
  * @property cluster [ClusterSpec] if this is a distributed cluster notary. If null then this is a single-node notary.
+ * @property startInProcess Should the notary be started in process.
  */
 data class NotarySpec(
         val name: CordaX500Name,
         val validating: Boolean = true,
         val rpcUsers: List<User> = emptyList(),
         val verifierType: VerifierType = VerifierType.InMemory,
-        val cluster: ClusterSpec? = null
+        val cluster: ClusterSpec? = null,
+        val startInProcess: Boolean = true
 ) {
     // These extra fields are handled this way to preserve Kotlin wire compatibility wrt additional parameters with default values.
     constructor(name: CordaX500Name,
@@ -27,7 +29,8 @@ data class NotarySpec(
                 rpcUsers: List<User> = emptyList(),
                 verifierType: VerifierType = VerifierType.InMemory,
                 cluster: ClusterSpec? = null,
-                maximumHeapSize: String = "512m"): this(name, validating, rpcUsers, verifierType, cluster) {
+                startInProcess: Boolean = true,
+                maximumHeapSize: String = "512m"): this(name, validating, rpcUsers, verifierType, cluster, startInProcess) {
         this.maximumHeapSize = maximumHeapSize
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -575,7 +575,7 @@ class DriverDSLImpl(
             localNetworkMap,
             NodeParameters(rpcUsers = spec.rpcUsers,
                 verifierType = spec.verifierType,
-                startInSameProcess = true,
+                startInSameProcess = spec.startInProcess,
                 customOverrides = notaryConfig + customOverrides,
                 maximumHeapSize = spec.maximumHeapSize)
         ).map { listOf(it) }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -571,9 +571,13 @@ class DriverDSLImpl(
     private fun startSingleNotary(spec: NotarySpec, localNetworkMap: LocalNetworkMap?, customOverrides: Map<String, Any?>): CordaFuture<List<NodeHandle>> {
         val notaryConfig = mapOf("notary" to mapOf("validating" to spec.validating))
         return startRegisteredNode(
-                spec.name,
-                localNetworkMap,
-                NodeParameters(rpcUsers = spec.rpcUsers, verifierType = spec.verifierType, customOverrides = notaryConfig + customOverrides, maximumHeapSize = spec.maximumHeapSize)
+            spec.name,
+            localNetworkMap,
+            NodeParameters(rpcUsers = spec.rpcUsers,
+                verifierType = spec.verifierType,
+                startInSameProcess = true,
+                customOverrides = notaryConfig + customOverrides,
+                maximumHeapSize = spec.maximumHeapSize)
         ).map { listOf(it) }
     }
 


### PR DESCRIPTION
This PR is trying to start the notary node in the same process as the test whenever possible. This will reduce the amount of time it takes the tests to run and should reduce the resources it uses.

To force the notary to run in its own process, one needs to set the `startInProcess` in the notary spec.
