### PR TITLE
EG-3456: Make network parameters path configurable

### DIFF
--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:8u192
+FROM azul/zulu-openjdk:8u242
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \

--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:8u242
+FROM azul/zulu-openjdk:8u192
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \

--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -21,7 +21,7 @@ import java.security.cert.X509Certificate
 class NetworkParametersReader(private val trustRoot: X509Certificate,
                               private val networkMapClient: NetworkMapClient?,
                               private val baseDirectory: Path,
-                              private val networkParamsPath: Path) {
+                              private val networkParamsPath: Path = baseDirectory) {
     companion object {
         private val logger = contextLogger()
     }
@@ -39,7 +39,7 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
         )
     }
 
-    private val networkParamsFile = networkParamsPath
+    private val networkParamsFile = networkParamsPath / NETWORK_PARAMS_FILE_NAME
 
     fun read(): NetworkParametersAndSigned {
         val advertisedParametersHash = try {
@@ -73,7 +73,7 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
     }
 
     private fun readParametersUpdate(advertisedParametersHash: SecureHash, previousParametersHash: SecureHash): SignedNetworkParameters {
-        val parametersUpdateFile = baseDirectory / NETWORK_PARAMS_UPDATE_FILE_NAME
+        val parametersUpdateFile = networkParamsPath / NETWORK_PARAMS_UPDATE_FILE_NAME
         if (!parametersUpdateFile.exists()) {
             throw Error.OldParams(previousParametersHash, advertisedParametersHash, networkParamsPath)
         }

--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -20,8 +20,7 @@ import java.security.cert.X509Certificate
 
 class NetworkParametersReader(private val trustRoot: X509Certificate,
                               private val networkMapClient: NetworkMapClient?,
-                              private val baseDirectory: Path,
-                              private val networkParamsPath: Path = baseDirectory) {
+                              private val networkParamsPath: Path) {
     companion object {
         private val logger = contextLogger()
     }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -87,6 +87,8 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
 
     val networkParameterAcceptanceSettings: NetworkParameterAcceptanceSettings?
 
+    val networkParametersPath: Path
+
     val blacklistedAttachmentSigningKeys: List<String>
 
     val flowExternalOperationThreadPoolSize: Int

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -14,6 +14,7 @@ import net.corda.nodeapi.internal.config.FileBasedCertificateStoreSupplier
 import net.corda.nodeapi.internal.config.MutualSslConfiguration
 import net.corda.nodeapi.internal.config.SslConfiguration
 import net.corda.nodeapi.internal.config.User
+import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.tools.shell.SSHDConfiguration
 import java.net.URL
@@ -84,7 +85,8 @@ data class NodeConfigurationImpl(
         override val configurationWithOptions: ConfigurationWithOptions,
         override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize,
         override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages,
-        override val reloadCheckpointAfterSuspend: Boolean = Defaults.reloadCheckpointAfterSuspend
+        override val reloadCheckpointAfterSuspend: Boolean = Defaults.reloadCheckpointAfterSuspend,
+        override val networkParametersPath: Path
 
 ) : NodeConfiguration {
     internal object Defaults {
@@ -127,6 +129,8 @@ data class NodeConfigurationImpl(
         val reloadCheckpointAfterSuspend: Boolean = System.getProperty("reloadCheckpointAfterSuspend", "false")!!.toBoolean()
 
         fun cordappsDirectories(baseDirectory: Path) = listOf(baseDirectory / CORDAPPS_DIR_NAME_DEFAULT)
+
+        fun networkParametersDefaultPath(baseDirectory: Path) = baseDirectory / NETWORK_PARAMS_FILE_NAME
 
         fun messagingServerExternal(messagingServerAddress: NetworkHostAndPort?) = messagingServerAddress != null
 

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -14,7 +14,6 @@ import net.corda.nodeapi.internal.config.FileBasedCertificateStoreSupplier
 import net.corda.nodeapi.internal.config.MutualSslConfiguration
 import net.corda.nodeapi.internal.config.SslConfiguration
 import net.corda.nodeapi.internal.config.User
-import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.tools.shell.SSHDConfiguration
 import java.net.URL
@@ -86,7 +85,7 @@ data class NodeConfigurationImpl(
         override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize,
         override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages,
         override val reloadCheckpointAfterSuspend: Boolean = Defaults.reloadCheckpointAfterSuspend,
-        override val networkParametersPath: Path
+        override val networkParametersPath: Path = baseDirectory
 
 ) : NodeConfiguration {
     internal object Defaults {
@@ -129,8 +128,6 @@ data class NodeConfigurationImpl(
         val reloadCheckpointAfterSuspend: Boolean = System.getProperty("reloadCheckpointAfterSuspend", "false")!!.toBoolean()
 
         fun cordappsDirectories(baseDirectory: Path) = listOf(baseDirectory / CORDAPPS_DIR_NAME_DEFAULT)
-
-        fun networkParametersDefaultPath(baseDirectory: Path) = baseDirectory / NETWORK_PARAMS_FILE_NAME
 
         fun messagingServerExternal(messagingServerAddress: NetworkHostAndPort?) = messagingServerAddress != null
 

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -6,12 +6,10 @@ import net.corda.common.configuration.parsing.internal.*
 import net.corda.common.validation.internal.Validated
 import net.corda.common.validation.internal.Validated.Companion.invalid
 import net.corda.common.validation.internal.Validated.Companion.valid
-import net.corda.core.internal.div
 import net.corda.node.services.config.*
 import net.corda.node.services.config.NodeConfigurationImpl.Defaults
 import net.corda.node.services.config.NodeConfigurationImpl.Defaults.reloadCheckpointAfterSuspend
 import net.corda.node.services.config.schema.parsers.*
-import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 
 internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfiguration>("NodeConfiguration") {
     private val myLegalName by string().mapValid(::toCordaX500Name)
@@ -83,7 +81,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
         val database = config[database] ?: Defaults.database(config[devMode])
         val baseDirectoryPath = config[baseDirectory]
         val cordappDirectories = config[cordappDirectories]?.map { baseDirectoryPath.resolve(it) } ?: Defaults.cordappsDirectories(baseDirectoryPath)
-        val networkParametersPath = config[networkParametersPath]?.div(NETWORK_PARAMS_FILE_NAME) ?: Defaults.networkParametersDefaultPath(baseDirectoryPath)
+        val networkParametersPath = config[networkParametersPath] ?: baseDirectoryPath
         val result = try {
             valid<NodeConfigurationImpl, Configuration.Validation.Error>(NodeConfigurationImpl(
                     baseDirectory = baseDirectoryPath,

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -81,7 +81,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
         val database = config[database] ?: Defaults.database(config[devMode])
         val baseDirectoryPath = config[baseDirectory]
         val cordappDirectories = config[cordappDirectories]?.map { baseDirectoryPath.resolve(it) } ?: Defaults.cordappsDirectories(baseDirectoryPath)
-        val networkParametersPath = config[networkParametersPath] ?: baseDirectoryPath
+        val networkParametersPath = if (config[networkParametersPath] != null) baseDirectoryPath.resolve(config[networkParametersPath]) else baseDirectoryPath
         val result = try {
             valid<NodeConfigurationImpl, Configuration.Validation.Error>(NodeConfigurationImpl(
                     baseDirectory = baseDirectoryPath,

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -332,6 +332,18 @@ class NodeConfigurationImplTest {
         assertTrue(rawConfig.parseAsNodeConfiguration().value().crlCheckArtemisServer)
     }
 
+    @Test(timeout=3_000)
+    fun `network parameters path is set as specified by node config`() {
+        val nodeConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("networkParametersPath" to "./network"))).parseAsNodeConfiguration().value()
+        assertEquals(nodeConfig.networkParametersPath.toString(), "./network")
+    }
+
+    @Test(timeout=3_000)
+    fun `network parameters path defaults to base directory`() {
+        val nodeConfig = getConfig("working-config.conf").parseAsNodeConfiguration().value()
+        assertEquals(nodeConfig.networkParametersPath, nodeConfig.baseDirectory)
+    }
+
     private fun configDebugOptions(devMode: Boolean, devModeOptions: DevModeOptions?): NodeConfigurationImpl {
         return testConfiguration.copy(devMode = devMode, devModeOptions = devModeOptions)
     }

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -35,7 +35,7 @@ class NodeConfigurationImplTest {
     @JvmField
     val tempFolder = TemporaryFolder()
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `can't have dev mode options if not in dev mode`() {
         val debugOptions = DevModeOptions()
         configDebugOptions(true, debugOptions)
@@ -44,7 +44,7 @@ class NodeConfigurationImplTest {
         configDebugOptions(false, null)
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `can't have tlsCertCrlDistPoint null when tlsCertCrlIssuer is given`() {
         val configValidationResult = configTlsCertCrlOptions(null, "C=US, L=New York, OU=Corda, O=R3 HoldCo LLC, CN=Corda Root CA").validate()
         assertTrue { configValidationResult.isNotEmpty() }
@@ -52,7 +52,7 @@ class NodeConfigurationImplTest {
         assertThat(configValidationResult.first()).contains("tlsCertCrlIssuer")
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `can't have tlsCertCrlDistPoint null when crlCheckSoftFail is false`() {
         val configValidationResult = configTlsCertCrlOptions(null, null, false).validate()
         assertTrue { configValidationResult.isNotEmpty() }
@@ -60,7 +60,7 @@ class NodeConfigurationImplTest {
         assertThat(configValidationResult.first()).contains("crlCheckSoftFail")
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `check crashShell flags helper`() {
         assertFalse { testConfiguration.copy(sshd = null).shouldStartSSHDaemon() }
         assertTrue { testConfiguration.copy(sshd = SSHDConfiguration(1234)).shouldStartSSHDaemon() }
@@ -72,7 +72,7 @@ class NodeConfigurationImplTest {
         assertFalse { testConfiguration.copy(noLocalShell = true, sshd = null).shouldInitCrashShell() }
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `Dev mode is autodetected correctly`() {
         val os = System.getProperty("os.name")
 
@@ -95,20 +95,20 @@ class NodeConfigurationImplTest {
         System.setProperty("os.name", os)
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `Dev mode is read from the config over the autodetect logic`() {
         assertTrue(getConfig("test-config-DevMode.conf").getBooleanCaseInsensitive("devMode"))
         assertFalse(getConfig("test-config-noDevMode.conf").getBooleanCaseInsensitive("devMode"))
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `Dev mode is true if overriden`() {
         assertTrue(getConfig("test-config-DevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to true))).getBooleanCaseInsensitive("devMode"))
         assertTrue(getConfig("test-config-noDevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to true))).getBooleanCaseInsensitive("devMode"))
         assertTrue(getConfig("test-config-empty.conf", ConfigFactory.parseMap(mapOf("devMode" to true))).getBooleanCaseInsensitive("devMode"))
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `Dev mode is false if overriden`() {
         assertFalse(getConfig("test-config-DevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to false))).getBooleanCaseInsensitive("devMode"))
         assertFalse(getConfig("test-config-noDevMode.conf", ConfigFactory.parseMap(mapOf("devMode" to false))).getBooleanCaseInsensitive("devMode"))
@@ -124,7 +124,7 @@ class NodeConfigurationImplTest {
         )
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `validation has error when compatibilityZoneURL is present and devMode is true`() {
         val configuration = testConfiguration.copy(
                 devMode = true,
@@ -135,7 +135,7 @@ class NodeConfigurationImplTest {
         assertThat(errors).hasOnlyOneElementSatisfying { error -> error.contains("compatibilityZoneURL") && error.contains("devMode") }
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `validation succeeds when compatibilityZoneURL is present and devMode is true and allowCompatibilityZoneURL is set`() {
         val configuration = testConfiguration.copy(
                 devMode = true,
@@ -146,7 +146,7 @@ class NodeConfigurationImplTest {
         assertThat(errors).isEmpty()
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `errors for nested config keys contain path`() {
         var rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
         val missingPropertyPath = "rpcSettings.address"
@@ -158,7 +158,7 @@ class NodeConfigurationImplTest {
         }
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `validation has error when compatibilityZone is present and devMode is true`() {
         val configuration = testConfiguration.copy(devMode = true, networkServices = NetworkServicesConfig(
                 URL("https://r3.com.doorman"),
@@ -169,7 +169,7 @@ class NodeConfigurationImplTest {
         assertThat(errors).hasOnlyOneElementSatisfying { error -> error.contains("networkServices") && error.contains("devMode") }
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `validation has error when both compatibilityZoneURL and networkServices are configured`() {
         val configuration = testConfiguration.copy(
                 devMode = false,
@@ -185,7 +185,7 @@ class NodeConfigurationImplTest {
         }
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `rpcAddress and rpcSettings_address are equivalent`() {
         var rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
         rawConfig = rawConfig.withoutPath("rpcSettings.address")
@@ -194,7 +194,7 @@ class NodeConfigurationImplTest {
         assertThat(rawConfig.parseAsNodeConfiguration().isValid).isTrue()
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `absolute base directory leads to correct cordapp directories`() {
         val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -212,7 +212,7 @@ class NodeConfigurationImplTest {
         assertEquals(listOf(baseDirPath / "./myCorDapps1", baseDirPath / "./myCorDapps2"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
     fun `absolute base directory leads to correct default cordapp directory`() {
         val rawConfig = ConfigFactory.parseResources("working-config-no-cordapps.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -230,7 +230,7 @@ class NodeConfigurationImplTest {
         assertEquals(listOf(baseDirPath / "cordapps"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
     fun `relative base dir leads to correct cordapp directories`() {
         val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -249,7 +249,7 @@ class NodeConfigurationImplTest {
         assertEquals(listOf(fullPath / "./myCorDapps1", fullPath / "./myCorDapps2"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
     fun `relative base dir leads to correct default cordapp directory`() {
         val rawConfig = ConfigFactory.parseResources("working-config-no-cordapps.conf", ConfigParseOptions.defaults().setAllowMissing(false))
 
@@ -268,7 +268,7 @@ class NodeConfigurationImplTest {
         assertEquals(listOf(fullPath / "cordapps"), nodeConfiguration.value().cordappDirectories)
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `missing rpcSettings_adminAddress cause a graceful failure`() {
         var rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
         rawConfig = rawConfig.withoutPath("rpcSettings.adminAddress")
@@ -278,7 +278,7 @@ class NodeConfigurationImplTest {
         assertThat(config.errors.asSequence().map(Configuration.Validation.Error::message).filter { it.contains("rpcSettings.adminAddress") }.toList()).isNotEmpty
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `compatibilityZoneURL populates NetworkServices`() {
         val compatibilityZoneURL = URI.create("https://r3.example.com").toURL()
         val configuration = testConfiguration.copy(
@@ -290,14 +290,14 @@ class NodeConfigurationImplTest {
         assertEquals(compatibilityZoneURL, configuration.networkServices!!.networkMapURL)
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `jmxReporterType is null and defaults to Jokolia`() {
         val rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("devMode" to true)))
         val nodeConfig = rawConfig.parseAsNodeConfiguration().value()
         assertEquals(JmxReporterType.JOLOKIA.toString(), nodeConfig.jmxReporterType.toString())
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `jmxReporterType is not null and is set to New Relic`() {
         var rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("devMode" to true)))
         rawConfig = rawConfig.withValue("jmxReporterType", ConfigValueFactory.fromAnyRef("NEW_RELIC"))
@@ -305,7 +305,7 @@ class NodeConfigurationImplTest {
         assertEquals(JmxReporterType.NEW_RELIC.toString(), nodeConfig.jmxReporterType.toString())
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `jmxReporterType is not null and set to Jokolia`() {
         var rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("devMode" to true)))
         rawConfig = rawConfig.withValue("jmxReporterType", ConfigValueFactory.fromAnyRef("JOLOKIA"))
@@ -313,7 +313,7 @@ class NodeConfigurationImplTest {
         assertEquals(JmxReporterType.JOLOKIA.toString(), nodeConfig.jmxReporterType.toString())
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
 	fun `network services`() {
         val rawConfig = getConfig("test-config-with-networkservices.conf")
         val nodeConfig = rawConfig.parseAsNodeConfiguration().value()
@@ -325,23 +325,54 @@ class NodeConfigurationImplTest {
         }
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
     fun `check crlCheckArtemisServer flag`() {
         assertFalse(getConfig("working-config.conf").parseAsNodeConfiguration().value().crlCheckArtemisServer)
         val rawConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("crlCheckArtemisServer" to true)))
         assertTrue(rawConfig.parseAsNodeConfiguration().value().crlCheckArtemisServer)
     }
 
-    @Test(timeout=3_000)
-    fun `network parameters path is set as specified by node config`() {
-        val nodeConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("networkParametersPath" to "./network"))).parseAsNodeConfiguration().value()
-        assertEquals(nodeConfig.networkParametersPath.toString(), "./network")
+    @Test(timeout=6_000)
+    fun `absolute network parameters path is set as specified by node config`() {
+        val nodeConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("networkParametersPath" to tempFolder.root.canonicalPath))).parseAsNodeConfiguration().value()
+        assertEquals(nodeConfig.networkParametersPath, tempFolder.root.toPath())
     }
 
-    @Test(timeout=3_000)
+    @Test(timeout=6_000)
+    fun `relative network parameters path is set as specified by node config`() {
+        val path = tempFolder.root.relativeTo(tempFolder.root.parentFile).toString()
+        val fullPath = File(".").resolve(path).toString()
+        val nodeConfig = getConfig("working-config.conf", ConfigFactory.parseMap(mapOf("networkParametersPath" to fullPath))).parseAsNodeConfiguration().value()
+        assertEquals(nodeConfig.networkParametersPath, nodeConfig.baseDirectory.resolve(fullPath))
+    }
+
+    @Test(timeout=6_000)
+    fun `network parameters path is set as specified by node config with overridden base directory`() {
+        val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
+        val finalConfig = configOf(
+                "baseDirectory" to "/path-to-base-directory",
+                "networkParametersPath" to "/network")
+                .withFallback(rawConfig)
+                .resolve()
+        val nodeConfig = finalConfig.parseAsNodeConfiguration().value()
+        assertEquals(nodeConfig.networkParametersPath, Paths.get("/network"))
+    }
+
+    @Test(timeout=6_000)
     fun `network parameters path defaults to base directory`() {
         val nodeConfig = getConfig("working-config.conf").parseAsNodeConfiguration().value()
         assertEquals(nodeConfig.networkParametersPath, nodeConfig.baseDirectory)
+    }
+
+    @Test(timeout=6_000)
+    fun `network parameters path defaults to overridden base directory`() {
+        val rawConfig = ConfigFactory.parseResources("working-config.conf", ConfigParseOptions.defaults().setAllowMissing(false))
+        val finalConfig = configOf(
+                "baseDirectory" to "/path-to-base-directory")
+                .withFallback(rawConfig)
+                .resolve()
+        val nodeConfig = finalConfig.parseAsNodeConfiguration().value()
+        assertEquals(nodeConfig.networkParametersPath, Paths.get("/path-to-base-directory"))
     }
 
     private fun configDebugOptions(devMode: Boolean, devModeOptions: DevModeOptions?): NodeConfigurationImpl {

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
@@ -75,12 +75,11 @@ class NetworkParametersReaderTest {
 
     @Test(timeout=300_000)
     fun `read correct set of parameters from specified network parameters path`() {
-        val baseDirectory = fs.getPath("/node").createDirectories()
-        val networkParamsPath = (baseDirectory / "network").createDirectories()
+        val networkParamsPath = fs.getPath("/node/network").createDirectories()
         val oldParameters = testNetworkParameters(epoch = 1)
         NetworkParametersCopier(oldParameters).install(networkParamsPath)
         NetworkParametersCopier(server.networkParameters, update = true).install(networkParamsPath) // Parameters update file.
-        val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, networkMapClient, baseDirectory, networkParamsPath).read().networkParameters
+        val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, networkMapClient, networkParamsPath).read().networkParameters
         assertFalse((networkParamsPath / NETWORK_PARAMS_UPDATE_FILE_NAME).exists())
         assertEquals(server.networkParameters, parameters)
         // Parameters from update should be moved to `network-parameters` file.

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
@@ -59,15 +59,15 @@ class NetworkParametersReaderTest {
 
     @Test(timeout=300_000)
 	fun `read correct set of parameters from file`() {
-        val baseDirectory = fs.getPath("/node").createDirectories()
+        val networkParamsPath = fs.getPath("/node").createDirectories()
         val oldParameters = testNetworkParameters(epoch = 1)
-        NetworkParametersCopier(oldParameters).install(baseDirectory)
-        NetworkParametersCopier(server.networkParameters, update = true).install(baseDirectory) // Parameters update file.
-        val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, networkMapClient, baseDirectory).read().networkParameters
-        assertFalse((baseDirectory / NETWORK_PARAMS_UPDATE_FILE_NAME).exists())
+        NetworkParametersCopier(oldParameters).install(networkParamsPath)
+        NetworkParametersCopier(server.networkParameters, update = true).install(networkParamsPath) // Parameters update file.
+        val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, networkMapClient, networkParamsPath).read().networkParameters
+        assertFalse((networkParamsPath / NETWORK_PARAMS_UPDATE_FILE_NAME).exists())
         assertEquals(server.networkParameters, parameters)
         // Parameters from update should be moved to `network-parameters` file.
-        val parametersFromFile = (baseDirectory / NETWORK_PARAMS_FILE_NAME)
+        val parametersFromFile = (networkParamsPath / NETWORK_PARAMS_FILE_NAME)
                 .readObject<SignedNetworkParameters>()
                 .verifiedNetworkParametersCert(DEV_ROOT_CA.certificate)
         assertEquals(server.networkParameters, parametersFromFile)
@@ -92,10 +92,10 @@ class NetworkParametersReaderTest {
     @Test(timeout=300_000)
 	fun `read network parameters from file when network map server is down`() {
         server.close()
-        val baseDirectory = fs.getPath("/node").createDirectories()
+        val networkParamsPath = fs.getPath("/node").createDirectories()
         val fileParameters = testNetworkParameters(epoch = 1)
-        NetworkParametersCopier(fileParameters).install(baseDirectory)
-        val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, networkMapClient, baseDirectory).read().networkParameters
+        NetworkParametersCopier(fileParameters).install(networkParamsPath)
+        val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, networkMapClient, networkParamsPath).read().networkParameters
         assertThat(parameters).isEqualTo(fileParameters)
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -54,6 +54,7 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.coretesting.internal.stubs.CertificateStoreStubs
 import net.corda.coretesting.internal.testThreadFactory
+import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 import net.corda.testing.node.*
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
 import org.apache.activemq.artemis.utils.ReusableLatch
@@ -479,6 +480,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
         certificatesDirectory.createDirectories()
         val config = mockNodeConfiguration(certificatesDirectory).also {
             doReturn(baseDirectory).whenever(it).baseDirectory
+            doReturn(baseDirectory/ NETWORK_PARAMS_FILE_NAME).whenever(it).networkParametersPath
             doReturn(parameters.legalName ?: CordaX500Name("Mock Company $id", "London", "GB")).whenever(it).myLegalName
             doReturn(makeTestDataSourceProperties("node_${id}_net_$networkId")).whenever(it).dataSourceProperties
             doReturn(emptyList<SecureHash>()).whenever(it).extraNetworkMapKeys

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -54,7 +54,6 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.coretesting.internal.stubs.CertificateStoreStubs
 import net.corda.coretesting.internal.testThreadFactory
-import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 import net.corda.testing.node.*
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
 import org.apache.activemq.artemis.utils.ReusableLatch
@@ -480,7 +479,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
         certificatesDirectory.createDirectories()
         val config = mockNodeConfiguration(certificatesDirectory).also {
             doReturn(baseDirectory).whenever(it).baseDirectory
-            doReturn(baseDirectory/ NETWORK_PARAMS_FILE_NAME).whenever(it).networkParametersPath
+            doReturn(baseDirectory).whenever(it).networkParametersPath
             doReturn(parameters.legalName ?: CordaX500Name("Mock Company $id", "London", "GB")).whenever(it).myLegalName
             doReturn(makeTestDataSourceProperties("node_${id}_net_$networkId")).whenever(it).dataSourceProperties
             doReturn(emptyList<SecureHash>()).whenever(it).extraNetworkMapKeys


### PR DESCRIPTION
The network parameters of a node are currently housed inside the node's base directory. This should be configurable, so that the network parameters file may be stored at the location specified by the node configuration. This change addresses this issue by introducing `networkParametersPath` and using the path specified by this field to store the network parameters. In case a path is not specified, the node's base directory is used by default. The specified path may be relative or absolute, and directories on the path that do not exist will be created accordingly. The file name continues to be the one defined by `NETWORK_PARAMS_FILE_NAME`. Test cases have been added to `NetworkParametersReaderTest` and `NodeConfigurationImplTest`, and the change has also been manually tested.