### PR TITLE
ENT-5494 fix for Could not reconnect to the RPC server“ error on shutdown via …

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -10,6 +10,7 @@ import net.corda.client.rpc.ConnectionFailureException
 import net.corda.client.rpc.CordaRPCClientConfiguration
 import net.corda.client.rpc.RPCException
 import net.corda.client.rpc.RPCSinceVersion
+import net.corda.client.rpc.internal.RPCUtils.isShutdownCmd
 import net.corda.core.context.Actor
 import net.corda.core.context.Trace
 import net.corda.core.context.Trace.InvocationId
@@ -342,7 +343,7 @@ internal class RPCClientProxyHandler(
                 "Generated several RPC requests with same ID $replyId"
             }
 
-            if (request.methodName.equals("terminate", true)){
+            if (request.isShutdownCmd()){
                 terminating = true
             }
 

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCUtils.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCUtils.kt
@@ -1,0 +1,15 @@
+package net.corda.client.rpc.internal
+
+import net.corda.nodeapi.RPCApi
+import java.lang.reflect.Method
+
+object RPCUtils {
+    fun isShutdownMethodName(methodName: String) =
+            methodName.equals("shutdown", true) ||
+                    methodName.equals("gracefulShutdown", true) ||
+                    methodName.equals("terminate", true)
+
+    fun RPCApi.ClientToServer.RpcRequest.isShutdownCmd() = isShutdownMethodName(methodName)
+    fun Method.isShutdown() = isShutdownMethodName(name)
+    fun Method.isStartFlow() = name.startsWith("startFlow") || name.startsWith("startTrackedFlow")
+}

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -10,6 +10,8 @@ import net.corda.client.rpc.PermissionException
 import net.corda.client.rpc.RPCConnection
 import net.corda.client.rpc.RPCException
 import net.corda.client.rpc.UnrecoverableRPCException
+import net.corda.client.rpc.internal.RPCUtils.isShutdown
+import net.corda.client.rpc.internal.RPCUtils.isStartFlow
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps.ReconnectingRPCConnection.CurrentState.CLOSED
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps.ReconnectingRPCConnection.CurrentState.CONNECTED
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps.ReconnectingRPCConnection.CurrentState.CONNECTING
@@ -292,9 +294,6 @@ class ReconnectingCordaRPCOps private constructor(
         fun isClosed(): Boolean = currentState == CLOSED
     }
     private class ErrorInterceptingHandler(val reconnectingRPCConnection: ReconnectingRPCConnection) : InvocationHandler {
-        private fun Method.isStartFlow() = name.startsWith("startFlow") || name.startsWith("startTrackedFlow")
-        private fun Method.isShutdown() = name == "shutdown" || name == "gracefulShutdown" || name == "terminate"
-
         private fun checkIfIsStartFlow(method: Method, e: InvocationTargetException) {
             if (method.isStartFlow()) {
                 // Don't retry flows

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -14,6 +14,7 @@ import net.corda.client.rpc.CordaRPCClientConfiguration
 import net.corda.client.rpc.CordaRPCConnection
 import net.corda.client.rpc.GracefulReconnect
 import net.corda.client.rpc.PermissionException
+import net.corda.client.rpc.internal.RPCUtils.isShutdownMethodName
 import net.corda.client.rpc.notUsed
 import net.corda.core.CordaException
 import net.corda.core.concurrent.CordaFuture
@@ -110,8 +111,6 @@ object InteractiveShell {
         JSON,
         YAML
     }
-
-    private fun isShutdownCmd(cmd: String) = cmd == "shutdown" || cmd == "gracefulShutdown" || cmd == "terminate"
 
     fun startShell(configuration: ShellConfiguration, classLoader: ClassLoader? = null, standalone: Boolean = false) {
         makeRPCConnection = { username: String, password: String ->
@@ -625,7 +624,7 @@ object InteractiveShell {
                     throw e.rootCause
                 }
             }
-            if (isShutdownCmd(cmd)) {
+            if (isShutdownMethodName(cmd)) {
                 out.println("Called 'shutdown' on the node.\nQuitting the shell now.").also { out.flush() }
                 onExit.invoke()
             }


### PR DESCRIPTION
fix for Could not reconnect to the RPC server“ error on shutdown via Shell-Cli

an RPCUtils class created to centralize method name related operations