### PR TITLE
CORDA-3944 Clean up ExceptionsErrorCodeFunctionsTest

### DIFF
--- a/common/logging/src/test/kotlin/net/corda/commmon/logging/ExceptionsErrorCodeFunctionsTest.kt
+++ b/common/logging/src/test/kotlin/net/corda/commmon/logging/ExceptionsErrorCodeFunctionsTest.kt
@@ -9,26 +9,32 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class ExceptionsErrorCodeFunctionsTest {
-
-    @Test(timeout=3_000)
-    fun `error code for message prints out message and full stack trace`() {
-        val originalMessage = SimpleMessage("This is a test message")
-        var previous: Exception? = null
-        val throwables = (0..10).map {
-            val current = TestThrowable(it, previous)
-            previous = current
-            current
+    private companion object {
+        private const val EXCEPTION_MESSAGE = "This is exception "
+        private const val TEST_MESSAGE = "This is a test message"
+        private fun makeChain(previous: Exception?, ttl: Int): Exception {
+            val current = TestThrowable(ttl, previous)
+            return if (ttl == 0) {
+                current
+            } else {
+                makeChain(current, ttl - 1)
+            }
         }
-        val exception = throwables.last()
+    }
+
+    @Test(timeout=5_000)
+    fun `error code for message prints out message and full stack trace`() {
+        val originalMessage = SimpleMessage(TEST_MESSAGE)
+        val exception = makeChain(null, 10)
         val message = originalMessage.withErrorCodeFor(exception, Level.ERROR)
-        assertThat(message.formattedMessage, contains("This is a test message".toRegex()))
+        assertThat(message.formattedMessage, contains(TEST_MESSAGE.toRegex()))
         for (i in (0..10)) {
-            assertThat(message.formattedMessage, contains("This is exception $i".toRegex()))
+            assertThat(message.formattedMessage, contains("$EXCEPTION_MESSAGE $i".toRegex()))
         }
         assertEquals(message.format, originalMessage.format)
         assertEquals(message.parameters, originalMessage.parameters)
         assertEquals(message.throwable, originalMessage.throwable)
     }
 
-    private class TestThrowable(index: Int, cause: Exception?) : Exception("This is exception $index", cause)
+    private class TestThrowable(index: Int, cause: Exception?) : Exception("$EXCEPTION_MESSAGE $index", cause)
 }


### PR DESCRIPTION
* Increase timeout to provide more of an error margin, after seeing a test failure in Jenkins.
* Move shared strings to constants.
* Extract chain building code into recursive function.