### PR TITLE
CORDA-3882 - Integrate new start method with reconnecting rpc client

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -402,6 +402,7 @@ class CordaRPCClientReconnectionTest {
             client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect).use {
                 val rpcOps = it.proxy as ReconnectingCordaRPCOps
                 val clientId = UUID.randomUUID().toString()
+                // assert result reconnectable futures returned from both 'startFlowWithClientId' and 'reattachFlowWithClientId'
                 val flowHandle0 = rpcOps.startFlowWithClientId(clientId, ::SimpleFlow)
                 val flowHandle1 = rpcOps.reattachFlowWithClientId<Int>(clientId)
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -531,7 +531,7 @@ class CordaRPCClientReconnectionTest {
             (client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect)).use {
                 val rpcOps = it.proxy as ReconnectingCordaRPCOps
                 val clientId = UUID.randomUUID().toString()
-                val flowHandle = rpcOps.startFlowWithClientId(clientId, ::SimpleFlow).returnValue.getOrThrow()
+                rpcOps.startFlowWithClientId(clientId, ::SimpleFlow).returnValue.getOrThrow()
 
                 node.stop()
                 thread {

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -386,7 +386,7 @@ class CordaRPCClientReconnectionTest {
     }
 
     @Test(timeout=300_000)
-    fun `rpc returned flow result future continue working when the node crashes and restarts`() {
+    fun `rpc returned flow -started with cient id- result future continue working when the node crashes and restarts`() {
         driver(DriverParameters(inMemoryDB = false, cordappsForAllNodes = listOf(this.enclosedCordapp()))) {
             val address = NetworkHostAndPort("localhost", portAllocator.nextPort())
             fun startNode(): NodeHandle {
@@ -450,7 +450,7 @@ class CordaRPCClientReconnectionTest {
     }
 
     @Test(timeout=300_000)
-    fun `rpc returned flow exception future continue working when the node crashes and restarts`() {
+    fun `rpc returned flow -started with cient id- exception future continue working when the node crashes and restarts`() {
         driver(DriverParameters(inMemoryDB = false, cordappsForAllNodes = listOf(this.enclosedCordapp()))) {
             val address = NetworkHostAndPort("localhost", portAllocator.nextPort())
             fun startNode(): NodeHandle {

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -382,7 +382,7 @@ class CordaRPCClientReconnectionTest {
         }
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `rpc returned flow result future continue working when the server crashes and restarts`() {
         driver(DriverParameters(cordappsForAllNodes = listOf(this.enclosedCordapp()))) {
             val address = NetworkHostAndPort("localhost", portAllocator.nextPort())

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -402,7 +402,7 @@ class CordaRPCClientReconnectionTest {
             client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect).use {
                 val rpcOps = it.proxy as ReconnectingCordaRPCOps
                 val clientId = UUID.randomUUID().toString()
-                // assert result reconnectable futures returned from both 'startFlowWithClientId' and 'reattachFlowWithClientId'
+                // assert result reconnectable futures returned work from both 'startFlowWithClientId' and 'reattachFlowWithClientId'
                 val flowHandle0 = rpcOps.startFlowWithClientId(clientId, ::SimpleFlow)
                 val flowHandle1 = rpcOps.reattachFlowWithClientId<Int>(clientId)
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -398,7 +398,7 @@ class CordaRPCClientReconnectionTest {
 
             val node = startNode()
             val client = CordaRPCClient(node.rpcAddress, config)
-            (client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect)).use {
+            client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect).use {
                 val rpcOps = it.proxy as ReconnectingCordaRPCOps
                 val clientId = UUID.randomUUID().toString()
                 val flowHandle = rpcOps.startFlowWithClientId(clientId, ::SimpleFlow)

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -403,7 +403,7 @@ class CordaRPCClientReconnectionTest {
 
                 node.stop()
                 thread {
-                    Thread.sleep(35000)
+                    Thread.sleep(1000)
                     startNode()
                 }
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -65,10 +65,6 @@ class CordaRPCClientReconnectionTest {
         val rpcUser = User("user1", "test", permissions = setOf(Permissions.all()))
     }
 
-
-
-
-
     @Test(timeout=300_000)
     fun `rpc node start when FlowsDrainingModeEnabled throws RejectedCommandException and won't attempt to reconnect`() {
         driver(DriverParameters(cordappsForAllNodes = FINANCE_CORDAPPS)) {

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -44,7 +44,6 @@ import java.lang.Thread.sleep
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 import kotlin.test.assertEquals

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -384,7 +384,7 @@ class CordaRPCClientReconnectionTest {
 
     @Test(timeout=300_000)
     fun `rpc returned flow result future continue working when the server crashes and restarts`() {
-        driver(DriverParameters(cordappsForAllNodes = listOf(this.enclosedCordapp()))) {
+        driver(DriverParameters(inMemoryDB = false, cordappsForAllNodes = listOf(this.enclosedCordapp()))) {
             val address = NetworkHostAndPort("localhost", portAllocator.nextPort())
             fun startNode(): NodeHandle {
                 return startNode(
@@ -403,14 +403,12 @@ class CordaRPCClientReconnectionTest {
 
                 node.stop()
                 thread {
-                    Thread.sleep(1000)
+                    sleep(1000)
                     startNode()
                 }
-
                 val result = flowHandle.returnValue.get()
 
                 assertEquals(5, result!!)
-
                 assertThat(rpcOps.reconnectingRPCConnection.isClosed())
             }
         }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCUtils.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCUtils.kt
@@ -12,4 +12,5 @@ object RPCUtils {
     fun RPCApi.ClientToServer.RpcRequest.isShutdownCmd() = isShutdownMethodName(methodName)
     fun Method.isShutdown() = isShutdownMethodName(name)
     fun Method.isStartFlow() = name.startsWith("startFlow") || name.startsWith("startTrackedFlow")
+    fun Method.isStartFlowWithClientId() = name == "startFlowWithClientId" || name == "startFlowDynamicWithClientId"
 }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -303,7 +303,8 @@ class ReconnectingCordaRPCOps private constructor(
     private class ErrorInterceptingHandler(val reconnectingRPCConnection: ReconnectingRPCConnection) : InvocationHandler {
         private fun checkIfIsStartFlow(method: Method, e: InvocationTargetException) {
             if (method.isStartFlow() && !method.isStartFlowWithClientId()) {
-                // Don't retry flows
+                // Only retry flows that have started with a client id. For such flows alone it is safe to recall them since,
+                // on recalling trying to reconnect they will not start a new flow but re-hook to an existing one ,that matches the client id, instead.
                 throw CouldNotStartFlowException(e.targetException)
             }
         }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -10,6 +10,9 @@ import net.corda.client.rpc.PermissionException
 import net.corda.client.rpc.RPCConnection
 import net.corda.client.rpc.RPCException
 import net.corda.client.rpc.UnrecoverableRPCException
+import net.corda.client.rpc.internal.RPCUtils.isShutdown
+import net.corda.client.rpc.internal.RPCUtils.isStartFlow
+import net.corda.client.rpc.internal.RPCUtils.isStartFlowWithClientId
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps.ReconnectingRPCConnection.CurrentState.CLOSED
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps.ReconnectingRPCConnection.CurrentState.CONNECTED
 import net.corda.client.rpc.internal.ReconnectingCordaRPCOps.ReconnectingRPCConnection.CurrentState.CONNECTING
@@ -298,10 +301,6 @@ class ReconnectingCordaRPCOps private constructor(
         fun isClosed(): Boolean = currentState == CLOSED
     }
     private class ErrorInterceptingHandler(val reconnectingRPCConnection: ReconnectingRPCConnection) : InvocationHandler {
-        private fun Method.isStartFlow() = name.startsWith("startFlow") || name.startsWith("startTrackedFlow")
-        private fun Method.isStartFlowWithClientId() = name == "startFlowWithClientId" || name == "startFlowDynamicWithClientId"
-        private fun Method.isShutdown() = name == "shutdown" || name == "gracefulShutdown" || name == "terminate"
-
         private fun checkIfIsStartFlow(method: Method, e: InvocationTargetException) {
             if (method.isStartFlow() && !method.isStartFlowWithClientId()) {
                 // Don't retry flows


### PR DESCRIPTION
Integrate `startFlowWithClientId` and `startFlowDynamicWithClientId` with `ReconnectingCordaRPCOps`. This way, whenever a reconnecting client starts a flow with client id, the `FlowHandleWithClientId.returnValue` future returned back to the client is now reconnect-able, meaning it will keep trying to reconnect, and not throw a `ConnectionFailureException`. Upon reconnecting it will be populated with the flow's result/ exception.

`startFlowWithClientId` and `startFlowDynamicWithClientId` methods have been allowed to reconnect and it is safe to do so since, these methods upon re-called with the same `clientId`, will re-hook the existing flow (matching that `clientId`) and not start a new one.
 