### PR TITLE
CORDA-3932 Correct race condition in FlowVersioningTest

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -34,15 +34,18 @@ class FlowVersioningTest : NodeBasedTest() {
         @Suspendable
         override fun call(): Pair<Int, Int> {
             val session = initiateFlow(initiatedParty)
-            // Get counterparty flow info before we receive Alice's data, to ensure the flow is still open
-            val bobPlatformVersionAccordingToAlice = session.getCounterpartyFlowInfo().flowVersion
-            // Execute receive() outside of the Pair constructor to avoid Kotlin/Quasar instrumentation bug.
-            val alicePlatformVersionAccordingToBob = session.receive<Int>().unwrap { it }
-            session.close()
-            return Pair(
-                    alicePlatformVersionAccordingToBob,
-                    bobPlatformVersionAccordingToAlice
-            )
+            return try {
+                // Get counterparty flow info before we receive Alice's data, to ensure the flow is still open
+                val bobPlatformVersionAccordingToAlice = session.getCounterpartyFlowInfo().flowVersion
+                // Execute receive() outside of the Pair constructor to avoid Kotlin/Quasar instrumentation bug.
+                val alicePlatformVersionAccordingToBob = session.receive<Int>().unwrap { it }
+                Pair(
+                        alicePlatformVersionAccordingToBob,
+                        bobPlatformVersionAccordingToAlice
+                )
+            } finally {
+                session.close()
+            }
         }
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -33,12 +33,15 @@ class FlowVersioningTest : NodeBasedTest() {
     private class PretendInitiatingCoreFlow(val initiatedParty: Party) : FlowLogic<Pair<Int, Int>>() {
         @Suspendable
         override fun call(): Pair<Int, Int> {
-            // Execute receive() outside of the Pair constructor to avoid Kotlin/Quasar instrumentation bug.
             val session = initiateFlow(initiatedParty)
+            // Get counterparty flow info before we receive Alice's data, to ensure the flow is still open
+            val bobPlatformVersionAccordingToAlice = session.getCounterpartyFlowInfo().flowVersion
+            // Execute receive() outside of the Pair constructor to avoid Kotlin/Quasar instrumentation bug.
             val alicePlatformVersionAccordingToBob = session.receive<Int>().unwrap { it }
+            session.close()
             return Pair(
                     alicePlatformVersionAccordingToBob,
-                    session.getCounterpartyFlowInfo().flowVersion
+                    bobPlatformVersionAccordingToAlice
             )
         }
     }


### PR DESCRIPTION
Correct race condition in FlowVersioningTest where the last message is read (and the session close can be triggered)
before one side has finished reading metadata from the session.