### PR TITLE
NOTICK Filter out the RPC serialization context

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt
@@ -99,11 +99,8 @@ val _allEnabledSerializationEnvs: List<Pair<String, SerializationEnvironment>>
     get() = serializationEnvFields.mapNotNull { it.get()?.let { env -> Pair(it.name, env) } }
 
 val effectiveSerializationEnv: SerializationEnvironment
-    get() {
-        return _allEnabledSerializationEnvs.let {
-            checkNotNull(it.singleOrNull()?.second) {
+    get() = _allEnabledSerializationEnvs
+            .singleOrNull { it.second != _rpcClientSerializationEnv.get() }?.second ?: throw IllegalStateException(
                 "Expected exactly 1 of {${serializationEnvFields.joinToString(", ") { it.name }}} " +
-                        "but got: {${it.joinToString(", ") { it.first }}}"
-            }
-        }
-    }
+                        "but got: {${_allEnabledSerializationEnvs.joinToString(", ") { it.first }}}"
+    )


### PR DESCRIPTION
Filter out the RPC serialization context when determining the effective serialization context, to improve robustness in test setups.
