### PR TITLE
CORDA-5449 query should have x509name

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowOperatorTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowOperatorTests.kt
@@ -104,7 +104,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME)
                     ))
 
             assertEquals(2, result.size)
@@ -132,7 +132,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(daveParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(DAVE_NAME)
                     ))
 
             assertEquals(1, result.size)
@@ -152,7 +152,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME)
                     ))
 
             assertEquals(1, result.size)
@@ -176,7 +176,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(bobParty, daveParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(BOB_NAME, DAVE_NAME)
                     ))
 
             assertEquals(1, result.size)
@@ -199,7 +199,7 @@ class FlowOperatorTests {
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
                     WaitingFlowQuery(
-                            counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty),
+                            counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME),
                             onlyIfSuspendedLongerThan = 4.seconds
                     ))
             assertEquals(1, result.size)
@@ -227,8 +227,8 @@ class FlowOperatorTests {
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
                     WaitingFlowQuery(
-                            counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty),
-                            waitingSource = mutableListOf(WaitingSource.EXTERNAL_OPERATION, WaitingSource.RECEIVE, WaitingSource.GET_FLOW_INFO)
+                            counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME),
+                            waitingSources = mutableListOf(WaitingSource.EXTERNAL_OPERATION, WaitingSource.RECEIVE, WaitingSource.GET_FLOW_INFO)
                     ))
 
             assertEquals(2, result.size)
@@ -258,7 +258,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryFlowsCurrentlyWaitingForPartiesGrouped(WaitingFlowQuery(
-                    waitingSource = mutableListOf(WaitingSource.EXTERNAL_OPERATION, WaitingSource.RECEIVE)
+                    waitingSources = mutableListOf(WaitingSource.EXTERNAL_OPERATION, WaitingSource.RECEIVE)
             ))
 
             assertEquals(2, result.size)
@@ -303,7 +303,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(ids = mutableListOf(charlieStart.id, eugeneStart.id)
+                    WaitingFlowQuery(flowIds = mutableListOf(charlieStart.id, eugeneStart.id)
                     ))
 
             assertEquals(1, result.size)
@@ -323,7 +323,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME)
                     ))
 
             assertEquals(1, result.size)
@@ -343,7 +343,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME)
                     ))
 
             assertEquals(1, result.size)
@@ -366,7 +366,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds, { future.complete(Unit) }) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME)
                     ))
 
             assertEquals(1, result.size)
@@ -387,7 +387,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds, { future.complete("Hello") }) {
             val result = cut.queryWaitingFlows(WaitingFlowQuery(
-                    waitingSource = mutableListOf(WaitingSource.EXTERNAL_OPERATION)
+                    waitingSources = mutableListOf(WaitingSource.EXTERNAL_OPERATION)
             )) // the list of counter parties must be empty to get any external operation
 
             assertEquals(1, result.size)
@@ -444,7 +444,7 @@ class FlowOperatorTests {
 
         executeTest(5.seconds, { future.complete(Unit) }) {
             val result = cut.queryWaitingFlows(
-                    WaitingFlowQuery(counterParties = mutableListOf(aliceParty, bobParty, charlieParty, daveParty, eugeneParty)
+                    WaitingFlowQuery(counterParties = mutableListOf(ALICE_NAME, BOB_NAME, CHARLIE_NAME, DAVE_NAME, EUGENE_NAME)
                     ))
 
             assertEquals(1, result.size)


### PR DESCRIPTION
Changed the counter party parameter in the **query** to be CordaX509Name (used to be Party)
