### PR TITLE
CORDA-3950: Now disable SPHINCS for JDK8 as well as JDK11. Broken in …

### DIFF
--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -15,7 +15,6 @@ import net.corda.core.crypto.Crypto.generateKeyPair
 import net.corda.core.crypto.SignatureScheme
 import net.corda.core.crypto.newSecureRandom
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.internal.JavaVersion
 import net.corda.core.internal.div
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.deserialize

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -118,7 +118,7 @@ class X509UtilitiesTest {
     @Test(timeout=300_000)
 	fun `create valid self-signed CA certificate`() {
         Crypto.supportedSignatureSchemes().filter { it != COMPOSITE_KEY
-                && ( !JavaVersion.isVersionAtLeast(JavaVersion.Java_11) || it != SPHINCS256_SHA256)}.forEach { validSelfSignedCertificate(it) }
+                && ( it != SPHINCS256_SHA256)}.forEach { validSelfSignedCertificate(it) }
     }
 
     private fun validSelfSignedCertificate(signatureScheme: SignatureScheme) {
@@ -153,7 +153,7 @@ class X509UtilitiesTest {
 
     @Test(timeout=300_000)
 	fun `create valid server certificate chain`() {
-        certChainSchemeCombinations.filter{ !JavaVersion.isVersionAtLeast(JavaVersion.Java_11) || it.first != SPHINCS256_SHA256 }
+        certChainSchemeCombinations.filter{ it.first != SPHINCS256_SHA256 }
                                    .forEach { createValidServerCertChain(it.first, it.second) }
     }
 


### PR DESCRIPTION
Test for SPHINCS signature algo in X509UtilitiesTest removed. This signature is broken in JDK1.8_252.