### PR TITLE
EG-3458 Missing onError implementation message logged in the node log file with ERROR level

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -67,7 +67,7 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
 ) : AutoCloseable, NetworkParameterUpdateListener {
     companion object {
         private val logger = contextLogger()
-        private val defaultRetryInterval = 1.minutes
+        private val defaultWatchHttpNetworkMapRetryInterval = 1.minutes
         private const val bulkNodeInfoFetchThreshold = 50
         private val defaultWatchNodeInfoFilesRetryInterval = 10.seconds;
     }

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -35,7 +35,7 @@ sealed class NodeInfoUpdate {
  */
 // TODO: Use NIO watch service instead?
 class NodeInfoWatcher(private val nodePath: Path,
-                      private val scheduler: Scheduler,
+                      internal val scheduler: Scheduler,
                       private val pollInterval: Duration = 5.seconds) {
     companion object {
         private val logger = contextLogger()


### PR DESCRIPTION
Changes for EG-3458 (https://r3-cev.atlassian.net/browse/EG-3458)

I found that when the additional-node-infos folder is missing (as in the case exposed by the network bootstrapper), we get an Exception and the observable which polls the directory dies. This means we cannot pick up network map updates from the additional-node-infos directory even if we recreate it. It requires a node restart to restart the observable.

These changes re-subscribe to the observable and keep retrying after 10 second delays with warning messages output in the log. This means after getting the error and adding the folder we can pick up network map updates.

It also means if the error occurs in when running nodes in a bootstrapped network, the node won't need to be restarted.

The test will delete the folder in the JimFS in memory filestore, recreate the folder, and assert that new updates get picked up.

Questions:
- is 10 second delay too frequent? defaultRetryInterval for http network map service is 1 minute.
- does a WARN log level suit the log messages?

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
