### PR TITLE
CORDA-3942: Disable IRSDemoTest

### DIFF
--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -40,6 +40,7 @@ import rx.Observable
 import java.time.Duration
 import java.time.LocalDate
 
+@Ignore
 class IRSDemoTest {
     companion object {
         private val log = contextLogger()
@@ -51,7 +52,7 @@ class IRSDemoTest {
     private val maxWaitTime: Duration = 150.seconds
 
     @Test(timeout=300_000)
-	fun `runs IRS demo`() {
+    fun `runs IRS demo`() {
         springDriver(DriverParameters(
                 useTestClock = true,
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, rpcUsers = rpcUsers)),

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -39,6 +39,7 @@ import org.junit.Test
 import rx.Observable
 import java.time.Duration
 import java.time.LocalDate
+import org.junit.Ignore
 
 @Ignore
 class IRSDemoTest {


### PR DESCRIPTION
Temporarily disable IRSDemoTest as it is breaking many OS builds.

The IRS Demo tests are a frequent cause of build failures for OS. Of the last 7 build failures, 3 have included IRS demo as a failing test (builds 121, 126 and 130).

Recommend we disable this test as the frequency with which it fails make it unreliable in diagnosing problems in Corda.

https://ci01.dev.r3.com/job/Corda-Open-Source/job/Corda-OS-Release-Branch-Tests/job/corda/job/release%252Fos%252F4.6/