### PR TITLE
CORDA-3931 - Fixed a bug which was preventing the custom JVM arguments from  being picked up when the command line "-f" flag was used

### DIFF
--- a/node/capsule/src/main/java/CordaCaplet.java
+++ b/node/capsule/src/main/java/CordaCaplet.java
@@ -33,9 +33,8 @@ public class CordaCaplet extends Capsule {
 
     private Config parseConfigFile(List<String> args) {
         this.baseDir = getBaseDirectory(args);
-        String config = getOptionMultiple(args, Arrays.asList("--config-file", "-f"));
 
-        File configFile = (config == null) ? new File(baseDir, "node.conf") : new File(config);
+        File configFile = getConfigFile(args, baseDir);
         try {
             ConfigParseOptions parseOptions = ConfigParseOptions.defaults().setAllowMissing(false);
             Config defaultConfig = ConfigFactory.parseResources("corda-reference.conf", parseOptions);

--- a/node/capsule/src/main/java/CordaCaplet.java
+++ b/node/capsule/src/main/java/CordaCaplet.java
@@ -33,7 +33,8 @@ public class CordaCaplet extends Capsule {
 
     private Config parseConfigFile(List<String> args) {
         this.baseDir = getBaseDirectory(args);
-        String config = getOption(args, "--config-file");
+        String config = getOptionMultiple(args, Arrays.asList("--config-file", "-f"));
+
         File configFile = (config == null) ? new File(baseDir, "node.conf") : new File(config);
         try {
             ConfigParseOptions parseOptions = ConfigParseOptions.defaults().setAllowMissing(false);


### PR DESCRIPTION
**Bug Reported**
It has been reported that the command line "-f" flag did not pick up custom JVM arguments when the configuration file was not named node.conf or when the configuration file was not directly under the working directory. But the same issue did not happen with "--config-file".

**Bug Summary**
By inspecting the code, it was possible to notice that the flag "-f" was being ignored by the class CordaCaplet when loading the configuration file.

**Notes**
- The command line flags "-f" and "--config-file" are both used to specify the configuration file that should be used.
- The command line flag "-f" is the short format flag while the flag "--config-file" is the long format flag. Thus, both flags should always behave in the same way.

**Tests cases**

-  _No configuration flag is used_:  Test the default configuration: Ensure the default configuration is used if no configuration flag is used.

- _Long format (--config-file) - Test the configuration provided by the --config-file flag_: Ensure the configuration from node.conf is read when the file is directly under the working directory.

- _Long format (--config-file) - Test the configuration provided by the --config-file flag when the file is not directly under the the working directory_: Ensure the configuration from node.conf is read when the file is not under the working directory.

- _Long format (--config-file) - Test the configuration provided by the --config-file flag when the filename is not node.conf_: Ensure the configuration from notary.conf is read when the file is directly under the working directory.

- _Long format (--config-file) - Test the configuration provided by the --config-file flag when the filename is not node.conf and it is not under the working directory_: Ensure the configuration from notary.conf is read when the file is not under the working directory.

- _Short format (-f) - Test the configuration provided by the -f flag_: Ensure the configuration from node.conf is read when the file is directly under the working directory.

- _Short format (-f) - Test the configuration provided by the -f flag when the file is not directly under the the working directory_: Ensure the configuration from node.conf is read when the file is not under the working directory.

- _Short format (-f) - Test the configuration provided by the -f flag when the filename is not node.conf_: Ensure the configuration from notary.conf is read when the file is directly under the working directory.

- _Short format (-f) - Test the configuration provided by the -f flag when the filename is not node.conf and it is not under the working directory_: Ensure the configuration from notary.conf is read when the file is not under the working directory.

**Tips:**

- Useful commands: Start Corda: java -jar corda.jar  [--config-file filename, -f filename]
- Useful commands:  Check the argments passed to the jvm: jps -v (The flag -Xmx should match -Xmx512m or the value inside the configuration file)

- Logs: Check the log: less logs/node-20LDN-MAC292.local.log (Search for "CommandLine Args". The flag -Xmx should match -Xmx512m or the value inside the configuration file)