### PR TITLE
ENT-5666 Disable test due to Gradle process death

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintMigrationFromHashConstraintsTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintMigrationFromHashConstraintsTests.kt
@@ -14,6 +14,7 @@ import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.NodeParameters
 import net.corda.testing.node.internal.internalDriver
 import org.junit.Assume.assumeFalse
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -133,6 +134,7 @@ open class SignatureConstraintMigrationFromHashConstraintsTests : SignatureConst
         assertTrue(consumingTransaction.outputs.single().constraint is HashAttachmentConstraint)
     }
 
+    @Ignore("ENT-5676: Disabling to isolate Gradle process death cause")
     @Test(timeout=300_000)
 	fun `HashConstraint cannot be migrated to SignatureConstraint if a HashConstraint is specified for one state and another uses an AutomaticPlaceholderConstraint`() {
         assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -14,10 +14,8 @@ import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.internal.NodeBasedTest
 import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 
-@Ignore("ENT-5680: Needs to be stabler before this is re-enabled, fails about 1 in 10 times")
 class FlowVersioningTest : NodeBasedTest() {
     @Test(timeout=300_000)
 	fun `getFlowContext returns the platform version for core flows`() {

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -14,8 +14,10 @@ import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.internal.NodeBasedTest
 import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("ENT-5680: Needs to be stabler before this is re-enabled, fails about 1 in 10 times")
 class FlowVersioningTest : NodeBasedTest() {
     @Test(timeout=300_000)
 	fun `getFlowContext returns the platform version for core flows`() {


### PR DESCRIPTION
Disable SignatureConstraintMigrationFromHashConstraintsTests.HashConstraint cannot be migrated to SignatureConstraint if a HashConstraint is specified for one state and another uses an AutomaticPlaceholderConstraint() as it frequently appears in reports about Gradle process failures, to try isolating the actual cause.