### PR TITLE
ENT-5669 Improve robustness of FlowReloadAfterCheckpointTest

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowReloadAfterCheckpointTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowReloadAfterCheckpointTest.kt
@@ -98,15 +98,13 @@ class FlowReloadAfterCheckpointTest {
 
     @Test(timeout = 300_000)
     fun `flow will reload from its checkpoint after suspending when reloadCheckpointAfterSuspend is true and be kept for observation due to failed deserialization`() {
-        val reloads = ConcurrentLinkedQueue<StateMachineRunId>()
+        val observations = QueueWithCountdown<StateMachineRunId>(1)
+        val reloads = QueueWithCountdown<StateMachineRunId>(8)
         FlowStateMachineImpl.onReloadFlowFromCheckpoint = { id ->
             reloads.add(id)
         }
-        lateinit var flowKeptForObservation: StateMachineRunId
-        val lock = CountDownLatch(1)
         StaffedFlowHospital.onFlowKeptForOvernightObservation.add { id, _ ->
-            flowKeptForObservation = id
-            lock.countDown()
+            observations.add(id)
         }
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = cordapps)) {
 
@@ -121,9 +119,12 @@ class FlowReloadAfterCheckpointTest {
                 .getOrThrow()
 
             val handle = alice.rpc.startFlow(::ReloadFromCheckpointFlow, bob.nodeInfo.singleIdentity(), true, false, false)
-            val flowStartedByAlice = handle.id
-            lock.await()
-            assertEquals(flowStartedByAlice, flowKeptForObservation)
+            val flowStartedByAlice: StateMachineRunId = handle.id
+
+            // We can't wait on the flow ending, because it breaks, so we need to wait on internal status changes instead
+            observations.await()
+            reloads.await()
+            assertEquals(flowStartedByAlice, observations.singleOrNull())
             assertEquals(4, reloads.filter { it == flowStartedByAlice }.count())
             assertEquals(4, reloads.filter { it == ReloadFromCheckpointResponder.flowId }.count())
         }
@@ -131,7 +132,7 @@ class FlowReloadAfterCheckpointTest {
 
     @Test(timeout = 300_000)
     fun `flow will reload from a previous checkpoint after calling suspending function and skipping the persisting the current checkpoint when reloadCheckpointAfterSuspend is true`() {
-        val reloads = ConcurrentLinkedQueue<StateMachineRunId>()
+        val reloads = QueueWithCountdown<StateMachineRunId>(11)
         FlowStateMachineImpl.onReloadFlowFromCheckpoint = { id ->
             reloads.add(id)
         }
@@ -150,6 +151,7 @@ class FlowReloadAfterCheckpointTest {
             val handle = alice.rpc.startFlow(::ReloadFromCheckpointFlow, bob.nodeInfo.singleIdentity(), false, false, true)
             val flowStartedByAlice = handle.id
             handle.returnValue.getOrThrow()
+            reloads.await()
             assertEquals(5, reloads.filter { it == flowStartedByAlice }.count())
             assertEquals(6, reloads.filter { it == ReloadFromCheckpointResponder.flowId }.count())
         }
@@ -224,13 +226,11 @@ class FlowReloadAfterCheckpointTest {
 
     @Test(timeout = 300_000)
     fun `flow continues reloading from checkpoints after node restart when reloadCheckpointAfterSuspend is true`() {
-        val reloads = ConcurrentLinkedQueue<StateMachineRunId>()
+        val reloads = QueueWithCountdown<StateMachineRunId>(5)
         val firstLatch = CountDownLatch(2)
-        val secondLatch = CountDownLatch(5)
         FlowStateMachineImpl.onReloadFlowFromCheckpoint = { runId ->
             reloads.add(runId)
             firstLatch.countDown()
-            secondLatch.countDown()
         }
         driver(
             DriverParameters(
@@ -257,7 +257,7 @@ class FlowReloadAfterCheckpointTest {
                 customOverrides = mapOf(NodeConfiguration::reloadCheckpointAfterSuspend.name to true)
             ).getOrThrow()
 
-            assertTrue { secondLatch.await(20, TimeUnit.SECONDS) }
+            reloads.await()
             assertEquals(5, reloads.size)
         }
     }
@@ -266,11 +266,9 @@ class FlowReloadAfterCheckpointTest {
     fun `idempotent flow continues reloading from checkpoints after node restart when reloadCheckpointAfterSuspend is true`() {
         // restarts completely from the beginning and forgets the in-memory reload count therefore
         // it reloads an extra 2 times for checkpoints it had already reloaded before the node shutdown
-        val reloadsExpected = CountDownLatch(7)
-        val reloads = ConcurrentLinkedQueue<StateMachineRunId>()
+        val reloads = QueueWithCountdown<StateMachineRunId>(7)
         FlowStateMachineImpl.onReloadFlowFromCheckpoint = { runId ->
             reloads.add(runId)
-            reloadsExpected.countDown()
         }
         driver(
             DriverParameters(
@@ -298,14 +296,14 @@ class FlowReloadAfterCheckpointTest {
 
             // restarts completely from the beginning and forgets the in-memory reload count therefore
             // it reloads an extra 2 times for checkpoints it had already reloaded before the node shutdown
-            assertTrue { reloadsExpected.await(20, TimeUnit.SECONDS) }
+            reloads.await()
             assertEquals(7, reloads.size)
         }
     }
 
     @Test(timeout = 300_000)
     fun `more complicated flow will reload from its checkpoint after suspending when reloadCheckpointAfterSuspend is true`() {
-        val reloads = ConcurrentLinkedQueue<StateMachineRunId>()
+        val reloads = QueueWithCountdown<StateMachineRunId>(13)
         FlowStateMachineImpl.onReloadFlowFromCheckpoint = { id ->
             reloads.add(id)
         }
@@ -335,7 +333,7 @@ class FlowReloadAfterCheckpointTest {
                 .map(StateMachineTransactionMapping::stateMachineRunId)
                 .toSet()
                 .single()
-            Thread.sleep(10.seconds.toMillis())
+            reloads.await()
             assertEquals(7, reloads.filter { it == flowStartedByAlice }.size)
             assertEquals(6, reloads.filter { it == flowStartedByBob }.size)
         }
@@ -524,3 +522,4 @@ class FlowReloadAfterCheckpointTest {
 internal class BrokenMap<K, V>(delegate: MutableMap<K, V> = mutableMapOf()) : MutableMap<K, V> by delegate {
     override fun put(key: K, value: V): V? = throw IllegalStateException("Broken on purpose")
 }
+

--- a/node/src/integration-test/kotlin/net/corda/node/flows/QueueWithCountdown.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/QueueWithCountdown.kt
@@ -1,0 +1,30 @@
+package net.corda.node.flows
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+
+/**
+ * Helper class for waiting until another thread has put a set number of objects
+ * into a queue.
+ */
+internal class QueueWithCountdown<E>(count: Int = 0): Collection<E> {
+    private val latch: CountDownLatch = CountDownLatch(count)
+    private val queue: ConcurrentLinkedQueue<E> = ConcurrentLinkedQueue()
+
+    fun add(element: E) {
+        this.queue.add(element)
+        this.latch.countDown()
+    }
+
+    fun await() = this.latch.await()
+
+    override fun contains(element: E) = queue.contains(element)
+    override fun containsAll(elements: Collection<E>) = queue.containsAll(elements)
+    override fun isEmpty(): Boolean = queue.isEmpty()
+    override fun iterator() = queue.iterator()
+    override fun parallelStream() = queue.parallelStream()
+    override fun spliterator() = queue.spliterator()
+    override fun stream() = queue.stream()
+    override val size: Int
+            get() = queue.size
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/QueueWithCountdown.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/QueueWithCountdown.kt
@@ -2,29 +2,27 @@ package net.corda.node.flows
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Helper class for waiting until another thread has put a set number of objects
  * into a queue.
  */
-internal class QueueWithCountdown<E>(count: Int = 0): Collection<E> {
+internal class QueueWithCountdown<E> private constructor(
+        count: Int = 0,
+        private val queue: ConcurrentLinkedQueue<E>
+) : Collection<E> by queue {
+
+    constructor(count: Int = 0) : this(count, ConcurrentLinkedQueue<E>())
+
     private val latch: CountDownLatch = CountDownLatch(count)
-    private val queue: ConcurrentLinkedQueue<E> = ConcurrentLinkedQueue()
 
     fun add(element: E) {
-        this.queue.add(element)
-        this.latch.countDown()
+        queue.add(element)
+        latch.countDown()
     }
 
-    fun await() = this.latch.await()
+    fun await() = latch.await()
 
-    override fun contains(element: E) = queue.contains(element)
-    override fun containsAll(elements: Collection<E>) = queue.containsAll(elements)
-    override fun isEmpty(): Boolean = queue.isEmpty()
-    override fun iterator() = queue.iterator()
-    override fun parallelStream() = queue.parallelStream()
-    override fun spliterator() = queue.spliterator()
-    override fun stream() = queue.stream()
-    override val size: Int
-            get() = queue.size
+    fun await(timeout: Long, unit: TimeUnit) = latch.await(timeout, unit)
 }


### PR DESCRIPTION
Improve robustness of FlowReloadAfterCheckpointTest by adding a countdown latch to observe for when the reloads should have finished.