### PR TITLE
NOTICK Replace example URL with an unresolvable version

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -280,7 +280,7 @@ class NodeConfigurationImplTest {
 
     @Test(timeout=3_000)
 	fun `compatibilityZoneURL populates NetworkServices`() {
-        val compatibilityZoneURL = URI.create("https://r3.com").toURL()
+        val compatibilityZoneURL = URI.create("https://r3.example.com").toURL()
         val configuration = testConfiguration.copy(
                 devMode = false,
                 compatibilityZoneURL = compatibilityZoneURL)


### PR DESCRIPTION
Replace example URL with an unresolvable version to avoid issues with network failures causing
the test to fail, i.e. https://ci02.dev.r3.com/job/Corda-Enterprise/job/Corda-ENT-Release-Branch-Tests/job/enterprise/job/release%252Fent%252F4.6/127/testReport/net.corda.node.services.config/NodeConfigurationImplTest/compatibilityZoneURL_populates_NetworkServices/