### PR TITLE
INFRA-563: Upgrade to distributed-testing-plugin 1.3.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,9 +177,6 @@ buildscript {
                     includeGroupByRegex 'net\\.corda(\\..*)?'
                     includeGroupByRegex 'com\\.r3(\\..*)?'
                 }
-                mavenContent {
-                    snapshotsOnly()
-                }
             }
             maven {
                 url "${artifactory_contextUrl}/corda-releases"
@@ -217,7 +214,7 @@ buildscript {
         // Capsule gradle plugin forked and maintained locally to support Gradle 5.x
         // See https://github.com/corda/gradle-capsule-plugin
         classpath "us.kirchmeier:gradle-capsule-plugin:1.0.4_r3"
-        classpath group: "com.r3.testing", name: "gradle-distributed-testing-plugin", version: "1.3-SNAPSHOT", changing: true
+        classpath group: "com.r3.testing", name: "gradle-distributed-testing-plugin", version: '1.3.0'
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8"
     }
 


### PR DESCRIPTION
Use the latest release of the plugin. This version is still hosted by `corda-dependencies-dev`.