### PR TITLE
INFRA-570: Disable new SSL tests when running on JDK11

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
@@ -3,6 +3,7 @@ package net.corda.node.amqp
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
+import net.corda.core.internal.JavaVersion
 import net.corda.core.internal.div
 import net.corda.core.toFuture
 import net.corda.core.utilities.NetworkHostAndPort
@@ -19,6 +20,7 @@ import net.corda.nodeapi.internal.protonwrapper.netty.toRevocationConfig
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.driver.internal.incrementalPortAllocation
+import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -133,6 +135,9 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
 
     @Test(timeout = 300_000)
     fun trivialClientServerExchange() {
+        // SSL works quite differently in JDK 11 and re-work is needed
+        assumeFalse(JavaVersion.isVersionAtLeast(JavaVersion.Java_11))
+
         val serverPort = portAllocation.nextPort()
         val serverThread = ServerThread(serverKeyManagerFactory, serverTrustManagerFactory, serverPort).also { it.start() }
 
@@ -168,6 +173,9 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
 
     @Test(timeout = 300_000)
     fun amqpClientServerConnect() {
+        // SSL works quite differently in JDK 11 and re-work is needed
+        assumeFalse(JavaVersion.isVersionAtLeast(JavaVersion.Java_11))
+
         val serverPort = portAllocation.nextPort()
         val serverThread = ServerThread(serverKeyManagerFactory, serverTrustManagerFactory, serverPort)
                 .also { it.start() }
@@ -188,6 +196,9 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
 
     @Test(timeout = 300_000)
     fun amqpClientServerHandshakeTimeout() {
+        // SSL works quite differently in JDK 11 and re-work is needed
+        assumeFalse(JavaVersion.isVersionAtLeast(JavaVersion.Java_11))
+
         val serverPort = portAllocation.nextPort()
         val serverThread = ServerThread(serverKeyManagerFactory, serverTrustManagerFactory, serverPort, 5.seconds)
                 .also { it.start() }


### PR DESCRIPTION
SSL works quite differently in JDK 11 and re-work to TLS server is needed to make sure it is working as expected.

Looking at: https://ci02.dev.r3.com/job/Corda-Enterprise/job/Corda-ENT-Release-Branch-JDK11-Tests/job/enterprise/job/release%252Fent%252F4.6/110/testReport/junit/net.corda.node.amqp/AMQPClientSslErrorsTest/trivialClientServerExchange_iteration___1_/
The server never started properly due to:

```
?[m?[1;31m[ERROR] 16:28:50,599 [ServerThread-ServerThread] amqp.ServerThread. - Exception starting server
?[m javax.net.ssl.SSLException: Tag mismatch!
	at sun.security.ssl.Alert.createSSLException(Alert.java:133) ~[?:?]
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:320) ~[?:?]
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:263) ~[?:?]
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:258) ~[?:?]
	at sun.security.ssl.SSLTransport.decode(SSLTransport.java:129) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.decode(SSLEngineImpl.java:668) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.readRecord(SSLEngineImpl.java:623) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:441) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:420) ~[?:?]
	at javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:634) ~[?:?]
	at net.corda.node.amqp.NioSslServer.read(NioSslServer.java:183) ~[integrationTest/:?]
	at net.corda.node.amqp.NioSslServer.start(NioSslServer.java:110) ~[integrationTest/:?]
	at net.corda.node.amqp.ServerThread.lambda$start$0(ServerThread.java:43) ~[integrationTest/:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: javax.crypto.AEADBadTagException: Tag mismatch!
	at com.sun.crypto.provider.GaloisCounterMode.decryptFinal(GaloisCounterMode.java:623) ~[?:?]
	at com.sun.crypto.provider.CipherCore.finalNoPadding(CipherCore.java:1116) ~[?:?]
	at com.sun.crypto.provider.CipherCore.fillOutputBuffer(CipherCore.java:1053) ~[?:?]
	at com.sun.crypto.provider.CipherCore.doFinal(CipherCore.java:941) ~[?:?]
	at com.sun.crypto.provider.AESCipher.engineDoFinal(AESCipher.java:491) ~[?:?]
	at javax.crypto.CipherSpi.bufferCrypt(CipherSpi.java:779) ~[?:?]
	at javax.crypto.CipherSpi.engineDoFinal(CipherSpi.java:730) ~[?:?]
	at javax.crypto.Cipher.doFinal(Cipher.java:2497) ~[?:?]
	at sun.security.ssl.SSLCipher$T13GcmReadCipherGenerator$GcmReadCipher.decrypt(SSLCipher.java:1929) ~[?:?]
	at sun.security.ssl.SSLEngineInputRecord.decodeInputRecord(SSLEngineInputRecord.java:240) ~[?:?]
	at sun.security.ssl.SSLEngineInputRecord.decode(SSLEngineInputRecord.java:197) ~[?:?]
	at sun.security.ssl.SSLEngineInputRecord.decode(SSLEngineInputRecord.java:160) ~[?:?]
	at sun.security.ssl.SSLTransport.decode(SSLTransport.java:108) ~[?:?]
```
