### PR TITLE
EG-3458 - Missing onError implementation message logged in the node log file with ERROR level

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -21,6 +21,7 @@ import net.corda.core.serialization.serialize
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.minutes
+import net.corda.core.utilities.seconds
 import net.corda.node.services.api.NetworkMapCacheInternal
 import net.corda.node.services.config.NetworkParameterAcceptanceSettings
 import net.corda.node.utilities.NamedThreadFactory
@@ -64,7 +65,8 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
 ) : AutoCloseable {
     companion object {
         private val logger = contextLogger()
-        private val defaultRetryInterval = 1.minutes
+        private val defaultWatchHttpNetworkMapRetryInterval = 1.minutes
+        private val defaultWatchNodeInfoFilesRetryInterval = 10.seconds;
     }
 
     private val parametersUpdatesTrack = PublishSubject.create<ParametersUpdateInfo>()
@@ -126,6 +128,9 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
     private fun watchForNodeInfoFiles(): Subscription {
         return nodeInfoWatcher
                 .nodeInfoUpdates()
+                .doOnError { logger.warn("Error encountered while polling directory for network map updates, " +
+                        "will retry in ${defaultWatchNodeInfoFilesRetryInterval.seconds} seconds - $it") }
+                .retryWhen { t -> t.delay(defaultWatchNodeInfoFilesRetryInterval.seconds, TimeUnit.SECONDS, nodeInfoWatcher.scheduler) }
                 .subscribe {
                     for (update in it) {
                         when (update) {
@@ -153,8 +158,8 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
                 val nextScheduleDelay = try {
                     updateNetworkMapCache()
                 } catch (e: Exception) {
-                    logger.warn("Error encountered while updating network map, will retry in $defaultRetryInterval", e)
-                    defaultRetryInterval
+                    logger.warn("Error encountered while updating network map, will retry in $defaultWatchHttpNetworkMapRetryInterval", e)
+                    defaultWatchHttpNetworkMapRetryInterval
                 }
                 // Schedule the next update.
                 networkMapPoller.schedule(this, nextScheduleDelay.toMillis(), TimeUnit.MILLISECONDS)

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -35,7 +35,7 @@ sealed class NodeInfoUpdate {
  */
 // TODO: Use NIO watch service instead?
 class NodeInfoWatcher(private val nodePath: Path,
-                      private val scheduler: Scheduler,
+                      internal val scheduler: Scheduler,
                       private val pollInterval: Duration = 5.seconds) {
     companion object {
         private val logger = contextLogger()

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -17,6 +17,7 @@ import net.corda.core.internal.NODE_INFO_DIRECTORY
 import net.corda.core.internal.NetworkParametersStorage
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.createDirectory
 import net.corda.core.internal.delete
 import net.corda.core.internal.div
 import net.corda.core.internal.exists
@@ -274,6 +275,37 @@ class NetworkMapUpdaterTest {
         verify(networkMapCache, times(1)).addOrUpdateNode(any())
         verify(networkMapCache, times(1)).addOrUpdateNode(fileNodeInfoAndSigned.nodeInfo)
         assertThat(nodeReadyFuture).isDone()
+
+        assertThat(networkMapCache.allNodeHashes).containsOnly(fileNodeInfoAndSigned.nodeInfo.serialize().hash)
+    }
+
+    @Test(timeout=300_000)
+	fun `receive node infos from directory after an error due to missing additional-node-infos directory`() {
+        setUpdater(netMapClient = null)
+        val fileNodeInfoAndSigned = createNodeInfoAndSigned("Info from file")
+
+        // Not subscribed yet
+        verify(networkMapCache, times(0)).addOrUpdateNode(any())
+
+        nodeInfoDir.delete()
+        assertFalse(nodeInfoDir.exists())
+        // Observable will get a NoSuchFileException and log it
+        startUpdater()
+        // Updater will resubscribe to observable with delayed retry
+        advanceTime()
+        // no changes will be made to networkMapCache at this point
+        verify(networkMapCache, times(0)).addOrUpdateNode(any())
+
+        nodeInfoDir.createDirectory()
+        assertTrue(nodeInfoDir.exists())
+
+        // Now that directory has been created, save a nodeInfo and assert that the file polling watcher behaves as expected
+        NodeInfoWatcher.saveToFile(nodeInfoDir, fileNodeInfoAndSigned)
+        assertThat(nodeReadyFuture).isNotDone
+        advanceTime()
+
+        verify(networkMapCache, times(1)).addOrUpdateNode(fileNodeInfoAndSigned.nodeInfo)
+        assertThat(nodeReadyFuture).isDone
 
         assertThat(networkMapCache.allNodeHashes).containsOnly(fileNodeInfoAndSigned.nodeInfo.serialize().hash)
     }


### PR DESCRIPTION
Changes for EG-3458 (https://r3-cev.atlassian.net/browse/EG-3458)

I found that when the additional-node-infos folder is missing (as in the case exposed by the network bootstrapper), we get an Exception and the observable which polls the directory dies. This means we cannot pick up network map updates from the additional-node-infos directory even if we recreate it. It requires a node restart to restart the observable.

These changes re-subscribe to the observable and keep retrying after 10 second delays with warning messages output in the log. This means after getting the error and adding the folder we can pick up network map updates.

It also means if the error occurs in when running nodes in a bootstrapped network, the node won't need to be restarted.

The test will delete the folder in the JimFS in memory filestore, recreate the folder, and assert that new updates get picked up.

Questions:
- is 10 second delay too frequent? defaultRetryInterval for http network map service is 1 minute.
- does a WARN log level suit the log messages?

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
