### PR TITLE
CORDA-3954: run database migration scripts during initial node registration

### DIFF
--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -168,17 +168,18 @@ open class NodeCmdLineOptions : SharedNodeCmdLineOptions() {
     var networkRootTrustStorePathParameter: Path? = null
 
     @Option(
-            names = ["-s", "--skip-schema-creation"],
-            description = ["Prevent database migration scripts to run during initial node registration "]
-    )
-    var skipSchemaCreation: Boolean = false
-
-    @Option(
             names = ["-p", "--network-root-truststore-password"],
             description = ["DEPRECATED. Network root trust store password obtained from network operator."],
             hidden = true
     )
     var networkRootTrustStorePassword: String? = null
+
+    @Option(
+            names = ["-s", "--skip-schema-creation"],
+            description = ["DEPRECATED. Prevent database migration scripts to run during initial node registration."],
+            hidden = true
+    )
+    var skipSchemaCreation: Boolean = false
 
     override fun parseConfiguration(configuration: Config): Valid<NodeConfiguration> {
         return super.parseConfiguration(configuration).doIfValid { config ->

--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -168,6 +168,12 @@ open class NodeCmdLineOptions : SharedNodeCmdLineOptions() {
     var networkRootTrustStorePathParameter: Path? = null
 
     @Option(
+            names = ["-s", "--skip-schema-creation"],
+            description = ["Prevent database migration scripts to run during initial node registration "]
+    )
+    var skipSchemaCreation: Boolean = false
+
+    @Option(
             names = ["-p", "--network-root-truststore-password"],
             description = ["DEPRECATED. Network root trust store password obtained from network operator."],
             hidden = true

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -120,6 +120,7 @@ open class NodeStartupCli : CordaCliWrapper("corda", "Runs a Corda Node") {
                 requireNotNull(cmdLineOptions.networkRootTrustStorePassword) { "Network root trust store password must be provided in registration mode using --network-root-truststore-password." }
                 initialRegistrationCli.networkRootTrustStorePassword = cmdLineOptions.networkRootTrustStorePassword!!
                 initialRegistrationCli.networkRootTrustStorePathParameter = cmdLineOptions.networkRootTrustStorePathParameter
+                initialRegistrationCli.skipSchemaCreation = cmdLineOptions.skipSchemaCreation
                 initialRegistrationCli.cmdLineOptions.copyFrom(cmdLineOptions)
                 initialRegistrationCli.runProgram()
             }

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -81,11 +81,10 @@ class InitialRegistration(val baseDirectory: Path, private val networkRootTrustS
         // Minimal changes to make registration tool create node identity.
         // TODO: Move node identity generation logic from node to registration helper.
         val node = startup.createNode(conf, versionInfo)
-
-        if(!skipSchemaMigration)
+        if(!skipSchemaMigration) {
             node.runDatabaseMigrationScripts(updateCoreSchemas = true, updateAppSchemas = true, updateAppSchemasWithCheckpoints = false)
-
-        var nodeInfo = node.generateAndSaveNodeInfo()
+        }
+        node.generateAndSaveNodeInfo()
 
         println("Successfully registered Corda node with compatibility zone, node identity keys and certificates are stored in '${conf.certificatesDirectory}', it is advised to backup the private keys and certificates.")
         println("Corda node will now terminate.")

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -25,9 +25,12 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
     @Option(names = ["-p", "--network-root-truststore-password"], description = ["Network root trust store password obtained from network operator."], required = true)
     var networkRootTrustStorePassword: String = ""
 
+    @Option(names = ["-s", "--skip-schema-creation"], description = ["Prevent database migration scripts to run during initial node registration "], required = false)
+    var skipSchemaCreation: Boolean = false
+
     override fun runProgram() : Int {
         val networkRootTrustStorePath: Path = networkRootTrustStorePathParameter ?: cmdLineOptions.baseDirectory / "certificates" / "network-root-truststore.jks"
-        return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, startup))
+        return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, skipSchemaCreation, startup))
     }
 
     override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
@@ -36,7 +39,8 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
     val cmdLineOptions = InitialRegistrationCmdLineOptions()
 }
 
-class InitialRegistration(val baseDirectory: Path, private val networkRootTrustStorePath: Path, networkRootTrustStorePassword: String, private val startup: NodeStartup) : RunAfterNodeInitialisation, NodeStartupLogging {
+class InitialRegistration(val baseDirectory: Path, private val networkRootTrustStorePath: Path, networkRootTrustStorePassword: String,
+                          private val skipSchemaMigration: Boolean, private val startup: NodeStartup) : RunAfterNodeInitialisation, NodeStartupLogging {
     companion object {
         private const val INITIAL_REGISTRATION_MARKER = ".initialregistration"
 
@@ -76,7 +80,12 @@ class InitialRegistration(val baseDirectory: Path, private val networkRootTrustS
 
         // Minimal changes to make registration tool create node identity.
         // TODO: Move node identity generation logic from node to registration helper.
-        startup.createNode(conf, versionInfo).generateAndSaveNodeInfo()
+        val node = startup.createNode(conf, versionInfo)
+
+        if(!skipSchemaMigration)
+            node.runDatabaseMigrationScripts(updateCoreSchemas = true, updateAppSchemas = true, updateAppSchemasWithCheckpoints = false)
+
+        var nodeInfo = node.generateAndSaveNodeInfo()
 
         println("Successfully registered Corda node with compatibility zone, node identity keys and certificates are stored in '${conf.certificatesDirectory}', it is advised to backup the private keys and certificates.")
         println("Corda node will now terminate.")


### PR DESCRIPTION
Added step to run database migration script during initial node registration.
Always run by default, can be disabled via command parameter -s / --skip-schema-creation.

Migration with checkpoints is disabled (@mnesbit @VCAMP)
