### PR TITLE
[EG-2254] added `checkpoints debug` shell command

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/messaging/FlowManagerRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/messaging/FlowManagerRPCOps.kt
@@ -10,4 +10,8 @@ interface FlowManagerRPCOps : RPCOps {
      * Dump all the current flow checkpoints as JSON into a zip file in the node's log directory.
      */
     fun dumpCheckpoints()
+
+    /** Dump all the current flow checkpoints, alongside with the node's main jar, all CorDapps and driver jars
+     * into a zip file in the node's log directory. */
+    fun debugCheckpoints()
 }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -370,7 +370,12 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     @Volatile
     private var _started: S? = null
 
-    private val checkpointDumper = CheckpointDumperImpl(checkpointStorage, database, services, services.configuration.baseDirectory)
+    private val checkpointDumper = CheckpointDumperImpl(
+            checkpointStorage,
+            database,
+            services,
+            services.configuration.baseDirectory,
+            services.configuration.cordappDirectories)
 
     private var notaryService: NotaryService? = null
 

--- a/node/src/main/kotlin/net/corda/node/internal/checkpoints/FlowManagerRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/checkpoints/FlowManagerRPCOpsImpl.kt
@@ -12,4 +12,6 @@ internal class FlowManagerRPCOpsImpl(private val checkpointDumper: CheckpointDum
     override val protocolVersion: Int = PLATFORM_VERSION
 
     override fun dumpCheckpoints() = checkpointDumper.dumpCheckpoints()
+
+    override fun debugCheckpoints() = checkpointDumper.debugCheckpoints()
 }

--- a/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/CheckpointDumperImplTest.kt
@@ -56,6 +56,7 @@ class CheckpointDumperImplTest {
     private val myself = TestIdentity(CordaX500Name(organisation, "London", "GB"))
     private val currentTimestamp = Instant.parse("2019-12-25T10:15:30.00Z")
     private val baseDirectory = Files.createTempDirectory("CheckpointDumperTest")
+    private val corDappDirectories = listOf(baseDirectory.resolve("cordapps"))
     private val file = baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME /
             "checkpoints_dump-${CheckpointDumperImpl.TIME_FORMATTER.format(currentTimestamp)}.zip"
 
@@ -102,7 +103,7 @@ class CheckpointDumperImplTest {
 
     @Test(timeout=300_000)
 	fun testDumpCheckpoints() {
-        val dumper = CheckpointDumperImpl(checkpointStorage, database, services, baseDirectory)
+        val dumper = CheckpointDumperImpl(checkpointStorage, database, services, baseDirectory, corDappDirectories)
         dumper.update(mockAfterStartEvent)
 
         // add a checkpoint
@@ -117,7 +118,7 @@ class CheckpointDumperImplTest {
 
     @Test(timeout=300_000)
     fun `Checkpoint dumper doesn't output completed checkpoints`() {
-        val dumper = CheckpointDumperImpl(checkpointStorage, database, services, baseDirectory)
+        val dumper = CheckpointDumperImpl(checkpointStorage, database, services, baseDirectory, corDappDirectories)
         dumper.update(mockAfterStartEvent)
 
         // add a checkpoint
@@ -157,7 +158,7 @@ class CheckpointDumperImplTest {
     // -javaagent:tools/checkpoint-agent/build/libs/checkpoint-agent.jar
     @Test(timeout=300_000)
 	fun testDumpCheckpointsAndAgentDiagnostics() {
-        val dumper = CheckpointDumperImpl(checkpointStorage, database, services, Paths.get("."))
+        val dumper = CheckpointDumperImpl(checkpointStorage, database, services, Paths.get("."), Paths.get("cordapps"))
         dumper.update(mockAfterStartEvent)
 
         // add a checkpoint

--- a/tools/shell/src/main/java/net/corda/tools/shell/CheckpointShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/CheckpointShellCommand.java
@@ -24,4 +24,11 @@ public class CheckpointShellCommand extends InteractiveShellCommand<FlowManagerR
     public void dump() {
         runDumpCheckpoints(ops());
     }
+
+    @Command
+    @Man("Outputs the contents of all started flow checkpoints in a zip file")
+    @Usage("Outputs the contents of all started flow checkpoints in a zip file")
+    public void debug() {
+        runDebugCheckpoints(ops());
+    }
 }

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -566,6 +566,11 @@ object InteractiveShell {
     }
 
     @JvmStatic
+    fun runDebugCheckpoints(rpcOps: FlowManagerRPCOps) {
+        rpcOps.debugCheckpoints()
+    }
+
+    @JvmStatic
     fun runRPCFromString(input: List<String>, out: RenderPrintWriter, context: InvocationContext<out Any>, cordaRPCOps: CordaRPCOps,
                          inputObjectMapper: ObjectMapper): Any? {
         val cmd = input.joinToString(" ").trim { it <= ' ' }


### PR DESCRIPTION
I added a shell command to dump a zip file containing all node checkpoints and all jars in the node classpath, this is required to use
https://github.com/corda/enterprise/tree/woggioni/EG-3461/tools/flow-necromancer
