### PR TITLE
EG-3218 Business Networks integration tests

### DIFF
--- a/business-networks/business-networks-workflows/build.gradle
+++ b/business-networks/business-networks-workflows/build.gradle
@@ -4,6 +4,25 @@ apply plugin: 'net.corda.plugins.cordapp'
 
 description 'Corda Business Networks'
 
+sourceSets {
+    integrationTest {
+        kotlin {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integration-test/kotlin')
+        }
+        resources {
+            srcDir file('src/integration-test/resources')
+        }
+    }
+}
+
+configurations {
+    testArtifacts.extendsFrom testRuntimeClasspath
+    integrationTestCompile.extendsFrom testCompile
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 dependencies {
     cordaCompile project(':core')
     cordaCompile project(':business-networks:business-networks-contracts')
@@ -12,4 +31,9 @@ dependencies {
 
     // Bring in the MockNode infrastructure for writing protocol unit tests.
     testCompile project(":node-driver")
+}
+
+task integrationTest(type: Test, dependsOn: []) {
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
 }

--- a/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/AbstractBusinessNetworksTest.kt
+++ b/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/AbstractBusinessNetworksTest.kt
@@ -1,0 +1,332 @@
+package net.corda.bn.flows
+
+import net.corda.bn.states.BNIdentity
+import net.corda.bn.states.BNORole
+import net.corda.bn.states.BNRole
+import net.corda.bn.states.GroupState
+import net.corda.bn.states.MembershipState
+import net.corda.bn.states.MembershipStatus
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.messaging.vaultTrackBy
+import net.corda.core.node.services.Vault
+import net.corda.core.serialization.CordaSerializable
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.core.expect
+import net.corda.testing.core.expectEvents
+import net.corda.testing.core.sequence
+import net.corda.testing.driver.InProcess
+import net.corda.testing.driver.NodeHandle
+import rx.Observable
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+abstract class AbstractBusinessNetworksTest {
+
+    companion object {
+        private const val NUMBER_OF_MEMBERS = 4
+    }
+
+    protected val bnoIdentity = TestIdentity(CordaX500Name.parse("O=BNO,L=New York,C=US")).party
+    protected val membersIdentities = (0..NUMBER_OF_MEMBERS).mapIndexed { idx, _ -> TestIdentity(CordaX500Name.parse("O=Member$idx,L=New York,C=US")).party }
+
+    @CordaSerializable
+    data class MyIdentity(val name: String) : BNIdentity
+
+    data class VaultUpdates(val membershipUpdates: Observable<Vault.Update<MembershipState>>, val groupUpdates: Observable<Vault.Update<GroupState>>)
+
+    /** Calls [CreateBusinessNetworkFlow] on [bnoNode] and performs ledger checks. **/
+    @Suppress("LongParameterList")
+    protected fun createBusinessNetworkAndCheck(
+            bnoNode: NodeHandle,
+            networkId: UniqueIdentifier,
+            businessIdentity: BNIdentity,
+            groupId: UniqueIdentifier,
+            groupName: String,
+            notary: Party
+    ): UniqueIdentifier {
+        val bnoVaultUpdates = bnoNode.rpc.run {
+            VaultUpdates(vaultTrackBy<MembershipState>().updates, vaultTrackBy<GroupState>().updates)
+        }
+
+        val membershipId = bnoNode.createBusinessNetwork(
+                networkId,
+                businessIdentity,
+                groupId,
+                groupName,
+                notary
+        ).linearId
+
+        bnoVaultUpdates.apply {
+            membershipUpdates.expectEvents(isStrict = false) {
+                sequence(
+                        expect { update ->
+                            val membership = update.produced.single().state.data
+                            assertEquals(networkId.toString(), membership.networkId)
+                            assertEquals(bnoNode.identity(), membership.identity.cordaIdentity)
+                            assertEquals(businessIdentity, membership.identity.businessIdentity)
+                            assertEquals(MembershipStatus.PENDING, membership.status)
+                            assertEquals(emptySet(), membership.roles)
+                        },
+                        expect { update ->
+                            val membership = update.produced.single().state.data
+                            assertEquals(networkId.toString(), membership.networkId)
+                            assertEquals(bnoNode.identity(), membership.identity.cordaIdentity)
+                            assertEquals(businessIdentity, membership.identity.businessIdentity)
+                            assertEquals(MembershipStatus.ACTIVE, membership.status)
+                            assertEquals(emptySet(), membership.roles)
+                        },
+                        expect { update ->
+                            val membership = update.produced.single().state.data
+                            assertEquals(networkId.toString(), membership.networkId)
+                            assertEquals(bnoNode.identity(), membership.identity.cordaIdentity)
+                            assertEquals(businessIdentity, membership.identity.businessIdentity)
+                            assertEquals(MembershipStatus.ACTIVE, membership.status)
+                            assertEquals(setOf(BNORole()), membership.roles)
+                        }
+                )
+            }
+            groupUpdates.expectEvents(isStrict = false) {
+                expect { update ->
+                    val group = update.produced.single().state.data
+                    assertEquals(networkId.toString(), group.networkId)
+                    assertEquals(groupName, group.name)
+                    assertEquals(groupId, group.linearId)
+                    assertEquals(setOf(bnoNode.identity()), group.participants.toSet())
+                }
+            }
+        }
+
+        return membershipId
+    }
+
+    /** Calls [RequestMembershipFlow] on [bnoNode] and performs ledger checks. **/
+    protected fun requestMembershipAndCheck(
+            memberNode: NodeHandle,
+            bnoNode: NodeHandle,
+            networkId: String,
+            businessIdentity: BNIdentity,
+            notary: Party
+    ): UniqueIdentifier {
+        val allVaultUpdates = listOf(bnoNode, memberNode).map { node ->
+            node.rpc.run {
+                VaultUpdates(vaultTrackBy<MembershipState>().updates, vaultTrackBy<GroupState>().updates)
+            }
+        }
+
+        val membershipId = memberNode.requestMembership(bnoNode.identity(), networkId, businessIdentity, notary).linearId
+
+        allVaultUpdates.forEach { vaultUpdates ->
+            vaultUpdates.membershipUpdates.expectEvents(isStrict = false) {
+                expect { update ->
+                    val membership = update.produced.single().state.data
+                    assertEquals(networkId, membership.networkId)
+                    assertEquals(memberNode.identity(), membership.identity.cordaIdentity)
+                    assertEquals(businessIdentity, membership.identity.businessIdentity)
+                    assertEquals(MembershipStatus.PENDING, membership.status)
+                    assertTrue(membership.roles.isEmpty())
+                }
+            }
+        }
+
+        return membershipId
+    }
+
+    /** Calls [ActivateMembershipFlow] on [bnoNode] and performs ledger checks. **/
+    protected fun activateMembershipAndCheck(
+            bnoNode: NodeHandle,
+            memberNodes: List<NodeHandle>,
+            membershipId: UniqueIdentifier,
+            notary: Party
+    ) {
+        val allVaultUpdates = (memberNodes + bnoNode).map { node ->
+            node.rpc.run {
+                VaultUpdates(vaultTrackBy<MembershipState>().updates, vaultTrackBy<GroupState>().updates)
+            }
+        }
+
+        bnoNode.activateMembership(membershipId, notary)
+
+        allVaultUpdates.forEach { vaultUpdates ->
+            vaultUpdates.membershipUpdates.expectEvents(isStrict = false) {
+                expect { update ->
+                    val membership = update.produced.single().state.data
+                    assertEquals(MembershipStatus.ACTIVE, membership.status)
+                    assertEquals(membershipId, membership.linearId)
+                }
+            }
+        }
+    }
+
+    /** Calls [SuspendMembershipFlow] on [bnoNode] and performs ledger checks. **/
+    protected fun suspendMembershipAndCheck(
+            bnoNode: NodeHandle,
+            memberNodes: List<NodeHandle>,
+            membershipId: UniqueIdentifier,
+            notary: Party
+    ) {
+        val allVaultUpdates = (memberNodes + bnoNode).map { node ->
+            node.rpc.run {
+                VaultUpdates(vaultTrackBy<MembershipState>().updates, vaultTrackBy<GroupState>().updates)
+            }
+        }
+
+        bnoNode.suspendMembership(membershipId, notary)
+
+        allVaultUpdates.forEach { vaultUpdates ->
+            vaultUpdates.membershipUpdates.expectEvents(isStrict = false) {
+                expect { update ->
+                    val membership = update.produced.single().state.data
+                    assertEquals(MembershipStatus.SUSPENDED, membership.status)
+                    assertEquals(membershipId, membership.linearId)
+                }
+            }
+        }
+    }
+
+    /** Calls [RevokeMembershipFlow] on [bnoNode] and performs ledger checks. **/
+    @Suppress("LongParameterList")
+    protected fun revokeMembershipAndCheck(
+            bnoNode: InProcess,
+            memberNodes: List<InProcess>,
+            membershipId: UniqueIdentifier,
+            notary: Party,
+            networkId: String,
+            revokedParty: Party
+    ) {
+        bnoNode.revokeMembership(membershipId, notary)
+
+        (memberNodes + bnoNode).forEach { node ->
+            val service = node.services.cordaService(DatabaseService::class.java)
+
+            assertNull(service.getMembership(membershipId))
+            assertTrue(service.getAllBusinessNetworkGroups(networkId).all { revokedParty !in it.state.data.participants })
+        }
+    }
+
+    /** Calls [ModifyRolesFlow] on [bnoNode] and performs ledger checks. **/
+    protected fun modifyRolesAndCheck(
+            bnoNode: NodeHandle,
+            memberNodes: List<NodeHandle>,
+            membershipId: UniqueIdentifier,
+            roles: Set<BNRole>,
+            notary: Party
+    ) {
+        val allVaultUpdates = (memberNodes + bnoNode).map { node ->
+            node.rpc.run {
+                VaultUpdates(vaultTrackBy<MembershipState>().updates, vaultTrackBy<GroupState>().updates)
+            }
+        }
+
+        bnoNode.modifyRoles(membershipId, roles, notary)
+
+        allVaultUpdates.forEach { vaultUpdates ->
+            vaultUpdates.membershipUpdates.expectEvents(isStrict = false) {
+                expect { update ->
+                    val membership = update.produced.single().state.data
+                    assertEquals(roles, membership.roles)
+                    assertEquals(membershipId, membership.linearId)
+                }
+            }
+        }
+    }
+
+    /** Calls [ModifyBusinessIdentityFlow] on [bnoNode] and performs ledger checks. **/
+    protected fun modifyBusinessIdentityAndCheck(
+            bnoNode: NodeHandle,
+            memberNodes: List<NodeHandle>,
+            membershipId: UniqueIdentifier,
+            businessIdentity: BNIdentity,
+            notary: Party
+    ) {
+        val allVaultUpdates = (memberNodes + bnoNode).map { node ->
+            node.rpc.run {
+                VaultUpdates(vaultTrackBy<MembershipState>().updates, vaultTrackBy<GroupState>().updates)
+            }
+        }
+
+        bnoNode.modifyBusinessIdentity(membershipId, businessIdentity, notary)
+
+        allVaultUpdates.forEach { vaultUpdates ->
+            vaultUpdates.membershipUpdates.expectEvents(isStrict = false) {
+                expect { update ->
+                    val membership = update.produced.single().state.data
+                    assertEquals(businessIdentity, membership.identity.businessIdentity)
+                    assertEquals(membershipId, membership.linearId)
+                }
+            }
+        }
+    }
+
+    /** Calls [CreateGroupFlow] on [bnoNode] and performs ledger checks. **/
+    @Suppress("LongParameterList")
+    protected fun createGroupAndCheck(
+            bnoNode: InProcess,
+            memberNodes: List<InProcess>,
+            networkId: String,
+            groupId: UniqueIdentifier,
+            groupName: String,
+            additionalParticipants: Set<UniqueIdentifier>,
+            notary: Party,
+            expectedParticipants: Set<Party>
+    ) {
+        bnoNode.createGroup(networkId, groupId, groupName, additionalParticipants, notary)
+
+        (memberNodes + bnoNode).forEach { node ->
+            val service = node.services.cordaService(DatabaseService::class.java)
+
+            val group = service.getBusinessNetworkGroup(groupId)
+            assertNotNull(group)
+            group?.state?.data?.let {
+                assertEquals(networkId, it.networkId)
+                assertEquals(groupName, it.name)
+                assertEquals(groupId, it.linearId)
+                assertEquals(expectedParticipants, it.participants.toSet())
+            }
+        }
+    }
+
+    /** Calls [ModifyGroupFlow] on [bnoNode] and performs ledger checks. **/
+    @Suppress("LongParameterList")
+    protected fun modifyGroupAndCheck(
+            bnoNode: InProcess,
+            memberNodes: List<InProcess>,
+            groupId: UniqueIdentifier,
+            name: String,
+            participants: Set<UniqueIdentifier>,
+            notary: Party,
+            expectedParticipants: Set<Party>
+    ) {
+        bnoNode.modifyGroup(groupId, name, participants, notary)
+
+        (memberNodes + bnoNode).forEach { node ->
+            val service = node.services.cordaService(DatabaseService::class.java)
+
+            val group = service.getBusinessNetworkGroup(groupId)
+            assertNotNull(group)
+            group?.state?.data?.let {
+                assertEquals(name, it.name)
+                assertEquals(groupId, it.linearId)
+                assertEquals(expectedParticipants, it.participants.toSet())
+            }
+        }
+    }
+
+    /** Calls [DeleteGroupFlow] on [bnoNode] and performs ledger checks. **/
+    protected fun deleteGroupAndCheck(
+            bnoNode: InProcess,
+            memberNodes: List<InProcess>,
+            groupId: UniqueIdentifier,
+            notary: Party
+    ) {
+        bnoNode.deleteGroup(groupId, notary)
+
+        (memberNodes + bnoNode).forEach { node ->
+            val service = node.services.cordaService(DatabaseService::class.java)
+            assertNull(service.getBusinessNetworkGroup(groupId))
+        }
+    }
+}

--- a/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/CentralisedBusinessNetworksTest.kt
+++ b/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/CentralisedBusinessNetworksTest.kt
@@ -1,0 +1,217 @@
+package net.corda.bn.flows
+
+import net.corda.bn.states.AdminPermission
+import net.corda.bn.states.BNRole
+import net.corda.bn.states.MemberRole
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.serialization.CordaSerializable
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.TestCordapp
+import org.junit.Test
+
+class CentralisedBusinessNetworksTest : AbstractBusinessNetworksTest() {
+
+    @CordaSerializable
+    class MembershipAdminRole : BNRole(
+            "Membership Administrator",
+            setOf(AdminPermission.CAN_ACTIVATE_MEMBERSHIP, AdminPermission.CAN_SUSPEND_MEMBERSHIP, AdminPermission.CAN_REVOKE_MEMBERSHIP)
+    )
+
+    @CordaSerializable
+    class RolesAdminRole : BNRole("Roles Administrator", setOf(AdminPermission.CAN_MODIFY_ROLE))
+
+    @Test(timeout = 300_000)
+    fun `public centralised business network test`() {
+        driver(DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.bn.contracts"), TestCordapp.findCordapp("net.corda.bn.flows"))
+        )) {
+            // start bno (Business Network creator) and subsequent member nodes
+            val bnoNode = startNodes(listOf(bnoIdentity)).single()
+            val memberNodes = startNodes(membersIdentities)
+
+            // create a Business Network
+            val networkId = UniqueIdentifier()
+            val bnoBusinessIdentity = MyIdentity("BNO")
+            val groupId = UniqueIdentifier()
+            val groupName = "default-group"
+            val bnoMembershipId = createBusinessNetworkAndCheck(bnoNode, networkId, bnoBusinessIdentity, groupId, groupName, defaultNotaryIdentity)
+
+            // create membership requests from all [memberNodes]
+            val membershipIds = memberNodes.mapIndexed { idx, node ->
+                val memberBusinessIdentity = MyIdentity("Member$idx")
+                val linearId = requestMembershipAndCheck(node, bnoNode, networkId.toString(), memberBusinessIdentity, defaultNotaryIdentity)
+
+                linearId to node
+            }.toMap()
+
+            // activate all pending memberships
+            membershipIds.forEach { (membershipId, node) ->
+                activateMembershipAndCheck(bnoNode, listOf(node), membershipId, defaultNotaryIdentity)
+            }
+
+            // add all activated memberships to initial global group
+            modifyGroupAndCheck(
+                    bnoNode,
+                    memberNodes,
+                    groupId,
+                    groupName,
+                    membershipIds.keys + bnoMembershipId,
+                    defaultNotaryIdentity,
+                    (memberNodes + bnoNode).map { it.identity() }.toSet()
+            )
+
+            val iterator = membershipIds.entries.iterator()
+
+            // modify business identity of the first member node in the list
+            iterator.next().also { (membershipId, _) ->
+                modifyBusinessIdentityAndCheck(bnoNode, memberNodes, membershipId, MyIdentity("SpecialMember"), defaultNotaryIdentity)
+            }
+
+            // suspend and revoke second member node in the list
+            iterator.next().also { (membershipId, node) ->
+                suspendMembershipAndCheck(bnoNode, memberNodes, membershipId, defaultNotaryIdentity)
+                revokeMembershipAndCheck(bnoNode, memberNodes, membershipId, defaultNotaryIdentity, networkId.toString(), node.identity())
+            }
+
+            // directly revoke third member node in the list
+            iterator.next().also { (membershipId, node) ->
+                revokeMembershipAndCheck(bnoNode, memberNodes, membershipId, defaultNotaryIdentity, networkId.toString(), node.identity())
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `private centralised business network test`() {
+        driver(DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.bn.contracts"), TestCordapp.findCordapp("net.corda.bn.flows"))
+        )) {
+            // start bno (Business Network creator) and subsequent member nodes
+            val bnoNode = startNodes(listOf(bnoIdentity)).single()
+            val memberNodes = startNodes(membersIdentities)
+
+            // create a Business Network
+            val networkId = UniqueIdentifier()
+            val bnoBusinessIdentity = MyIdentity("BNO")
+            val groupId = UniqueIdentifier()
+            val groupName = "default-group"
+            createBusinessNetworkAndCheck(bnoNode, networkId, bnoBusinessIdentity, groupId, groupName, defaultNotaryIdentity)
+
+            // create membership requests from all [memberNodes]
+            val membershipIds = memberNodes.mapIndexed { idx, node ->
+                val memberBusinessIdentity = MyIdentity("Member$idx")
+                val linearId = requestMembershipAndCheck(node, bnoNode, networkId.toString(), memberBusinessIdentity, defaultNotaryIdentity)
+
+                linearId to node
+            }.toMap()
+
+            // activate each pending membership and add it to new group created just for it and BNO node
+            val groupIds = membershipIds.map { (membershipId, node) ->
+                activateMembershipAndCheck(bnoNode, listOf(node), membershipId, defaultNotaryIdentity)
+
+                UniqueIdentifier().also { groupId ->
+                    createGroupAndCheck(
+                            bnoNode,
+                            listOf(node),
+                            networkId.toString(),
+                            groupId,
+                            "custom-group-$membershipId",
+                            setOf(membershipId),
+                            defaultNotaryIdentity,
+                            setOf(bnoNode.identity(), node.identity())
+                    )
+                }
+            }
+
+            // modify business identity of each member in the Business Network (except BNO)
+            membershipIds.forEach { (membershipId, node) ->
+                modifyBusinessIdentityAndCheck(bnoNode, listOf(node), membershipId, MyIdentity("SpecialMember-$membershipId"), defaultNotaryIdentity)
+            }
+
+            // suspend each Business Network member (except BNO)
+            membershipIds.forEach { (membershipId, node) ->
+                suspendMembershipAndCheck(bnoNode, listOf(node), membershipId, defaultNotaryIdentity)
+            }
+
+            // revoke each Business Network member (except BNO)
+            membershipIds.forEach { (membershipId, node) ->
+                revokeMembershipAndCheck(bnoNode, memberNodes, membershipId, defaultNotaryIdentity, networkId.toString(), node.identity())
+            }
+
+            // delete all groups that were created for each revoked Business Network member
+            groupIds.forEach {
+                deleteGroupAndCheck(bnoNode, memberNodes, it, defaultNotaryIdentity)
+            }
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `rbac oriented business network test`() {
+        driver(DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.bn.contracts"), TestCordapp.findCordapp("net.corda.bn.flows"))
+        )) {
+            // start bno (Business Network creator) and subsequent member nodes
+            val bnoNode = startNodes(listOf(bnoIdentity)).single()
+            val memberNodes = startNodes(membersIdentities)
+
+            // create a Business Network
+            val networkId = UniqueIdentifier()
+            val bnoBusinessIdentity = MyIdentity("BNO")
+            val groupId = UniqueIdentifier()
+            val groupName = "default-group"
+            val bnoMembershipId = createBusinessNetworkAndCheck(bnoNode, networkId, bnoBusinessIdentity, groupId, groupName, defaultNotaryIdentity)
+
+            // request new membership, activate it, add to initial global group and assign it [MembershipAdminRole] which grants it
+            // permissions to activate, suspend and revoke memberships
+            val (membershipAdminId, membershipAdminNode) = memberNodes.first().let { node ->
+                val memberBusinessIdentity = MyIdentity("Member0")
+                val linearId = requestMembershipAndCheck(node, bnoNode, networkId.toString(), memberBusinessIdentity, defaultNotaryIdentity)
+                activateMembershipAndCheck(bnoNode, listOf(node), linearId, defaultNotaryIdentity)
+                modifyGroupAndCheck(bnoNode, listOf(node), groupId, groupName, setOf(bnoMembershipId, linearId), defaultNotaryIdentity, setOf(bnoNode.identity(), node.identity()))
+                modifyRolesAndCheck(bnoNode, listOf(node), linearId, setOf(MembershipAdminRole()), defaultNotaryIdentity)
+                linearId to node
+            }
+
+            // create membership requests from all the other nodes
+            val membershipIds = memberNodes.filterNot { it == membershipAdminNode }.mapIndexed { idx, node ->
+                val memberBusinessIdentity = MyIdentity("Member$idx")
+                val linearId = requestMembershipAndCheck(node, bnoNode, networkId.toString(), memberBusinessIdentity, defaultNotaryIdentity)
+
+                linearId to node
+            }.toMap()
+
+            // activate all pending memberships using the member that was assigned [MembershipAdminRole]
+            membershipIds.forEach { (membershipId, node) ->
+                activateMembershipAndCheck(membershipAdminNode, listOf(bnoNode, node), membershipId, defaultNotaryIdentity)
+            }
+
+            // add all activated memberships to initial global group
+            modifyGroupAndCheck(
+                    bnoNode,
+                    memberNodes,
+                    groupId,
+                    groupName,
+                    membershipIds.keys + bnoMembershipId + membershipAdminId,
+                    defaultNotaryIdentity,
+                    (memberNodes + bnoNode).map { it.identity() }.toSet()
+            )
+
+            // assign [RolesAdminRole] to another member which grants it permission to modify memberships' roles.
+            val iterator = membershipIds.entries.iterator()
+            val roleAdminNode = iterator.next().let { (membershipId, node) ->
+                modifyRolesAndCheck(bnoNode, memberNodes, membershipId, setOf(RolesAdminRole()), defaultNotaryIdentity)
+                node
+            }
+
+            // change roles of all other members to [MemberRole] using the member that was assigned [RolesAdminRole]
+            while (iterator.hasNext()) {
+                iterator.next().also { (membershipId, _) ->
+                    modifyRolesAndCheck(roleAdminNode, memberNodes, membershipId, setOf(MemberRole()), defaultNotaryIdentity)
+                }
+            }
+        }
+    }
+}

--- a/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/DecentralisedBusinessNetworksTest.kt
+++ b/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/DecentralisedBusinessNetworksTest.kt
@@ -1,0 +1,65 @@
+package net.corda.bn.flows
+
+import net.corda.bn.states.BNORole
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.TestCordapp
+import org.junit.Test
+
+class DecentralisedBusinessNetworksTest : AbstractBusinessNetworksTest() {
+
+    @Test(timeout = 300_000)
+    fun `public decentralised business network test`() {
+        driver(DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.bn.contracts"), TestCordapp.findCordapp("net.corda.bn.flows"))
+        )) {
+            // start bno (Business Network creator) and subsequent member nodes
+            val bnoNode = startNodes(listOf(bnoIdentity)).single()
+            val memberNodes = startNodes(membersIdentities)
+
+            // create a Business Network
+            val networkId = UniqueIdentifier()
+            val bnoBusinessIdentity = MyIdentity("BNO")
+            val groupId = UniqueIdentifier()
+            val groupName = "default-group"
+            val bnoMembershipId = createBusinessNetworkAndCheck(bnoNode, networkId, bnoBusinessIdentity, groupId, groupName, defaultNotaryIdentity)
+
+            // create membership requests from all [memberNodes]
+            val membershipIds = memberNodes.mapIndexed { idx, node ->
+                val memberBusinessIdentity = MyIdentity("Member$idx")
+                val linearId = requestMembershipAndCheck(node, bnoNode, networkId.toString(), memberBusinessIdentity, defaultNotaryIdentity)
+
+                linearId to node
+            }.toMap()
+
+            // activate all pending memberships
+            membershipIds.forEach { (membershipId, node) ->
+                activateMembershipAndCheck(bnoNode, listOf(node), membershipId, defaultNotaryIdentity)
+            }
+
+            // add all activated memberships to initial global group
+            modifyGroupAndCheck(
+                    bnoNode,
+                    memberNodes,
+                    groupId,
+                    groupName,
+                    membershipIds.keys + bnoMembershipId,
+                    defaultNotaryIdentity,
+                    (memberNodes + bnoNode).map { it.identity() }.toSet()
+            )
+
+            // assign each member a [BNORole] to form fully decentralised network
+            membershipIds.forEach { (membershipId, _) ->
+                modifyRolesAndCheck(bnoNode, memberNodes, membershipId, setOf(BNORole()), defaultNotaryIdentity)
+            }
+
+            // use one of the members to modify Business Network creator's business identity
+            modifyBusinessIdentityAndCheck(memberNodes.first(), memberNodes + bnoNode, bnoMembershipId, MyIdentity("SpecialBNO"), defaultNotaryIdentity)
+
+            // use one of the members to revoke Business Network creator's membership
+            revokeMembershipAndCheck(memberNodes[1], memberNodes + bnoNode, bnoMembershipId, defaultNotaryIdentity, networkId.toString(), bnoNode.identity())
+        }
+    }
+}

--- a/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/NodeDriverUtils.kt
+++ b/business-networks/business-networks-workflows/src/integration-test/kotlin/net/corda/bn/flows/NodeDriverUtils.kt
@@ -1,0 +1,100 @@
+package net.corda.bn.flows
+
+import net.corda.bn.states.BNIdentity
+import net.corda.bn.states.BNRole
+import net.corda.bn.states.GroupState
+import net.corda.bn.states.MembershipState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.Party
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.testing.driver.DriverDSL
+import net.corda.testing.driver.InProcess
+import net.corda.testing.driver.NodeHandle
+
+/** Starts multiple nodes simultaneously, then waits for them all to be ready. **/
+fun DriverDSL.startNodes(identities: List<Party>) = identities.map {
+    startNode(providedName = it.name)
+}.map {
+    it.getOrThrow() as InProcess
+}
+
+/** Returns identity of [NodeHandle] calling the method. **/
+fun NodeHandle.identity() = nodeInfo.legalIdentities.single()
+
+/** Helper method to call [CreateBusinessNetworkFlow] from [NodeHandle]. **/
+fun NodeHandle.createBusinessNetwork(
+        networkId: UniqueIdentifier = UniqueIdentifier(),
+        businessIdentity: BNIdentity? = null,
+        groupId: UniqueIdentifier = UniqueIdentifier(),
+        groupName: String? = null,
+        notary: Party? = null
+): MembershipState {
+    val stx = rpc.startFlow(::CreateBusinessNetworkFlow, networkId, businessIdentity, groupId, groupName, notary)
+            .returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as MembershipState
+}
+
+/** Helper method to call [RequestMembershipFlow] from [NodeHandle]. **/
+fun NodeHandle.requestMembership(
+        authorisedParty: Party,
+        networkId: String,
+        businessIdentity: BNIdentity? = null,
+        notary: Party? = null
+): MembershipState {
+    val stx = rpc.startFlow(::RequestMembershipFlow, authorisedParty, networkId, businessIdentity, notary)
+            .returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as MembershipState
+}
+
+/** Helper method to call [ActivateMembershipFlow] from [NodeHandle]. **/
+fun NodeHandle.activateMembership(membershipId: UniqueIdentifier, notary: Party? = null): MembershipState {
+    val stx = rpc.startFlow(::ActivateMembershipFlow, membershipId, notary).returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as MembershipState
+}
+
+/** Helper method to call [SuspendMembershipFlow] from [NodeHandle]. **/
+fun NodeHandle.suspendMembership(membershipId: UniqueIdentifier, notary: Party? = null): MembershipState {
+    val stx = rpc.startFlow(::SuspendMembershipFlow, membershipId, notary).returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as MembershipState
+}
+
+/** Helper method to call [RevokeMembershipFlow] from [NodeHandle]. **/
+fun NodeHandle.revokeMembership(membershipId: UniqueIdentifier, notary: Party? = null) {
+    rpc.startFlow(::RevokeMembershipFlow, membershipId, notary).returnValue.getOrThrow()
+}
+
+/** Helper method to call [ModifyRolesFlow] from [NodeHandle]. **/
+fun NodeHandle.modifyRoles(membershipId: UniqueIdentifier, roles: Set<BNRole>, notary: Party? = null): MembershipState {
+    val stx = rpc.startFlow(::ModifyRolesFlow, membershipId, roles, notary).returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as MembershipState
+}
+
+/** Helper method to call [ModifyBusinessIdentityFlow] from [NodeHandle]. **/
+fun NodeHandle.modifyBusinessIdentity(membershipId: UniqueIdentifier, businessIdentity: BNIdentity, notary: Party? = null): MembershipState {
+    val stx = rpc.startFlow(::ModifyBusinessIdentityFlow, membershipId, businessIdentity, notary).returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as MembershipState
+}
+
+/** Helper method to call [CreateGroupFlow] from [NodeHandle]. **/
+fun NodeHandle.createGroup(
+        networkId: String,
+        groupId: UniqueIdentifier = UniqueIdentifier(),
+        groupName: String? = null,
+        additionalParticipants: Set<UniqueIdentifier> = emptySet(),
+        notary: Party? = null
+): GroupState {
+    val stx = rpc.startFlow(::CreateGroupFlow, networkId, groupId, groupName, additionalParticipants, notary).returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as GroupState
+}
+
+/** Helper method to call [ModifyGroupFlow] from [NodeHandle]. **/
+fun NodeHandle.modifyGroup(groupId: UniqueIdentifier, name: String? = null, participants: Set<UniqueIdentifier>? = null, notary: Party? = null): GroupState {
+    val stx = rpc.startFlow(::ModifyGroupFlow, groupId, name, participants, notary).returnValue.getOrThrow()
+    return stx.tx.outputStates.single() as GroupState
+}
+
+/** Helper method to call [DeleteGroupFlow] from [NodeHandle]. **/
+fun NodeHandle.deleteGroup(groupId: UniqueIdentifier, notary: Party? = null) {
+    rpc.startFlow(::DeleteGroupFlow, groupId, notary).returnValue.getOrThrow()
+}

--- a/business-networks/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/DatabaseServiceTest.kt
+++ b/business-networks/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/DatabaseServiceTest.kt
@@ -1,0 +1,259 @@
+package net.corda.bn.flows
+
+import net.corda.bn.states.BNORole
+import net.corda.bn.states.MembershipState
+import net.corda.bn.states.MembershipStatus
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.CordaX500Name
+import net.corda.testing.core.TestIdentity
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DatabaseServiceTest : MembershipManagementFlowTest(numberOfAuthorisedMembers = 1, numberOfRegularMembers = 1) {
+
+    private fun DatabaseService.getAllMemberships(networkId: String) = getAllMembershipsWithStatus(
+            networkId,
+            MembershipStatus.PENDING, MembershipStatus.ACTIVE, MembershipStatus.SUSPENDED
+    ).map {
+        it.state.data.linearId
+    }
+
+    @Test(timeout = 300_000)
+    fun `business network exists method should work`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMemberService = authorisedMember.services.cordaService(DatabaseService::class.java)
+        val regularMemberService = regularMember.services.cordaService(DatabaseService::class.java)
+
+        val invalidNetworkId = "invalid-network-id"
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertFalse(service.businessNetworkExists(invalidNetworkId)) }
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        assertTrue(authorisedMemberService.businessNetworkExists(networkId))
+        assertFalse(regularMemberService.businessNetworkExists(networkId))
+
+        val membership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.businessNetworkExists(networkId)) }
+
+        runSuspendMembershipFlow(authorisedMember, membership.linearId)
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.businessNetworkExists(networkId)) }
+
+        runRevokeMembershipFlow(authorisedMember, membership.linearId)
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.businessNetworkExists(networkId)) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `get membership methods should work`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMemberService = authorisedMember.services.cordaService(DatabaseService::class.java)
+        val regularMemberService = regularMember.services.cordaService(DatabaseService::class.java)
+
+        val invalidMembershipId = UniqueIdentifier()
+        val invalidNetworkId = "invalid-network-id"
+        val invalidIdentity = TestIdentity(CordaX500Name.parse("O=InvalidOrganisation,L=New York,C=US")).party
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertNull(service.getMembership(invalidMembershipId))
+            assertNull(service.getMembership(invalidNetworkId, invalidIdentity))
+        }
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        authorisedMembership.apply {
+            assertEquals(linearId, authorisedMemberService.getMembership(linearId)?.state?.data?.linearId)
+            assertEquals(linearId, authorisedMemberService.getMembership(networkId, identity.cordaIdentity)?.state?.data?.linearId)
+            assertNull(regularMemberService.getMembership(linearId))
+            assertNull(regularMemberService.getMembership(networkId, identity.cordaIdentity))
+        }
+
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, authorisedMembership.networkId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMembership, regularMembership).forEach { membership ->
+            membership.apply {
+                assertEquals(linearId, authorisedMemberService.getMembership(linearId)?.state?.data?.linearId)
+                assertEquals(linearId, authorisedMemberService.getMembership(networkId, identity.cordaIdentity)?.state?.data?.linearId)
+                assertEquals(linearId, regularMemberService.getMembership(linearId)?.state?.data?.linearId)
+                assertEquals(linearId, regularMemberService.getMembership(networkId, identity.cordaIdentity)?.state?.data?.linearId)
+            }
+        }
+
+        val suspendedMembership = runSuspendMembershipFlow(authorisedMember, regularMembership.linearId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMembership, suspendedMembership).forEach { membership ->
+            membership.apply {
+                assertEquals(linearId, authorisedMemberService.getMembership(linearId)?.state?.data?.linearId)
+                assertEquals(linearId, authorisedMemberService.getMembership(networkId, identity.cordaIdentity)?.state?.data?.linearId)
+                assertEquals(linearId, regularMemberService.getMembership(linearId)?.state?.data?.linearId)
+                assertEquals(linearId, regularMemberService.getMembership(networkId, identity.cordaIdentity)?.state?.data?.linearId)
+            }
+        }
+
+        runRevokeMembershipFlow(authorisedMember, suspendedMembership.linearId)
+        authorisedMembership.apply {
+            assertEquals(linearId, authorisedMemberService.getMembership(linearId)?.state?.data?.linearId)
+            assertEquals(linearId, authorisedMemberService.getMembership(networkId, identity.cordaIdentity)?.state?.data?.linearId)
+            assertNull(regularMemberService.getMembership(linearId))
+            assertNull(regularMemberService.getMembership(networkId, identity.cordaIdentity))
+        }
+        suspendedMembership.apply {
+            assertNull(authorisedMemberService.getMembership(linearId))
+            assertNull(authorisedMemberService.getMembership(networkId, identity.cordaIdentity))
+            assertNull(regularMemberService.getMembership(linearId))
+            assertNull(regularMemberService.getMembership(networkId, identity.cordaIdentity))
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `get all memberships with status method should work`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMemberService = authorisedMember.services.cordaService(DatabaseService::class.java)
+        val regularMemberService = regularMember.services.cordaService(DatabaseService::class.java)
+
+        val invalidNetworkId = "invalid-network-id"
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.getAllMemberships(invalidNetworkId).isEmpty()) }
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        assertEquals(setOf(authorisedMembership.linearId), authorisedMemberService.getAllMemberships(authorisedMembership.networkId).toSet())
+        assertTrue(regularMemberService.getAllMemberships(authorisedMembership.networkId).isEmpty())
+
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, authorisedMembership.networkId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertEquals(setOf(authorisedMembership.linearId, regularMembership.linearId), service.getAllMemberships(authorisedMembership.networkId).toSet())
+        }
+
+        val suspendedMembership = runSuspendMembershipFlow(authorisedMember, regularMembership.linearId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertEquals(setOf(authorisedMembership.linearId, suspendedMembership.linearId), service.getAllMemberships(authorisedMembership.networkId).toSet())
+            assertEquals(setOf(authorisedMembership.linearId), service.getAllMembershipsWithStatus(authorisedMembership.networkId, MembershipStatus.ACTIVE).map { it.state.data.linearId }.toSet())
+            assertEquals(setOf(suspendedMembership.linearId), service.getAllMembershipsWithStatus(authorisedMembership.networkId, MembershipStatus.SUSPENDED).map { it.state.data.linearId }.toSet())
+            assertTrue(service.getAllMembershipsWithStatus(authorisedMembership.networkId, MembershipStatus.PENDING).isEmpty())
+        }
+
+        runRevokeMembershipFlow(authorisedMember, suspendedMembership.linearId)
+        assertEquals(setOf(authorisedMembership.linearId), authorisedMemberService.getAllMemberships(authorisedMembership.networkId).toSet())
+        assertTrue(regularMemberService.getAllMemberships(authorisedMembership.networkId).isEmpty())
+    }
+
+    @Test(timeout = 300_000)
+    fun `get members authorised to modify membership method should work`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMemberService = authorisedMember.services.cordaService(DatabaseService::class.java)
+        val regularMemberService = regularMember.services.cordaService(DatabaseService::class.java)
+
+        val invalidNetworkId = "invalid-network-id"
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.getMembersAuthorisedToModifyMembership(invalidNetworkId).isEmpty()) }
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        assertEquals(setOf(authorisedMembership.linearId), authorisedMemberService.getMembersAuthorisedToModifyMembership(authorisedMembership.networkId).map { it.state.data.linearId }.toSet())
+        assertTrue(regularMemberService.getMembersAuthorisedToModifyMembership(authorisedMembership.networkId).isEmpty())
+
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, authorisedMembership.networkId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertEquals(setOf(authorisedMembership.linearId), service.getMembersAuthorisedToModifyMembership(authorisedMembership.networkId).map { it.state.data.linearId }.toSet())
+        }
+
+        val bnoMembership = runModifyRolesFlow(authorisedMember, regularMembership.linearId, setOf(BNORole())).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertEquals(setOf(authorisedMembership.linearId, bnoMembership.linearId), service.getMembersAuthorisedToModifyMembership(authorisedMembership.networkId).map { it.state.data.linearId }.toSet())
+        }
+
+        val suspendedMembership = runSuspendMembershipFlow(authorisedMember, bnoMembership.linearId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertEquals(setOf(authorisedMembership.linearId, suspendedMembership.linearId), service.getMembersAuthorisedToModifyMembership(authorisedMembership.networkId).map { it.state.data.linearId }.toSet())
+        }
+
+        runRevokeMembershipFlow(authorisedMember, suspendedMembership.linearId)
+        assertEquals(setOf(authorisedMembership.linearId), authorisedMemberService.getMembersAuthorisedToModifyMembership(authorisedMembership.networkId).map { it.state.data.linearId }.toSet())
+        assertTrue(regularMemberService.getMembersAuthorisedToModifyMembership(authorisedMembership.networkId).isEmpty())
+    }
+
+    @Test(timeout = 300_000)
+    fun `business network groups exists method should work`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMemberService = authorisedMember.services.cordaService(DatabaseService::class.java)
+        val regularMemberService = regularMember.services.cordaService(DatabaseService::class.java)
+
+        val invalidGroupId = UniqueIdentifier()
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertFalse(service.businessNetworkGroupExists(invalidGroupId)) }
+
+        val groupId = UniqueIdentifier()
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember, groupId = groupId).tx.outputStates.single() as MembershipState).networkId
+        assertTrue(authorisedMemberService.businessNetworkGroupExists(groupId))
+        assertFalse(regularMemberService.businessNetworkGroupExists(groupId))
+
+        val membership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.businessNetworkGroupExists(groupId)) }
+
+        runSuspendMembershipFlow(authorisedMember, membership.linearId)
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.businessNetworkGroupExists(groupId)) }
+
+        runRevokeMembershipFlow(authorisedMember, membership.linearId)
+        assertTrue(authorisedMemberService.businessNetworkGroupExists(groupId))
+        assertFalse(regularMemberService.businessNetworkGroupExists(groupId))
+    }
+
+    @Test(timeout = 300_000)
+    fun `get business network group method should work`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMemberService = authorisedMember.services.cordaService(DatabaseService::class.java)
+        val regularMemberService = regularMember.services.cordaService(DatabaseService::class.java)
+
+        val invalidGroupId = UniqueIdentifier()
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertNull(service.getBusinessNetworkGroup(invalidGroupId)) }
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val groupId = authorisedMemberService.getAllBusinessNetworkGroups(networkId).single().state.data.linearId
+        assertEquals(setOf(authorisedMember.identity()), authorisedMemberService.getBusinessNetworkGroup(groupId)?.state?.data?.participants?.toSet())
+        assertNull(regularMemberService.getBusinessNetworkGroup(groupId))
+
+        val membership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertEquals(setOf(authorisedMember.identity(), regularMember.identity()), service.getBusinessNetworkGroup(groupId)?.state?.data?.participants?.toSet())
+        }
+
+        runSuspendMembershipFlow(authorisedMember, membership.linearId).tx.outputStates.single()
+        listOf(authorisedMemberService, regularMemberService).forEach { service ->
+            assertEquals(setOf(authorisedMember.identity(), regularMember.identity()), service.getBusinessNetworkGroup(groupId)?.state?.data?.participants?.toSet())
+        }
+
+        runRevokeMembershipFlow(authorisedMember, membership.linearId)
+        assertEquals(setOf(authorisedMember.identity()), authorisedMemberService.getBusinessNetworkGroup(groupId)?.state?.data?.participants?.toSet())
+        assertNull(regularMemberService.getBusinessNetworkGroup(groupId))
+    }
+
+    @Test(timeout = 300_000)
+    fun `get all business network groups method should work`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMemberService = authorisedMember.services.cordaService(DatabaseService::class.java)
+        val regularMemberService = regularMember.services.cordaService(DatabaseService::class.java)
+
+        val invalidNetworkId = "invalid-network-id"
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.getAllBusinessNetworkGroups(invalidNetworkId).isEmpty()) }
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        assertTrue(authorisedMemberService.getAllBusinessNetworkGroups(networkId).isNotEmpty())
+        assertTrue(regularMemberService.getAllBusinessNetworkGroups(networkId).isEmpty())
+
+        val membership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.getAllBusinessNetworkGroups(networkId).isNotEmpty()) }
+
+        runSuspendMembershipFlow(authorisedMember, membership.linearId).tx.outputStates.single()
+        listOf(authorisedMemberService, regularMemberService).forEach { service -> assertTrue(service.getAllBusinessNetworkGroups(networkId).isNotEmpty()) }
+
+        runRevokeMembershipFlow(authorisedMember, membership.linearId)
+        assertTrue(authorisedMemberService.getAllBusinessNetworkGroups(networkId).isNotEmpty())
+        assertTrue(regularMemberService.getAllBusinessNetworkGroups(networkId).isEmpty())
+    }
+}

--- a/business-networks/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/RevokeMembershipFlowTest.kt
+++ b/business-networks/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/RevokeMembershipFlowTest.kt
@@ -64,15 +64,18 @@ class RevokeMembershipFlowTest : MembershipManagementFlowTest(numberOfAuthorised
         }
 
         // also check ledgers
-        listOf(authorisedMember, regularMember).forEach { member ->
+        authorisedMember.also { member ->
             getAllMembershipsFromVault(member, networkId).single().apply {
-                assertEquals(authorisedMember.identity(), identity.cordaIdentity, "Expected to have ${authorisedMember.identity()} in ${member.identity()} vault")
+                assertEquals(authorisedMember.identity(), identity.cordaIdentity)
                 assertEquals(setOf(authorisedMember.identity()), participants.toSet())
             }
-
             getAllGroupsFromVault(member, networkId).single().apply {
                 assertEquals(setOf(authorisedMember.identity()), participants.toSet())
             }
+        }
+        regularMember.also { member ->
+            assertTrue(getAllMembershipsFromVault(member, networkId).isEmpty())
+            assertTrue(getAllGroupsFromVault(member, networkId).isEmpty())
         }
     }
 }


### PR DESCRIPTION
## Description

This PR finally introduces integration tests that support typical Business Networks scenarios from bootstrapping to actual lifecycle of it. For more details about those scenarios please go to [primitives doc](https://github.com/corda/platform-eng-design/blob/master/extensions/biznet/primitives-design.md#sample-scenarios).

Integration tests are part of `CentralisedBusinessNetworksTest` and `DecentralisedBusinessNetworksTest` which both extend `AbstractBusinessNetworksTest` having helper methods for running Business Network management flows and performing checks over vault updates. 

We also adapt `DatabaseService` so that now revoked members cannot fetch any information about members or group of the Business Networks they've been revoked from. Members also can't fetch information about members if they are not participants in at least one common group. In the end we write supporting unit tests for this adaptation.

## Test Plan

Ensure all existing and new tests pass. Also ensure all BN management operations work when deploying nodes.