### PR TITLE
ENT-5652: Allow schema property in node.conf

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -33,6 +33,7 @@ const val NODE_DATABASE_PREFIX = "node_"
 
 // This class forms part of the node config and so any changes to it must be handled with care
 data class DatabaseConfig(
+        val schema: String? = null,
         val exportHibernateJMXStatistics: Boolean = Defaults.exportHibernateJMXStatistics,
         val mappedSchemaCacheSize: Long = Defaults.mappedSchemaCacheSize
 ) {

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
@@ -279,6 +279,7 @@ internal object DatabaseConfigSpec : Configuration.Specification<DatabaseConfig>
     private val transactionIsolationLevel by enum(TransactionIsolationLevel::class).optional()
     private val exportHibernateJMXStatistics by boolean().optional().withDefaultValue(DatabaseConfig.Defaults.exportHibernateJMXStatistics)
     private val mappedSchemaCacheSize by long().optional().withDefaultValue(DatabaseConfig.Defaults.mappedSchemaCacheSize)
+    private val schema by string().optional()
 
     override fun parseValid(configuration: Config, options: Configuration.Options): Valid<DatabaseConfig> {
         if (initialiseSchema.isSpecifiedBy(configuration)){
@@ -292,7 +293,7 @@ internal object DatabaseConfigSpec : Configuration.Specification<DatabaseConfig>
         }
         val config = configuration.withOptions(options)
 
-        return valid(DatabaseConfig(config[exportHibernateJMXStatistics], config[mappedSchemaCacheSize]))
+        return valid(DatabaseConfig(config[schema], config[exportHibernateJMXStatistics], config[mappedSchemaCacheSize]))
     }
 }
 


### PR DESCRIPTION
The `schema` property for `node.conf` has been introduced to OS, furthering the harmonisation between OS and Enterprise.