### PR TITLE
CORDA-3987: Upgrade to Corda Gradle plugins 5.0.12.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -4,7 +4,7 @@
 
 cordaVersion=4.6
 versionSuffix=SNAPSHOT
-gradlePluginsVersion=5.0.11
+gradlePluginsVersion=5.0.12
 kotlinVersion=1.2.71
 java8MinUpdateVersion=171
 # ***************************************************************#


### PR DESCRIPTION
The updated version of `quasar-utils` uses Quasar 0.7.13_r3 by default.

See [Release Notes for 5.0.12](https://github.com/corda/corda-gradle-plugins/releases/tag/release%2F5.0.12).