### PR TITLE
CORDA-3612 - Delete flow results/ exceptions once received by rpc client

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -33,11 +33,11 @@ interface CheckpointStorage {
     /**
      * Remove existing checkpoint from the store.
      *
-     * [mayBeFinished] is used for optimization. If set to [false] it will not attempt to delete the database result or the database exception.
-     * Please note that if there is a doubt on whether a flow could be finished or not [mayBeFinished] should be set to [true].
+     * [mayHavePersistentResults] is used for optimization. If set to [false] it will not attempt to delete the database result or the database exception.
+     * Please note that if there is a doubt on whether a flow could be finished or not [mayHavePersistentResults] should be set to [true].
      * @return whether the id matched a checkpoint that was removed.
      */
-    fun removeCheckpoint(id: StateMachineRunId, mayBeFinished: Boolean = true): Boolean
+    fun removeCheckpoint(id: StateMachineRunId, mayHavePersistentResults: Boolean = true): Boolean
 
     /**
      * Load an existing checkpoint from the store.

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -32,9 +32,12 @@ interface CheckpointStorage {
 
     /**
      * Remove existing checkpoint from the store.
+     *
+     * [mayBeFinished] is used for optimization. If set to [false] it will not attempt to delete the database result or the database exception.
+     * Please note that if there is a doubt on whether a flow could be finished or not [mayBeFinished] should be set to [true].
      * @return whether the id matched a checkpoint that was removed.
      */
-    fun removeCheckpoint(id: StateMachineRunId): Boolean
+    fun removeCheckpoint(id: StateMachineRunId, mayBeFinished: Boolean = true): Boolean
 
     /**
      * Load an existing checkpoint from the store.

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -482,16 +482,16 @@ class DBCheckpointStorage(
         query.executeUpdate()
     }
 
-    // We cant have a result and an exception for the same checkpoint. The below method should be changed to get a [succeeded: Boolean] parameter
-    // so that it only deletes a result or an exception. That way we ll save an extra delete statement everytime we remove a checkpoint.
     @Suppress("MagicNumber")
-    override fun removeCheckpoint(id: StateMachineRunId): Boolean {
+    override fun removeCheckpoint(id: StateMachineRunId, mayBeFinished: Boolean): Boolean {
         var deletedRows = 0
         val flowId = id.uuid.toString()
         deletedRows += deleteRow(DBFlowCheckpoint::class.java, DBFlowCheckpoint::flowId.name, flowId)
         deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
-        deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
-        deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
+        if (mayBeFinished) {
+            deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
+            deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
+        }
         deletedRows += deleteRow(DBFlowMetadata::class.java, DBFlowMetadata::flowId.name, flowId)
         return deletedRows >= 2
     }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -483,12 +483,12 @@ class DBCheckpointStorage(
     }
 
     @Suppress("MagicNumber")
-    override fun removeCheckpoint(id: StateMachineRunId, mayBeFinished: Boolean): Boolean {
+    override fun removeCheckpoint(id: StateMachineRunId, mayHavePersistentResults: Boolean): Boolean {
         var deletedRows = 0
         val flowId = id.uuid.toString()
         deletedRows += deleteRow(DBFlowCheckpoint::class.java, DBFlowCheckpoint::flowId.name, flowId)
         deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
-        if (mayBeFinished) {
+        if (mayHavePersistentResults) {
             deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
             deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -488,11 +488,11 @@ class DBCheckpointStorage(
     override fun removeCheckpoint(id: StateMachineRunId): Boolean {
         var deletedRows = 0
         val flowId = id.uuid.toString()
-        deletedRows += deleteRow(DBFlowMetadata::class.java, DBFlowMetadata::flowId.name, flowId)
-        deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
-        deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
-        deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
         deletedRows += deleteRow(DBFlowCheckpoint::class.java, DBFlowCheckpoint::flowId.name, flowId)
+        deletedRows += deleteRow(DBFlowCheckpointBlob::class.java, DBFlowCheckpointBlob::flowId.name, flowId)
+        deletedRows += deleteRow(DBFlowResult::class.java, DBFlowResult::flow_id.name, flowId)
+        deletedRows += deleteRow(DBFlowException::class.java, DBFlowException::flow_id.name, flowId)
+        deletedRows += deleteRow(DBFlowMetadata::class.java, DBFlowMetadata::flowId.name, flowId)
         return deletedRows >= 2
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -482,6 +482,8 @@ class DBCheckpointStorage(
         query.executeUpdate()
     }
 
+    // We cant have a result and an exception for the same checkpoint. The below method should be changed to get a [succeeded: Boolean] parameter
+    // so that it only deletes a result or an exception. That way we ll save an extra delete statement everytime we remove a checkpoint.
     @Suppress("MagicNumber")
     override fun removeCheckpoint(id: StateMachineRunId): Boolean {
         var deletedRows = 0

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -58,9 +58,11 @@ sealed class Action {
     data class PersistCheckpoint(val id: StateMachineRunId, val checkpoint: Checkpoint, val isCheckpointUpdate: Boolean) : Action()
 
     /**
-     * Remove the checkpoint corresponding to [id].
+     * Remove the checkpoint corresponding to [id]. [mayBeFinished] denotes that at the time of injecting a [RemoveCheckpoint]
+     * the flow could have finished and persisted with such a state in the database.
+     * For more information see [CheckpointStorage.removeCheckpoint].
      */
-    data class RemoveCheckpoint(val id: StateMachineRunId) : Action()
+    data class RemoveCheckpoint(val id: StateMachineRunId, val mayBeFinished: Boolean = false) : Action()
 
     /**
      * Persist the deduplication facts of [deduplicationHandlers].

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -58,11 +58,11 @@ sealed class Action {
     data class PersistCheckpoint(val id: StateMachineRunId, val checkpoint: Checkpoint, val isCheckpointUpdate: Boolean) : Action()
 
     /**
-     * Remove the checkpoint corresponding to [id]. [mayBeFinished] denotes that at the time of injecting a [RemoveCheckpoint]
-     * the flow could have finished and persisted with such a state in the database.
+     * Remove the checkpoint corresponding to [id]. [mayHavePersistentResults] denotes that at the time of injecting a [RemoveCheckpoint]
+     * the flow could have persisted its database result or exception.
      * For more information see [CheckpointStorage.removeCheckpoint].
      */
-    data class RemoveCheckpoint(val id: StateMachineRunId, val mayBeFinished: Boolean = false) : Action()
+    data class RemoveCheckpoint(val id: StateMachineRunId, val mayHavePersistentResults: Boolean = false) : Action()
 
     /**
      * Persist the deduplication facts of [deduplicationHandlers].

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -151,7 +151,7 @@ internal class ActionExecutorImpl(
 
     @Suspendable
     private fun executeRemoveCheckpoint(action: Action.RemoveCheckpoint) {
-        checkpointStorage.removeCheckpoint(action.id, action.mayBeFinished)
+        checkpointStorage.removeCheckpoint(action.id, action.mayHavePersistentResults)
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -151,7 +151,7 @@ internal class ActionExecutorImpl(
 
     @Suspendable
     private fun executeRemoveCheckpoint(action: Action.RemoveCheckpoint) {
-        checkpointStorage.removeCheckpoint(action.id)
+        checkpointStorage.removeCheckpoint(action.id, action.mayBeFinished)
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -942,7 +942,7 @@ internal class SingleThreadedStateMachineManager(
                 if (existingStatus is FlowWithClientIdStatus.Removed) {
                     removedFlowId = existingStatus.flowId
                     null
-                } else { // don't remove
+                } else {
                     existingStatus
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -938,8 +938,8 @@ internal class SingleThreadedStateMachineManager(
     override fun removeClientId(clientId: String): Boolean {
         var removedFlowId: StateMachineRunId? = null
         innerState.withLock {
-            clientIdsToFlowIds.compute(clientId) { _, existingStatus ->
-                if (existingStatus != null && existingStatus is FlowWithClientIdStatus.Removed) {
+            clientIdsToFlowIds.computeIfPresent(clientId) { _, existingStatus ->
+                if (existingStatus is FlowWithClientIdStatus.Removed) {
                     removedFlowId = existingStatus.flowId
                     null
                 } else { // don't remove

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -949,8 +949,7 @@ internal class SingleThreadedStateMachineManager(
         }
 
         removedFlowId?.let {
-            database.transaction { checkpointStorage.removeCheckpoint(it, mayBeFinished = true) }
-            return true
+            return database.transaction { checkpointStorage.removeCheckpoint(it, mayBeFinished = true) }
         }
         return false
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -329,7 +329,7 @@ internal class SingleThreadedStateMachineManager(
                 // The checkpoint and soft locks are removed here instead of relying on the processing of the next event after setting
                 // the killed flag. This is to ensure a flow can be removed from the database, even if it is stuck in a infinite loop.
                 database.transaction {
-                    checkpointStorage.removeCheckpoint(id)
+                    checkpointStorage.removeCheckpoint(id, mayBeFinished = true)
                     serviceHub.vaultService.softLockRelease(id.uuid)
                 }
                 // the same code is NOT done in remove flow when an error occurs
@@ -342,7 +342,7 @@ internal class SingleThreadedStateMachineManager(
                 true
             } else {
                 // It may be that the id refers to a checkpoint that couldn't be deserialised into a flow, so we delete it if it exists.
-                database.transaction { checkpointStorage.removeCheckpoint(id) }
+                database.transaction { checkpointStorage.removeCheckpoint(id, mayBeFinished = true) }
             }
         }
         return if (killFlowResult) {
@@ -949,7 +949,7 @@ internal class SingleThreadedStateMachineManager(
         }
 
         removedFlowId?.let {
-            database.transaction { checkpointStorage.removeCheckpoint(it) }
+            database.transaction { checkpointStorage.removeCheckpoint(it, mayBeFinished = true) }
             return true
         }
         return false

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -329,7 +329,7 @@ internal class SingleThreadedStateMachineManager(
                 // The checkpoint and soft locks are removed here instead of relying on the processing of the next event after setting
                 // the killed flag. This is to ensure a flow can be removed from the database, even if it is stuck in a infinite loop.
                 database.transaction {
-                    checkpointStorage.removeCheckpoint(id, mayBeFinished = true)
+                    checkpointStorage.removeCheckpoint(id, mayHavePersistentResults = true)
                     serviceHub.vaultService.softLockRelease(id.uuid)
                 }
                 // the same code is NOT done in remove flow when an error occurs
@@ -342,7 +342,7 @@ internal class SingleThreadedStateMachineManager(
                 true
             } else {
                 // It may be that the id refers to a checkpoint that couldn't be deserialised into a flow, so we delete it if it exists.
-                database.transaction { checkpointStorage.removeCheckpoint(id, mayBeFinished = true) }
+                database.transaction { checkpointStorage.removeCheckpoint(id, mayHavePersistentResults = true) }
             }
         }
         return if (killFlowResult) {
@@ -949,7 +949,7 @@ internal class SingleThreadedStateMachineManager(
         }
 
         removedFlowId?.let {
-            return database.transaction { checkpointStorage.removeCheckpoint(it, mayBeFinished = true) }
+            return database.transaction { checkpointStorage.removeCheckpoint(it, mayHavePersistentResults = true) }
         }
         return false
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -44,7 +44,7 @@ class KilledFlowTransition(
             }
             // The checkpoint and soft locks are also removed directly in [StateMachineManager.killFlow]
             if (startingState.isAnyCheckpointPersisted) {
-                actions.add(Action.RemoveCheckpoint(context.id, mayBeFinished = true))
+                actions.add(Action.RemoveCheckpoint(context.id, mayHavePersistentResults = true))
             }
             actions.addAll(
                 arrayOf(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -44,7 +44,7 @@ class KilledFlowTransition(
             }
             // The checkpoint and soft locks are also removed directly in [StateMachineManager.killFlow]
             if (startingState.isAnyCheckpointPersisted) {
-                actions.add(Action.RemoveCheckpoint(context.id))
+                actions.add(Action.RemoveCheckpoint(context.id, mayBeFinished = true))
             }
             actions.addAll(
                 arrayOf(

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -297,6 +297,55 @@ class FlowClientIdTests {
     }
 
     @Test(timeout=300_000)
+    fun `removing a client id result clears resources properly`() {
+        val clientId = UUID.randomUUID().toString()
+        aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5)).resultFuture.getOrThrow()
+        // assert database status before remove
+        aliceNode.services.database.transaction {
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowResult>().size)
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
+        }
+
+        aliceNode.smm.removeClientId(clientId)
+
+        // assert database status after remove
+        aliceNode.services.database.transaction {
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowResult>().size)
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
+        }
+    }
+
+    @Test(timeout=300_000)
+    fun `removing a client id exception clears resources properly`() {
+        val clientId = UUID.randomUUID().toString()
+        ResultFlow.hook = { throw IllegalStateException() }
+        assertFailsWith<IllegalStateException> {
+            aliceNode.services.startFlowWithClientId(clientId, ResultFlow(Unit)).resultFuture.getOrThrow()
+        }
+        // assert database status before remove
+        aliceNode.services.database.transaction {
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
+            assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
+        }
+
+        aliceNode.smm.removeClientId(clientId)
+
+        // assert database status after remove
+        aliceNode.services.database.transaction {
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().size)
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpointBlob>().size)
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowException>().size)
+            assertEquals(0, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
+        }
+    }
+
+    @Test(timeout=300_000)
     fun `flow's client id mapping can only get removed once the flow gets removed`() {
         val clientId = UUID.randomUUID().toString()
         var tries = 0


### PR DESCRIPTION
Enhance rpc acknowledgement method (removeClientId) to remove checkpoint from all checkpoint database tables.

Optimize CheckpointStorage.removeCheckpoint to not attempt to delete from database results (DBFlowResult) or exceptions (DBFlowException) if not needed.