### PR TITLE
CORDA-3491 - Do not keep flow state in memory after a flow has finished

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -160,7 +160,7 @@ class DBCheckpointStorage(
         var checkpoint: ByteArray = EMPTY_BYTE_ARRAY,
 
         @Type(type = "corda-blob")
-        @Column(name = "flow_state")
+        @Column(name = "flow_state", nullable = true)
         var flowStack: ByteArray?,
 
         @Type(type = "corda-wrapper-binary")

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -83,6 +83,7 @@ internal class ActionExecutorImpl(
         val checkpoint = action.checkpoint
         val flowState = checkpoint.flowState
         val serializedFlowState = when(flowState) {
+            null -> null
             FlowState.Completed -> null
             // upon implementing CORDA-3816: If we have errored or hospitalized then we don't need to serialize the flowState as it will not get saved in the DB
             else -> flowState.checkpointSerialize(checkpointSerializationContext)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -83,7 +83,6 @@ internal class ActionExecutorImpl(
         val checkpoint = action.checkpoint
         val flowState = checkpoint.flowState
         val serializedFlowState = when(flowState) {
-            null -> null
             FlowState.Completed -> null
             // upon implementing CORDA-3816: If we have errored or hospitalized then we don't need to serialize the flowState as it will not get saved in the DB
             else -> flowState.checkpointSerialize(checkpointSerializationContext)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -83,7 +83,7 @@ internal class ActionExecutorImpl(
         val checkpoint = action.checkpoint
         val flowState = checkpoint.flowState
         val serializedFlowState = when(flowState) {
-            FlowState.Completed -> null
+            FlowState.Finished -> null
             // upon implementing CORDA-3816: If we have errored or hospitalized then we don't need to serialize the flowState as it will not get saved in the DB
             else -> flowState.checkpointSerialize(checkpointSerializationContext)
         }
@@ -92,8 +92,8 @@ internal class ActionExecutorImpl(
         if (action.isCheckpointUpdate) {
             checkpointStorage.updateCheckpoint(action.id, checkpoint, serializedFlowState, serializedCheckpointState)
         } else {
-            if (flowState is FlowState.Completed) {
-                throw IllegalStateException("A new checkpoint cannot be created with a Completed FlowState.")
+            if (flowState is FlowState.Finished) {
+                throw IllegalStateException("A new checkpoint cannot be created with a finished flow state.")
             }
             checkpointStorage.addCheckpoint(action.id, checkpoint, serializedFlowState!!, serializedCheckpointState)
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -767,7 +767,7 @@ internal class SingleThreadedStateMachineManager(
             is FlowState.Started -> {
                 Fiber.unparkDeserialized(flow.fiber, scheduler)
             }
-            is FlowState.Completed -> throw IllegalStateException("Cannot start (or resume) a completed flow.")
+            is FlowState.Finished -> throw IllegalStateException("Cannot start (or resume) a finished flow.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -349,7 +349,7 @@ sealed class FlowState {
     object Paused: FlowState()
 
     /**
-     * The flow has completed. It does not have a running fiber that needs to be serialized and checkpointed.
+     * The flow has finished. It does not have a running fiber that needs to be serialized and checkpointed.
      */
     object Finished : FlowState()
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -81,7 +81,7 @@ data class StateMachineState(
  */
 data class Checkpoint(
         val checkpointState: CheckpointState,
-        val flowState: FlowState?,
+        val flowState: FlowState,
         val errorState: ErrorState,
         val result: Any? = null,
         val status: FlowStatus = FlowStatus.RUNNABLE,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -206,7 +206,7 @@ data class Checkpoint(
         fun deserialize(checkpointSerializationContext: CheckpointSerializationContext): Checkpoint {
             val flowState = when(status) {
                 FlowStatus.PAUSED -> FlowState.Paused
-                FlowStatus.COMPLETED -> FlowState.Finished
+                FlowStatus.COMPLETED, FlowStatus.FAILED -> FlowState.Finished
                 else -> serializedFlowState!!.checkpointDeserialize(checkpointSerializationContext)
             }
             return Checkpoint(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -206,7 +206,7 @@ data class Checkpoint(
         fun deserialize(checkpointSerializationContext: CheckpointSerializationContext): Checkpoint {
             val flowState = when(status) {
                 FlowStatus.PAUSED -> FlowState.Paused
-                FlowStatus.COMPLETED -> FlowState.Completed
+                FlowStatus.COMPLETED -> FlowState.Finished
                 else -> serializedFlowState!!.checkpointDeserialize(checkpointSerializationContext)
             }
             return Checkpoint(
@@ -351,7 +351,7 @@ sealed class FlowState {
     /**
      * The flow has completed. It does not have a running fiber that needs to be serialized and checkpointed.
      */
-    object Completed : FlowState()
+    object Finished : FlowState()
 
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -81,7 +81,7 @@ data class StateMachineState(
  */
 data class Checkpoint(
         val checkpointState: CheckpointState,
-        val flowState: FlowState,
+        val flowState: FlowState?,
         val errorState: ErrorState,
         val result: Any? = null,
         val status: FlowStatus = FlowStatus.RUNNABLE,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -33,7 +33,6 @@ class DoRemainingWorkTransition(
             is FlowState.Started -> StartedFlowTransition(context, startingState, flowState).transition()
             is FlowState.Completed -> throw IllegalStateException("Cannot transition a state with completed flow state.")
             is FlowState.Paused -> throw IllegalStateException("Cannot transition a state with paused flow state.")
-            null -> throw IllegalStateException("Cannot transition a state with null flow state.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -32,6 +32,7 @@ class DoRemainingWorkTransition(
             is FlowState.Started -> StartedFlowTransition(context, startingState, flowState).transition()
             is FlowState.Completed -> throw IllegalStateException("Cannot transition a state with completed flow state.")
             is FlowState.Paused -> throw IllegalStateException("Cannot transition a state with paused flow state.")
+            null -> throw IllegalStateException("Cannot transition a state with null flow state.")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -25,6 +25,7 @@ class DoRemainingWorkTransition(
     }
 
     // If the flow is clean check the FlowState
+    @Suppress("ThrowsCount")
     private fun cleanTransition(): TransitionResult {
         val flowState = startingState.checkpoint.flowState
         return when (flowState) {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt
@@ -31,7 +31,7 @@ class DoRemainingWorkTransition(
         return when (flowState) {
             is FlowState.Unstarted -> UnstartedFlowTransition(context, startingState, flowState).transition()
             is FlowState.Started -> StartedFlowTransition(context, startingState, flowState).transition()
-            is FlowState.Completed -> throw IllegalStateException("Cannot transition a state with completed flow state.")
+            is FlowState.Finished -> throw IllegalStateException("Cannot transition a state with finished flow state.")
             is FlowState.Paused -> throw IllegalStateException("Cannot transition a state with paused flow state.")
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
@@ -64,7 +64,7 @@ class ErrorFlowTransition(
                 val removeOrPersistCheckpoint = if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
                     Action.RemoveCheckpoint(context.id)
                 } else {
-                    Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
+                    Action.PersistCheckpoint(context.id, newCheckpoint.copy(flowState = null), isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
                 }
 
                 actions.addAll(arrayOf(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
@@ -64,7 +64,7 @@ class ErrorFlowTransition(
                 val removeOrPersistCheckpoint = if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
                     Action.RemoveCheckpoint(context.id)
                 } else {
-                    Action.PersistCheckpoint(context.id, newCheckpoint.copy(flowState = FlowState.Completed), isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
+                    Action.PersistCheckpoint(context.id, newCheckpoint.copy(flowState = FlowState.Finished), isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
                 }
 
                 actions.addAll(arrayOf(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
@@ -64,7 +64,7 @@ class ErrorFlowTransition(
                 val removeOrPersistCheckpoint = if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
                     Action.RemoveCheckpoint(context.id)
                 } else {
-                    Action.PersistCheckpoint(context.id, newCheckpoint.copy(flowState = null), isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
+                    Action.PersistCheckpoint(context.id, newCheckpoint.copy(flowState = FlowState.Completed), isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
                 }
 
                 actions.addAll(arrayOf(

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -248,7 +248,7 @@ class TopLevelTransition(
                             actions.add(
                                 Action.PersistCheckpoint(
                                     context.id,
-                                    currentState.checkpoint.copy(flowState = FlowState.Finished),
+                                    currentState.checkpoint,
                                     isCheckpointUpdate = currentState.isAnyCheckpointPersisted
                                 )
                             )

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -248,7 +248,7 @@ class TopLevelTransition(
                             actions.add(
                                 Action.PersistCheckpoint(
                                     context.id,
-                                    currentState.checkpoint,
+                                    currentState.checkpoint.copy(flowState = null),
                                     isCheckpointUpdate = currentState.isAnyCheckpointPersisted
                                 )
                             )

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -248,7 +248,7 @@ class TopLevelTransition(
                             actions.add(
                                 Action.PersistCheckpoint(
                                     context.id,
-                                    currentState.checkpoint.copy(flowState = null),
+                                    currentState.checkpoint.copy(flowState = FlowState.Completed),
                                     isCheckpointUpdate = currentState.isAnyCheckpointPersisted
                                 )
                             )

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -232,7 +232,7 @@ class TopLevelTransition(
                                 checkpointState = checkpoint.checkpointState.copy(
                                         numberOfSuspends = checkpoint.checkpointState.numberOfSuspends + 1
                                 ),
-                                flowState = FlowState.Completed,
+                                flowState = FlowState.Finished,
                                 result = event.returnValue,
                                 status = Checkpoint.FlowStatus.COMPLETED
                             ),
@@ -248,7 +248,7 @@ class TopLevelTransition(
                             actions.add(
                                 Action.PersistCheckpoint(
                                     context.id,
-                                    currentState.checkpoint.copy(flowState = FlowState.Completed),
+                                    currentState.checkpoint.copy(flowState = FlowState.Finished),
                                     isCheckpointUpdate = currentState.isAnyCheckpointPersisted
                                 )
                             )

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -446,7 +446,7 @@ class DBCheckpointStorageTests {
         database.transaction { checkpointStorage.updateCheckpoint(id, updatedCheckpoint, updatedSerializedFlowState, updatedCheckpoint.serializeCheckpointState()) }
         database.transaction {
             // Checkpoint always returns clean error state when retrieved via [getCheckpoint]
-            assertTrue(checkpointStorage.getCheckpoint(id)!!.errorState is ErrorState.Clean)
+            assertTrue(checkpointStorage.getCheckpoint(id)!!.deserialize().errorState is ErrorState.Clean)
             val exceptionDetails = session.get(DBCheckpointStorage.DBFlowCheckpoint::class.java, id.uuid.toString()).exceptionDetails
             assertNotNull(exceptionDetails)
             assertEquals(exception::class.java.name, exceptionDetails!!.type)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -446,7 +446,7 @@ class DBCheckpointStorageTests {
         database.transaction { checkpointStorage.updateCheckpoint(id, updatedCheckpoint, updatedSerializedFlowState, updatedCheckpoint.serializeCheckpointState()) }
         database.transaction {
             // Checkpoint always returns clean error state when retrieved via [getCheckpoint]
-            assertTrue(checkpointStorage.getCheckpoint(id)!!.deserialize().errorState is ErrorState.Clean)
+            assertTrue(checkpointStorage.getCheckpoint(id)!!.errorState is ErrorState.Clean)
             val exceptionDetails = session.get(DBCheckpointStorage.DBFlowCheckpoint::class.java, id.uuid.toString()).exceptionDetails
             assertNotNull(exceptionDetails)
             assertEquals(exception::class.java.name, exceptionDetails!!.type)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -88,7 +88,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             assertEquals(serializedFlowState, checkpointStorage.checkpoints().single().serializedFlowState)
@@ -115,7 +115,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         val logic: FlowLogic<*> = object : FlowLogic<String>() {
             override fun call(): String {
@@ -148,7 +148,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
 
         val completedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.COMPLETED)
@@ -168,7 +168,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
 
         val pausedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.PAUSED)
@@ -189,7 +189,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.addError(exception)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -228,7 +228,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.copy(result = "The result", status = Checkpoint.FlowStatus.COMPLETED)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -269,8 +269,8 @@ class DBCheckpointStorageTests {
         val (id2, checkpoint2) = newCheckpoint()
         val serializedFlowState2 = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
-            checkpointStorage.addCheckpoint(id2, checkpoint2, serializedFlowState2, checkpoint2.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id2, checkpoint2, serializedFlowState2!!, checkpoint2.serializeCheckpointState())
             checkpointStorage.removeCheckpoint(id)
         }
         database.transaction {
@@ -294,12 +294,12 @@ class DBCheckpointStorageTests {
         val serializedFirstFlowState = firstCheckpoint.serializeFlowState()
 
         database.transaction {
-            checkpointStorage.addCheckpoint(id, firstCheckpoint, serializedFirstFlowState, firstCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, firstCheckpoint, serializedFirstFlowState!!, firstCheckpoint.serializeCheckpointState())
         }
         val (id2, secondCheckpoint) = newCheckpoint()
         val serializedSecondFlowState = secondCheckpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id2, secondCheckpoint, serializedSecondFlowState, secondCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id2, secondCheckpoint, serializedSecondFlowState!!, secondCheckpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.removeCheckpoint(id)
@@ -324,7 +324,7 @@ class DBCheckpointStorageTests {
         val (id, originalCheckpoint) = newCheckpoint()
         val serializedOriginalFlowState = originalCheckpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, originalCheckpoint, serializedOriginalFlowState, originalCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, originalCheckpoint, serializedOriginalFlowState!!, originalCheckpoint.serializeCheckpointState())
         }
         newCheckpointStorage()
         val reconstructedCheckpoint = database.transaction {
@@ -348,7 +348,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             session.get(DBCheckpointStorage.DBFlowMetadata::class.java, id.uuid.toString()).also {
@@ -362,7 +362,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         val metadata = database.transaction {
             session.get(DBCheckpointStorage.DBFlowMetadata::class.java, id.uuid.toString()).also {
@@ -389,7 +389,7 @@ class DBCheckpointStorageTests {
         database.transaction {
             val (id, checkpoint) = newCheckpoint(1)
             val serializedFlowState = checkpoint.serializeFlowState()
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
 
         database.transaction {
@@ -399,7 +399,7 @@ class DBCheckpointStorageTests {
         database.transaction {
             val (id1, checkpoint1) = newCheckpoint(2)
             val serializedFlowState1 = checkpoint1.serializeFlowState()
-            checkpointStorage.addCheckpoint(id1, checkpoint1, serializedFlowState1, checkpoint1.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id1, checkpoint1, serializedFlowState1!!, checkpoint1.serializeCheckpointState())
         }
 
         assertThatThrownBy {
@@ -416,7 +416,7 @@ class DBCheckpointStorageTests {
         val serializedFlowState =
             checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.copy(result = result, status = Checkpoint.FlowStatus.COMPLETED)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -439,7 +439,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.addError(exception)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -464,14 +464,14 @@ class DBCheckpointStorageTests {
     fun `Checkpoint can be updated with flow io request information`() {
         val (id, checkpoint) = newCheckpoint(1)
         database.transaction {
-            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+            val serializedFlowState = checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
             val checkpointFromStorage = checkpointStorage.getCheckpoint(id)
             assertNull(checkpointFromStorage!!.flowIoRequest)
         }
         database.transaction {
             val newCheckpoint = checkpoint.copy(flowIoRequest = FlowIORequest.Sleep::class.java.simpleName)
-            val serializedFlowState = newCheckpoint.flowState.checkpointSerialize(
+            val serializedFlowState = newCheckpoint.flowState!!.checkpointSerialize(
                 context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
             )
             checkpointStorage.updateCheckpoint(id, newCheckpoint, serializedFlowState, newCheckpoint.serializeCheckpointState())
@@ -489,7 +489,7 @@ class DBCheckpointStorageTests {
         val maxProgressStepLength = 256
         val (id, checkpoint) = newCheckpoint(1)
         database.transaction {
-            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+            val serializedFlowState = checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
             val checkpointFromStorage = checkpointStorage.getCheckpoint(id)
             assertNull(checkpointFromStorage!!.progressStep)
@@ -500,7 +500,7 @@ class DBCheckpointStorageTests {
         """.trimIndent()
         database.transaction {
             val newCheckpoint = checkpoint.copy(progressStep = longString)
-            val serializedFlowState = newCheckpoint.flowState.checkpointSerialize(
+            val serializedFlowState = newCheckpoint.flowState!!.checkpointSerialize(
                 context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
             )
             checkpointStorage.updateCheckpoint(id, newCheckpoint, serializedFlowState, newCheckpoint.serializeCheckpointState())
@@ -526,7 +526,7 @@ class DBCheckpointStorageTests {
 
         database.transaction {
             val serializedFlowState =
-                checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+                checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
             checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), runnable, serializedFlowState, runnable.serializeCheckpointState())
             checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), hospitalized, serializedFlowState, hospitalized.serializeCheckpointState())
@@ -568,7 +568,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.updateCheckpoint(id, checkpoint.addError(smallerStackTraceException), serializedFlowState, checkpoint.serializeCheckpointState())
@@ -609,7 +609,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.updateCheckpoint(id, checkpoint.addError(biggerStackTraceException), serializedFlowState, checkpoint.serializeCheckpointState())
@@ -638,7 +638,7 @@ class DBCheckpointStorageTests {
         val serializedFlowState = checkpoint.serializeFlowState()
         val pausedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.PAUSED)
         database.transaction {
-            checkpointStorage.addCheckpoint(id, pausedCheckpoint, serializedFlowState, pausedCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, pausedCheckpoint, serializedFlowState!!, pausedCheckpoint.serializeCheckpointState())
         }
 
         database.transaction {
@@ -672,7 +672,7 @@ class DBCheckpointStorageTests {
         val paused = changeStatus(checkpoint, Checkpoint.FlowStatus.PAUSED)
         database.transaction {
             val serializedFlowState =
-                    checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+                    checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
             checkpointStorage.addCheckpoint(runnable.id, runnable.checkpoint, serializedFlowState, runnable.checkpoint.serializeCheckpointState())
             checkpointStorage.addCheckpoint(hospitalized.id, hospitalized.checkpoint, serializedFlowState, hospitalized.checkpoint.serializeCheckpointState())
@@ -701,7 +701,7 @@ class DBCheckpointStorageTests {
     @Test(timeout = 300_000)
     fun `'updateCheckpoint' setting 'DBFlowCheckpoint_blob' to null whenever flow fails or gets hospitalized doesn't break ORM relationship`() {
         val (id, checkpoint) = newCheckpoint()
-        val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+        val serializedFlowState = checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
         database.transaction {
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
@@ -723,7 +723,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.updateStatus(id, Checkpoint.FlowStatus.HOSPITALIZED)
@@ -748,7 +748,7 @@ class DBCheckpointStorageTests {
 
         database.transaction {
             val serializedFlowState =
-                checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+                checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
             checkpointStorage.addCheckpoint(runnable.id, runnable.checkpoint, serializedFlowState, runnable.checkpoint.serializeCheckpointState())
             checkpointStorage.addCheckpoint(hospitalized.id, hospitalized.checkpoint, serializedFlowState, hospitalized.checkpoint.serializeCheckpointState())
@@ -814,8 +814,8 @@ class DBCheckpointStorageTests {
         return id to checkpoint
     }
 
-    private fun Checkpoint.serializeFlowState(): SerializedBytes<FlowState> {
-        return flowState.checkpointSerialize(CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+    private fun Checkpoint.serializeFlowState(): SerializedBytes<FlowState>? {
+        return flowState?.checkpointSerialize(CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 
     private fun Checkpoint.serializeCheckpointState(): SerializedBytes<CheckpointState> {

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -88,7 +88,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             assertEquals(serializedFlowState, checkpointStorage.checkpoints().single().serializedFlowState)
@@ -115,7 +115,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         val logic: FlowLogic<*> = object : FlowLogic<String>() {
             override fun call(): String {
@@ -148,7 +148,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
 
         val completedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.COMPLETED)
@@ -168,7 +168,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
 
         val pausedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.PAUSED)
@@ -189,7 +189,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.addError(exception)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -228,7 +228,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.copy(result = "The result", status = Checkpoint.FlowStatus.COMPLETED)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -269,8 +269,8 @@ class DBCheckpointStorageTests {
         val (id2, checkpoint2) = newCheckpoint()
         val serializedFlowState2 = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
-            checkpointStorage.addCheckpoint(id2, checkpoint2, serializedFlowState2!!, checkpoint2.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id2, checkpoint2, serializedFlowState2, checkpoint2.serializeCheckpointState())
             checkpointStorage.removeCheckpoint(id)
         }
         database.transaction {
@@ -294,12 +294,12 @@ class DBCheckpointStorageTests {
         val serializedFirstFlowState = firstCheckpoint.serializeFlowState()
 
         database.transaction {
-            checkpointStorage.addCheckpoint(id, firstCheckpoint, serializedFirstFlowState!!, firstCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, firstCheckpoint, serializedFirstFlowState, firstCheckpoint.serializeCheckpointState())
         }
         val (id2, secondCheckpoint) = newCheckpoint()
         val serializedSecondFlowState = secondCheckpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id2, secondCheckpoint, serializedSecondFlowState!!, secondCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id2, secondCheckpoint, serializedSecondFlowState, secondCheckpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.removeCheckpoint(id)
@@ -324,7 +324,7 @@ class DBCheckpointStorageTests {
         val (id, originalCheckpoint) = newCheckpoint()
         val serializedOriginalFlowState = originalCheckpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, originalCheckpoint, serializedOriginalFlowState!!, originalCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, originalCheckpoint, serializedOriginalFlowState, originalCheckpoint.serializeCheckpointState())
         }
         newCheckpointStorage()
         val reconstructedCheckpoint = database.transaction {
@@ -348,7 +348,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             session.get(DBCheckpointStorage.DBFlowMetadata::class.java, id.uuid.toString()).also {
@@ -362,7 +362,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         val metadata = database.transaction {
             session.get(DBCheckpointStorage.DBFlowMetadata::class.java, id.uuid.toString()).also {
@@ -389,7 +389,7 @@ class DBCheckpointStorageTests {
         database.transaction {
             val (id, checkpoint) = newCheckpoint(1)
             val serializedFlowState = checkpoint.serializeFlowState()
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
 
         database.transaction {
@@ -399,7 +399,7 @@ class DBCheckpointStorageTests {
         database.transaction {
             val (id1, checkpoint1) = newCheckpoint(2)
             val serializedFlowState1 = checkpoint1.serializeFlowState()
-            checkpointStorage.addCheckpoint(id1, checkpoint1, serializedFlowState1!!, checkpoint1.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id1, checkpoint1, serializedFlowState1, checkpoint1.serializeCheckpointState())
         }
 
         assertThatThrownBy {
@@ -416,7 +416,7 @@ class DBCheckpointStorageTests {
         val serializedFlowState =
             checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.copy(result = result, status = Checkpoint.FlowStatus.COMPLETED)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -439,7 +439,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         val updatedCheckpoint = checkpoint.addError(exception)
         val updatedSerializedFlowState = updatedCheckpoint.serializeFlowState()
@@ -464,14 +464,14 @@ class DBCheckpointStorageTests {
     fun `Checkpoint can be updated with flow io request information`() {
         val (id, checkpoint) = newCheckpoint(1)
         database.transaction {
-            val serializedFlowState = checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
             val checkpointFromStorage = checkpointStorage.getCheckpoint(id)
             assertNull(checkpointFromStorage!!.flowIoRequest)
         }
         database.transaction {
             val newCheckpoint = checkpoint.copy(flowIoRequest = FlowIORequest.Sleep::class.java.simpleName)
-            val serializedFlowState = newCheckpoint.flowState!!.checkpointSerialize(
+            val serializedFlowState = newCheckpoint.flowState.checkpointSerialize(
                 context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
             )
             checkpointStorage.updateCheckpoint(id, newCheckpoint, serializedFlowState, newCheckpoint.serializeCheckpointState())
@@ -489,7 +489,7 @@ class DBCheckpointStorageTests {
         val maxProgressStepLength = 256
         val (id, checkpoint) = newCheckpoint(1)
         database.transaction {
-            val serializedFlowState = checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+            val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
             val checkpointFromStorage = checkpointStorage.getCheckpoint(id)
             assertNull(checkpointFromStorage!!.progressStep)
@@ -500,7 +500,7 @@ class DBCheckpointStorageTests {
         """.trimIndent()
         database.transaction {
             val newCheckpoint = checkpoint.copy(progressStep = longString)
-            val serializedFlowState = newCheckpoint.flowState!!.checkpointSerialize(
+            val serializedFlowState = newCheckpoint.flowState.checkpointSerialize(
                 context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT
             )
             checkpointStorage.updateCheckpoint(id, newCheckpoint, serializedFlowState, newCheckpoint.serializeCheckpointState())
@@ -526,7 +526,7 @@ class DBCheckpointStorageTests {
 
         database.transaction {
             val serializedFlowState =
-                checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+                checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
             checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), runnable, serializedFlowState, runnable.serializeCheckpointState())
             checkpointStorage.addCheckpoint(StateMachineRunId.createRandom(), hospitalized, serializedFlowState, hospitalized.serializeCheckpointState())
@@ -568,7 +568,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.updateCheckpoint(id, checkpoint.addError(smallerStackTraceException), serializedFlowState, checkpoint.serializeCheckpointState())
@@ -609,7 +609,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.updateCheckpoint(id, checkpoint.addError(biggerStackTraceException), serializedFlowState, checkpoint.serializeCheckpointState())
@@ -638,7 +638,7 @@ class DBCheckpointStorageTests {
         val serializedFlowState = checkpoint.serializeFlowState()
         val pausedCheckpoint = checkpoint.copy(status = Checkpoint.FlowStatus.PAUSED)
         database.transaction {
-            checkpointStorage.addCheckpoint(id, pausedCheckpoint, serializedFlowState!!, pausedCheckpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, pausedCheckpoint, serializedFlowState, pausedCheckpoint.serializeCheckpointState())
         }
 
         database.transaction {
@@ -672,7 +672,7 @@ class DBCheckpointStorageTests {
         val paused = changeStatus(checkpoint, Checkpoint.FlowStatus.PAUSED)
         database.transaction {
             val serializedFlowState =
-                    checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+                    checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
             checkpointStorage.addCheckpoint(runnable.id, runnable.checkpoint, serializedFlowState, runnable.checkpoint.serializeCheckpointState())
             checkpointStorage.addCheckpoint(hospitalized.id, hospitalized.checkpoint, serializedFlowState, hospitalized.checkpoint.serializeCheckpointState())
@@ -701,7 +701,7 @@ class DBCheckpointStorageTests {
     @Test(timeout = 300_000)
     fun `'updateCheckpoint' setting 'DBFlowCheckpoint_blob' to null whenever flow fails or gets hospitalized doesn't break ORM relationship`() {
         val (id, checkpoint) = newCheckpoint()
-        val serializedFlowState = checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+        val serializedFlowState = checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
         database.transaction {
             checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
@@ -723,7 +723,7 @@ class DBCheckpointStorageTests {
         val (id, checkpoint) = newCheckpoint()
         val serializedFlowState = checkpoint.serializeFlowState()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState!!, checkpoint.serializeCheckpointState())
+            checkpointStorage.addCheckpoint(id, checkpoint, serializedFlowState, checkpoint.serializeCheckpointState())
         }
         database.transaction {
             checkpointStorage.updateStatus(id, Checkpoint.FlowStatus.HOSPITALIZED)
@@ -748,7 +748,7 @@ class DBCheckpointStorageTests {
 
         database.transaction {
             val serializedFlowState =
-                checkpoint.flowState!!.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+                checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
 
             checkpointStorage.addCheckpoint(runnable.id, runnable.checkpoint, serializedFlowState, runnable.checkpoint.serializeCheckpointState())
             checkpointStorage.addCheckpoint(hospitalized.id, hospitalized.checkpoint, serializedFlowState, hospitalized.checkpoint.serializeCheckpointState())
@@ -814,8 +814,8 @@ class DBCheckpointStorageTests {
         return id to checkpoint
     }
 
-    private fun Checkpoint.serializeFlowState(): SerializedBytes<FlowState>? {
-        return flowState?.checkpointSerialize(CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+    private fun Checkpoint.serializeFlowState(): SerializedBytes<FlowState> {
+        return flowState.checkpointSerialize(CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 
     private fun Checkpoint.serializeCheckpointState(): SerializedBytes<CheckpointState> {

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -157,7 +157,7 @@ class DBCheckpointStorageTests {
         }
         database.transaction {
             assertEquals(
-                completedCheckpoint.copy(flowState = FlowState.Completed),
+                completedCheckpoint.copy(flowState = FlowState.Finished),
                 checkpointStorage.checkpoints().single().deserialize()
             )
         }

--- a/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
@@ -126,7 +126,7 @@ class CheckpointDumperImplTest {
             checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint), serializeCheckpointState(checkpoint))
         }
         val newCheckpoint = checkpoint.copy(
-            flowState = FlowState.Completed,
+            flowState = FlowState.Finished,
             status = Checkpoint.FlowStatus.COMPLETED
         )
         database.transaction {

--- a/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
@@ -108,7 +108,7 @@ class CheckpointDumperImplTest {
         // add a checkpoint
         val (id, checkpoint) = newCheckpoint()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint), serializeCheckpointState(checkpoint))
+            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint)!!, serializeCheckpointState(checkpoint))
         }
 
         dumper.dumpCheckpoints()
@@ -123,7 +123,7 @@ class CheckpointDumperImplTest {
         // add a checkpoint
         val (id, checkpoint) = newCheckpoint()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint), serializeCheckpointState(checkpoint))
+            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint)!!, serializeCheckpointState(checkpoint))
         }
         val newCheckpoint = checkpoint.copy(
             flowState = FlowState.Completed,
@@ -163,7 +163,7 @@ class CheckpointDumperImplTest {
         // add a checkpoint
         val (id, checkpoint) = newCheckpoint()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint), serializeCheckpointState(checkpoint))
+            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint)!!, serializeCheckpointState(checkpoint))
         }
 
         dumper.dumpCheckpoints()
@@ -198,8 +198,8 @@ class CheckpointDumperImplTest {
         return id to checkpoint
     }
 
-    private fun serializeFlowState(checkpoint: Checkpoint): SerializedBytes<FlowState> {
-        return checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+    private fun serializeFlowState(checkpoint: Checkpoint): SerializedBytes<FlowState>? {
+        return checkpoint.flowState?.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 
     private fun serializeCheckpointState(checkpoint: Checkpoint): SerializedBytes<CheckpointState> {

--- a/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
@@ -108,7 +108,7 @@ class CheckpointDumperImplTest {
         // add a checkpoint
         val (id, checkpoint) = newCheckpoint()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint)!!, serializeCheckpointState(checkpoint))
+            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint), serializeCheckpointState(checkpoint))
         }
 
         dumper.dumpCheckpoints()
@@ -123,7 +123,7 @@ class CheckpointDumperImplTest {
         // add a checkpoint
         val (id, checkpoint) = newCheckpoint()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint)!!, serializeCheckpointState(checkpoint))
+            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint), serializeCheckpointState(checkpoint))
         }
         val newCheckpoint = checkpoint.copy(
             flowState = FlowState.Completed,
@@ -163,7 +163,7 @@ class CheckpointDumperImplTest {
         // add a checkpoint
         val (id, checkpoint) = newCheckpoint()
         database.transaction {
-            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint)!!, serializeCheckpointState(checkpoint))
+            checkpointStorage.addCheckpoint(id, checkpoint, serializeFlowState(checkpoint), serializeCheckpointState(checkpoint))
         }
 
         dumper.dumpCheckpoints()
@@ -198,8 +198,8 @@ class CheckpointDumperImplTest {
         return id to checkpoint
     }
 
-    private fun serializeFlowState(checkpoint: Checkpoint): SerializedBytes<FlowState>? {
-        return checkpoint.flowState?.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
+    private fun serializeFlowState(checkpoint: Checkpoint): SerializedBytes<FlowState> {
+        return checkpoint.flowState.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 
     private fun serializeCheckpointState(checkpoint: Checkpoint): SerializedBytes<CheckpointState> {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -672,7 +672,7 @@ class FlowClientIdTests {
         assertEquals("Flow's ${flowHandle0!!.id} exception was not found in the database. Something is very wrong.", e.message)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `completed flow started with a client id nulls its flow state in database after its lifetime`() {
         val clientId = UUID.randomUUID().toString()
         val flowHandle = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
@@ -684,7 +684,7 @@ class FlowClientIdTests {
         }
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `failed flow started with a client id nulls its flow state in database after its lifetime`() {
         val clientId = UUID.randomUUID().toString()
         ResultFlow.hook = { throw IllegalStateException() }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -688,6 +688,10 @@ class FlowFrameworkTests {
                 firstExecution = false
                 throw HospitalizeFlowException()
             } else {
+                // the below sleep should be removed when we switch flow's status to 'RUNNABLE' in a flow event instead of
+                // StateMachineManager.start. The reason why we needed is because the thread's transaction executing
+                // StateMachineManager.start takes long and doesn't commit before flow starts running.
+                Thread.sleep(3000)
                 dbCheckpointStatusBeforeSuspension = aliceNode.internals.checkpointStorage.getCheckpoints().toList().single().second.status
                 currentDBSession().clear() // clear session as Hibernate with fails with 'org.hibernate.NonUniqueObjectException' once it tries to save a DBFlowCheckpoint upon checkpoint
                 inMemoryCheckpointStatusBeforeSuspension = flowFiber.transientState.checkpoint.status
@@ -736,6 +740,10 @@ class FlowFrameworkTests {
                 firstExecution = false
                 throw HospitalizeFlowException()
             } else {
+                // the below sleep should be removed when we switch flow's status to 'RUNNABLE' in a flow event instead of
+                // StateMachineManager.start. The reason why we needed is because the thread's transaction executing
+                // StateMachineManager.start takes long and doesn't commit before flow starts running.
+                Thread.sleep(3000)
                 dbCheckpointStatus = aliceNode.internals.checkpointStorage.getCheckpoints().toList().single().second.status
                 inMemoryCheckpointStatus = flowFiber.transientState.checkpoint.status
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -688,9 +688,8 @@ class FlowFrameworkTests {
                 firstExecution = false
                 throw HospitalizeFlowException()
             } else {
-                // the below sleep should be removed when we switch flow's status to 'RUNNABLE' in a flow event instead of
-                // StateMachineManager.start. The reason why we needed is because the thread's transaction executing
-                // StateMachineManager.start takes long and doesn't commit before flow starts running.
+                // the below sleep should be removed once we fix : The thread's transaction executing StateMachineManager.start takes long
+                // and doesn't commit before flow starts running.
                 Thread.sleep(3000)
                 dbCheckpointStatusBeforeSuspension = aliceNode.internals.checkpointStorage.getCheckpoints().toList().single().second.status
                 currentDBSession().clear() // clear session as Hibernate with fails with 'org.hibernate.NonUniqueObjectException' once it tries to save a DBFlowCheckpoint upon checkpoint
@@ -740,9 +739,8 @@ class FlowFrameworkTests {
                 firstExecution = false
                 throw HospitalizeFlowException()
             } else {
-                // the below sleep should be removed when we switch flow's status to 'RUNNABLE' in a flow event instead of
-                // StateMachineManager.start. The reason why we needed is because the thread's transaction executing
-                // StateMachineManager.start takes long and doesn't commit before flow starts running.
+                // the below sleep should be removed once we fix : The thread's transaction executing StateMachineManager.start takes long
+                // and doesn't commit before flow starts running.
                 Thread.sleep(3000)
                 dbCheckpointStatus = aliceNode.internals.checkpointStorage.getCheckpoints().toList().single().second.status
                 inMemoryCheckpointStatus = flowFiber.transientState.checkpoint.status
@@ -858,6 +856,9 @@ class FlowFrameworkTests {
         var secondRun = false
         SuspendingFlow.hookBeforeCheckpoint = {
             if(secondRun) {
+                // the below sleep should be removed once we fix : The thread's transaction executing StateMachineManager.start takes long
+                // and doesn't commit before flow starts running.
+                Thread.sleep(3000)
                 aliceNode.database.transaction {
                     checkpointStatusAfterRestart = findRecordsFromDatabase<DBCheckpointStorage.DBFlowCheckpoint>().single().status
                     dbExceptionAfterRestart = findRecordsFromDatabase()


### PR DESCRIPTION
Do not retain in database `checkpoint.flowState` for flows that have completed or failed and have started with a client id, after their lifetime.