### PR TITLE
CORDA-3973 Fix memory leak due to DB not shutting down

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkPersistenceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkPersistenceTests.kt
@@ -2,7 +2,6 @@ package net.corda.node.services.statemachine
 
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.Party
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.persistence.checkpoints
 import net.corda.testing.core.ALICE_NAME

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkPersistenceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkPersistenceTests.kt
@@ -129,7 +129,7 @@ class FlowFrameworkPersistenceTests {
         mockNet.runNetwork()
         fut1.getOrThrow()
 
-        val receivedCount = receivedSessionMessages.count { it.isPayloadTransfer } ?: 0
+        val receivedCount = receivedSessionMessages.count { it.isPayloadTransfer }
         // Check flows completed cleanly and didn't get out of phase
         assertEquals(4, receivedCount, "Flow should have exchanged 4 unique messages")// Two messages each way
         // can't give a precise value as every addMessageHandler re-runs the undelivered messages

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -589,11 +589,12 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
     }
 
     fun stopNodes() {
-        try {
-            nodes.forEach { node -> node.started?.dispose() }
-        } finally {
-            serializationEnv.close()
-            cordappClassLoader?.close()
+        cordappClassLoader.use { _ ->
+            // Serialization env must be unset even if other parts of this method fail.
+            serializationEnv.use {
+                nodes.forEach { it.started?.dispose() }
+            }
+            messagingNetwork.stop()
         }
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -589,12 +589,11 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
     }
 
     fun stopNodes() {
-        cordappClassLoader.use { _ ->
-            // Serialization env must be unset even if other parts of this method fail.
-            serializationEnv.use {
-                nodes.forEach { it.started?.dispose() }
-            }
-            messagingNetwork.stop()
+        try {
+            nodes.forEach { node -> node.started?.dispose() }
+        } finally {
+            serializationEnv.close()
+            cordappClassLoader?.close()
         }
     }
 


### PR DESCRIPTION
Fix memory leak due to DB not shutting down in FlowFrameworkPersistenceTests.flow restarted just after receiving payload.

Also reduces number of class-wide variables to reduce scope for references being accidentally held between runs.