### PR TITLE
EG-2295 Business Networks sample CorDapp test coverage

### DIFF
--- a/samples/business-networks-demo/README.md
+++ b/samples/business-networks-demo/README.md
@@ -1,0 +1,1 @@
+# Attachment Demo

--- a/samples/business-networks-demo/business-networks-demo-contracts/src/test/kotlin/net/corda/bn/demo/contracts/LoanContractTest.kt
+++ b/samples/business-networks-demo/business-networks-demo-contracts/src/test/kotlin/net/corda/bn/demo/contracts/LoanContractTest.kt
@@ -1,0 +1,284 @@
+package net.corda.bn.demo.contracts
+
+import net.corda.bn.states.BNIdentity
+import net.corda.bn.states.MembershipIdentity
+import net.corda.bn.states.MembershipState
+import net.corda.bn.states.MembershipStatus
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.TypeOnlyCommandData
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.node.MockServices
+import net.corda.testing.node.ledger
+import net.corda.testing.node.makeTestIdentityService
+import org.junit.Test
+
+class DummyContract : Contract {
+
+    companion object {
+        const val CONTRACT_NAME = "net.corda.bn.demo.contracts.DummyContract"
+    }
+
+    override fun verify(tx: LedgerTransaction) {}
+}
+
+class DummyCommand : TypeOnlyCommandData()
+
+@CordaSerializable
+class DummyIdentity : BNIdentity
+
+class LoanContractTest {
+
+    private val ledgerServices = MockServices(
+            cordappPackages = listOf("net.corda.bn.demo.contracts"),
+            initialIdentityName = CordaX500Name.parse("O=Lender,L=London,C=GB"),
+            identityService = makeTestIdentityService(),
+            networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+    )
+
+    private val lenderIdentity = TestIdentity(CordaX500Name.parse("O=Lender,L=London,C=GB")).party
+    private val borrowerIdentity = TestIdentity(CordaX500Name.parse("O=Borrower,L=London,C=GB")).party
+
+    private val lenderMembership = MembershipState(
+            identity = MembershipIdentity(lenderIdentity, BankIdentity("BANKGB00")),
+            networkId = "network-id",
+            status = MembershipStatus.ACTIVE,
+            participants = listOf(lenderIdentity, borrowerIdentity)
+    )
+    private val borrowerMembership = MembershipState(
+            identity = MembershipIdentity(borrowerIdentity, BankIdentity("BANKGB01")),
+            networkId = "network-id",
+            status = MembershipStatus.ACTIVE,
+            participants = listOf(lenderIdentity, borrowerIdentity)
+    )
+
+    private val loanState = LoanState(
+            lender = lenderIdentity,
+            borrower = borrowerIdentity,
+            amount = 10,
+            networkId = "network-id",
+            participants = listOf(lenderIdentity, borrowerIdentity)
+    )
+
+    @Suppress("ComplexMethod")
+    private fun testMembershipVerification(isExit: Boolean) {
+        ledgerServices.ledger {
+            val input = loanState
+            val cmd = if (isExit) LoanContract.Commands.Exit::class.java else LoanContract.Commands.Settle::class.java
+            val commandName = if (isExit) "exit" else "settlement"
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                this `fails with` "Loan $commandName transaction should have 2 reference states"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, input)
+                reference(LoanContract.CONTRACT_NAME, input.copy(amount = 15))
+                this `fails with` "Loan $commandName transaction should contain only reference MembershipStates"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, lenderMembership)
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership.copy(networkId = "other-network-id"))
+                this `fails with` "Loan $commandName transaction should contain only reference membership states from Business Network with ${input.networkId} ID"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership)
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership)
+                this `fails with` "Loan $commandName transaction should have lender's reference membership state"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, lenderMembership)
+                reference(LoanContract.CONTRACT_NAME, lenderMembership)
+                this `fails with` "Loan $commandName transaction should have borrowers's reference membership state"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership)
+                reference(LoanContract.CONTRACT_NAME, lenderMembership.copy(status = MembershipStatus.SUSPENDED))
+                this `fails with` "Lender should be active member of Business Network with ${input.networkId}"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership)
+                reference(LoanContract.CONTRACT_NAME, lenderMembership.run { copy(identity = MembershipIdentity(identity.cordaIdentity)) })
+                this `fails with` "Lender should have business identity of BankIdentity type"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership.copy(status = MembershipStatus.SUSPENDED))
+                reference(LoanContract.CONTRACT_NAME, lenderMembership)
+                this `fails with` "Borrower should be active member of Business Network with ${input.networkId}"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership)
+                reference(LoanContract.CONTRACT_NAME, lenderMembership.run { copy(identity = MembershipIdentity(identity.cordaIdentity, DummyIdentity())) })
+                this `fails with` "Lender should have business identity of BankIdentity type"
+            }
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                if (!isExit) output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), cmd.getConstructor().newInstance())
+                reference(LoanContract.CONTRACT_NAME, borrowerMembership)
+                reference(LoanContract.CONTRACT_NAME, lenderMembership)
+                verifies()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test common contract verification`() {
+        ledgerServices.ledger {
+            transaction {
+                val input = loanState
+                output(LoanContract.CONTRACT_NAME, input)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), DummyCommand())
+                fails()
+            }
+            transaction {
+                val input = loanState
+                input(DummyContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, input)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Input state has to be validated by ${LoanContract.CONTRACT_NAME}"
+            }
+            transaction {
+                val input = loanState
+                input(LoanContract.CONTRACT_NAME, input)
+                output(DummyContract.CONTRACT_NAME, input)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Output state has to be validated by ${LoanContract.CONTRACT_NAME}"
+            }
+            transaction {
+                val input = loanState.copy(amount = 0)
+                input(LoanContract.CONTRACT_NAME, input)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Exit())
+                this `fails with` "Input state should have positive amount"
+            }
+            transaction {
+                val output = loanState.copy(amount = -1)
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Issue())
+                this `fails with` "Output state should have positive amount"
+            }
+            transaction {
+                val input = loanState.copy(participants = listOf(lenderIdentity))
+                input(LoanContract.CONTRACT_NAME, input)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Exit())
+                this `fails with` "Input state's participants list should contain lender and borrower only"
+            }
+            transaction {
+                val output = loanState.copy(participants = emptyList())
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Issue())
+                this `fails with` "Output state's participants list should contain lender and borrower only"
+            }
+
+            val input = loanState
+            transaction {
+                val output = loanState.copy(lender = borrowerIdentity, participants = listOf(borrowerIdentity))
+                input(LoanContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Input and output state should have same lender"
+            }
+            transaction {
+                val output = loanState.copy(borrower = lenderIdentity, participants = listOf(lenderIdentity))
+                input(LoanContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Input and output state should have same borrower"
+            }
+            transaction {
+                val output = loanState.copy(networkId = "new-network-id")
+                input(LoanContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Input and output state should have same network ID"
+            }
+            transaction {
+                val output = loanState.copy(linearId = UniqueIdentifier())
+                input(LoanContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Input and output state should have same linear ID"
+            }
+            transaction {
+                val output = loanState.run { copy(amount = amount + 1) }
+                input(LoanContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Output state should have lower amount than input state"
+            }
+            transaction {
+                val output = loanState.run { copy(amount = amount - 1) }
+                input(LoanContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey), LoanContract.Commands.Settle())
+                this `fails with` "Transaction should be signed by all loan states' participants only"
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test issue loan command contract verification`() {
+        ledgerServices.ledger {
+            val output = loanState
+            transaction {
+                input(LoanContract.CONTRACT_NAME, output.run { copy(amount = amount + 1) })
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Issue())
+                this `fails with` "Loan issuance transaction shouldn't contain any inputs"
+            }
+            transaction {
+                output(LoanContract.CONTRACT_NAME, output)
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Issue())
+                verifies()
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `test settle loan command contract verification`() {
+        testMembershipVerification(false)
+    }
+
+    @Test(timeout = 300_000)
+    fun `test exit load command contract verification`() {
+        ledgerServices.ledger {
+            val input = loanState
+            transaction {
+                input(LoanContract.CONTRACT_NAME, input)
+                output(LoanContract.CONTRACT_NAME, input.run { copy(amount = amount - 1) })
+                command(listOf(lenderIdentity.owningKey, borrowerIdentity.owningKey), LoanContract.Commands.Exit())
+                this `fails with` "Loan exit transaction shouldn't contain any outputs"
+            }
+        }
+        testMembershipVerification(true)
+    }
+}

--- a/samples/business-networks-demo/business-networks-demo-contracts/src/test/kotlin/net/corda/bn/demo/contracts/LoanStateTest.kt
+++ b/samples/business-networks-demo/business-networks-demo-contracts/src/test/kotlin/net/corda/bn/demo/contracts/LoanStateTest.kt
@@ -1,0 +1,20 @@
+package net.corda.bn.demo.contracts
+
+import com.nhaarman.mockito_kotlin.mock
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class LoanStateTest {
+
+    private fun mockLoanState(amount: Int) = LoanState(lender = mock(), borrower = mock(), amount = amount, networkId = "network-id")
+
+    @Test(timeout = 300_000)
+    fun `loan state helper methods should work`() {
+        mockLoanState(10).settle(5).apply { assertEquals(5, amount) }
+        mockLoanState(10).settle(5).settle(3).apply { assertEquals(2, amount) }
+        mockLoanState(5).settle(0).apply { assertEquals(5, amount) }
+        mockLoanState(10).settle(10).apply { assertEquals(0, amount) }
+        mockLoanState(10).settle(5).settle(5).apply { assertEquals(0, amount) }
+        mockLoanState(5).settle(15).apply { assertEquals(-10, amount) }
+    }
+}

--- a/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/AssignBICFlowTest.kt
+++ b/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/AssignBICFlowTest.kt
@@ -1,0 +1,44 @@
+package net.corda.bn.demo.workflows
+
+import net.corda.bn.contracts.MembershipContract
+import net.corda.bn.demo.contracts.BankIdentity
+import net.corda.bn.flows.IllegalFlowArgumentException
+import net.corda.bn.states.MembershipState
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AssignBICFlowTest : LoanFlowTest(numberOfLenders = 1, numberOfBorrowers = 0) {
+
+    @Test(timeout = 300_000)
+    fun `assign bic flow should fail if invalid bic is provided`() {
+        val lender = lenders.first()
+
+        val membershipId = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).linearId
+        val illegalBic = "ILLEGAL-BIC"
+        assertFailsWith<IllegalFlowArgumentException> { runAssignBICFlow(lender, membershipId, illegalBic) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `assign bic flow happy path`() {
+        val lender = lenders.first()
+
+        val membershipId = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).linearId
+        val bic = "BANKGB00"
+        val (membership, command) = runAssignBICFlow(lender, membershipId, bic).run {
+            assertEquals(1, tx.inputs.size)
+            verifyRequiredSignatures()
+            tx.outputs.single() to tx.commands.single()
+        }
+
+        membership.apply {
+            assertEquals(MembershipContract.CONTRACT_NAME, membership.contract)
+            assertTrue(data is MembershipState)
+            val data = data as MembershipState
+            assertEquals(lender.identity(), data.identity.cordaIdentity)
+            assertEquals(BankIdentity(bic), data.identity.businessIdentity)
+        }
+        assertTrue(command.value is MembershipContract.Commands.ModifyBusinessIdentity)
+    }
+}

--- a/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/AssignLoanIssuerRoleFlowTest.kt
+++ b/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/AssignLoanIssuerRoleFlowTest.kt
@@ -1,0 +1,43 @@
+package net.corda.bn.demo.workflows
+
+import net.corda.bn.contracts.MembershipContract
+import net.corda.bn.demo.contracts.LoanIssuerRole
+import net.corda.bn.flows.MembershipNotFoundException
+import net.corda.bn.states.MembershipState
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AssignLoanIssuerRoleFlowTest : LoanFlowTest(numberOfLenders = 1, numberOfBorrowers = 0) {
+
+    @Test(timeout = 300_000)
+    fun `assign loan issuer role flow should fail if initiator is not member of business network`() {
+        val lender = lenders.first()
+
+        val networkId = "network-id"
+        assertFailsWith<MembershipNotFoundException> { runAssignLoanIssuerRole(lender, networkId) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `assign loan issuer role flow happy path`() {
+        val lender = lenders.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).networkId
+        val (membership, command) = runAssignLoanIssuerRole(lender, networkId).run {
+            assertEquals(1, tx.inputs.size)
+            verifyRequiredSignatures()
+            tx.outputs.single() to tx.commands.single()
+        }
+
+        membership.apply {
+            assertEquals(MembershipContract.CONTRACT_NAME, membership.contract)
+            assertTrue(data is MembershipState)
+            val data = data as MembershipState
+            assertEquals(lender.identity(), data.identity.cordaIdentity)
+            assertNotNull(data.roles.find { it is LoanIssuerRole })
+        }
+        assertTrue(command.value is MembershipContract.Commands.ModifyRoles)
+    }
+}

--- a/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/IssueLoanFlowTest.kt
+++ b/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/IssueLoanFlowTest.kt
@@ -1,0 +1,130 @@
+package net.corda.bn.demo.workflows
+
+import net.corda.bn.demo.contracts.LoanContract
+import net.corda.bn.demo.contracts.LoanState
+import net.corda.bn.flows.DatabaseService
+import net.corda.bn.flows.IllegalMembershipStatusException
+import net.corda.bn.flows.MembershipAuthorisationException
+import net.corda.bn.flows.MembershipNotFoundException
+import net.corda.bn.states.MembershipState
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class IssueLoanFlowTest : LoanFlowTest(numberOfLenders = 1, numberOfBorrowers = 1) {
+
+    @Test(timeout = 300_000)
+    fun `issue loan flow should fail if one of the parties is not member of business network`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        // both lender and borrower are not members of a business network
+        val illegalNetworkId = "network-id"
+        assertFailsWith<MembershipNotFoundException> { runIssueLoanFlow(lender, illegalNetworkId, borrower.identity(), 10) }
+
+        // now only borrower is not member of a business network
+        val (networkId, membershipId) = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).run { networkId to linearId }
+        runAssignBICFlow(lender, membershipId, "BANKGB00")
+        runAssignLoanIssuerRole(lender, networkId)
+        assertFailsWith<MembershipNotFoundException> { runIssueLoanFlow(lender, networkId, borrower.identity(), 10) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `issue loan flow should fail if one of the parties is not active member of business network`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        // borrower's membership is in pending status
+        val (networkId, membershipId) = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).run { networkId to linearId }
+        runAssignBICFlow(lender, membershipId, "BANKGB00")
+        runAssignLoanIssuerRole(lender, networkId)
+        runRequestMembershipFlow(borrower, lender.identity(), networkId)
+        assertFailsWith<IllegalMembershipStatusException> { runIssueLoanFlow(lender, networkId, borrower.identity(), 10) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `issue loan flow should fail if one of the parties does not have bank identity`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        // both lender and borrower don't have bank identity
+        val (networkId, membershipId) = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).run { networkId to linearId }
+        runRequestMembershipFlow(borrower, lender.identity(), networkId).apply {
+            val membership = tx.outputStates.single() as MembershipState
+            runActivateMembershipFlow(lender, membership.linearId)
+        }
+        assertFailsWith<IllegalMembershipBusinessIdentityException> { runIssueLoanFlow(lender, networkId, borrower.identity(), 10) }
+
+        // now only borrower doesn't have bank identity
+        val bic = "BANKGB00"
+        runAssignBICFlow(lender, membershipId, bic)
+        runAssignLoanIssuerRole(lender, networkId)
+        assertFailsWith<IllegalMembershipBusinessIdentityException> { runIssueLoanFlow(lender, networkId, borrower.identity(), 10) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `issue loan flow should fail if lender is not authorised to run issue loans`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        val (networkId, lenderMembershipId) = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).run { networkId to linearId }
+        val borrowerMembershipId = runRequestMembershipFlow(borrower, lender.identity(), networkId).run {
+            val membership = tx.outputStates.single() as MembershipState
+            runActivateMembershipFlow(lender, membership.linearId)
+            membership.linearId
+        }
+        val bic = "BANKGB00"
+        listOf(lenderMembershipId, borrowerMembershipId).forEach { runAssignBICFlow(lender, it, bic) }
+
+        assertFailsWith<MembershipAuthorisationException> { runIssueLoanFlow(lender, networkId, borrower.identity(), 10) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `issue loan flow happy path`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        val (networkId, lenderMembershipId) = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).run { networkId to linearId }
+        val borrowerMembershipId = runRequestMembershipFlow(borrower, lender.identity(), networkId).run {
+            val membership = tx.outputStates.single() as MembershipState
+            runActivateMembershipFlow(lender, membership.linearId)
+            membership.linearId
+        }
+        val bic = "BANKGB00"
+        listOf(lenderMembershipId, borrowerMembershipId).forEach { runAssignBICFlow(lender, it, bic) }
+        runAssignLoanIssuerRole(lender, networkId)
+
+        val groupId = lender.services.cordaService(DatabaseService::class.java).run {
+            getAllBusinessNetworkGroups(networkId).single().state.data.linearId
+        }
+        runModifyGroupFlow(lender, groupId, setOf(lenderMembershipId, borrowerMembershipId))
+
+        val (loan, command) = runIssueLoanFlow(lender, networkId, borrower.identity(), 10).run {
+            assertTrue(tx.inputs.isEmpty())
+            verifyRequiredSignatures()
+            tx.outputs.single() to tx.commands.single()
+        }
+
+        val loanState = loan.run {
+            assertEquals(LoanContract.CONTRACT_NAME, contract)
+            assertTrue(data is LoanState)
+            val data = data as LoanState
+            assertEquals(lender.identity(), data.lender)
+            assertEquals(borrower.identity(), data.borrower)
+            assertEquals(10, data.amount)
+            assertEquals(networkId, data.networkId)
+
+            data
+        }
+        assertTrue(command.value is LoanContract.Commands.Issue)
+
+        // also check ledgers
+        listOf(lender, borrower).forEach { node ->
+            getAllLoansFromVault(node).apply {
+                assertEquals(1, size, "Vault size assertion failed for ${node.identity()}")
+                assertEquals(loanState, single(), "Expected persisted LoanState mismatch for ${node.identity()}")
+            }
+        }
+    }
+}

--- a/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/LoanFlowTest.kt
+++ b/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/LoanFlowTest.kt
@@ -1,0 +1,113 @@
+package net.corda.bn.demo.workflows
+
+import net.corda.bn.demo.contracts.LoanState
+import net.corda.bn.flows.ActivateMembershipFlow
+import net.corda.bn.flows.CreateBusinessNetworkFlow
+import net.corda.bn.flows.ModifyGroupFlow
+import net.corda.bn.flows.RequestMembershipFlow
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.node.services.Vault
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.getOrThrow
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
+import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.TestCordapp
+import org.junit.After
+import org.junit.Before
+
+abstract class LoanFlowTest(private val numberOfLenders: Int, private val numberOfBorrowers: Int) {
+
+    protected lateinit var lenders: List<StartedMockNode>
+    protected lateinit var borrowers: List<StartedMockNode>
+    private lateinit var mockNetwork: MockNetwork
+
+    @Before
+    fun setUp() {
+        mockNetwork = MockNetwork(MockNetworkParameters(
+                cordappsForAllNodes = listOf(
+                        TestCordapp.findCordapp("net.corda.bn.contracts"),
+                        TestCordapp.findCordapp("net.corda.bn.flows"),
+                        TestCordapp.findCordapp("net.corda.bn.demo.contracts"),
+                        TestCordapp.findCordapp("net.corda.bn.demo.workflows")
+                ),
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+        ))
+
+        lenders = (0..numberOfLenders).mapIndexed { idx, _ ->
+            createNode(CordaX500Name.parse("O=Lender_$idx,L=New York,C=US"))
+        }
+        borrowers = (0..numberOfBorrowers).mapIndexed { idx, _ ->
+            createNode(CordaX500Name.parse("O=Borrower_$idx,L=New York,C=US"))
+        }
+
+        mockNetwork.runNetwork()
+    }
+
+    @After
+    fun tearDown() {
+        mockNetwork.stopNodes()
+    }
+
+    private fun createNode(name: CordaX500Name) = mockNetwork.createNode(MockNodeParameters(legalName = name))
+
+    protected fun runCreateBusinessNetworkFlow(initiator: StartedMockNode): SignedTransaction {
+        val future = initiator.startFlow(CreateBusinessNetworkFlow())
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runRequestMembershipFlow(initiator: StartedMockNode, authorisedParty: Party, networkId: String): SignedTransaction {
+        val future = initiator.startFlow(RequestMembershipFlow(authorisedParty, networkId))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runActivateMembershipFlow(initiator: StartedMockNode, membershipId: UniqueIdentifier): SignedTransaction {
+        val future = initiator.startFlow(ActivateMembershipFlow(membershipId))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runModifyGroupFlow(initiator: StartedMockNode, groupId: UniqueIdentifier, participants: Set<UniqueIdentifier>): SignedTransaction {
+        val future = initiator.startFlow(ModifyGroupFlow(groupId, null, participants))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runAssignBICFlow(initiator: StartedMockNode, membershipId: UniqueIdentifier, bic: String, notary: Party? = null): SignedTransaction {
+        val future = initiator.startFlow(AssignBICFlow(membershipId, bic, notary))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runAssignLoanIssuerRole(initiator: StartedMockNode, networkId: String, notary: Party? = null): SignedTransaction {
+        val future = initiator.startFlow(AssignLoanIssuerRoleFlow(networkId, notary))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runIssueLoanFlow(initiator: StartedMockNode, networkId: String, borrower: Party, amount: Int): SignedTransaction {
+        val future = initiator.startFlow(IssueLoanFlow(networkId, borrower, amount))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun runSettleLoanFlow(initiator: StartedMockNode, loanId: UniqueIdentifier, amountToSettle: Int): SignedTransaction {
+        val future = initiator.startFlow(SettleLoanFlow(loanId, amountToSettle))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
+    protected fun getAllLoansFromVault(node: StartedMockNode): List<LoanState> {
+        val criteria = QueryCriteria.VaultQueryCriteria(Vault.StateStatus.UNCONSUMED)
+        return node.services.vaultService.queryBy(LoanState::class.java, criteria).states.map { it.state.data }
+    }
+}
+
+fun StartedMockNode.identity() = info.legalIdentities.single()

--- a/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/SettleLoanFlowTest.kt
+++ b/samples/business-networks-demo/business-networks-demo-workflows/src/test/kotlin/net/corda/bn/demo/workflows/SettleLoanFlowTest.kt
@@ -1,0 +1,103 @@
+package net.corda.bn.demo.workflows
+
+import net.corda.bn.demo.contracts.LoanContract
+import net.corda.bn.demo.contracts.LoanState
+import net.corda.bn.flows.DatabaseService
+import net.corda.bn.flows.IllegalFlowArgumentException
+import net.corda.bn.states.MembershipState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.testing.node.StartedMockNode
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class SettleLoanFlowTest : LoanFlowTest(numberOfLenders = 1, numberOfBorrowers = 1) {
+
+    private fun issueLoan(lender: StartedMockNode, borrower: StartedMockNode, amount: Int): LoanState {
+        val (networkId, lenderMembershipId) = (runCreateBusinessNetworkFlow(lender).tx.outputStates.single() as MembershipState).run { networkId to linearId }
+        val borrowerMembershipId = runRequestMembershipFlow(borrower, lender.identity(), networkId).run {
+            val membership = tx.outputStates.single() as MembershipState
+            runActivateMembershipFlow(lender, membership.linearId)
+            membership.linearId
+        }
+        val bic = "BANKGB00"
+        listOf(lenderMembershipId, borrowerMembershipId).forEach { runAssignBICFlow(lender, it, bic) }
+        runAssignLoanIssuerRole(lender, networkId)
+
+        val groupId = lender.services.cordaService(DatabaseService::class.java).run {
+            getAllBusinessNetworkGroups(networkId).single().state.data.linearId
+        }
+        runModifyGroupFlow(lender, groupId, setOf(lenderMembershipId, borrowerMembershipId))
+
+        return runIssueLoanFlow(lender, networkId, borrower.identity(), amount).tx.outputStates.single() as LoanState
+    }
+
+    @Test(timeout = 300_000)
+    fun `settle loan flow should fail if loan with given linear ID is not found`() {
+        val borrower = borrowers.first()
+
+        assertFailsWith<LoanNotFoundException> { runSettleLoanFlow(borrower, UniqueIdentifier(), 5) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `settle loan flow should fail if someone else than borrower initiates it`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        val loan = issueLoan(lender, borrower, 10)
+        assertFailsWith<IllegalFlowInitiatorException> { runSettleLoanFlow(lender, loan.linearId, 5) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `settle loan flow should fail if settlement amount is illegal`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        val loan = issueLoan(lender, borrower, 10)
+        assertFailsWith<IllegalFlowArgumentException> { runSettleLoanFlow(borrower, loan.linearId, -5) }
+        assertFailsWith<IllegalFlowArgumentException> { runSettleLoanFlow(borrower, loan.linearId, 15) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `settle loan flow happy path`() {
+        val lender = lenders.first()
+        val borrower = borrowers.first()
+
+        // first partially settle loan
+        val loan = issueLoan(lender, borrower, 10)
+        val (settledLoan, command) = runSettleLoanFlow(borrower, loan.linearId, 5).run {
+            assertEquals(1, tx.inputs.size)
+            verifyRequiredSignatures()
+            tx.outputs.single() to tx.commands.single()
+        }
+
+        val settledLoanState = settledLoan.run {
+            assertEquals(LoanContract.CONTRACT_NAME, contract)
+            assertTrue(data is LoanState)
+            val data = data as LoanState
+            assertEquals(lender.identity(), data.lender)
+            assertEquals(borrower.identity(), data.borrower)
+            assertEquals(5, data.amount)
+
+            data
+        }
+        assertTrue(command.value is LoanContract.Commands.Settle)
+
+        // also check ledgers
+        listOf(lender, borrower).forEach { node ->
+            getAllLoansFromVault(node).apply {
+                assertEquals(1, size, "Vault size assertion failed for ${node.identity()}")
+                assertEquals(settledLoanState, single(), "Expected persisted LoanState mismatch for ${node.identity()}")
+            }
+        }
+
+        // now fully settle remaining amount
+        runSettleLoanFlow(borrower, loan.linearId, 5).run {
+            assertEquals(1, tx.inputs.size)
+            verifyRequiredSignatures()
+            assertTrue(tx.outputs.isEmpty())
+            assertTrue(tx.commands.single().value is LoanContract.Commands.Exit)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR provides full test coverage for the sample CorDapp introduced in [6546](https://github.com/corda/corda/pull/6546).

We introduce following contract tests:
- `LoanStateTest`
- `LoanContractTest`

We also build flow tests which all extend nice abstract class with helper methods under name `LoanFlowTest`:
- `AssignBICFlowTest`
- `AssignLoanIssuerRoleFlowTest`
- `IssueLoanFlowTest`
- `SettleLoanFlowTest`

## Test Plan

Ensure all existing and new tests pass.