### PR TITLE
INFRA-504: Replace out of process nodes with in process nodes

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -17,6 +17,7 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.coretesting.internal.DEV_ROOT_CA
+import net.corda.testing.driver.NodeParameters
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.SharedCompatibilityZoneParams
 import net.corda.testing.node.internal.internalDriver
@@ -85,9 +86,13 @@ class NodeRegistrationTest {
                 compatibilityZone = compatibilityZone,
                 notarySpecs = listOf(NotarySpec(notaryName)),
                 notaryCustomOverrides = mapOf("devMode" to false),
+                startNodesInProcess = true,
                 allowHibernateToManageAppSchema = false
         ) {
-            startNode(providedName = aliceName, customOverrides = mapOf("devMode" to false)).getOrThrow()
+            startNode(NodeParameters(
+                    providedName = aliceName,
+                    customOverrides = mapOf("devMode" to false)
+            )).getOrThrow()
 
             assertThat(registrationHandler.idsPolled).containsOnly(
                     aliceName.organisation,

--- a/node/src/integration-test/java/net/corda/serialization/reproduction/GenericReturnFailureReproductionIntegrationTest.java
+++ b/node/src/integration-test/java/net/corda/serialization/reproduction/GenericReturnFailureReproductionIntegrationTest.java
@@ -20,7 +20,7 @@ public class GenericReturnFailureReproductionIntegrationTest {
     public void flowShouldReturnGenericList() {
         User user = new User("yes", "yes", Collections.singleton(Permissions.startFlow(SuperSimpleGenericFlow.class)));
         DriverParameters defaultParameters = new DriverParameters();
-        Driver.<Void>driver(defaultParameters, (driver) -> {
+        Driver.<Void>driver(defaultParameters.withStartNodesInProcess(true), (driver) -> {
             NodeHandle startedNode = getOrThrow(driver.startNode(new NodeParameters().withRpcUsers(Collections.singletonList(user)).withStartInSameProcess(true)));
             (new CordaRPCClient(startedNode.getRpcAddress())).<Void>use("yes", "yes", (cordaRPCConnection -> {
                 getOrThrow(cordaRPCConnection.getProxy().startFlowDynamic(SuperSimpleGenericFlow.class).getReturnValue());

--- a/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
@@ -13,6 +13,7 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.enclosedCordapp
@@ -24,10 +25,19 @@ class CordappScanningDriverTest {
 	fun `sub-classed initiated flow pointing to the same initiating flow as its super-class`() {
         val user = User("u", "p", setOf(startFlow<ReceiveFlow>()))
         // The driver will automatically pick up the annotated flows below
-        driver(DriverParameters(notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
+        driver(DriverParameters(
+                notarySpecs = emptyList(),
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(enclosedCordapp())
+        )) {
             val (alice, bob) = listOf(
-                    startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)),
-                    startNode(providedName = BOB_NAME)).transpose().getOrThrow()
+                    startNode(NodeParameters(
+                            providedName = ALICE_NAME,
+                            rpcUsers = listOf(user)
+                    )),
+                    startNode(NodeParameters(
+                            providedName = BOB_NAME
+                    ))).transpose().getOrThrow()
             val initiatedFlowClass = CordaRPCClient(alice.rpcAddress)
                     .start(user.username, user.password)
                     .proxy


### PR DESCRIPTION
Make tests use in process nodes wherever possible in the hopes of a substantial speed increase.

NodeRegistrationTest.`node registration correct root cert`
 - Before: 45s 252ms (first run) | 45s 666ms (second run)
 - After: 18s 820ms (first run) | 17S 850ms (second run)
**~60% speedup**

GenericReturnFailureReproductionIntegrationTest.flowShouldReturnGenericList
 - Before: 18s 996ms (first run) | 18s 560ms (second run)
 - After: 22s 585ms (first run) | 18s 818ms (second run)
**No real difference on this one outside of jitter**

CordappScanningDriverTest.`sub-classed initiated flow pointing to the same initiating flow as its super-class`
 - Before: 26s 964ms (first run) | 28s 500ms (second run)
 - After: 22s 689ms (first run) | 23s 162ms (second run)
**~18% Speedup**