### PR TITLE
CORDA-3986 Increase sleep in `FlowSessionCloseTest`

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowSessionCloseTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowSessionCloseTest.kt
@@ -185,7 +185,9 @@ class FlowSessionCloseTest {
             }
 
             session.send(responderReaction)
-            sleep(1.seconds)
+
+            // Give time to the other flow to receive the message, close its session and send the end session message back
+            sleep(20.seconds)
 
             if (accessClosedSessionWithApi != null) {
                 when(accessClosedSessionWithApi) {

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowSessionCloseTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowSessionCloseTest.kt
@@ -187,7 +187,7 @@ class FlowSessionCloseTest {
             session.send(responderReaction)
 
             // Give time to the other flow to receive the message, close its session and send the end session message back
-            sleep(20.seconds)
+            sleep(5.seconds)
 
             if (accessClosedSessionWithApi != null) {
                 when(accessClosedSessionWithApi) {


### PR DESCRIPTION
A sleep duration needed to be increased to ensure that an end session
message has time to be processed by the other node.

Locks do not fully fix this because some internal processing needs to be
completed that can't be waited for using a lock. Therefore the sleep
time was increased generously.