### PR TITLE
EG-3402 Removed the dependency 'io.spring.dependency-management' from the gradle files in irs-demo

### DIFF
--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "org.springframework.boot" version "1.5.21.RELEASE"
-    id 'io.spring.dependency-management' version '1.0.9.RELEASE' apply false
 }
 
 // Spring Boot plugin adds a numerous hardcoded dependencies in the version much lower then Corda expects

--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -13,7 +13,6 @@ buildscript {
 
 plugins {
     id 'com.craigburke.client-dependencies' version '1.4.0'
-    id 'io.spring.dependency-management'
     id 'org.springframework.boot'
 }
 


### PR DESCRIPTION
**Bug Reported**
It has been reported that the dependency 'io.spring.dependency-management' was causing build issues.

**Bug Summary**
It was not possible to reproduce the issue during testing because the bug reported only happens sometimes. However, it was noticed that the dependency 'io.spring.dependency-management' was not needed for the irs-demo project. The dependency was removed from the two gradle files present in irs-demo project.

**Tests cases**
- A clean build was performed to ensure the irs-demo project still builds correctly without the dependency 'io.spring.dependency-management'. 

