### PR TITLE
CORDA-3612 - Delete flow results/ exceptions once received by rpc client

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowIsKilledTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowIsKilledTest.kt
@@ -15,7 +15,6 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.minutes
 import net.corda.core.utilities.seconds
-import net.corda.node.services.statemachine.Checkpoint
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
@@ -77,9 +76,10 @@ class FlowIsKilledTest {
                 assertEquals(11, AFlowThatWantsToDieAndKillsItsFriends.position)
                 assertTrue(AFlowThatWantsToDieAndKillsItsFriendsResponder.receivedKilledExceptions[BOB_NAME]!!)
                 assertTrue(AFlowThatWantsToDieAndKillsItsFriendsResponder.receivedKilledExceptions[CHARLIE_NAME]!!)
-                assertEquals(1, alice.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(2, bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(1, bob.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+                val aliceCheckpoints = alice.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, aliceCheckpoints)
+                val bobCheckpoints = bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, bobCheckpoints)
             }
         }
     }
@@ -109,9 +109,10 @@ class FlowIsKilledTest {
                 handle.returnValue.getOrThrow(1.minutes)
             }
             assertEquals(11, AFlowThatGetsMurderedByItsFriendResponder.position)
-            assertEquals(2, alice.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-            assertEquals(1, alice.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-            assertEquals(1, bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+            val aliceCheckpoints = alice.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(1, aliceCheckpoints)
+            val bobCheckpoints = bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(1, bobCheckpoints)
         }
     }
 
@@ -358,20 +359,6 @@ class FlowIsKilledTest {
                     rs.getLong(1)
                 }
             }
-        }
-    }
-
-    @StartableByRPC
-    class GetNumberOfFailedCheckpointsFlow : FlowLogic<Long>() {
-        override fun call(): Long {
-            return serviceHub.jdbcSession()
-                .prepareStatement("select count(*) from node_checkpoints where status = ${Checkpoint.FlowStatus.FAILED.ordinal}")
-                .use { ps ->
-                    ps.executeQuery().use { rs ->
-                        rs.next()
-                        rs.getLong(1)
-                    }
-                }
         }
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowReloadAfterCheckpointTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowReloadAfterCheckpointTest.kt
@@ -509,3 +509,7 @@ class FlowReloadAfterCheckpointTest {
         }
     }
 }
+
+internal class BrokenMap<K, V>(delegate: MutableMap<K, V> = mutableMapOf()) : MutableMap<K, V> by delegate {
+    override fun put(key: K, value: V): V? = throw IllegalStateException("Broken on purpose")
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
@@ -161,7 +161,7 @@ class FlowRetryTest {
     }
 
     @Test(timeout = 300_000)
-    fun `General external exceptions are not retried and propagate`() {
+    fun `general external exceptions are not retried and propagate`() {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = cordapps)) {
 
             val (nodeAHandle, nodeBHandle) = listOf(ALICE_NAME, BOB_NAME)
@@ -176,10 +176,7 @@ class FlowRetryTest {
                 ).returnValue.getOrThrow()
             }
             assertEquals(0, GeneralExternalFailureFlow.retryCount)
-            assertEquals(
-                1,
-                nodeAHandle.rpc.startFlow(::GetCheckpointNumberOfStatusFlow, Checkpoint.FlowStatus.FAILED).returnValue.get()
-            )
+            assertEquals(0, nodeAHandle.rpc.startFlow(::GetCheckpointNumberOfStatusFlow, Checkpoint.FlowStatus.FAILED).returnValue.get())
         }
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt
@@ -304,10 +304,6 @@ enum class Step { First, BeforeInitiate, AfterInitiate, AfterInitiateSendReceive
 
 data class Visited(val sessionNum: Int, val iterationNum: Int, val step: Step)
 
-class BrokenMap<K, V>(delegate: MutableMap<K, V> = mutableMapOf()) : MutableMap<K, V> by delegate {
-    override fun put(key: K, value: V): V? = throw IllegalStateException("Broken on purpose")
-}
-
 @StartableByRPC
 class RetryFlow() : FlowLogic<String>(), IdempotentFlow {
     companion object {

--- a/node/src/integration-test/kotlin/net/corda/node/flows/KillFlowTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/KillFlowTest.kt
@@ -26,7 +26,6 @@ import net.corda.core.utilities.seconds
 import net.corda.finance.DOLLARS
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashIssueFlow
-import net.corda.node.services.statemachine.Checkpoint
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
@@ -61,7 +60,8 @@ class KillFlowTest {
                 assertFailsWith<KilledFlowException> {
                     handle.returnValue.getOrThrow(1.minutes)
                 }
-                assertEquals(1, rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+                val checkpoints = rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, checkpoints)
             }
         }
     }
@@ -88,11 +88,12 @@ class KillFlowTest {
                 AFlowThatGetsMurderedWhenItTriesToSuspendAndSomehowKillsItsFriendsResponder.locks.forEach { it.value.acquire() }
                 assertTrue(AFlowThatGetsMurderedWhenItTriesToSuspendAndSomehowKillsItsFriendsResponder.receivedKilledExceptions[BOB_NAME]!!)
                 assertTrue(AFlowThatGetsMurderedWhenItTriesToSuspendAndSomehowKillsItsFriendsResponder.receivedKilledExceptions[CHARLIE_NAME]!!)
-                assertEquals(1, rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(2, bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(1, bob.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(2, charlie.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(1, charlie.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+                val aliceCheckpoints = rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, aliceCheckpoints)
+                val bobCheckpoints = bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, bobCheckpoints)
+                val charlieCheckpoints = charlie.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, charlieCheckpoints)
             }
         }
     }
@@ -112,7 +113,8 @@ class KillFlowTest {
                 }
                 assertTrue(time < 1.minutes.toMillis(), "It should at a minimum, take less than a minute to kill this flow")
                 assertTrue(time < 5.seconds.toMillis(), "Really, it should take less than a few seconds to kill a flow")
-                assertEquals(1, rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+                val checkpoints = rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, checkpoints)
             }
         }
     }
@@ -150,7 +152,8 @@ class KillFlowTest {
         }
         assertTrue(time < 1.minutes.toMillis(), "It should at a minimum, take less than a minute to kill this flow")
         assertTrue(time < 5.seconds.toMillis(), "Really, it should take less than a few seconds to kill a flow")
-        assertEquals(1, startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+        val checkpoints = startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+        assertEquals(1, checkpoints)
     }
 
     @Test(timeout = 300_000)
@@ -168,7 +171,8 @@ class KillFlowTest {
                 }
                 assertTrue(time < 1.minutes.toMillis(), "It should at a minimum, take less than a minute to kill this flow")
                 assertTrue(time < 5.seconds.toMillis(), "Really, it should take less than a few seconds to kill a flow")
-                assertEquals(1, rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+                val checkpoints = rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, checkpoints)
             }
         }
     }
@@ -188,7 +192,8 @@ class KillFlowTest {
                 }
                 assertTrue(time < 1.minutes.toMillis(), "It should at a minimum, take less than a minute to kill this flow")
                 assertTrue(time < 5.seconds.toMillis(), "Really, it should take less than a few seconds to kill a flow")
-                assertEquals(1, rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+                val checkpoints = rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, checkpoints)
             }
         }
     }
@@ -217,11 +222,12 @@ class KillFlowTest {
                 }
                 assertTrue(AFlowThatGetsMurderedAndSomehowKillsItsFriendsResponder.receivedKilledExceptions[BOB_NAME]!!)
                 assertTrue(AFlowThatGetsMurderedAndSomehowKillsItsFriendsResponder.receivedKilledExceptions[CHARLIE_NAME]!!)
-                assertEquals(1, rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(2, bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(1, bob.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(2, charlie.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-                assertEquals(1, charlie.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+                val aliceCheckpoints = rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, aliceCheckpoints)
+                val bobCheckpoints = bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, bobCheckpoints)
+                val charlieCheckpoints = charlie.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+                assertEquals(1, charlieCheckpoints)
             }
         }
     }
@@ -251,11 +257,12 @@ class KillFlowTest {
             assertTrue(AFlowThatGetsMurderedByItsFriend.receivedKilledException)
             assertFalse(AFlowThatGetsMurderedByItsFriendResponder.receivedKilledExceptions[BOB_NAME]!!)
             assertTrue(AFlowThatGetsMurderedByItsFriendResponder.receivedKilledExceptions[CHARLIE_NAME]!!)
-            assertEquals(2, alice.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-            assertEquals(1, alice.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-            assertEquals(1, bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-            assertEquals(2, charlie.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds))
-            assertEquals(1, charlie.rpc.startFlow(::GetNumberOfFailedCheckpointsFlow).returnValue.getOrThrow(20.seconds))
+            val aliceCheckpoints = alice.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(1, aliceCheckpoints)
+            val bobCheckpoints = bob.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(1, bobCheckpoints)
+            val charlieCheckpoints = charlie.rpc.startFlow(::GetNumberOfCheckpointsFlow).returnValue.getOrThrow(20.seconds)
+            assertEquals(1, charlieCheckpoints)
         }
     }
 
@@ -586,20 +593,6 @@ class KillFlowTest {
                     rs.getLong(1)
                 }
             }
-        }
-    }
-
-    @StartableByRPC
-    class GetNumberOfFailedCheckpointsFlow : FlowLogic<Long>() {
-        override fun call(): Long {
-            return serviceHub.jdbcSession()
-                .prepareStatement("select count(*) from node_checkpoints where status = ${Checkpoint.FlowStatus.FAILED.ordinal}")
-                .use { ps ->
-                    ps.executeQuery().use { rs ->
-                        rs.next()
-                        rs.getLong(1)
-                    }
-                }
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -32,9 +32,12 @@ interface CheckpointStorage {
 
     /**
      * Remove existing checkpoint from the store.
+     *
+     * [mayBeFinished] is used for optimization. If set to [false] it will not attempt to delete the database result or the database exception.
+     * Please note that if there is a doubt on whether a flow could be finished or not [mayBeFinished] should be set to [true].
      * @return whether the id matched a checkpoint that was removed.
      */
-    fun removeCheckpoint(id: StateMachineRunId): Boolean
+    fun removeCheckpoint(id: StateMachineRunId, mayBeFinished: Boolean = true): Boolean
 
     /**
      * Load an existing checkpoint from the store.

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -75,5 +75,7 @@ interface CheckpointStorage {
      */
     fun getFlowResult(id: StateMachineRunId, throwIfMissing: Boolean = false): Any?
 
+    fun removeFlowException(id: StateMachineRunId): Boolean
+
     fun updateStatus(runId: StateMachineRunId, flowStatus: Checkpoint.FlowStatus)
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -75,6 +75,12 @@ interface CheckpointStorage {
      */
     fun getFlowResult(id: StateMachineRunId, throwIfMissing: Boolean = false): Any?
 
+    /**
+     * Load a flow exception from the store. If [throwIfMissing] is true then it throws an [IllegalStateException]
+     * if the flow exception is missing in the database.
+     */
+    fun getFlowException(id: StateMachineRunId, throwIfMissing: Boolean = false): Any?
+
     fun removeFlowException(id: StateMachineRunId): Boolean
 
     fun updateStatus(runId: StateMachineRunId, flowStatus: Checkpoint.FlowStatus)

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -482,16 +482,16 @@ class DBCheckpointStorage(
         query.executeUpdate()
     }
 
-    // We cant have a result and an exception for the same checkpoint. The below method should be changed to get a [succeeded: Boolean] parameter
-    // so that it only deletes a result or an exception. That way we ll save an extra delete statement everytime we remove a checkpoint.
     @Suppress("MagicNumber")
-    override fun removeCheckpoint(id: StateMachineRunId): Boolean {
+    override fun removeCheckpoint(id: StateMachineRunId, mayBeFinished: Boolean): Boolean {
         var deletedRows = 0
         val flowId = id.uuid.toString()
         deletedRows += deleteRow(DBFlowCheckpoint::class.java, DBFlowCheckpoint::flowId.name, flowId)
         deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
-        deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
-        deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
+        if (mayBeFinished) {
+            deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
+            deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
+        }
         deletedRows += deleteRow(DBFlowMetadata::class.java, DBFlowMetadata::flowId.name, flowId)
         return deletedRows >= 2
     }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -467,10 +467,10 @@ class DBCheckpointStorage(
         currentDBSession().update(dbFlowCheckpoint)
         blob?.let { currentDBSession().update(it) }
         dbFlowResult?.let { currentDBSession().save(it) }
+        dbFlowException?.let { currentDBSession().save(it) }
         if (checkpoint.isFinished()) {
             setDBFlowMetadataFinishTime(flowId, now)
         }
-        dbFlowException?.let { currentDBSession().save(it) }
     }
 
     override fun markAllPaused() {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -488,11 +488,11 @@ class DBCheckpointStorage(
     override fun removeCheckpoint(id: StateMachineRunId): Boolean {
         var deletedRows = 0
         val flowId = id.uuid.toString()
-        deletedRows += deleteRow(DBFlowMetadata::class.java, DBFlowMetadata::flowId.name, flowId)
-        deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
-        deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
-        deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
         deletedRows += deleteRow(DBFlowCheckpoint::class.java, DBFlowCheckpoint::flowId.name, flowId)
+        deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
+        deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
+        deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
+        deletedRows += deleteRow(DBFlowMetadata::class.java, DBFlowMetadata::flowId.name, flowId)
         return deletedRows >= 2
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -628,7 +628,7 @@ class DBCheckpointStorage(
                 type = it::class.java.name.truncate(MAX_EXC_TYPE_LENGTH, true),
                 message = it.message?.truncate(MAX_EXC_MSG_LENGTH, false),
                 stackTrace = it.stackTraceToString(),
-                value = null, // TODO to be populated upon implementing https://r3-cev.atlassian.net/browse/CORDA-3681
+                value = it.storageSerialize().bytes,
                 persistedInstant = now
             )
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -549,13 +549,13 @@ class DBCheckpointStorage(
         }
     }
 
-    // This method needs modification once CORDA-3681 is implemented to include FAILED flows as well
     override fun getFinishedFlowsResultsMetadata(): Stream<Pair<StateMachineRunId, FlowResultMetadata>> {
         val session = currentDBSession()
-        val jpqlQuery = """select new ${DBFlowResultMetadataFields::class.java.name}(checkpoint.id, checkpoint.status, metadata.userSuppliedIdentifier) 
+        val jpqlQuery =
+            """select new ${DBFlowResultMetadataFields::class.java.name}(checkpoint.id, checkpoint.status, metadata.userSuppliedIdentifier) 
                 from ${DBFlowCheckpoint::class.java.name} checkpoint 
                 join ${DBFlowMetadata::class.java.name} metadata on metadata.id = checkpoint.flowMetadata  
-                where checkpoint.status = ${FlowStatus.COMPLETED.ordinal}""".trimIndent()
+                where checkpoint.status = ${FlowStatus.COMPLETED.ordinal} or checkpoint.status = ${FlowStatus.FAILED.ordinal}""".trimIndent()
         val query = session.createQuery(jpqlQuery, DBFlowResultMetadataFields::class.java)
         return query.resultList.stream().map {
             StateMachineRunId(UUID.fromString(it.id)) to FlowResultMetadata(it.status, it.clientId)

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -567,6 +567,11 @@ class DBCheckpointStorage(
         return serializedFlowResult?.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
     }
 
+    override fun removeFlowException(id: StateMachineRunId): Boolean {
+        val flowId = id.uuid.toString()
+        return deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId) == 1
+    }
+
     override fun updateStatus(runId: StateMachineRunId, flowStatus: FlowStatus) {
         val update = "Update ${NODE_DATABASE_PREFIX}checkpoints set status = ${flowStatus.ordinal} where flow_id = '${runId.uuid}'"
         currentDBSession().createNativeQuery(update).executeUpdate()

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -482,6 +482,8 @@ class DBCheckpointStorage(
         query.executeUpdate()
     }
 
+    // We cant have a result and an exception for the same checkpoint. The below method should be changed to get a [succeeded: Boolean] parameter
+    // so that it only deletes a result or an exception. That way we ll save an extra delete statement everytime we remove a checkpoint.
     @Suppress("MagicNumber")
     override fun removeCheckpoint(id: StateMachineRunId): Boolean {
         var deletedRows = 0

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -58,9 +58,11 @@ sealed class Action {
     data class PersistCheckpoint(val id: StateMachineRunId, val checkpoint: Checkpoint, val isCheckpointUpdate: Boolean) : Action()
 
     /**
-     * Remove the checkpoint corresponding to [id].
+     * Remove the checkpoint corresponding to [id]. [mayBeFinished] denotes that at the time of injecting a [RemoveCheckpoint]
+     * the flow could have finished and persisted with such a state in the database.
+     * For more information see [CheckpointStorage.removeCheckpoint].
      */
-    data class RemoveCheckpoint(val id: StateMachineRunId) : Action()
+    data class RemoveCheckpoint(val id: StateMachineRunId, val mayBeFinished: Boolean = false) : Action()
 
     /**
      * Persist the deduplication facts of [deduplicationHandlers].

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -151,7 +151,7 @@ internal class ActionExecutorImpl(
 
     @Suspendable
     private fun executeRemoveCheckpoint(action: Action.RemoveCheckpoint) {
-        checkpointStorage.removeCheckpoint(action.id)
+        checkpointStorage.removeCheckpoint(action.id, action.mayBeFinished)
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -835,7 +835,12 @@ internal class SingleThreadedStateMachineManager(
         drainFlowEventQueue(flow)
         // Complete the started future, needed when the flow fails during flow init (before completing an [UnstartedFlowTransition])
         startedFutures.remove(flow.fiber.id)?.set(Unit)
-        flow.fiber.clientId?.let { setClientIdAsFailed(it, flow.fiber.id) }
+        flow.fiber.clientId?.let {
+            if (flow.fiber.isKilled) {
+                clientIdsToFlowIds.remove(it)
+            } else {
+                setClientIdAsFailed(it, flow.fiber.id) }
+            }
         val flowError = removalReason.flowErrors[0] // TODO what to do with several?
         val exception = flowError.exception
         (exception as? FlowException)?.originalErrorId = flowError.errorId

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -476,6 +476,10 @@ internal class SingleThreadedStateMachineManager(
                 tryDeserializeCheckpoint(serializedCheckpoint, flowId)?.also {
                     if (it.status == Checkpoint.FlowStatus.HOSPITALIZED) {
                         checkpointStorage.updateStatus(flowId, Checkpoint.FlowStatus.RUNNABLE)
+                        if (!checkpointStorage.removeFlowException(flowId)) {
+                            logger.error("Unable to remove database exception for flow $flowId. Something is very wrong. The flow will not retry.")
+                            return@transaction null
+                        }
                     }
                 } ?: return@transaction null
             } ?: return

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -464,11 +464,6 @@ internal class SingleThreadedStateMachineManager(
             return
         }
         val flow = if (currentState.isAnyCheckpointPersisted) {
-
-            if (currentState.checkpoint.status == Checkpoint.FlowStatus.HOSPITALIZED) {
-                checkpointStorage.updateStatus(flowId, Checkpoint.FlowStatus.RUNNABLE)
-            }
-
             // We intentionally grab the checkpoint from storage rather than relying on the one referenced by currentState. This is so that
             // we mirror exactly what happens when restarting the node.
             val serializedCheckpoint = database.transaction { checkpointStorage.getCheckpoint(flowId) }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -435,7 +435,7 @@ internal class SingleThreadedStateMachineManager(
                     if (it.status == Checkpoint.FlowStatus.HOSPITALIZED) {
                         checkpointStorage.updateStatus(id, Checkpoint.FlowStatus.RUNNABLE)
                         if (!checkpointStorage.removeFlowException(id)) {
-                            logger.error("Unable to remove database exception for flow $id. Something is very wrong.")
+                            logger.error("Unable to remove database exception for flow $id. Something is very wrong. The flow will not be loaded and run.")
                             return@mapNotNull null
                         }
                     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -329,7 +329,7 @@ internal class SingleThreadedStateMachineManager(
                 // The checkpoint and soft locks are removed here instead of relying on the processing of the next event after setting
                 // the killed flag. This is to ensure a flow can be removed from the database, even if it is stuck in a infinite loop.
                 database.transaction {
-                    checkpointStorage.removeCheckpoint(id)
+                    checkpointStorage.removeCheckpoint(id, mayBeFinished = true)
                     serviceHub.vaultService.softLockRelease(id.uuid)
                 }
                 // the same code is NOT done in remove flow when an error occurs
@@ -342,7 +342,7 @@ internal class SingleThreadedStateMachineManager(
                 true
             } else {
                 // It may be that the id refers to a checkpoint that couldn't be deserialised into a flow, so we delete it if it exists.
-                database.transaction { checkpointStorage.removeCheckpoint(id) }
+                database.transaction { checkpointStorage.removeCheckpoint(id, mayBeFinished = true) }
             }
         }
         return if (killFlowResult) {
@@ -949,7 +949,7 @@ internal class SingleThreadedStateMachineManager(
         }
 
         removedFlowId?.let {
-            database.transaction { checkpointStorage.removeCheckpoint(it) }
+            database.transaction { checkpointStorage.removeCheckpoint(it, mayBeFinished = true) }
             return true
         }
         return false

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -5,7 +5,6 @@ import co.paralleluniverse.fibers.FiberExecutorScheduler
 import co.paralleluniverse.fibers.instrument.JavaAgent
 import com.codahale.metrics.Gauge
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import net.corda.core.CordaRuntimeException
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
 import net.corda.core.flows.FlowException

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -464,6 +464,11 @@ internal class SingleThreadedStateMachineManager(
             return
         }
         val flow = if (currentState.isAnyCheckpointPersisted) {
+
+            if (currentState.checkpoint.status == Checkpoint.FlowStatus.HOSPITALIZED) {
+                checkpointStorage.updateStatus(flowId, Checkpoint.FlowStatus.RUNNABLE)
+            }
+
             // We intentionally grab the checkpoint from storage rather than relying on the one referenced by currentState. This is so that
             // we mirror exactly what happens when restarting the node.
             val serializedCheckpoint = database.transaction { checkpointStorage.getCheckpoint(flowId) }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -192,7 +192,7 @@ internal class SingleThreadedStateMachineManager(
                 if (finishedFlowResult.status == Checkpoint.FlowStatus.COMPLETED) {
                     innerState.clientIdsToFlowIds[it] = FlowWithClientIdStatus.Removed(id, true)
                 } else {
-                    // - FAILED flows need to be fetched upon implementing https://r3-cev.atlassian.net/browse/CORDA-3681
+                    innerState.clientIdsToFlowIds[it] = FlowWithClientIdStatus.Removed(id, false)
                 }
             } ?: logger.error("Found finished flow $id without a client id. Something is very wrong and this flow will be ignored.")
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
@@ -61,9 +61,14 @@ class ErrorFlowTransition(
             if (!currentState.isRemoved) {
                 val newCheckpoint = startingState.checkpoint.copy(status = Checkpoint.FlowStatus.FAILED)
 
+                actions.add(Action.CreateTransaction)
+                if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
+                    actions.add(Action.RemoveCheckpoint(context.id))
+                } else {
+                    actions.add(Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = currentState.isAnyCheckpointPersisted))
+                }
+
                 actions.addAll(arrayOf(
-                        Action.CreateTransaction,
-                        Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = currentState.isAnyCheckpointPersisted),
                         Action.PersistDeduplicationFacts(currentState.pendingDeduplicationHandlers),
                         Action.ReleaseSoftLocks(context.id.uuid),
                         Action.CommitTransaction,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -44,7 +44,7 @@ class KilledFlowTransition(
             }
             // The checkpoint and soft locks are also removed directly in [StateMachineManager.killFlow]
             if (startingState.isAnyCheckpointPersisted) {
-                actions.add(Action.RemoveCheckpoint(context.id))
+                actions.add(Action.RemoveCheckpoint(context.id, mayBeFinished = true))
             }
             actions.addAll(
                 arrayOf(

--- a/node/src/main/resources/migration/node-core.changelog-v19-keys.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v19-keys.xml
@@ -21,6 +21,9 @@
         <createIndex indexName="node_flow_results_idx" tableName="node_flow_results" clustered="false" unique="true">
             <column name="flow_id"/>
         </createIndex>
+        <createIndex indexName="node_flow_exceptions_idx" tableName="node_flow_exceptions" clustered="false" unique="true">
+            <column name="flow_id"/>
+        </createIndex>
         <createIndex indexName="node_flow_metadata_idx" tableName="node_flow_metadata" clustered="false" unique="true">
             <column name="flow_id"/>
         </createIndex>

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -738,7 +738,6 @@ class DBCheckpointStorageTests {
         }
     }
 
-    // This test needs modification once CORDA-3681 is implemented to include FAILED flows as well
     @Test(timeout = 300_000)
     fun `'getFinishedFlowsResultsMetadata' fetches flows results metadata for finished flows only`() {
         val (_, checkpoint) = newCheckpoint(1)
@@ -770,7 +769,10 @@ class DBCheckpointStorageTests {
         }.toList()
 
         assertEquals(6, checkpointsInDb)
-        assertEquals(Checkpoint.FlowStatus.COMPLETED, resultsMetadata.single().second.status)
+
+        val finishedStatuses = resultsMetadata.map { it.second.status }
+        assertTrue(Checkpoint.FlowStatus.COMPLETED in finishedStatuses)
+        assertTrue(Checkpoint.FlowStatus.FAILED in finishedStatuses)
     }
 
     data class IdAndCheckpoint(val id: StateMachineRunId, val checkpoint: Checkpoint)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -452,6 +452,7 @@ class DBCheckpointStorageTests {
             assertEquals(exception::class.java.name, exceptionDetails!!.type)
             assertEquals(exception.message, exceptionDetails.message)
             val deserializedException = exceptionDetails.value?.let { SerializedBytes<Any>(it) }?.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+            // IllegalStateException does not implement [CordaThrowable] therefore gets deserialized as a [CordaRuntimeException]
             assertTrue(deserializedException is CordaRuntimeException)
             val cordaRuntimeException = deserializedException as CordaRuntimeException
             assertEquals(IllegalStateException::class.java.name, cordaRuntimeException.originalExceptionClassName)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -38,7 +38,6 @@ import org.junit.After
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.time.Clock
@@ -181,51 +180,6 @@ class DBCheckpointStorageTests {
         }
     }
 
-    @Ignore
-    @Test(timeout = 300_000)
-    fun `removing a checkpoint deletes from all checkpoint tables`() {
-        val exception = IllegalStateException("I am a naughty exception")
-        val (id, checkpoint) = newCheckpoint()
-        val serializedFlowState = checkpoint.serializeFlowState()
-        database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
-        }
-        val updatedCheckpoint = checkpoint.addError(exception).copy(result = "The result")
-        val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
-        database.transaction { checkpointStorage.updateCheckpoint(id, updatedCheckpoint, updatedSerializedFlowState, updatedCheckpoint.serializeCheckpointState()) }
-
-        database.transaction {
-            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
-            // The result not stored yet
-            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowResult>().size)
-            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
-            // The saving of checkpoint blobs needs to be fixed
-            assertEquals(2, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
-            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
-        }
-
-        database.transaction {
-            checkpointStorage.removeCheckpoint(id)
-        }
-        database.transaction {
-            assertThat(checkpointStorage.checkpoints()).isEmpty()
-        }
-        newCheckpointStorage()
-        database.transaction {
-            assertThat(checkpointStorage.checkpoints()).isEmpty()
-        }
-
-        database.transaction {
-            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
-            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowResult>().size)
-            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
-            // The saving of checkpoint blobs needs to be fixed
-            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
-            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
-        }
-    }
-
-    @Ignore
     @Test(timeout = 300_000)
     fun `removing a checkpoint when there is no result does not fail`() {
         val exception = IllegalStateException("I am a naughty exception")
@@ -240,11 +194,9 @@ class DBCheckpointStorageTests {
 
         database.transaction {
             assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
-            // The result not stored yet
             assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowResult>().size)
             assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
-            // The saving of checkpoint blobs needs to be fixed
-            assertEquals(2, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
             assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
         }
 
@@ -263,8 +215,7 @@ class DBCheckpointStorageTests {
             assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
             assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowResult>().size)
             assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
-            // The saving of checkpoint blobs needs to be fixed
-            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
             assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
         }
     }
@@ -479,7 +430,6 @@ class DBCheckpointStorageTests {
         }
     }
 
-    @Ignore
     @Test(timeout = 300_000)
     fun `update checkpoint with error information creates a new error database record`() {
         val exception = IllegalStateException("I am a naughty exception")
@@ -499,57 +449,6 @@ class DBCheckpointStorageTests {
             assertEquals(exception::class.java.name, exceptionDetails!!.type)
             assertEquals(exception.message, exceptionDetails.message)
             assertEquals(1,  findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
-        }
-    }
-
-    @Ignore
-    @Test(timeout = 300_000)
-    fun `update checkpoint with new error information updates the existing error database record`() {
-        val illegalStateException = IllegalStateException("I am a naughty exception")
-        val illegalArgumentException = IllegalArgumentException("I am a very naughty exception")
-        val (id, checkpoint) = newCheckpoint()
-        val serializedFlowState = checkpoint.serializeFlowState()
-        database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
-        }
-        val updatedCheckpoint1 = checkpoint.addError(illegalStateException)
-        val updatedSerializedFlowState1 = updatedCheckpoint1.serializeFlowState()
-        database.transaction { checkpointStorage.updateCheckpoint(id, updatedCheckpoint1, updatedSerializedFlowState1, updatedCheckpoint1.serializeCheckpointState()) }
-        // Set back to clean
-        val updatedCheckpoint2 = checkpoint.addError(illegalArgumentException)
-        val updatedSerializedFlowState2 = updatedCheckpoint2.serializeFlowState()
-        database.transaction { checkpointStorage.updateCheckpoint(id, updatedCheckpoint2, updatedSerializedFlowState2, updatedCheckpoint2.serializeCheckpointState()) }
-        database.transaction {
-            assertTrue(checkpointStorage.getCheckpoint(id)!!.deserialize().errorState is ErrorState.Clean)
-            val exceptionDetails = session.get(DBCheckpointStorage.DBFlowCheckpoint::class.java, id.uuid.toString()).exceptionDetails
-            assertNotNull(exceptionDetails)
-            assertEquals(illegalArgumentException::class.java.name, exceptionDetails!!.type)
-            assertEquals(illegalArgumentException.message, exceptionDetails.message)
-            assertEquals(1,  findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
-        }
-    }
-
-    @Test(timeout = 300_000)
-    fun `clean checkpoints delete the error record from the database`() {
-        val exception = IllegalStateException("I am a naughty exception")
-        val (id, checkpoint) = newCheckpoint()
-        val serializedFlowState = checkpoint.serializeFlowState()
-        database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
-        }
-        val updatedCheckpoint = checkpoint.addError(exception)
-        val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
-        database.transaction { checkpointStorage.updateCheckpoint(id, updatedCheckpoint, updatedSerializedFlowState, updatedCheckpoint.serializeCheckpointState()) }
-        database.transaction {
-            // Checkpoint always returns clean error state when retrieved via [getCheckpoint]
-            assertTrue(checkpointStorage.getCheckpoint(id)!!.deserialize().errorState is ErrorState.Clean)
-        }
-        // Set back to clean
-        database.transaction { checkpointStorage.updateCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState()) }
-        database.transaction {
-            assertTrue(checkpointStorage.getCheckpoint(id)!!.deserialize().errorState is ErrorState.Clean)
-            assertNull(session.get(DBCheckpointStorage.DBFlowCheckpoint::class.java, id.uuid.toString()).exceptionDetails)
-            assertEquals(0,  findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
         }
     }
 
@@ -642,9 +541,9 @@ class DBCheckpointStorageTests {
         }
     }
 
-    @Ignore
     @Test(timeout = 300_000)
     fun `-not greater than DBCheckpointStorage_MAX_STACKTRACE_LENGTH- stackTrace gets persisted as a whole`() {
+        //System.setProperty("line.separator", "\n")
         val smallerDummyStackTrace = ArrayList<StackTraceElement>()
         val dummyStackTraceElement = StackTraceElement("class", "method", "file", 0)
 
@@ -675,9 +574,9 @@ class DBCheckpointStorageTests {
         }
     }
 
-    @Ignore
     @Test(timeout = 300_000)
     fun `-greater than DBCheckpointStorage_MAX_STACKTRACE_LENGTH- stackTrace gets truncated to MAX_LENGTH_VARCHAR, and persisted`() {
+        //System.setProperty("line.separator", "\n")
         val smallerDummyStackTrace = ArrayList<StackTraceElement>()
         val dummyStackTraceElement = StackTraceElement("class", "method", "file", 0)
 
@@ -721,9 +620,9 @@ class DBCheckpointStorageTests {
 
     private fun iterationsBasedOnLineSeparatorLength() = when {
         System.getProperty("line.separator").length == 1 -> // Linux or Mac
-            158
+            78
         System.getProperty("line.separator").length == 2 -> // Windows
-            152
+            75
         else -> throw IllegalStateException("Unknown line.separator")
     }
 
@@ -794,7 +693,7 @@ class DBCheckpointStorageTests {
     }
 
     @Test(timeout = 300_000)
-    fun `updateCheckpoint setting DBFlowCheckpoint_blob to null whenever flow fails or gets hospitalized doesn't break ORM relationship`() {
+    fun `'updateCheckpoint' setting 'DBFlowCheckpoint_blob' to null whenever flow fails or gets hospitalized doesn't break ORM relationship`() {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
@@ -803,8 +702,8 @@ class DBCheckpointStorageTests {
         }
 
         database.transaction {
-            val paused = changeStatus(checkpoint, Checkpoint.FlowStatus.FAILED) // the exact same behaviour applies for 'HOSPITALIZED' as well
-            checkpointStorage.updateCheckpoint(id, paused.checkpoint, serializedFlowState, paused.checkpoint.serializeCheckpointState())
+            val failed = checkpoint.addError(IllegalStateException()) // the exact same behaviour applies for 'HOSPITALIZED' as well
+            checkpointStorage.updateCheckpoint(id, failed, serializedFlowState, failed.serializeCheckpointState())
         }
 
         database.transaction {
@@ -928,7 +827,8 @@ class DBCheckpointStorageTests {
                         exception
                     )
                 ), 0, false
-            )
+            ),
+            status = Checkpoint.FlowStatus.FAILED
         )
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -539,7 +539,7 @@ class FlowClientIdTests {
         assertEquals(5, result)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `flow that fails does not retain its checkpoint nor its exception in the database if not started with a client id`() {
         assertFailsWith<IllegalStateException> {
             aliceNode.services.startFlow(ExceptionFlow { IllegalStateException("another exception") }).resultFuture.getOrThrow()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -181,8 +181,6 @@ class FlowClientIdTests {
         Assert.assertEquals(result0, result1)
     }
 
-    // TODO: this is to be unignored upon implementing CORDA-3681 (saving of exception blob in the database)
-    @Ignore
     @Test(timeout=300_000)
     fun `failing flow's exception is available after flow's lifetime if flow is started with a client id`() {
         ResultFlow.hook = { throw IllegalStateException() }
@@ -192,21 +190,7 @@ class FlowClientIdTests {
             aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         }
 
-        // assert DB status
-//        aliceNode.database.transaction {
-//            val checkpoint = aliceNode.internals.checkpointStorage.checkpoints().single()
-//            Assert.assertEquals(Checkpoint.FlowStatus.FAILED, checkpoint.status)
-//
-//            // assert all fields of DBFlowException
-//            val persistedException = aliceNode.internals.checkpointStorage.getDBCheckpoint(flowId!!)!!.exceptionDetails
-//            Assert.assertEquals(FlowException::class.java.name, persistedException!!.type)
-//            Assert.assertEquals("Just an exception", persistedException.message)
-//            Assert.assertEquals(ExceptionUtils.getStackTrace(e), persistedException.stackTrace)
-//            // TODO: this needs change once we save the exception blob
-//            Assert.assertEquals(null, persistedException.value)
-//        }
-
-        assertFailsWith<IllegalStateException> {
+        assertFailsWith<CordaRuntimeException> {
             aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         }
     }
@@ -526,7 +510,6 @@ class FlowClientIdTests {
         }
     }
 
-    // TODO: Hospitalization tests -> ()
 }
 
 internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -181,15 +181,30 @@ class FlowClientIdTests {
         Assert.assertEquals(result0, result1)
     }
 
-    @Ignore // this is to be unignored upon implementing CORDA-3681
+    // TODO: this is to be unignored upon implementing CORDA-3681 (saving of exception blob in the database)
+    @Ignore
     @Test(timeout=300_000)
-    fun `flow's exception is available after flow's lifetime if flow is started with a client id`() {
+    fun `failing flow's exception is available after flow's lifetime if flow is started with a client id`() {
         ResultFlow.hook = { throw IllegalStateException() }
         val clientId = UUID.randomUUID().toString()
 
         assertFailsWith<IllegalStateException> {
             aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
         }
+
+        // assert DB status
+//        aliceNode.database.transaction {
+//            val checkpoint = aliceNode.internals.checkpointStorage.checkpoints().single()
+//            Assert.assertEquals(Checkpoint.FlowStatus.FAILED, checkpoint.status)
+//
+//            // assert all fields of DBFlowException
+//            val persistedException = aliceNode.internals.checkpointStorage.getDBCheckpoint(flowId!!)!!.exceptionDetails
+//            Assert.assertEquals(FlowException::class.java.name, persistedException!!.type)
+//            Assert.assertEquals("Just an exception", persistedException.message)
+//            Assert.assertEquals(ExceptionUtils.getStackTrace(e), persistedException.stackTrace)
+//            // TODO: this needs change once we save the exception blob
+//            Assert.assertEquals(null, persistedException.value)
+//        }
 
         assertFailsWith<IllegalStateException> {
             aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -367,6 +367,7 @@ class FlowClientIdTests {
         Assert.assertEquals(5, flowHandle1.resultFuture.getOrThrow(20.seconds))
     }
 
+    // the below test has to be made available only in ENT
 //    @Test(timeout=300_000)
 //    fun `on node restart -paused- flows with client id are hook-able`() {
 //        val clientId = UUID.randomUUID().toString()
@@ -465,6 +466,7 @@ class FlowClientIdTests {
         assertEquals(1, counter)
     }
 
+    // the below test has to be made available only in ENT
 //    @Test(timeout=300_000)
 //    fun `On 'startFlowInternal' throwing, subsequent request with same client hits the time window in which the previous request was about to remove the client id mapping`() {
 //        val clientId = UUID.randomUUID().toString()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -21,7 +21,6 @@ import net.corda.testing.node.internal.startFlowWithClientId
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import rx.Observable
 import java.lang.IllegalStateException

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -24,6 +24,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import rx.Observable
+import java.lang.IllegalArgumentException
 import java.lang.IllegalStateException
 import java.sql.SQLTransientConnectionException
 import java.util.UUID
@@ -595,12 +596,14 @@ class FlowClientIdTests {
     @Test(timeout=300_000)
     fun `subsequent request to failed flow that cannot find a 'DBFlowException' in the database, fails with 'IllegalStateException'`() {
         ResultFlow.hook = {
-            throw Exception()
+            // just throwing a different exception from the one expected out of startFlowWithClientId second call below ([IllegalStateException])
+            // to be sure [IllegalStateException] gets thrown from [DBFlowException] that is missing
+            throw IllegalArgumentException()
         }
         val clientId = UUID.randomUUID().toString()
 
         var flowHandle0: FlowStateMachineHandle<Int>? = null
-        assertFailsWith<Exception> {
+        assertFailsWith<IllegalArgumentException> {
             flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
             flowHandle0!!.resultFuture.getOrThrow()
         }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -785,7 +785,6 @@ class FlowFrameworkTests {
         }
     }
 
-    // TODO: modify the below to test to assert the same but BEFORE suspension after we add -> clearing the exception on 'retryFlowFromSafePoint'
     @Test(timeout=300_000)
     fun `Checkpoint status and error in memory and in DB are not dirtied upon flow retry`() {
         var firstExecution = true

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -694,14 +694,13 @@ class FlowFrameworkTests {
                 futureFiber.complete(flowFiber)
             }
         }
-        // TODO: make this test more strict => assert the below before checkpoint (after we add -> clearing the exception on 'StateMachineManager.start')
         SuspendingFlow.hookAfterCheckpoint = {
             dbCheckpointStatusAfterSuspension = aliceNode.internals.checkpointStorage.getCheckpointsToRun().toList().single()
                     .second.status
         }
 
         assertFailsWith<TimeoutException> {
-            aliceNode.services.startFlow(SuspendingFlow()).resultFuture.getOrThrow(30.seconds) // wait till flow gets hospitalized
+            aliceNode.services.startFlow(SuspendingFlow()).resultFuture.getOrThrow(10.seconds) // wait till flow gets hospitalized
         }
         // flow is in hospital
         assertTrue(flowState is FlowState.Unstarted)
@@ -716,7 +715,7 @@ class FlowFrameworkTests {
         aliceNode = mockNet.restartNode(aliceNode)
         futureFiber.get().resultFuture.getOrThrow() // wait until the flow has completed
         // checkpoint states ,after flow retried, before and after suspension
-        assertEquals(Checkpoint.FlowStatus.HOSPITALIZED, dbCheckpointStatusBeforeSuspension)
+        assertEquals(Checkpoint.FlowStatus.RUNNABLE, dbCheckpointStatusBeforeSuspension)
         assertEquals(Checkpoint.FlowStatus.RUNNABLE, inMemoryCheckpointStatusBeforeSuspension)
         assertEquals(Checkpoint.FlowStatus.RUNNABLE, dbCheckpointStatusAfterSuspension)
     }
@@ -744,7 +743,7 @@ class FlowFrameworkTests {
         }
 
         assertFailsWith<TimeoutException> {
-            aliceNode.services.startFlow(SuspendingFlow()).resultFuture.getOrThrow(30.seconds) // wait till flow gets hospitalized
+            aliceNode.services.startFlow(SuspendingFlow()).resultFuture.getOrThrow(10.seconds) // wait till flow gets hospitalized
         }
         // flow is in hospital
         assertTrue(flowState is FlowState.Started)
@@ -757,7 +756,7 @@ class FlowFrameworkTests {
         aliceNode = mockNet.restartNode(aliceNode)
         futureFiber.get().resultFuture.getOrThrow() // wait until the flow has completed
         // checkpoint states ,after flow retried, after suspension
-        assertEquals(Checkpoint.FlowStatus.HOSPITALIZED, dbCheckpointStatus)
+        assertEquals(Checkpoint.FlowStatus.RUNNABLE, dbCheckpointStatus)
         assertEquals(Checkpoint.FlowStatus.RUNNABLE, inMemoryCheckpointStatus)
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -817,6 +817,7 @@ class FlowFrameworkTests {
         var firstRun = true
         var counter = 0
         val waitUntilHospitalizedTwice = Semaphore(-1)
+
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
             ++counter
             if (firstRun) {
@@ -830,8 +831,13 @@ class FlowFrameworkTests {
             }
             waitUntilHospitalizedTwice.release()
         }
+
+        var counterRes = 0
+        StaffedFlowHospital.onFlowResuscitated.add { _, _, _ -> ++counterRes }
+
         waitUntilHospitalizedTwice.acquire()
         assertEquals(2, counter)
+        assertEquals(0, counterRes)
     }
     //region Helpers
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -75,7 +75,6 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import rx.Notification
 import rx.Observable
@@ -761,8 +760,6 @@ class FlowFrameworkTests {
         assertEquals(Checkpoint.FlowStatus.RUNNABLE, inMemoryCheckpointStatus)
     }
 
-    // Upon implementing CORDA-3681 unignore this test; DBFlowException is not currently integrated
-    @Ignore
     @Test(timeout=300_000)
     fun `Checkpoint is updated in DB with FAILED status and the error when flow fails`() {
         var flowId: StateMachineRunId? = null
@@ -786,8 +783,6 @@ class FlowFrameworkTests {
         }
     }
 
-    // Upon implementing CORDA-3681 unignore this test; DBFlowException is not currently integrated
-    @Ignore
     @Test(timeout=300_000)
     fun `Checkpoint is updated in DB with HOSPITALIZED status and the error when flow is kept for overnight observation` () {
         var flowId: StateMachineRunId? = null

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -813,25 +813,6 @@ class FlowFrameworkTests {
         assertEquals(null, persistedException)
     }
 
-    @Test(timeout=300_000)
-    fun `hospitalized flow, retains its database exception`() {
-        aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("hospitalizing") })
-
-        val waitUntilHospitalized = Semaphore(0)
-        StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
-            waitUntilHospitalized.release()
-        }
-
-        waitUntilHospitalized.acquire()
-        Thread.sleep(3000) // wait until flow saves overnight observation state in database
-
-        aliceNode.services.database.transaction {
-            val checkpointStatus =  findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().single().status
-            assertEquals(Checkpoint.FlowStatus.HOSPITALIZED, checkpointStatus)
-            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
-        }
-    }
-
     // When ported to ENT use the existing API there to properly retry the flow
     @Test(timeout=300_000)
     fun `Hospitalized flow, resets to 'RUNNABLE' and clears exception when retried`() {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -4,6 +4,8 @@ import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.concurrent.Semaphore
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
 import net.corda.client.rpc.notUsed
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.ContractState
@@ -829,6 +831,7 @@ class FlowFrameworkTests {
         }
     }
 
+    // When ported to ENT use the existing API there to properly retry the flow
     @Test
     fun `Hospitalized flow, resets to 'RUNNABLE' and clears exception when retried`() {
         aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("hospitalizing") })

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -813,10 +813,7 @@ class FlowFrameworkTests {
 
     @Test
     fun `Hospitalized flow, resets to 'RUNNABLE' and clears exception when retried`() {
-        aliceNode.services.startFlow(ExceptionFlow {
-            HospitalizeFlowException("hospitalizing")
-        }
-        )
+        aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("hospitalizing") })
 
         var firstRun = true
         var counter = 0

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -308,8 +308,7 @@ class FlowFrameworkTests {
             .withStackTraceContaining(ReceiveFlow::class.java.name)  // Make sure the stack trace is that of the receiving flow
             .withStackTraceContaining("Received counter-flow exception from peer")
         bobNode.database.transaction {
-            val checkpoint = bobNode.internals.checkpointStorage.checkpoints().single()
-            assertEquals(Checkpoint.FlowStatus.FAILED, checkpoint.status)
+            assertThat(bobNode.internals.checkpointStorage.checkpoints()).isEmpty()
         }
 
         assertThat(receivingFiber.state).isEqualTo(Strand.State.WAITING)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -1182,7 +1182,7 @@ internal class SuspendingFlow : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         stateMachine.hookBeforeCheckpoint()
-        sleep(1.seconds) // flow checkpoints => checkpoint is in DB
+        stateMachine.suspend(FlowIORequest.ForceCheckpoint, maySkipCheckpoint = false) // flow checkpoints => checkpoint is in DB
         stateMachine.hookAfterCheckpoint()
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -812,7 +812,7 @@ class FlowFrameworkTests {
         assertEquals(null, persistedException)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `hospitalized flow, retains its database exception`() {
         aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("hospitalizing") })
 
@@ -832,7 +832,7 @@ class FlowFrameworkTests {
     }
 
     // When ported to ENT use the existing API there to properly retry the flow
-    @Test
+    @Test(timeout=300_000)
     fun `Hospitalized flow, resets to 'RUNNABLE' and clears exception when retried`() {
         aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("hospitalizing") })
 
@@ -862,7 +862,7 @@ class FlowFrameworkTests {
         assertEquals(0, counterRes)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `Hospitalized flow, resets to 'RUNNABLE' and clears database exception on node start`() {
         var checkpointStatusAfterRestart: Checkpoint.FlowStatus? = null
         var dbExceptionAfterRestart: List<DBCheckpointStorage.DBFlowException>? = null

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -30,6 +30,7 @@ import net.corda.core.internal.declaredField
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.node.services.PartyInfo
 import net.corda.core.node.services.queryBy
+import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
@@ -775,11 +776,13 @@ class FlowFrameworkTests {
             assertEquals(Checkpoint.FlowStatus.HOSPITALIZED, checkpoint.status)
 
             // assert all fields of DBFlowException
-            val persistedException = aliceNode.internals.checkpointStorage.getDBCheckpoint(flowId!!)!!.exceptionDetails
-            assertEquals(HospitalizeFlowException::class.java.name, persistedException!!.type)
-            assertEquals("Overnight observation", persistedException.message)
-            // TODO: this needs change once we save the exception blob
-            assertEquals(null, persistedException.value)
+            val exceptionDetails = aliceNode.internals.checkpointStorage.getDBCheckpoint(flowId!!)!!.exceptionDetails
+            assertEquals(HospitalizeFlowException::class.java.name, exceptionDetails!!.type)
+            assertEquals("Overnight observation", exceptionDetails.message)
+            val deserializedException = exceptionDetails.value?.let { SerializedBytes<Any>(it) }?.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)
+            assertNotNull(deserializedException)
+            val hospitalizeFlowException = deserializedException as HospitalizeFlowException
+            assertEquals("Overnight observation", hospitalizeFlowException.message)
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -64,7 +64,6 @@ import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.getMessage
 import net.corda.testing.node.internal.startFlow
 import net.corda.testing.node.internal.startFlowWithClientId
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType
@@ -817,7 +816,7 @@ class FlowFrameworkTests {
 
         var firstRun = true
         var counter = 0
-        val flowHospitalizedTwice = Semaphore(-1)
+        val waitUntilHospitalizedTwice = Semaphore(-1)
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
             ++counter
             if (firstRun) {
@@ -829,9 +828,9 @@ class FlowFrameworkTests {
                     fiber.scheduleEvent(Event.RetryFlowFromSafePoint)
                 }
             }
-            flowHospitalizedTwice.release()
+            waitUntilHospitalizedTwice.release()
         }
-        flowHospitalizedTwice.acquire()
+        waitUntilHospitalizedTwice.acquire()
         assertEquals(2, counter)
     }
     //region Helpers

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -685,6 +685,7 @@ class FlowFrameworkTests {
             flowState = flowFiber!!.transientState.checkpoint.flowState
 
             if (firstExecution) {
+                firstExecution = false
                 throw HospitalizeFlowException()
             } else {
                 dbCheckpointStatusBeforeSuspension = aliceNode.internals.checkpointStorage.getCheckpoints().toList().single().second.status
@@ -711,7 +712,6 @@ class FlowFrameworkTests {
             assertEquals(Checkpoint.FlowStatus.HOSPITALIZED, checkpoint.status)
         }
         // restart Node - flow will be loaded from checkpoint
-        firstExecution = false
         aliceNode = mockNet.restartNode(aliceNode)
         futureFiber.get().resultFuture.getOrThrow() // wait until the flow has completed
         // checkpoint states ,after flow retried, before and after suspension
@@ -733,6 +733,7 @@ class FlowFrameworkTests {
             flowState = flowFiber!!.transientState.checkpoint.flowState
 
             if (firstExecution) {
+                firstExecution = false
                 throw HospitalizeFlowException()
             } else {
                 dbCheckpointStatus = aliceNode.internals.checkpointStorage.getCheckpoints().toList().single().second.status
@@ -752,7 +753,6 @@ class FlowFrameworkTests {
             assertEquals(Checkpoint.FlowStatus.HOSPITALIZED, checkpoint.status)
         }
         // restart Node - flow will be loaded from checkpoint
-        firstExecution = false
         aliceNode = mockNet.restartNode(aliceNode)
         futureFiber.get().resultFuture.getOrThrow() // wait until the flow has completed
         // checkpoint states ,after flow retried, after suspension

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -4,8 +4,6 @@ import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.concurrent.Semaphore
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.whenever
 import net.corda.client.rpc.notUsed
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.ContractState

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -814,8 +814,6 @@ class FlowFrameworkTests {
     // When ported to ENT use the existing API there to properly retry the flow
     @Test(timeout=300_000)
     fun `Hospitalized flow, resets to 'RUNNABLE' and clears exception when retried`() {
-        aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("hospitalizing") })
-
         var firstRun = true
         var counter = 0
         val waitUntilHospitalizedTwice = Semaphore(-1)
@@ -836,6 +834,8 @@ class FlowFrameworkTests {
 
         var counterRes = 0
         StaffedFlowHospital.onFlowResuscitated.add { _, _, _ -> ++counterRes }
+
+        aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("hospitalizing") })
 
         waitUntilHospitalizedTwice.acquire()
         assertEquals(2, counter)
@@ -861,8 +861,6 @@ class FlowFrameworkTests {
             throw HospitalizeFlowException("hospitalizing")
         }
 
-        aliceNode.services.startFlow(SuspendingFlow())
-
         var counter = 0
         val waitUntilHospitalized = Semaphore(0)
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { _, _ ->
@@ -872,6 +870,8 @@ class FlowFrameworkTests {
 
         var counterRes = 0
         StaffedFlowHospital.onFlowResuscitated.add { _, _, _ -> ++counterRes }
+
+        aliceNode.services.startFlow(SuspendingFlow())
 
         waitUntilHospitalized.acquire()
         Thread.sleep(3000) // wait until flow saves overnight observation state in database


### PR DESCRIPTION
Enhance rpc acknowledgement method (`removeClientId`) to remove checkpoint from all checkpoint database tables.

Optimize `CheckpointStorage.removeCheckpoint`  to not attempt to delete from database results (`DBFlowResult`) or exceptions (`DBFlowException`) if not needed.