### PR TITLE
CORDA-3981: Change test to avoid timeout

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
@@ -1,30 +1,23 @@
 package net.corda.node.services.config
 
-import com.natpryce.hamkrest.assertion.assertThat
-import com.natpryce.hamkrest.containsSubstring
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.verify
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.delete
 import net.corda.core.internal.div
-import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.Node
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.core.Appender
-import org.apache.logging.log4j.core.Logger
-import org.apache.logging.log4j.core.LogEvent
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
+import org.mockito.ArgumentMatchers.contains
+import org.slf4j.Logger
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
 import java.nio.file.Files
 import java.nio.file.Path
-import java.time.Duration
 import kotlin.test.assertFalse
 
 class ConfigHelperTests {
@@ -74,34 +67,30 @@ class ConfigHelperTests {
                 "corda.sshd.port" to sshPort.toString())
     }
 
-    @Ignore("CORDA-3981: Test is not stable")
     @Test(timeout = 300_000)
     fun `bad keys are ignored and warned for`() {
-        val appender = mock<Appender>()
-        val logMessage = openFuture<String>()
-        whenever(appender.name).doReturn("mock")
-        whenever(appender.isStarted).doReturn(true)
-        whenever(appender.append(any())).thenAnswer {
-            val event: LogEvent = it.getArgument(0)
-            logMessage.set(event.message.format)
-            null
-        }
-        val logger = LogManager.getLogger(Node::class.java.canonicalName) as Logger
-        logger.addAppender(appender)
+        val loggerField = Node::class.java.getDeclaredField("staticLog")
+        loggerField.isAccessible = true
+        val modifiersField = Field::class.java.getDeclaredField("modifiers")
+        modifiersField.isAccessible = true
+        modifiersField.setInt(loggerField, loggerField.modifiers and Modifier.FINAL.inv())
+        val originalLogger = loggerField.get(null) as Logger
+        val spyLogger = spy(originalLogger)
+        loggerField.set(null, spyLogger)
 
         val baseDirectory = mock<Path>()
         val configFile = createTempFile()
         configFile.deleteOnExit()
         System.setProperty("corda_bad_key", "2077")
-
-
         val config = ConfigHelper.loadConfig(baseDirectory, configFile.toPath())
-        val warning = logMessage.getOrThrow(Duration.ofMinutes(3))
-        assertThat(warning, containsSubstring("(property or environment variable) cannot be mapped to an existing Corda"))
+
+        verify(spyLogger).warn(contains("(property or environment variable) cannot be mapped to an existing Corda"))
         assertFalse(config.hasPath("corda_bad_key"))
 
         System.clearProperty("corda_bad_key")
+        loggerField.set(null, originalLogger)
     }
+
     /**
      * Load the node configuration with the given environment variable
      * overrides.


### PR DESCRIPTION
Replacting the append log listener with spy over the log.