### PR TITLE
CORDA-3995 Redeliver external events if number of suspends differs

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt
@@ -73,6 +73,7 @@ class DatabaseTransaction(
         firstExceptionInDatabaseTransaction = null
     }
 
+    @Throws(SQLException::class)
     fun commit() {
         firstExceptionInDatabaseTransaction?.let {
             throw DatabaseTransactionException(it)

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineErrorHandlingTest.kt
@@ -112,11 +112,10 @@ abstract class StateMachineErrorHandlingTest {
         submit.addScripts(listOf(ScriptText("Test script", rules)))
     }
 
-    internal fun getBytemanOutput(nodeHandle: NodeHandle): List<String> {
-        return nodeHandle.baseDirectory
-            .list()
-            .first { it.toString().contains("net.corda.node.Corda") && it.toString().contains("stdout.log") }
-            .readAllLines()
+    private fun NodeHandle.getBytemanOutput(): List<String> {
+        return baseDirectory.list()
+            .filter { "net.corda.node.Corda" in it.toString() && "stdout.log" in it.toString() }
+            .flatMap { it.readAllLines() }
     }
 
     internal fun OutOfProcessImpl.stop(timeout: Duration): Boolean {
@@ -124,6 +123,10 @@ abstract class StateMachineErrorHandlingTest {
             destroy()
             waitFor(timeout.seconds, TimeUnit.SECONDS)
         }.also { onStopCallback() }
+    }
+
+    internal fun NodeHandle.assertBytemanOutput(string: String, count: Int) {
+        assertEquals(count, getBytemanOutput().filter { string in it }.size)
     }
 
     @Suppress("LongParameterList")

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineErrorHandlingTest.kt
@@ -249,6 +249,7 @@ abstract class StateMachineErrorHandlingTest {
     // Internal use for testing only!!
     @StartableByRPC
     class GetHospitalCountersFlow : FlowLogic<HospitalCounts>() {
+        @Suspendable
         override fun call(): HospitalCounts =
             HospitalCounts(
                 serviceHub.cordaService(HospitalCounter::class.java).dischargedCounter,

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFlowInitErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFlowInitErrorHandlingTest.kt
@@ -384,10 +384,10 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
 
                 RULE Throw exception on executeSignalFlowHasStarted action
                 CLASS $actionExecutorClassName
-                METHOD executeSignalFlowHasStarted
-                AT ENTRY
+                METHOD executeCommitTransaction
+                AT EXIT
                 IF readCounter("counter") < 3
-                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("i wish i was a sql exception")
+                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
                 ENDRULE
                 
                 RULE Log external start flow event
@@ -676,11 +676,10 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
 
                 RULE Throw exception on executeSignalFlowHasStarted action
                 CLASS $actionExecutorClassName
-                METHOD executeSignalFlowHasStarted
-                # METHOD executeAcknowledgeMessages
-                AT ENTRY
+                METHOD executeCommitTransaction
+                AT EXIT
                 IF readCounter("counter") < 3
-                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("i wish i was a sql exception")
+                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
                 ENDRULE
                 
                 RULE Log external start flow event
@@ -1000,10 +999,10 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
 
                 RULE Throw exception on executeSignalFlowHasStarted action
                 CLASS $actionExecutorClassName
-                METHOD executeSignalFlowHasStarted
-                AT ENTRY
+                METHOD executeCommitTransaction
+                AT EXIT
                 IF readCounter("counter") < 3
-                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("i wish i was a sql exception")
+                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
                 ENDRULE
                 
                 RULE Log session init event

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFlowInitErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFlowInitErrorHandlingTest.kt
@@ -6,6 +6,7 @@ import net.corda.core.messaging.startFlowWithClientId
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
 import net.corda.node.services.api.CheckpointStorage
+import net.corda.nodeapi.internal.persistence.DatabaseTransaction
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.singleIdentity
@@ -382,12 +383,20 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 DO traceln("Counter created")
                 ENDRULE
 
-                RULE Throw exception on executeSignalFlowHasStarted action
+                RULE Flag when commit transaction reached
                 CLASS $actionExecutorClassName
                 METHOD executeCommitTransaction
+                AT ENTRY
+                IF true
+                DO flag("commit")
+                ENDRULE
+                
+                RULE Throw exception on executeSignalFlowHasStarted action
+                CLASS ${DatabaseTransaction::class.java.name}
+                METHOD commit
                 AT EXIT
-                IF readCounter("counter") < 3
-                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
+                IF readCounter("counter") < 3 && flagged("commit")
+                DO incrementCounter("counter"); clear("commit"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
                 ENDRULE
                 
                 RULE Log external start flow event
@@ -674,12 +683,20 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 DO traceln("Counter created")
                 ENDRULE
 
-                RULE Throw exception on executeSignalFlowHasStarted action
+                RULE Flag when commit transaction reached
                 CLASS $actionExecutorClassName
                 METHOD executeCommitTransaction
+                AT ENTRY
+                IF true
+                DO flag("commit")
+                ENDRULE
+                
+                RULE Throw exception on executeSignalFlowHasStarted action
+                CLASS ${DatabaseTransaction::class.java.name}
+                METHOD commit
                 AT EXIT
-                IF readCounter("counter") < 3
-                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
+                IF readCounter("counter") < 3 && flagged("commit")
+                DO incrementCounter("counter"); clear("commit"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
                 ENDRULE
                 
                 RULE Log external start flow event
@@ -997,12 +1014,20 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 DO traceln("Counter created")
                 ENDRULE
 
-                RULE Throw exception on executeSignalFlowHasStarted action
+               RULE Flag when commit transaction reached
                 CLASS $actionExecutorClassName
                 METHOD executeCommitTransaction
+                AT ENTRY
+                IF true
+                DO flag("commit")
+                ENDRULE
+                
+                RULE Throw exception on executeSignalFlowHasStarted action
+                CLASS ${DatabaseTransaction::class.java.name}
+                METHOD commit
                 AT EXIT
-                IF readCounter("counter") < 3
-                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
+                IF readCounter("counter") < 3 && flagged("commit")
+                DO incrementCounter("counter"); clear("commit"); traceln("Throwing exception"); throw new java.sql.SQLException("you thought it worked didnt you!", "1")
                 ENDRULE
                 
                 RULE Log session init event

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFlowInitErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFlowInitErrorHandlingTest.kt
@@ -59,6 +59,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 3
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("die dammit die", "1")
                 ENDRULE
+                
+                RULE Log external start flow event
+                CLASS $stateMachineManagerClassName
+                METHOD onExternalStartFlow
+                AT ENTRY
+                IF true
+                DO traceln("External start flow event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -70,6 +78,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 30.seconds
             )
 
+            alice.assertBytemanOutput("External start flow event", 4)
             alice.rpc.assertNumberOfCheckpointsAllZero()
             alice.rpc.assertHospitalCounts(discharged = 3)
             assertEquals(0, alice.rpc.stateMachinesSnapshot().size)
@@ -257,6 +266,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 4
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("die dammit die", "1")
                 ENDRULE
+                
+                RULE Log external start flow event
+                CLASS $stateMachineManagerClassName
+                METHOD onExternalStartFlow
+                AT ENTRY
+                IF true
+                DO traceln("External start flow event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -268,6 +285,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
             // flow is not signaled as started calls to [getOrThrow] will hang, sleeping instead
             Thread.sleep(30.seconds.toMillis())
 
+            alice.assertBytemanOutput("External start flow event", 4)
             alice.rpc.assertNumberOfCheckpoints(hospitalized = 1)
             alice.rpc.assertHospitalCounts(
                 discharged = 3,
@@ -371,6 +389,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 3
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("i wish i was a sql exception")
                 ENDRULE
+                
+                RULE Log external start flow event
+                CLASS $stateMachineManagerClassName
+                METHOD onExternalStartFlow
+                AT ENTRY
+                IF true
+                DO traceln("External start flow event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -382,6 +408,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 30.seconds
             )
 
+            alice.assertBytemanOutput("External start flow event", 1)
             alice.rpc.assertNumberOfCheckpointsAllZero()
             alice.rpc.assertHospitalCounts(discharged = 3)
             assertEquals(0, alice.rpc.stateMachinesSnapshot().size)
@@ -421,6 +448,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 3
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("die dammit die", "1")
                 ENDRULE
+                
+                RULE Log external start flow event
+                CLASS $stateMachineManagerClassName
+                METHOD onExternalStartFlow
+                AT ENTRY
+                IF true
+                DO traceln("External start flow event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -433,6 +468,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 30.seconds
             )
 
+            alice.assertBytemanOutput("External start flow event", 4)
             alice.rpc.assertNumberOfCheckpoints(completed = 1)
             alice.rpc.assertHospitalCounts(discharged = 3)
             assertEquals(0, alice.rpc.stateMachinesSnapshot().size)
@@ -517,6 +553,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 4
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("die dammit die", "1")
                 ENDRULE
+                
+                RULE Log external start flow event
+                CLASS $stateMachineManagerClassName
+                METHOD onExternalStartFlow
+                AT ENTRY
+                IF true
+                DO traceln("External start flow event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -532,6 +576,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
             // flow is not signaled as started calls to [getOrThrow] will hang, sleeping instead
             Thread.sleep(30.seconds.toMillis())
 
+            alice.assertBytemanOutput("External start flow event", 4)
             alice.rpc.assertNumberOfCheckpoints(hospitalized = 1)
             alice.rpc.assertHospitalCounts(
                 discharged = 3,
@@ -637,6 +682,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 3
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("i wish i was a sql exception")
                 ENDRULE
+                
+                RULE Log external start flow event
+                CLASS $stateMachineManagerClassName
+                METHOD onExternalStartFlow
+                AT ENTRY
+                IF true
+                DO traceln("External start flow event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -649,6 +702,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 30.seconds
             )
 
+            alice.assertBytemanOutput("External start flow event", 1)
             alice.rpc.assertNumberOfCheckpoints(completed = 1)
             alice.rpc.assertHospitalCounts(discharged = 3)
             assertEquals(0, alice.rpc.stateMachinesSnapshot().size)
@@ -687,6 +741,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 3
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("die dammit die", "1")
                 ENDRULE
+                
+                RULE Log session init event
+                CLASS $stateMachineManagerClassName
+                METHOD onSessionInit
+                AT ENTRY
+                IF true
+                DO traceln("On session init event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -699,6 +761,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
             )
 
             alice.rpc.assertNumberOfCheckpointsAllZero()
+            charlie.assertBytemanOutput("On session init event", 4)
             charlie.rpc.assertNumberOfCheckpointsAllZero()
             charlie.rpc.assertHospitalCounts(discharged = 3)
         }
@@ -735,6 +798,14 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter") < 4
                 DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.sql.SQLException("die dammit die", "1")
                 ENDRULE
+                
+                RULE Log session init event
+                CLASS $stateMachineManagerClassName
+                METHOD onSessionInit
+                AT ENTRY
+                IF true
+                DO traceln("On session init event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)
@@ -747,6 +818,7 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
             Thread.sleep(30.seconds.toMillis())
 
             alice.rpc.assertNumberOfCheckpoints(runnable = 1)
+            charlie.assertBytemanOutput("On session init event", 4)
             charlie.rpc.assertNumberOfCheckpoints(hospitalized = 1)
             charlie.rpc.assertHospitalCounts(
                 discharged = 3,
@@ -891,6 +963,71 @@ class StateMachineFlowInitErrorHandlingTest : StateMachineErrorHandlingTest() {
             )
             assertEquals(1, alice.rpc.stateMachinesSnapshot().size)
             assertEquals(1, charlie.rpc.stateMachinesSnapshot().size)
+        }
+    }
+
+    /**
+     * Throws an exception when after the first [Action.CommitTransaction] event before the flow has initialised (remains in an unstarted state).
+     * This is to cover transient issues, where the transaction committed the checkpoint but failed to respond to the node.
+     *
+     * The exception is thrown when performing [Action.SignalFlowHasStarted], the error won't actually appear here but it makes it easier
+     * to test.
+     *
+     * The exception is thrown 3 times.
+     *
+     * This causes the transition to be discharged from the hospital 3 times (retries 3 times). On the final retry the transition
+     * succeeds and the flow finishes.
+     *
+     * Each time the flow retries, it starts from the beginning of the flow (due to being in an unstarted state).
+     *
+     * The first retry will load the checkpoint that the flow doesn't know exists ([StateMachineState.isAnyCheckpointPersisted] is false
+     * at this point). The flag gets switched to true after this first retry and the flow has now returned to an expected state.
+     *
+     */
+    @Test(timeout = 300_000)
+    fun `responding flow - error during transition when checkpoint commits but transient db exception is thrown during flow initialisation will retry and complete successfully`() {
+        startDriver {
+            val (alice, charlie, port) = createNodeAndBytemanNode(ALICE_NAME, CHARLIE_NAME)
+
+            val rules = """
+                RULE Create Counter
+                CLASS $actionExecutorClassName
+                METHOD executeCommitTransaction
+                AT ENTRY
+                IF createCounter("counter", $counter)
+                DO traceln("Counter created")
+                ENDRULE
+
+                RULE Throw exception on executeSignalFlowHasStarted action
+                CLASS $actionExecutorClassName
+                METHOD executeSignalFlowHasStarted
+                AT ENTRY
+                IF readCounter("counter") < 3
+                DO incrementCounter("counter"); traceln("Throwing exception"); throw new java.lang.RuntimeException("i wish i was a sql exception")
+                ENDRULE
+                
+                RULE Log session init event
+                CLASS $stateMachineManagerClassName
+                METHOD onSessionInit
+                AT ENTRY
+                IF true
+                DO traceln("On session init event")
+                ENDRULE
+            """.trimIndent()
+
+            submitBytemanRules(rules, port)
+
+            alice.rpc.startFlow(
+                StateMachineErrorHandlingTest::SendAMessageFlow,
+                charlie.nodeInfo.singleIdentity()
+            ).returnValue.getOrThrow(
+                30.seconds
+            )
+
+            alice.rpc.assertNumberOfCheckpointsAllZero()
+            charlie.assertBytemanOutput("On session init event", 1)
+            charlie.rpc.assertNumberOfCheckpointsAllZero()
+            charlie.rpc.assertHospitalCounts(discharged = 3)
         }
     }
 }

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineGeneralErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineGeneralErrorHandlingTest.kt
@@ -513,6 +513,14 @@ class StateMachineGeneralErrorHandlingTest : StateMachineErrorHandlingTest() {
                 IF readCounter("counter_2") < 3
                 DO incrementCounter("counter_2"); traceln("Throwing exception getting checkpoint"); throw new java.sql.SQLTransientConnectionException("Connection is not available")
                 ENDRULE
+                
+                RULE Log external start flow event
+                CLASS $stateMachineManagerClassName
+                METHOD onExternalStartFlow
+                AT ENTRY
+                IF true
+                DO traceln("External start flow event")
+                ENDRULE
             """.trimIndent()
 
             submitBytemanRules(rules, port)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -149,6 +149,8 @@ sealed class Action {
         override fun toString() = "CommitTransaction"
     }
 
+    data class IncrementNumberOfCommits(val currentState: StateMachineState) : Action()
+
     /**
      * Execute the specified [operation].
      */

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -145,11 +145,9 @@ sealed class Action {
     /**
      * Commit the current database transaction.
      */
-    object CommitTransaction : Action() {
+    data class CommitTransaction(val currentState: StateMachineState) : Action() {
         override fun toString() = "CommitTransaction"
     }
-
-    data class IncrementNumberOfCommits(val currentState: StateMachineState) : Action()
 
     /**
      * Execute the specified [operation].

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -61,8 +61,7 @@ internal class ActionExecutorImpl(
             is Action.RemoveFlow -> executeRemoveFlow(action)
             is Action.CreateTransaction -> executeCreateTransaction()
             is Action.RollbackTransaction -> executeRollbackTransaction()
-            is Action.CommitTransaction -> executeCommitTransaction()
-            is Action.IncrementNumberOfCommits -> executeIncrementNumberOfCommits(action)
+            is Action.CommitTransaction -> executeCommitTransaction(action)
             is Action.ExecuteAsyncOperation -> executeAsyncOperation(fiber, action)
             is Action.ReleaseSoftLocks -> executeReleaseSoftLocks(action)
             is Action.RetryFlowFromSafePoint -> executeRetryFlowFromSafePoint(action)
@@ -220,17 +219,14 @@ internal class ActionExecutorImpl(
 
     @Suspendable
     @Throws(SQLException::class)
-    private fun executeCommitTransaction() {
+    private fun executeCommitTransaction(action: Action.CommitTransaction) {
         try {
             contextTransaction.commit()
         } finally {
             contextTransaction.close()
             contextTransactionOrNull = null
         }
-    }
-
-    private fun executeIncrementNumberOfCommits(action: Action.IncrementNumberOfCommits) {
-        action.currentState.checkpoint.checkpointState.numberOfCommits += 1
+        action.currentState.run { numberOfCommits = checkpoint.checkpointState.numberOfCommits }
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -62,6 +62,7 @@ internal class ActionExecutorImpl(
             is Action.CreateTransaction -> executeCreateTransaction()
             is Action.RollbackTransaction -> executeRollbackTransaction()
             is Action.CommitTransaction -> executeCommitTransaction()
+            is Action.IncrementNumberOfCommits -> executeIncrementNumberOfCommits(action)
             is Action.ExecuteAsyncOperation -> executeAsyncOperation(fiber, action)
             is Action.ReleaseSoftLocks -> executeReleaseSoftLocks(action)
             is Action.RetryFlowFromSafePoint -> executeRetryFlowFromSafePoint(action)
@@ -226,6 +227,10 @@ internal class ActionExecutorImpl(
             contextTransaction.close()
             contextTransactionOrNull = null
         }
+    }
+
+    private fun executeIncrementNumberOfCommits(action: Action.IncrementNumberOfCommits) {
+        action.currentState.checkpoint.checkpointState.numberOfCommits += 1
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -103,7 +103,9 @@ class FlowCreator(
             updateCompatibleInDb(runId, true)
             checkpoint = checkpoint.copy(compatible = true)
         }
+
         checkpoint = checkpoint.copy(status = Checkpoint.FlowStatus.RUNNABLE)
+        checkpoint.checkpointState.numberOfCommits += 1
 
         fiber.logic.stateMachine = fiber
         verifyFlowLogicIsSuspendable(fiber.logic)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -163,7 +163,7 @@ class FlowCreator(
             fiber = flowStateMachineImpl,
             anyCheckpointPersisted = existingCheckpoint != null,
             reloadCheckpointAfterSuspendCount = if (reloadCheckpointAfterSuspend) 0 else null,
-            numberOfCommits = 0,
+            numberOfCommits = existingCheckpoint?.checkpointState?.numberOfCommits ?: 0,
             lock = Semaphore(1),
             deduplicationHandler = deduplicationHandler,
             senderUUID = senderUUID

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -105,7 +105,6 @@ class FlowCreator(
         }
 
         checkpoint = checkpoint.copy(status = Checkpoint.FlowStatus.RUNNABLE)
-        checkpoint.checkpointState.numberOfCommits += 1
 
         fiber.logic.stateMachine = fiber
         verifyFlowLogicIsSuspendable(fiber.logic)
@@ -116,6 +115,7 @@ class FlowCreator(
             anyCheckpointPersisted = true,
             reloadCheckpointAfterSuspendCount = reloadCheckpointAfterSuspendCount
                 ?: if (reloadCheckpointAfterSuspend) checkpoint.checkpointState.numberOfSuspends else null,
+            numberOfCommits = checkpoint.checkpointState.numberOfCommits,
             lock = lock
         )
         injectOldProgressTracker(progressTracker, fiber.logic)
@@ -163,6 +163,7 @@ class FlowCreator(
             fiber = flowStateMachineImpl,
             anyCheckpointPersisted = existingCheckpoint != null,
             reloadCheckpointAfterSuspendCount = if (reloadCheckpointAfterSuspend) 0 else null,
+            numberOfCommits = 0,
             lock = Semaphore(1),
             deduplicationHandler = deduplicationHandler,
             senderUUID = senderUUID
@@ -244,6 +245,7 @@ class FlowCreator(
         fiber: FlowStateMachineImpl<*>,
         anyCheckpointPersisted: Boolean,
         reloadCheckpointAfterSuspendCount: Int?,
+        numberOfCommits: Int,
         lock: Semaphore,
         deduplicationHandler: DeduplicationHandler? = null,
         senderUUID: String? = null
@@ -261,6 +263,7 @@ class FlowCreator(
             flowLogic = fiber.logic,
             senderUUID = senderUUID,
             reloadCheckpointAfterSuspendCount = reloadCheckpointAfterSuspendCount,
+            numberOfCommits = numberOfCommits,
             lock = lock
         )
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -575,10 +575,11 @@ internal class SingleThreadedStateMachineManager(
 
 
     /**
-     * Extract all the incomplete deduplication handlers as well as the [ExternalEvent] and [Event.Pause] events from this flows event queue
-     * [oldEventQueue]. Then schedule them (in the same order) for the new flow. This means that if a retried flow has a pause event
-     * scheduled then the retried flow will eventually pause. The new flow will not retry again if future retry events have been scheduled.
-     * When this method is called this flow must have been replaced by the new flow in [StateMachineInnerState.flows].
+     * Extract all the (unpersisted) incomplete deduplication handlers [currentState.pendingDeduplicationHandlers], as well as the
+     * [ExternalEvent] and [Event.Pause] events from this flows event queue [oldEventQueue]. Then schedule them (in the same order) for the
+     * new flow. This means that if a retried flow has a pause event scheduled then the retried flow will eventually pause. The new flow
+     * will not retry again if future retry events have been scheduled. When this method is called this flow must have been replaced by the
+     * new flow in [StateMachineInnerState.flows].
      *
      * This method differs from [extractAndQueueExternalEventsForPausedFlow] where (only) [externalEvents] are extracted and scheduled
      * straight away.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -587,8 +587,8 @@ internal class SingleThreadedStateMachineManager(
      *
      * @param currentState The current state of the flow, used to extract processed events (held in [StateMachineState.pendingDeduplicationHandlers])
      *
-     * @param numberOfCommitsFromCheckpoint The number of commits that the checkpoint loaded from the database had,
-     * to compare to the commits the flow has currently reached
+     * @param numberOfCommitsFromCheckpoint The number of commits that the checkpoint loaded from the database has, to compare to the
+     * commits the flow has currently reached
      */
     private fun extractAndScheduleEventsForRetry(
         oldEventQueue: Channel<Event>,
@@ -605,7 +605,7 @@ internal class SingleThreadedStateMachineManager(
         } while (event != null)
 
         // Only redeliver events if they were not persisted to the database
-        if (currentState.checkpoint.checkpointState.numberOfCommits > numberOfCommitsFromCheckpoint) {
+        if (currentState.numberOfCommits >= numberOfCommitsFromCheckpoint) {
             for (externalEvent in currentState.pendingDeduplicationHandlers) {
                 deliverExternalEvent(externalEvent.externalCause)
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -129,7 +129,8 @@ data class Checkpoint(
                         emptyMap(),
                         emptySet(),
                         listOf(topLevelSubFlow),
-                        numberOfSuspends = 0
+                        numberOfSuspends = 0,
+                        numberOfCommits = 1
                     ),
                     flowState = FlowState.Unstarted(flowStart, frozenFlowLogic),
                     errorState = ErrorState.Clean
@@ -238,12 +239,13 @@ data class Checkpoint(
  */
 @CordaSerializable
 data class CheckpointState(
-        val invocationContext: InvocationContext,
-        val ourIdentity: Party,
-        val sessions: SessionMap, // This must preserve the insertion order!
-        val sessionsToBeClosed: Set<SessionId>,
-        val subFlowStack: List<SubFlow>,
-        val numberOfSuspends: Int
+    val invocationContext: InvocationContext,
+    val ourIdentity: Party,
+    val sessions: SessionMap, // This must preserve the insertion order!
+    val sessionsToBeClosed: Set<SessionId>,
+    val subFlowStack: List<SubFlow>,
+    val numberOfSuspends: Int,
+    var numberOfCommits: Int
 )
 
 /**

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -133,6 +133,7 @@ data class Checkpoint(
                         emptySet(),
                         listOf(topLevelSubFlow),
                         numberOfSuspends = 0,
+                        // We set this to 1 here to avoid an extra copy and increment in UnstartedFlowTransition.createInitialCheckpoint
                         numberOfCommits = 1
                     ),
                     flowState = FlowState.Unstarted(flowStart, frozenFlowLogic),

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -29,39 +29,31 @@ class KilledFlowTransition(
                 startingState.checkpoint.checkpointState.sessions,
                 errorMessages
             )
-            val newCheckpoint = startingState.checkpoint.setSessions(sessions = newSessions)
-            currentState = currentState.copy(checkpoint = newCheckpoint)
-            actions.add(
-                Action.PropagateErrors(
-                    errorMessages,
-                    initiatedSessions,
-                    startingState.senderUUID
-                )
-            )
-
-            if (!startingState.isFlowResumed) {
-                actions.add(Action.CreateTransaction)
-            }
-            // The checkpoint and soft locks are also removed directly in [StateMachineManager.killFlow]
-            if (startingState.isAnyCheckpointPersisted) {
-                actions.add(Action.RemoveCheckpoint(context.id, mayHavePersistentResults = true))
-            }
-            actions.addAll(
-                arrayOf(
-                    Action.PersistDeduplicationFacts(currentState.pendingDeduplicationHandlers),
-                    Action.ReleaseSoftLocks(context.id.uuid),
-                    Action.CommitTransaction,
-                    Action.AcknowledgeMessages(currentState.pendingDeduplicationHandlers),
-                    Action.RemoveSessionBindings(currentState.checkpoint.checkpointState.sessions.keys)
-                )
-            )
-
             currentState = currentState.copy(
+                checkpoint = startingState.checkpoint.setSessions(sessions = newSessions),
                 pendingDeduplicationHandlers = emptyList(),
                 isRemoved = true
             )
+            actions += Action.PropagateErrors(
+                errorMessages,
+                initiatedSessions,
+                startingState.senderUUID
+            )
 
-            actions.add(Action.RemoveFlow(context.id, createKilledRemovalReason(killedFlowError), currentState))
+            if (!startingState.isFlowResumed) {
+                actions += Action.CreateTransaction
+            }
+            // The checkpoint and soft locks are also removed directly in [StateMachineManager.killFlow]
+            if (startingState.isAnyCheckpointPersisted) {
+                actions += Action.RemoveCheckpoint(context.id, mayHavePersistentResults = true)
+            }
+            actions += Action.PersistDeduplicationFacts(startingState.pendingDeduplicationHandlers)
+            actions += Action.ReleaseSoftLocks(context.id.uuid)
+            actions += Action.CommitTransaction(currentState)
+            actions += Action.AcknowledgeMessages(startingState.pendingDeduplicationHandlers)
+            actions += Action.RemoveSessionBindings(startingState.checkpoint.checkpointState.sessions.keys)
+            actions += Action.RemoveFlow(context.id, createKilledRemovalReason(killedFlowError), currentState)
+
             FlowContinuation.Abort
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
@@ -121,7 +121,7 @@ class StartedFlowTransition(
                 actions = listOf(
                     Action.CreateTransaction,
                     Action.TrackTransaction(flowIORequest.hash, state),
-                    Action.CommitTransaction
+                    Action.CommitTransaction(state)
                 )
             )
         } else {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -190,18 +190,15 @@ class TopLevelTransition(
     private fun suspendTransition(event: Event.Suspend): TransitionResult {
         return builder {
             val newCheckpoint = startingState.checkpoint.run {
-                val newCheckpointState = if (checkpointState.invocationContext.arguments!!.isNotEmpty()) {
-                    checkpointState.copy(
-                        invocationContext = checkpointState.invocationContext.copy(arguments = emptyList()),
-                        numberOfSuspends = checkpointState.numberOfSuspends + 1,
-                        numberOfCommits = checkpointState.numberOfCommits + 1
-                    )
-                } else {
-                    checkpointState.copy(
-                        numberOfSuspends = checkpointState.numberOfSuspends + 1,
-                        numberOfCommits = checkpointState.numberOfCommits + 1
-                    )
-                }
+                val newCheckpointState = checkpointState.copy(
+                   invocationContext = if (checkpointState.invocationContext.arguments!!.isNotEmpty()) {
+                       checkpointState.invocationContext.copy(arguments = emptyList())
+                   } else {
+                       checkpointState.invocationContext
+                   },
+                   numberOfSuspends = checkpointState.numberOfSuspends + 1,
+                   numberOfCommits = checkpointState.numberOfCommits + 1
+                )
                 copy(
                     flowState = FlowState.Started(event.ioRequest, event.fiber),
                     checkpointState = newCheckpointState,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -189,14 +189,18 @@ class TopLevelTransition(
 
     private fun suspendTransition(event: Event.Suspend): TransitionResult {
         return builder {
-            val newCheckpoint = currentState.checkpoint.run {
+            val newCheckpoint = startingState.checkpoint.run {
                 val newCheckpointState = if (checkpointState.invocationContext.arguments!!.isNotEmpty()) {
                     checkpointState.copy(
                         invocationContext = checkpointState.invocationContext.copy(arguments = emptyList()),
-                        numberOfSuspends = checkpointState.numberOfSuspends + 1
+                        numberOfSuspends = checkpointState.numberOfSuspends + 1,
+                        numberOfCommits = checkpointState.numberOfCommits + 1
                     )
                 } else {
-                    checkpointState.copy(numberOfSuspends = checkpointState.numberOfSuspends + 1)
+                    checkpointState.copy(
+                        numberOfSuspends = checkpointState.numberOfSuspends + 1,
+                        numberOfCommits = checkpointState.numberOfCommits + 1
+                    )
                 }
                 copy(
                     flowState = FlowState.Started(event.ioRequest, event.fiber),
@@ -206,32 +210,26 @@ class TopLevelTransition(
                 )
             }
             if (event.maySkipCheckpoint) {
-                actions.addAll(arrayOf(
-                        Action.CommitTransaction,
-                        Action.ScheduleEvent(Event.DoRemainingWork)
-                ))
-                currentState = currentState.copy(
+                currentState = startingState.copy(
                     checkpoint = newCheckpoint,
                     isFlowResumed = false
                 )
+                actions += Action.CommitTransaction(currentState)
+                actions += Action.ScheduleEvent(Event.DoRemainingWork)
             } else {
-                actions.addAll(arrayOf(
-                        Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = currentState.isAnyCheckpointPersisted),
-                        Action.PersistDeduplicationFacts(currentState.pendingDeduplicationHandlers),
-                        Action.CommitTransaction,
-                        Action.AcknowledgeMessages(currentState.pendingDeduplicationHandlers)
-                ))
-
-                currentState = currentState.copy(
+                currentState = startingState.copy(
                     checkpoint = newCheckpoint,
                     pendingDeduplicationHandlers = emptyList(),
                     isFlowResumed = false,
                     isAnyCheckpointPersisted = true
                 )
-
-                actions += Action.IncrementNumberOfCommits(currentState)
+                actions += Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = startingState.isAnyCheckpointPersisted)
+                actions += Action.PersistDeduplicationFacts(startingState.pendingDeduplicationHandlers)
+                actions += Action.CommitTransaction(currentState)
+                actions += Action.AcknowledgeMessages(startingState.pendingDeduplicationHandlers)
                 actions += Action.ScheduleEvent(Event.DoRemainingWork)
             }
+
             FlowContinuation.ProcessEvents
         }
     }
@@ -241,43 +239,38 @@ class TopLevelTransition(
             val checkpoint = currentState.checkpoint
             when (checkpoint.errorState) {
                 ErrorState.Clean -> {
-                    val pendingDeduplicationHandlers = currentState.pendingDeduplicationHandlers
-                    currentState = currentState.copy(
-                            checkpoint = checkpoint.copy(
-                                checkpointState = checkpoint.checkpointState.copy(
-                                        numberOfSuspends = checkpoint.checkpointState.numberOfSuspends + 1
-                                ),
-                                flowState = FlowState.Finished,
-                                result = event.returnValue,
-                                status = Checkpoint.FlowStatus.COMPLETED
+                    currentState = startingState.copy(
+                        checkpoint = checkpoint.copy(
+                            checkpointState = checkpoint.checkpointState.copy(
+                                numberOfSuspends = checkpoint.checkpointState.numberOfSuspends + 1,
+                                numberOfCommits = checkpoint.checkpointState.numberOfCommits + 1
                             ),
-                            pendingDeduplicationHandlers = emptyList(),
-                            isFlowResumed = false,
-                            isRemoved = true
+                            flowState = FlowState.Finished,
+                            result = event.returnValue,
+                            status = Checkpoint.FlowStatus.COMPLETED
+                        ),
+                        pendingDeduplicationHandlers = emptyList(),
+                        isFlowResumed = false,
+                        isRemoved = true
                     )
 
-                    if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
-                        if (currentState.isAnyCheckpointPersisted) {
+                    if (startingState.checkpoint.checkpointState.invocationContext.clientId == null) {
+                        if (startingState.isAnyCheckpointPersisted) {
                             actions += Action.RemoveCheckpoint(context.id)
                         }
                     } else {
                         actions += Action.PersistCheckpoint(
                             context.id,
                             currentState.checkpoint,
-                            isCheckpointUpdate = currentState.isAnyCheckpointPersisted
+                            isCheckpointUpdate = startingState.isAnyCheckpointPersisted
                         )
                     }
 
-                    actions += Action.PersistDeduplicationFacts(pendingDeduplicationHandlers)
+                    actions += Action.PersistDeduplicationFacts(startingState.pendingDeduplicationHandlers)
                     actions += Action.ReleaseSoftLocks(event.softLocksId)
-                    actions += Action.CommitTransaction
-                    actions += Action.AcknowledgeMessages(pendingDeduplicationHandlers)
-                    actions += Action.RemoveSessionBindings(currentState.checkpoint.checkpointState.sessions.keys)
-
-                    if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
-                        actions += Action.IncrementNumberOfCommits(currentState)
-                    }
-
+                    actions += Action.CommitTransaction(currentState)
+                    actions += Action.AcknowledgeMessages(startingState.pendingDeduplicationHandlers)
+                    actions += Action.RemoveSessionBindings(startingState.checkpoint.checkpointState.sessions.keys)
                     actions += Action.RemoveFlow(context.id, FlowRemovalReason.OrderlyFinish(event.returnValue), currentState)
 
                     sendEndMessages()
@@ -362,18 +355,22 @@ class TopLevelTransition(
 
     private fun overnightObservationTransition(): TransitionResult {
         return builder {
-            val flowStartEvents = currentState.pendingDeduplicationHandlers.filter(::isFlowStartEvent)
+            val flowStartEvents = startingState.pendingDeduplicationHandlers.filter(::isFlowStartEvent)
             val newCheckpoint = startingState.checkpoint.copy(status = Checkpoint.FlowStatus.HOSPITALIZED)
-            currentState = currentState.copy(
-                checkpoint = startingState.checkpoint.copy(status = Checkpoint.FlowStatus.HOSPITALIZED),
-                pendingDeduplicationHandlers = currentState.pendingDeduplicationHandlers - flowStartEvents
+            currentState = startingState.copy(
+                checkpoint = startingState.checkpoint.copy(
+                    status = Checkpoint.FlowStatus.HOSPITALIZED,
+                    checkpointState = startingState.checkpoint.checkpointState.copy(
+                        numberOfCommits = startingState.checkpoint.checkpointState.numberOfCommits + 1
+                    )
+                ),
+                pendingDeduplicationHandlers = startingState.pendingDeduplicationHandlers - flowStartEvents
             )
             actions += Action.CreateTransaction
             actions += Action.PersistDeduplicationFacts(flowStartEvents)
-            actions += Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = currentState.isAnyCheckpointPersisted)
-            actions += Action.CommitTransaction
+            actions += Action.PersistCheckpoint(context.id, newCheckpoint, isCheckpointUpdate = startingState.isAnyCheckpointPersisted)
+            actions += Action.CommitTransaction(currentState)
             actions += Action.AcknowledgeMessages(flowStartEvents)
-            actions += Action.IncrementNumberOfCommits(currentState)
             FlowContinuation.ProcessEvents
         }
     }
@@ -399,15 +396,11 @@ class TopLevelTransition(
     private fun pausedFlowTransition(): TransitionResult {
         return builder {
             if (!startingState.isFlowResumed) {
-                actions.add(Action.CreateTransaction)
+                actions += Action.CreateTransaction
             }
-            actions.addAll(
-                arrayOf(
-                    Action.UpdateFlowStatus(context.id, Checkpoint.FlowStatus.PAUSED),
-                    Action.CommitTransaction,
-                    Action.MoveFlowToPaused(currentState)
-                )
-            )
+            actions += Action.UpdateFlowStatus(context.id, Checkpoint.FlowStatus.PAUSED)
+            actions += Action.CommitTransaction(currentState)
+            actions += Action.MoveFlowToPaused(currentState)
             FlowContinuation.Abort
         }
     }


### PR DESCRIPTION
When retrying a flow, only redeliver external events held in a flow's
pending deduplication handlers if there is a difference in the
`currentState`'s `numberOfCommits` or the `numberOfCommits`
the checkpoint has recorded in the database.

If the checkpoint committed, but the flow retried, then the external
events would have been persisted to the database as part of the same
transaction. Therefore there is no need to replay them, as they have
already been processed as saved as part of the checkpoint.

This change is only relevant when the checkpoint persists, but the flow
still needs to retry after this occurs (within the same
transition/event).