### PR TITLE
CORDA-3908: Update corda-4.5 .ci/api-current.txt to match the previous release (corda-4.4)

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -478,6 +478,8 @@ public interface net.corda.core.contracts.Attachment extends net.corda.core.cont
 public interface net.corda.core.contracts.AttachmentConstraint
   public abstract boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
 ##
+public final class net.corda.core.contracts.AttachmentConstraintKt extends java.lang.Object
+##
 @CordaSerializable
 public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)
@@ -498,6 +500,12 @@ public final class net.corda.core.contracts.AutomaticPlaceholderConstraint exten
 ##
 public @interface net.corda.core.contracts.BelongsToContract
   public abstract Class<? extends net.corda.core.contracts.Contract> value()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.BrokenAttachmentException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
 ##
 @CordaSerializable
 public final class net.corda.core.contracts.Command extends java.lang.Object
@@ -569,6 +577,7 @@ public interface net.corda.core.contracts.Contract
   public abstract void verify(net.corda.core.transactions.LedgerTransaction)
 ##
 @DoNotImplement
+@CordaSerializable
 public final class net.corda.core.contracts.ContractAttachment extends java.lang.Object implements net.corda.core.contracts.Attachment
   public <init>(net.corda.core.contracts.Attachment, String)
   public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>)
@@ -647,6 +656,11 @@ public final class net.corda.core.contracts.HashAttachmentConstraint extends jav
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   @NotNull
   public String toString()
+  public static final net.corda.core.contracts.HashAttachmentConstraint$Companion Companion
+##
+public static final class net.corda.core.contracts.HashAttachmentConstraint$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getDisableHashConstraints()
 ##
 @CordaSerializable
 public final class net.corda.core.contracts.InsufficientBalanceException extends net.corda.core.flows.FlowException
@@ -675,15 +689,20 @@ public final class net.corda.core.contracts.Issued extends java.lang.Object
 public @interface net.corda.core.contracts.LegalProseReference
   public abstract String uri()
 ##
+@DoNotImplement
 @CordaSerializable
 public final class net.corda.core.contracts.LinearPointer extends net.corda.core.contracts.StatePointer
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.contracts.UniqueIdentifier, Class<T>)
+  public <init>(net.corda.core.contracts.UniqueIdentifier, Class<T>, boolean)
+  public <init>(net.corda.core.contracts.UniqueIdentifier, Class, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public boolean equals(Object)
   @NotNull
   public net.corda.core.contracts.UniqueIdentifier getPointer()
   @NotNull
   public Class<T> getType()
   public int hashCode()
+  public boolean isResolved()
   @NotNull
   public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
@@ -871,6 +890,7 @@ public final class net.corda.core.contracts.StateAndRef extends java.lang.Object
   @NotNull
   public String toString()
 ##
+@DoNotImplement
 @CordaSerializable
 public abstract class net.corda.core.contracts.StatePointer extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
@@ -878,10 +898,15 @@ public abstract class net.corda.core.contracts.StatePointer extends java.lang.Ob
   public abstract Object getPointer()
   @NotNull
   public abstract Class<T> getType()
+  public abstract boolean isResolved()
   @NotNull
   public abstract net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
   public abstract net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.core.contracts.StatePointer$Companion Companion
+##
+public static final class net.corda.core.contracts.StatePointer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public final class net.corda.core.contracts.StateRef extends java.lang.Object
@@ -899,15 +924,20 @@ public final class net.corda.core.contracts.StateRef extends java.lang.Object
   @NotNull
   public String toString()
 ##
+@DoNotImplement
 @CordaSerializable
 public final class net.corda.core.contracts.StaticPointer extends net.corda.core.contracts.StatePointer
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.contracts.StateRef, Class<T>)
+  public <init>(net.corda.core.contracts.StateRef, Class<T>, boolean)
+  public <init>(net.corda.core.contracts.StateRef, Class, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public boolean equals(Object)
   @NotNull
   public net.corda.core.contracts.StateRef getPointer()
   @NotNull
   public Class<T> getType()
   public int hashCode()
+  public boolean isResolved()
   @NotNull
   public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
@@ -1010,10 +1040,15 @@ public final class net.corda.core.contracts.TransactionState extends java.lang.O
 ##
 public final class net.corda.core.contracts.TransactionStateKt extends java.lang.Object
 ##
+@CordaSerializable
 public abstract class net.corda.core.contracts.TransactionVerificationException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
   @NotNull
   public final net.corda.core.crypto.SecureHash getTxId()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$BrokenTransactionException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ConflictingAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
@@ -1023,6 +1058,7 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ConstraintPropagationRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, String, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.AttachmentConstraint)
   @NotNull
   public final String getContractClass()
@@ -1035,6 +1071,7 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ContractCreationError extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
   public <init>(net.corda.core.crypto.SecureHash, String, Throwable, String)
   @NotNull
   public final String getContractClass()
@@ -1052,10 +1089,30 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   public static net.corda.core.contracts.TransactionVerificationException$Direction[] values()
 ##
 @CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.Attachment)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachmentId()
+##
+@CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateInputStates extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
   @NotNull
   public final net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef> getDuplicates()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$InvalidAttachmentException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentHash()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$InvalidConstraintRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, String)
+  @NotNull
+  public final String getContractClass()
+  @NotNull
+  public final String getReason()
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$InvalidNotaryChange extends net.corda.core.contracts.TransactionVerificationException
@@ -1066,6 +1123,11 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   public <init>(net.corda.core.crypto.SecureHash, String)
   @NotNull
   public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MissingNetworkParametersException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SecureHash)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$MoreThanOneNotary extends net.corda.core.contracts.TransactionVerificationException
@@ -1082,6 +1144,8 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$OverlappingAttachmentsException extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getPath()
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$PackageOwnershipException extends net.corda.core.contracts.TransactionVerificationException
@@ -1101,11 +1165,13 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionContractConflictException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionDuplicateEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, int)
+  public <init>(net.corda.core.crypto.SecureHash, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionMissingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
@@ -1115,16 +1181,32 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   public final int getMissing()
 ##
 @CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNetworkParameterOrderingException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.StateRef, net.corda.core.node.NetworkParameters, net.corda.core.node.NetworkParameters)
+##
+@CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNonMatchingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, java.util.Collection<Integer>)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNotaryMismatchEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, int, int, net.corda.core.identity.Party, net.corda.core.identity.Party)
+  public <init>(net.corda.core.crypto.SecureHash, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionRequiredContractUnspecifiedException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$UntrustedAttachmentsException extends net.corda.core.CordaException
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
 ##
 @CordaSerializable
 public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.lang.Object implements net.corda.core.contracts.CommandData
@@ -1367,6 +1449,48 @@ public final class net.corda.core.cordapp.CordappContext extends java.lang.Objec
 public static final class net.corda.core.cordapp.CordappContext$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
+@CordaSerializable
+public final class net.corda.core.cordapp.CordappInfo extends java.lang.Object
+  public <init>(String, String, String, int, int, String, String, String, net.corda.core.crypto.SecureHash$SHA256)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final String component3()
+  public final int component4()
+  public final int component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final String component7()
+  @NotNull
+  public final String component8()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 component9()
+  @NotNull
+  public final net.corda.core.cordapp.CordappInfo copy(String, String, String, int, int, String, String, String, net.corda.core.crypto.SecureHash$SHA256)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getJarHash()
+  @NotNull
+  public final String getLicence()
+  public final int getMinimumPlatformVersion()
+  @NotNull
+  public final String getName()
+  @NotNull
+  public final String getShortName()
+  public final int getTargetPlatformVersion()
+  @NotNull
+  public final String getType()
+  @NotNull
+  public final String getVendor()
+  @NotNull
+  public final String getVersion()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
 @DoNotImplement
 public interface net.corda.core.cordapp.CordappProvider
   @NotNull
@@ -1528,6 +1652,8 @@ public final class net.corda.core.crypto.CordaObjectIdentifier extends java.lang
 ##
 public final class net.corda.core.crypto.CordaSecurityProvider extends java.security.Provider
   public <init>()
+  @Nullable
+  public java.security.Provider$Service getService(String, String)
   public static final net.corda.core.crypto.CordaSecurityProvider$Companion Companion
   @NotNull
   public static final String PROVIDER_NAME = "Corda"
@@ -1679,6 +1805,9 @@ public static class net.corda.core.crypto.DigitalSignature$WithKey extends net.c
   public final boolean verify(byte[])
   @NotNull
   public final net.corda.core.crypto.DigitalSignature withoutKey()
+##
+public final class net.corda.core.crypto.DummySecureRandom extends java.security.SecureRandom
+  public static final net.corda.core.crypto.DummySecureRandom INSTANCE
 ##
 public abstract class net.corda.core.crypto.MerkleTree extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
@@ -1860,6 +1989,8 @@ public static final class net.corda.core.crypto.SecureHash$Companion extends jav
 @CordaSerializable
 public static final class net.corda.core.crypto.SecureHash$SHA256 extends net.corda.core.crypto.SecureHash
   public <init>(byte[])
+  public boolean equals(Object)
+  public int hashCode()
 ##
 public final class net.corda.core.crypto.SecureHashKt extends java.lang.Object
   @NotNull
@@ -2154,11 +2285,17 @@ public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.F
   @Suspendable
   protected void verifyDataRequest(net.corda.core.internal.FetchDataFlow$Request$Data)
 ##
+@DoNotImplement
+public interface net.corda.core.flows.Destination
+##
 @InitiatingFlow
 public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.node.StatesToRecord, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>)
@@ -2338,6 +2475,9 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public final net.corda.core.node.ServiceHub getServiceHub()
   @Suspendable
   @NotNull
+  public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.flows.Destination)
+  @Suspendable
+  @NotNull
   public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.identity.Party)
   @Suspendable
   public final void persistFlowStackSnapshot()
@@ -2417,6 +2557,8 @@ public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
   @Suspendable
   @NotNull
   public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo(boolean)
+  @NotNull
+  public abstract net.corda.core.flows.Destination getDestination()
   @Suspendable
   @NotNull
   public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>)
@@ -2472,6 +2614,13 @@ public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends j
   @NotNull
   public String toString()
 ##
+@CordaSerializable
+public class net.corda.core.flows.HospitalizeFlowException extends net.corda.core.CordaRuntimeException
+  public <init>()
+  public <init>(String)
+  public <init>(String, Throwable)
+  public <init>(Throwable)
+##
 public interface net.corda.core.flows.IdentifiableException
   @Nullable
   public Long getErrorId()
@@ -2487,6 +2636,22 @@ public @interface net.corda.core.flows.InitiatedBy
 ##
 public @interface net.corda.core.flows.InitiatingFlow
   public abstract int version()
+##
+@CordaSerializable
+public final class net.corda.core.flows.MaybeSerializedSignedTransaction extends java.lang.Object implements net.corda.core.contracts.NamedByHash
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction)
+  @Nullable
+  public final net.corda.core.transactions.SignedTransaction get()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @Nullable
+  public final net.corda.core.transactions.SignedTransaction getNonSerialised()
+  @Nullable
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.SignedTransaction> getSerialized()
+  public final boolean isNull()
+  @NotNull
+  public final String payloadContentDescription()
+  public final int serializedByteCount()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.NotarisationPayload extends java.lang.Object
@@ -2561,6 +2726,11 @@ public final class net.corda.core.flows.NotaryChangeFlow extends net.corda.core.
 ##
 @CordaSerializable
 public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public static final net.corda.core.flows.NotaryError$Companion Companion
+  public static final int NUM_STATES = 5
+##
+public static final class net.corda.core.flows.NotaryError$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
@@ -2668,6 +2838,10 @@ public final class net.corda.core.flows.NotaryFlow extends java.lang.Object
 public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.internal.BackpressureAwareTimedFlow
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker, boolean)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.transactions.SignedTransaction, boolean)
+  public <init>(net.corda.core.transactions.SignedTransaction, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public java.util.List<net.corda.core.crypto.TransactionSignature> call()
@@ -2983,6 +3157,7 @@ public final class net.corda.core.identity.IdentityUtils extends java.lang.Objec
   public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>)
   @NotNull
   public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>, boolean)
+  public static final boolean x500Matches(String, boolean, net.corda.core.identity.CordaX500Name)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -3077,6 +3252,8 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   @RPCReturnsObservables
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<net.corda.core.messaging.ParametersUpdateInfo, net.corda.core.messaging.ParametersUpdateInfo> networkParametersFeed()
+  @NotNull
+  public abstract net.corda.core.node.NodeDiagnosticInfo nodeDiagnosticInfo()
   @NotNull
   public abstract net.corda.core.node.NodeInfo nodeInfo()
   @Nullable
@@ -3382,9 +3559,22 @@ public static final class net.corda.core.messaging.StateMachineUpdate$Removed ex
 @DoNotImplement
 public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.ServiceHub
   @NotNull
+  public abstract net.corda.core.node.services.vault.CordaTransactionSupport getDatabase()
+  public abstract void register(int, kotlin.jvm.functions.Function1<? super net.corda.core.node.services.ServiceLifecycleEvent, ? extends T>)
+  public abstract void register(int, net.corda.core.node.services.ServiceLifecycleObserver)
+  @NotNull
   public abstract net.corda.core.messaging.FlowHandle<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
   @NotNull
   public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  public static final net.corda.core.node.AppServiceHub$Companion Companion
+  public static final int SERVICE_PRIORITY_HIGH = 200
+  public static final int SERVICE_PRIORITY_LOW = 20
+  public static final int SERVICE_PRIORITY_NORMAL = 100
+##
+public static final class net.corda.core.node.AppServiceHub$Companion extends java.lang.Object
+  public static final int SERVICE_PRIORITY_HIGH = 200
+  public static final int SERVICE_PRIORITY_LOW = 20
+  public static final int SERVICE_PRIORITY_NORMAL = 100
 ##
 public @interface net.corda.core.node.AutoAcceptable
 ##
@@ -3435,6 +3625,34 @@ public final class net.corda.core.node.NetworkParameters extends java.lang.Objec
   public String toString()
 ##
 @CordaSerializable
+public final class net.corda.core.node.NodeDiagnosticInfo extends java.lang.Object
+  public <init>(String, String, int, String, java.util.List<net.corda.core.cordapp.CordappInfo>)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final java.util.List<net.corda.core.cordapp.CordappInfo> component5()
+  @NotNull
+  public final net.corda.core.node.NodeDiagnosticInfo copy(String, String, int, String, java.util.List<net.corda.core.cordapp.CordappInfo>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.cordapp.CordappInfo> getCordapps()
+  public final int getPlatformVersion()
+  @NotNull
+  public final String getRevision()
+  @NotNull
+  public final String getVendor()
+  @NotNull
+  public final String getVersion()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
 public final class net.corda.core.node.NodeInfo extends java.lang.Object
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
   @NotNull
@@ -3459,6 +3677,7 @@ public final class net.corda.core.node.NodeInfo extends java.lang.Object
   public final net.corda.core.identity.PartyAndCertificate identityAndCertFromX500Name(net.corda.core.identity.CordaX500Name)
   @NotNull
   public final net.corda.core.identity.Party identityFromX500Name(net.corda.core.identity.CordaX500Name)
+  public final boolean isLegalIdentity(net.corda.core.identity.CordaX500Name)
   public final boolean isLegalIdentity(net.corda.core.identity.Party)
   @NotNull
   public String toString()
@@ -3501,6 +3720,8 @@ public interface net.corda.core.node.ServiceHub extends net.corda.core.node.Serv
   public abstract java.time.Clock getClock()
   @NotNull
   public abstract net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public abstract net.corda.core.node.services.diagnostics.DiagnosticsService getDiagnosticsService()
   @NotNull
   public abstract net.corda.core.node.services.KeyManagementService getKeyManagementService()
   @NotNull
@@ -3550,6 +3771,8 @@ public interface net.corda.core.node.ServicesForResolution
   public abstract net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
   @NotNull
   public abstract java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public net.corda.core.transactions.LedgerTransaction specialise(net.corda.core.transactions.LedgerTransaction)
 ##
 public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
   public static net.corda.core.node.StatesToRecord valueOf(String)
@@ -3588,11 +3811,18 @@ public interface net.corda.core.node.services.ContractUpgradeService
 ##
 public @interface net.corda.core.node.services.CordaService
 ##
+public final class net.corda.core.node.services.CordaServiceCriticalFailureException extends java.lang.Exception
+  public <init>(String)
+  public <init>(String, Throwable)
+##
 @DoNotImplement
 public interface net.corda.core.node.services.IdentityService
   public abstract void assertOwnership(net.corda.core.identity.Party, net.corda.core.identity.AnonymousParty)
   @Nullable
   public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
+  @Suspendable
+  @Nullable
+  public abstract java.util.UUID externalIdForPublicKey(java.security.PublicKey)
   @NotNull
   public abstract Iterable<net.corda.core.identity.PartyAndCertificate> getAllIdentities()
   @NotNull
@@ -3606,6 +3836,9 @@ public interface net.corda.core.node.services.IdentityService
   @Nullable
   public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
   @NotNull
+  public abstract Iterable<java.security.PublicKey> publicKeysForExternalId(java.util.UUID)
+  public abstract void registerKey(java.security.PublicKey, net.corda.core.identity.Party, java.util.UUID)
+  @NotNull
   public abstract net.corda.core.identity.Party requireWellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
   @Nullable
   public abstract net.corda.core.identity.PartyAndCertificate verifyAndRegisterIdentity(net.corda.core.identity.PartyAndCertificate)
@@ -3615,6 +3848,9 @@ public interface net.corda.core.node.services.IdentityService
   public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
   @Nullable
   public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  public static final net.corda.core.node.services.IdentityService$Companion Companion
+##
+public static final class net.corda.core.node.services.IdentityService$Companion extends java.lang.Object
 ##
 @DoNotImplement
 public interface net.corda.core.node.services.KeyManagementService
@@ -3625,7 +3861,13 @@ public interface net.corda.core.node.services.KeyManagementService
   public abstract java.security.PublicKey freshKey()
   @Suspendable
   @NotNull
+  public abstract java.security.PublicKey freshKey(java.util.UUID)
+  @Suspendable
+  @NotNull
   public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean, java.util.UUID)
   @NotNull
   public abstract java.util.Set<java.security.PublicKey> getKeys()
   @Suspendable
@@ -3767,6 +4009,10 @@ public static final class net.corda.core.node.services.PartyInfo$SingleNode exte
   public int hashCode()
   @NotNull
   public String toString()
+##
+public final class net.corda.core.node.services.ServiceLifecycleEvent extends java.lang.Enum
+  public static net.corda.core.node.services.ServiceLifecycleEvent valueOf(String)
+  public static net.corda.core.node.services.ServiceLifecycleEvent[] values()
 ##
 public interface net.corda.core.node.services.ServiceLifecycleObserver
   public abstract void onServiceLifecycleEvent(net.corda.core.node.services.ServiceLifecycleEvent)
@@ -3996,6 +4242,8 @@ public static final class net.corda.core.node.services.Vault$UpdateType extends 
 @CordaSerializable
 public final class net.corda.core.node.services.VaultQueryException extends net.corda.core.flows.FlowException
   public <init>(String)
+  public <init>(String, Exception)
+  public <init>(String, Exception, int, kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 public interface net.corda.core.node.services.VaultService
@@ -4045,6 +4293,34 @@ public interface net.corda.core.node.services.VaultService
 public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
   public static final int MAX_CONSTRAINT_DATA_SIZE = 20000
 ##
+@DoNotImplement
+public interface net.corda.core.node.services.diagnostics.DiagnosticsService
+  @NotNull
+  public abstract net.corda.core.node.services.diagnostics.NodeVersionInfo nodeVersionInfo()
+##
+public final class net.corda.core.node.services.diagnostics.NodeVersionInfo extends java.lang.Object
+  public <init>(String, String, int, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.node.services.diagnostics.NodeVersionInfo copy(String, String, int, String)
+  public boolean equals(Object)
+  public final int getPlatformVersion()
+  @NotNull
+  public final String getReleaseVersion()
+  @NotNull
+  public final String getRevision()
+  @NotNull
+  public final String getVendor()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
 @CordaSerializable
 public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum
   public static net.corda.core.node.services.vault.AggregateFunctionType valueOf(String)
@@ -4071,9 +4347,13 @@ public static final class net.corda.core.node.services.vault.AttachmentQueryCrit
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria extends net.corda.core.node.services.vault.AttachmentQueryCriteria
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>, net.corda.core.node.services.vault.ColumnPredicate<Integer>)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
@@ -4582,6 +4862,10 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Nul
   @NotNull
   public String toString()
 ##
+@DoNotImplement
+public interface net.corda.core.node.services.vault.CordaTransactionSupport
+  public abstract T transaction(kotlin.jvm.functions.Function1<? super net.corda.core.node.services.vault.SessionScope, ? extends T>)
+##
 @CordaSerializable
 public abstract class net.corda.core.node.services.vault.CriteriaExpression extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
@@ -4779,6 +5063,10 @@ public abstract static class net.corda.core.node.services.vault.QueryCriteria$Co
   @Nullable
   public abstract java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
   @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
+  @NotNull
+  public java.util.List<java.util.UUID> getExternalIds()
+  @Nullable
   public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   @NotNull
   public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
@@ -4789,17 +5077,30 @@ public abstract static class net.corda.core.node.services.vault.QueryCriteria$Co
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  @DeprecatedConstructorForDeserialization
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component1()
   @Nullable
@@ -4816,13 +5117,19 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component7()
   @NotNull
   public final net.corda.core.node.services.Vault$RelevancyStatus component8()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component9()
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> getIssuer()
   @Nullable
@@ -4844,6 +5151,8 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withExactParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withIssuer(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
@@ -4905,18 +5214,33 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  @DeprecatedConstructorForDeserialization
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component1()
@@ -4930,13 +5254,19 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Linea
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component5()
   @NotNull
   public final net.corda.core.node.services.Vault$RelevancyStatus component6()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component7()
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
   @Nullable
   public final java.util.List<String> getExternalId()
   @Nullable
@@ -4954,6 +5284,8 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Linea
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withExactParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withExternalId(java.util.List<String>)
   @NotNull
@@ -5024,9 +5356,13 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$TimeI
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
   public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
@@ -5068,19 +5404,38 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  @DeprecatedConstructorForDeserialization
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, java.util.List, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.Vault$StateStatus component1()
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component10()
+  @NotNull
+  public final java.util.List<java.util.UUID> component11()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component12()
   @Nullable
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component2()
   @Nullable
@@ -5101,6 +5456,10 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   @NotNull
   public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo$Type> getConstraintTypes()
@@ -5108,6 +5467,10 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo> getConstraints()
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
+  @NotNull
+  public java.util.List<java.util.UUID> getExternalIds()
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> getNotary()
   @Nullable
@@ -5133,6 +5496,10 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withConstraints(java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withExactParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withExternalIds(java.util.List<java.util.UUID>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withNotary(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
@@ -5161,6 +5528,11 @@ public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends
   public static final int DEFAULT_PAGE_NUM = 1
   public static final int DEFAULT_PAGE_SIZE = 200
   public static final int MAX_PAGE_SIZE = 2147483646
+##
+@DoNotImplement
+public interface net.corda.core.node.services.vault.SessionScope
+  @NotNull
+  public abstract org.hibernate.Session getSession()
 ##
 @CordaSerializable
 public final class net.corda.core.node.services.vault.Sort extends net.corda.core.node.services.vault.BaseSort
@@ -5273,6 +5645,10 @@ public static final class net.corda.core.node.services.vault.SortAttribute$Stand
   public int hashCode()
   @NotNull
   public String toString()
+##
+public final class net.corda.core.observable.Observables extends java.lang.Object
+  @NotNull
+  public static final rx.Observable<T> continueOnError(rx.Observable<T>)
 ##
 public final class net.corda.core.schemas.CommonSchema extends java.lang.Object
   public static final net.corda.core.schemas.CommonSchema INSTANCE
@@ -5464,6 +5840,7 @@ public final class net.corda.core.serialization.SerializationAPIKt extends java.
 ##
 @DoNotImplement
 public interface net.corda.core.serialization.SerializationContext
+  public abstract boolean getCarpenterDisabled()
   @NotNull
   public abstract java.util.Set<net.corda.core.serialization.SerializationCustomSerializer<?, ?>> getCustomSerializers()
   @NotNull
@@ -5503,6 +5880,8 @@ public interface net.corda.core.serialization.SerializationContext
   public abstract net.corda.core.serialization.SerializationContext withProperty(Object, Object)
   @NotNull
   public abstract net.corda.core.serialization.SerializationContext withWhitelisted(Class<?>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withoutCarpenter()
   @NotNull
   public abstract net.corda.core.serialization.SerializationContext withoutReferences()
 ##
@@ -5706,6 +6085,7 @@ public static final class net.corda.core.transactions.ContractUpgradeFilteredTra
 @DoNotImplement
 public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List, net.corda.core.node.NetworkParameters, net.corda.core.contracts.UpgradedContract, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
   @NotNull
@@ -5756,6 +6136,10 @@ public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction 
   public int hashCode()
   @NotNull
   public String toString()
+  public static final net.corda.core.transactions.ContractUpgradeLedgerTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.ContractUpgradeLedgerTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -5889,6 +6273,7 @@ public abstract class net.corda.core.transactions.FullTransaction extends net.co
 public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters, java.util.List, java.util.List, java.util.List, java.util.List, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function2, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.Command<T>> commandsOfType(Class<T>)
   @NotNull
@@ -6204,6 +6589,7 @@ public final class net.corda.core.transactions.SignedTransaction extends java.la
   public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable<net.corda.core.crypto.TransactionSignature>)
   public static final net.corda.core.transactions.SignedTransaction$Companion Companion
 ##
+@CordaSerializable
 public static final class net.corda.core.transactions.SignedTransaction$SignaturesMissingException extends java.security.SignatureException implements net.corda.core.CordaThrowable, net.corda.core.contracts.NamedByHash
   public <init>(java.util.Set<? extends java.security.PublicKey>, java.util.List<String>, net.corda.core.crypto.SecureHash)
   public void addSuppressed(Throwable[])
@@ -6250,6 +6636,8 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, net.corda.core.contracts.AttachmentConstraint)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, net.corda.core.identity.Party)
   @NotNull
@@ -6497,6 +6885,8 @@ public final class net.corda.core.utilities.KotlinUtilsKt extends java.lang.Obje
   @NotNull
   public static final org.slf4j.Logger contextLogger(Object)
   public static final void debug(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
+  @NotNull
+  public static final org.slf4j.Logger detailedLogger()
   public static final int exactAdd(int, int)
   public static final long exactAdd(long, long)
   @NotNull
@@ -6643,6 +7033,7 @@ public final class net.corda.core.utilities.ProgressTracker extends java.lang.Ob
   public final net.corda.core.utilities.ProgressTracker$Step nextStep()
   public final void setChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step, net.corda.core.utilities.ProgressTracker)
   public final void setCurrentStep(net.corda.core.utilities.ProgressTracker$Step)
+  public static final net.corda.core.utilities.ProgressTracker$Companion Companion
 ##
 @CordaSerializable
 public abstract static class net.corda.core.utilities.ProgressTracker$Change extends java.lang.Object
@@ -6719,12 +7110,14 @@ public static class net.corda.core.utilities.ProgressTracker$Step extends java.l
   public <init>(String)
   @Nullable
   public net.corda.core.utilities.ProgressTracker childProgressTracker()
+  public boolean equals(Object)
   @NotNull
   public rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
   @NotNull
   public java.util.Map<String, String> getExtraAuditData()
   @NotNull
   public String getLabel()
+  public int hashCode()
 ##
 @CordaSerializable
 public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED extends net.corda.core.utilities.ProgressTracker$Step
@@ -6733,6 +7126,10 @@ public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED ext
 ##
 public interface net.corda.core.utilities.PropertyDelegate
   public abstract T getValue(Object, kotlin.reflect.KProperty<?>)
+##
+public final class net.corda.core.utilities.SgxSupport extends java.lang.Object
+  public static final boolean isInsideEnclave()
+  public static final net.corda.core.utilities.SgxSupport INSTANCE
 ##
 @CordaSerializable
 public abstract class net.corda.core.utilities.Try extends java.lang.Object
@@ -6817,6 +7214,1479 @@ public static final class net.corda.core.utilities.UuidGenerator$Companion exten
 ##
 public interface net.corda.core.utilities.VariablePropertyDelegate extends net.corda.core.utilities.PropertyDelegate
   public abstract void setValue(Object, kotlin.reflect.KProperty<?>, T)
+##
+public final class net.corda.client.jackson.JacksonSupport extends java.lang.Object
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper()
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public final com.fasterxml.jackson.databind.Module getCordaModule()
+  public static final net.corda.client.jackson.JacksonSupport INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AmountDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.contracts.Amount<?> deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$AmountDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AmountSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.contracts.Amount<?>, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$AmountSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.AnonymousParty deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.AnonymousParty, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.CordaX500Name deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.CordaX500Name, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer INSTANCE
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$IdentityObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getFuzzyIdentityMatch()
+  @NotNull
+  public final net.corda.core.node.services.IdentityService getIdentityService()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(com.fasterxml.jackson.core.JsonFactory)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.node.NodeInfo deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$NodeInfoSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.node.NodeInfo, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$NodeInfoSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.utilities.OpaqueBytes deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.utilities.OpaqueBytes, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.Party deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$PartyDeserializer INSTANCE
+##
+@DoNotImplement
+public static interface net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public abstract boolean isFullParties()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$PartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.Party, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$PartySerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public java.security.PublicKey deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PublicKeySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(java.security.PublicKey, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$PublicKeySerializer INSTANCE
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$RpcObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getFuzzyIdentityMatch()
+  @NotNull
+  public final net.corda.core.messaging.CordaRPCOps getRpc()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$SecureHashDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  public <init>()
+  @NotNull
+  public T deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+##
+public static final class net.corda.client.jackson.JacksonSupport$SecureHashSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.crypto.SecureHash, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$SecureHashSerializer INSTANCE
+##
+public abstract static class net.corda.client.jackson.JacksonSupport$SignedTransactionMixin extends java.lang.Object
+  public <init>()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getId()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @JsonIgnore
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @JsonProperty
+  @NotNull
+  protected abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @JsonProperty
+  @NotNull
+  protected abstract net.corda.core.transactions.CoreTransaction getTransaction()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction getTx()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
+##
+public static final class net.corda.client.jackson.JacksonSupport$ToStringSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$ToStringSerializer INSTANCE
+##
+public abstract static class net.corda.client.jackson.JacksonSupport$WireTransactionMixin extends java.lang.Object
+  public <init>()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> getAvailableComponentHashes()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<Object> getAvailableComponents()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.MerkleTree getMerkleTree()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
+##
+@ThreadSafe
+public class net.corda.client.jackson.StringToMethodCallParser extends java.lang.Object
+  public <init>(Class<? extends T>)
+  public <init>(Class<? extends T>, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(Class, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(kotlin.reflect.KClass<? extends T>)
+  @NotNull
+  public final java.util.Map<String, String> getAvailableCommands()
+  @NotNull
+  protected final com.google.common.collect.Multimap<String, reflect.Method> getMethodMap()
+  @NotNull
+  public final java.util.Map<String, java.util.List<String>> getMethodParamNames()
+  @NotNull
+  public java.util.List<String> paramNamesFromConstructor(reflect.Constructor<?>)
+  @NotNull
+  public java.util.List<String> paramNamesFromMethod(reflect.Method)
+  @NotNull
+  public final net.corda.client.jackson.StringToMethodCallParser<T>.ParsedMethodCall parse(T, String)
+  @NotNull
+  public final Object[] parseArguments(String, java.util.List<? extends kotlin.Pair<String, ? extends reflect.Type>>, String)
+  public final void validateIsMatchingCtor(String, java.util.List<? extends kotlin.Pair<String, ? extends reflect.Type>>, String)
+  public static final net.corda.client.jackson.StringToMethodCallParser$Companion Companion
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.jackson.StringToMethodCallParser$ParsedMethodCall extends java.lang.Object implements java.util.concurrent.Callable
+  public <init>(net.corda.client.jackson.StringToMethodCallParser, T, reflect.Method, Object[])
+  @Nullable
+  public Object call()
+  @NotNull
+  public final Object[] getArgs()
+  @NotNull
+  public final reflect.Method getMethod()
+  @Nullable
+  public final Object invoke()
+##
+public static class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException extends net.corda.core.CordaException
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$FailedParse extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(Exception)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$MissingParameter extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, String, String)
+  @NotNull
+  public final String getParamName()
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$NoSuchFile extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$ReflectionDataMissing extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, int)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$TooManyParameters extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, String)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$UnknownMethod extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String)
+  @NotNull
+  public final String getMethodName()
+##
+public final class net.corda.testing.driver.Driver extends java.lang.Object
+  public static final A driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1<? super net.corda.testing.driver.DriverDSL, ? extends A>)
+##
+@DoNotImplement
+public interface net.corda.testing.driver.DriverDSL
+  @NotNull
+  public abstract java.nio.file.Path baseDirectory(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract net.corda.testing.driver.NotaryHandle getDefaultNotaryHandle()
+  @NotNull
+  public abstract net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> getDefaultNotaryNode()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.driver.NotaryHandle> getNotaryHandles()
+  public abstract int nextPort()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, String)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle, String)
+##
+public final class net.corda.testing.driver.DriverParameters extends java.lang.Object
+  public <init>()
+  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
+  public final boolean component1()
+  @NotNull
+  public final java.util.List<String> component10()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy component11()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component12()
+  @NotNull
+  public final java.util.Map<String, Object> component13()
+  public final boolean component14()
+  @Nullable
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component15()
+  @Nullable
+  public final java.nio.file.Path component16()
+  @NotNull
+  public final java.util.List<java.nio.file.Path> component17()
+  @NotNull
+  public final java.util.Map<String, String> component18()
+  @NotNull
+  public final java.nio.file.Path component2()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component3()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component4()
+  @NotNull
+  public final java.util.Map<String, String> component5()
+  public final boolean component6()
+  public final boolean component7()
+  public final boolean component8()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> component9()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
+  public boolean equals(Object)
+  @Nullable
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
+  @Nullable
+  public final java.nio.file.Path getDjvmBootstrapSource()
+  @NotNull
+  public final java.util.List<java.nio.file.Path> getDjvmCordaSource()
+  @NotNull
+  public final java.nio.file.Path getDriverDirectory()
+  @NotNull
+  public final java.util.Map<String, String> getEnvironmentVariables()
+  @NotNull
+  public final java.util.List<String> getExtraCordappPackagesToScan()
+  public final boolean getInMemoryDB()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy getJmxPolicy()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public final java.util.Map<String, Object> getNotaryCustomOverrides()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getPortAllocation()
+  public final boolean getStartNodesInProcess()
+  @NotNull
+  public final java.util.Map<String, String> getSystemProperties()
+  public final boolean getUseTestClock()
+  public final boolean getWaitForAllNodesToFinish()
+  public int hashCode()
+  public final boolean isDebug()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDjvmBootstrapSource(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDjvmCordaSource(java.util.List<? extends java.nio.file.Path>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withEnvironmentVariables(java.util.Map<String, String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(java.util.List<String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withInMemoryDB(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withIsDebug(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withJmxPolicy(net.corda.testing.driver.JmxPolicy)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotaryCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withStartNodesInProcess(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withSystemProperties(java.util.Map<String, String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withUseTestClock(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withWaitForAllNodesToFinish(boolean)
+##
+@DoNotImplement
+public interface net.corda.testing.driver.InProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServices()
+  @NotNull
+  public abstract rx.Observable<T> registerInitiatedFlow(Class<T>)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+##
+public final class net.corda.testing.driver.JmxPolicy extends java.lang.Object
+  public <init>()
+  public <init>(net.corda.testing.driver.PortAllocation)
+  public <init>(boolean, net.corda.testing.driver.PortAllocation)
+  public <init>(boolean, net.corda.testing.driver.PortAllocation, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean component1()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component2()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy copy(boolean, net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public static final net.corda.testing.driver.JmxPolicy defaultEnabled()
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getJmxHttpServerPortAllocation()
+  public final boolean getStartJmxHttpServer()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.testing.driver.JmxPolicy$Companion Companion
+##
+public static final class net.corda.testing.driver.JmxPolicy$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy defaultEnabled()
+##
+@DoNotImplement
+public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoCloseable
+  @NotNull
+  public abstract java.nio.file.Path getBaseDirectory()
+  @Nullable
+  public abstract net.corda.core.utilities.NetworkHostAndPort getJmxAddress()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getNodeInfo()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getP2pAddress()
+  @NotNull
+  public abstract net.corda.core.messaging.CordaRPCOps getRpc()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAddress()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAdminAddress()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.node.User> getRpcUsers()
+  public abstract void stop()
+##
+public final class net.corda.testing.driver.NodeParameters extends java.lang.Object
+  public <init>()
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component2()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component3()
+  @NotNull
+  public final java.util.Map<String, Object> component4()
+  @Nullable
+  public final Boolean component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component7()
+  @NotNull
+  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> component8()
+  @Nullable
+  public final String component9()
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
+  @NotNull
+  public final java.util.Map<String, Object> getCustomOverrides()
+  @NotNull
+  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> getFlowOverrides()
+  @Nullable
+  public final String getLogLevelOverride()
+  @NotNull
+  public final String getMaximumHeapSize()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getProvidedName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  @Nullable
+  public final Boolean getStartInSameProcess()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withAdditionalCordapps(java.util.Set<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withFlowOverrides(java.util.Map<Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withLogLevelOverride(String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withProvidedName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withRpcUsers(java.util.List<net.corda.testing.node.User>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withStartInSameProcess(Boolean)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withVerifierType(net.corda.testing.driver.VerifierType)
+##
+public final class net.corda.testing.driver.NotaryHandle extends java.lang.Object
+  public <init>(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> component3()
+  @NotNull
+  public final net.corda.testing.driver.NotaryHandle copy(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getIdentity()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> getNodeHandles()
+  public final boolean getValidating()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.testing.driver.OutOfProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract Process getProcess()
+##
+@DoNotImplement
+public abstract class net.corda.testing.driver.PortAllocation extends java.lang.Object
+  public <init>()
+  @NotNull
+  public static final net.corda.testing.driver.PortAllocation getDefaultAllocator()
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort nextHostAndPort()
+  public abstract int nextPort()
+  public static final net.corda.testing.driver.PortAllocation$Companion Companion
+  public static final int DEFAULT_START_PORT = 10000
+  public static final int FIRST_EPHEMERAL_PORT = 30000
+##
+public static final class net.corda.testing.driver.PortAllocation$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getDefaultAllocator()
+##
+@DoNotImplement
+public static class net.corda.testing.driver.PortAllocation$Incremental extends net.corda.testing.driver.PortAllocation
+  public <init>(int)
+  @NotNull
+  public final java.util.concurrent.atomic.AtomicInteger getPortCounter()
+  public int nextPort()
+##
+@DoNotImplement
+public class net.corda.testing.driver.SharedMemoryIncremental extends net.corda.testing.driver.PortAllocation
+  public int nextPort()
+  public static net.corda.testing.driver.SharedMemoryIncremental INSTANCE
+##
+public final class net.corda.testing.driver.VerifierType extends java.lang.Enum
+  public static net.corda.testing.driver.VerifierType valueOf(String)
+  public static net.corda.testing.driver.VerifierType[] values()
+##
+public final class net.corda.testing.driver.WebserverHandle extends java.lang.Object
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Process)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort component1()
+  @NotNull
+  public final Process component2()
+  @NotNull
+  public final net.corda.testing.driver.WebserverHandle copy(net.corda.core.utilities.NetworkHostAndPort, Process)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort getListenAddress()
+  @NotNull
+  public final Process getProcess()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.flows.FlowTestsUtilsKt extends java.lang.Object
+  @NotNull
+  public static final kotlin.Pair<net.corda.core.flows.FlowSession, T> from(T, net.corda.core.flows.FlowSession)
+  @NotNull
+  public static final R from(java.util.Map<net.corda.core.flows.FlowSession, ? extends net.corda.core.utilities.UntrustworthyData<?>>, net.corda.core.flows.FlowSession)
+  @NotNull
+  public static final kotlin.Pair<net.corda.core.flows.FlowSession, Class<T>> from(kotlin.reflect.KClass<T>, net.corda.core.flows.FlowSession)
+  @Suspendable
+  @NotNull
+  public static final java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(net.corda.core.flows.FlowLogic<?>, Class<R>, net.corda.core.flows.FlowSession, net.corda.core.flows.FlowSession...)
+  @Suspendable
+  @NotNull
+  public static final java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAll(net.corda.core.flows.FlowLogic<?>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>...)
+  @NotNull
+  public static final rx.Observable<T> registerCoreFlowFactory(net.corda.testing.node.internal.TestStartedNode, Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<T>, kotlin.jvm.functions.Function1<? super net.corda.core.flows.FlowSession, ? extends T>, boolean)
+##
+@DoNotImplement
+public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
+  public <init>()
+  public abstract int getClusterSize()
+##
+@DoNotImplement
+public static final class net.corda.testing.node.ClusterSpec$Raft extends net.corda.testing.node.ClusterSpec
+  public <init>(int)
+  public final int component1()
+  @NotNull
+  public final net.corda.testing.node.ClusterSpec$Raft copy(int)
+  public boolean equals(Object)
+  public int getClusterSize()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@ThreadSafe
+public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.corda.core.serialization.SingletonSerializeAsToken
+  public <init>(boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, org.apache.activemq.artemis.utils.ReusableLatch, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final synchronized java.util.List<net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService> getEndpointsExternal()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getReceivedMessages()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getSentMessages()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpSend(boolean)
+  public final void stop()
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle extends java.lang.Object implements net.corda.core.messaging.MessageRecipientGroup
+  public <init>(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle copy(net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static interface net.corda.testing.node.InMemoryMessagingNetwork$LatencyCalculator
+  @NotNull
+  public abstract java.time.Duration between(net.corda.core.messaging.SingleMessageRecipient, net.corda.core.messaging.SingleMessageRecipient)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer extends java.lang.Object
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence getMessageData()
+  @NotNull
+  public final net.corda.core.messaging.MessageRecipients getRecipients()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle getSender()
+  @NotNull
+  public String toString()
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.MockNodeMessagingService, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle extends java.lang.Object implements net.corda.core.messaging.SingleMessageRecipient
+  public <init>(int, net.corda.core.identity.CordaX500Name)
+  public final int component1()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle copy(int, net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  public final int getId()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public abstract static class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public abstract A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$Random extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+  public <init>()
+  public <init>(java.util.SplittableRandom)
+  public <init>(java.util.SplittableRandom, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.SplittableRandom getRandom()
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+  public <init>()
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+public final class net.corda.testing.node.MockNetFlowTimeOut extends java.lang.Object
+  public <init>(java.time.Duration, int, double)
+  public final double getBackoffBase()
+  public final int getMaxRestartCount()
+  @NotNull
+  public final java.time.Duration getTimeout()
+##
+public final class net.corda.testing.node.MockNetNotaryConfig extends java.lang.Object
+  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name)
+  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final String getClassName()
+  @Nullable
+  public final com.typesafe.config.Config getExtraConfig()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getServiceLegalName()
+  public final boolean getValidating()
+##
+public class net.corda.testing.node.MockNetwork extends java.lang.Object
+  public <init>(java.util.List<String>)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.testing.node.MockNetworkParameters)
+  @NotNull
+  public final java.nio.file.Path baseDirectory(int)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode()
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final java.util.List<String> getCordappPackages()
+  @NotNull
+  public final net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode getDefaultNotaryNode()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters getDefaultParameters()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public final boolean getNetworkSendManuallyPumped()
+  public final int getNextNodeId()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.StartedMockNode> getNotaryNodes()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  public final boolean getThreadPerNode()
+  public final void runNetwork()
+  public final void runNetwork(int)
+  public final void startNodes()
+  public final void stopNodes()
+  public final void waitQuiescent()
+##
+public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, String)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkNotarySpec copy(net.corda.core.identity.CordaX500Name, boolean)
+  public boolean equals(Object)
+  @Nullable
+  public final String getClassName()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  public final boolean getValidating()
+  public int hashCode()
+  public final void setClassName(String)
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.node.MockNetworkParameters extends java.lang.Object
+  public <init>()
+  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy component3()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> component4()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component5()
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component6()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public final boolean getNetworkSendManuallyPumped()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  public final boolean getThreadPerNode()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkSendManuallyPumped(boolean)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNotarySpecs(java.util.List<net.corda.testing.node.MockNetworkNotarySpec>)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withServicePeerAllocationStrategy(net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withThreadPerNode(boolean)
+##
+public final class net.corda.testing.node.MockNodeConfigOverrides extends java.lang.Object
+  public <init>()
+  public <init>(java.util.Map<String, String>, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut)
+  public <init>(java.util.Map, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.Map<String, String> getExtraDataSourceProperties()
+  @Nullable
+  public final net.corda.testing.node.MockNetFlowTimeOut getFlowTimeout()
+  @Nullable
+  public final net.corda.testing.node.MockNetNotaryConfig getNotary()
+##
+public final class net.corda.testing.node.MockNodeParameters extends java.lang.Object
+  public <init>()
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final Integer component1()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final java.math.BigInteger component3()
+  @Nullable
+  public final net.corda.testing.node.MockNodeConfigOverrides component4()
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component5()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
+  @Nullable
+  public final net.corda.testing.node.MockNodeConfigOverrides getConfigOverrides()
+  @NotNull
+  public final java.math.BigInteger getEntropyRoot()
+  @Nullable
+  public final Integer getForcedID()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getLegalName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withAdditionalCordapps(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withConfigOverrides(net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withEntropyRoot(java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withForcedID(Integer)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withLegalName(net.corda.core.identity.CordaX500Name)
+##
+public class net.corda.testing.node.MockServices extends java.lang.Object implements net.corda.core.node.ServiceHub
+  public <init>()
+  public <init>(Iterable<String>)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair[], net.corda.core.node.services.KeyManagementService)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
+  public <init>(Iterable, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.nodeapi.internal.cordapp.CordappLoader, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity, java.security.KeyPair[], net.corda.core.node.services.KeyManagementService, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
+  public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
+  public final void addMockCordapp(String)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public T cordaService(Class<T>)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.cordapp.CordappContext getAppContext()
+  @NotNull
+  public final net.corda.testing.services.MockAttachmentStorage getAttachments()
+  @NotNull
+  public net.corda.testing.node.TestClock getClock()
+  @NotNull
+  public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public final ClassLoader getCordappClassloader()
+  @NotNull
+  public net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public net.corda.core.node.services.diagnostics.DiagnosticsService getDiagnosticsService()
+  @NotNull
+  public net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public net.corda.core.node.services.KeyManagementService getKeyManagementService()
+  @NotNull
+  public net.corda.core.node.NodeInfo getMyInfo()
+  @NotNull
+  public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
+  @NotNull
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public net.corda.core.node.services.NetworkParametersService getNetworkParametersService()
+  @NotNull
+  protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
+  @NotNull
+  public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
+  @NotNull
+  public net.corda.core.node.services.TransactionStorage getValidatedTransactions()
+  @NotNull
+  public net.corda.core.node.services.VaultService getVaultService()
+  @NotNull
+  public java.sql.Connection jdbcSession()
+  @NotNull
+  public net.corda.core.contracts.Attachment loadContractAttachment(net.corda.core.contracts.StateRef)
+  @NotNull
+  public net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
+  @NotNull
+  public java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public static final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>, net.corda.testing.internal.TestingNamedCacheFactory)
+  public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  @NotNull
+  public Void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
+  public void setNetworkParametersService(net.corda.core.node.services.NetworkParametersService)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
+  public void withEntityManager(java.util.function.Consumer<javax.persistence.EntityManager>)
+  public T withEntityManager(kotlin.jvm.functions.Function1<? super javax.persistence.EntityManager, ? extends T>)
+  public static final net.corda.testing.node.MockServices$Companion Companion
+##
+public static final class net.corda.testing.node.MockServices$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>, net.corda.testing.internal.TestingNamedCacheFactory)
+##
+public final class net.corda.testing.node.MockServicesKt extends java.lang.Object
+  @NotNull
+  public static final T createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1<? super net.corda.core.node.AppServiceHub, ? extends T>)
+  @NotNull
+  public static final net.corda.core.node.services.IdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
+##
+public final class net.corda.testing.node.NodeTestUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.core.context.Actor testActor(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext testContext(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+##
+public final class net.corda.testing.node.NotarySpec extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  public final boolean component2()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component3()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component4()
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec component5()
+  @NotNull
+  public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec getCluster()
+  @NotNull
+  public final String getMaximumHeapSize()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  public final boolean getValidating()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
+  public int hashCode()
+  public final void setMaximumHeapSize(String)
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.node.StartedMockNode extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.TestStartedNode, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<kotlin.Pair<F, net.corda.core.concurrent.CordaFuture<?>>> findStateMachines(Class<F>)
+  public final int getId()
+  @NotNull
+  public final net.corda.core.node.NodeInfo getInfo()
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServices()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  @NotNull
+  public final rx.Observable<F> registerInitiatedFlow(Class<F>)
+  @NotNull
+  public final rx.Observable<F> registerInitiatedFlow(Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<F>)
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  public final void stop()
+  public final T transaction(kotlin.jvm.functions.Function0<? extends T>)
+  public static final net.corda.testing.node.StartedMockNode$Companion Companion
+##
+public static final class net.corda.testing.node.StartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@ThreadSafe
+public final class net.corda.testing.node.TestClock extends net.corda.node.MutableClock
+  public <init>(java.time.Clock)
+  public final synchronized void advanceBy(java.time.Duration)
+  public final synchronized void setTo(java.time.Instant)
+##
+@DoNotImplement
+public abstract class net.corda.testing.node.TestCordapp extends java.lang.Object
+  public <init>()
+  @NotNull
+  public static final net.corda.testing.node.TestCordapp findCordapp(String)
+  @NotNull
+  public abstract java.util.Map<String, Object> getConfig()
+  @NotNull
+  public abstract net.corda.testing.node.TestCordapp withConfig(java.util.Map<String, ?>)
+  public static final net.corda.testing.node.TestCordapp$Companion Companion
+##
+public static final class net.corda.testing.node.TestCordapp$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.node.TestCordapp findCordapp(String)
+##
+public final class net.corda.testing.node.UnstartedMockNode extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.InternalMockNetwork$MockNode, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int getId()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode getStarted()
+  @NotNull
+  public final T installCordaService(Class<T>)
+  public final boolean isStarted()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode start()
+  public static final net.corda.testing.node.UnstartedMockNode$Companion Companion
+##
+public static final class net.corda.testing.node.UnstartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.testing.node.User extends java.lang.Object
+  public <init>(String, String, java.util.Set<String>)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.util.Set<String> component3()
+  @NotNull
+  public final net.corda.testing.node.User copy(String, String, java.util.Set<String>)
+  public boolean equals(Object)
+  @NotNull
+  public final String getPassword()
+  @NotNull
+  public final java.util.Set<String> getPermissions()
+  @NotNull
+  public final String getUsername()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public class net.corda.client.rpc.ConnectionFailureException extends net.corda.client.rpc.RPCException
+  public <init>()
+  public <init>(Throwable)
+  public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(java.util.List, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(java.util.List, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.client.rpc.GracefulReconnect)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.client.rpc.GracefulReconnect)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name, net.corda.client.rpc.GracefulReconnect)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.identity.CordaX500Name, net.corda.client.rpc.GracefulReconnect)
+  public final A use(String, String, kotlin.jvm.functions.Function1<? super net.corda.client.rpc.CordaRPCConnection, ? extends A>)
+  public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
+##
+public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
+  public <init>()
+  public <init>(java.time.Duration)
+  public <init>(java.time.Duration, int)
+  public <init>(java.time.Duration, int, boolean)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.time.Duration component1()
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy()
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
+  public boolean equals(Object)
+  public int getCacheConcurrencyLevel()
+  @NotNull
+  public java.time.Duration getConnectionMaxRetryInterval()
+  @NotNull
+  public java.time.Duration getConnectionRetryInterval()
+  public double getConnectionRetryIntervalMultiplier()
+  @NotNull
+  public java.time.Duration getDeduplicationCacheExpiry()
+  public int getMaxFileSize()
+  public int getMaxReconnectAttempts()
+  public int getMinimumServerProtocolVersion()
+  public int getObservationExecutorPoolSize()
+  @NotNull
+  public java.time.Duration getReapInterval()
+  public boolean getTrackRpcCallSites()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
+  @NotNull
+  public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
+##
+public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
+  public <init>(net.corda.client.rpc.RPCConnection<? extends net.corda.core.messaging.CordaRPCOps>)
+  public <init>(net.corda.client.rpc.RPCConnection, java.util.concurrent.ExecutorService, net.corda.client.rpc.internal.ReconnectingCordaRPCOps, kotlin.jvm.internal.DefaultConstructorMarker)
+  public void close()
+  public void forceClose()
+  @NotNull
+  public net.corda.core.messaging.CordaRPCOps getProxy()
+  public int getServerProtocolVersion()
+  public void notifyServerAndClose()
+  public static final net.corda.client.rpc.CordaRPCConnection$Companion Companion
+##
+public static final class net.corda.client.rpc.CordaRPCConnection$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.rpc.GracefulReconnect extends java.lang.Object
+  public <init>()
+  public <init>(Runnable, Runnable)
+  public <init>(Runnable, Runnable, int)
+  public <init>(Runnable, Runnable, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(kotlin.jvm.functions.Function0<kotlin.Unit>, kotlin.jvm.functions.Function0<kotlin.Unit>, int)
+  public <init>(kotlin.jvm.functions.Function0, kotlin.jvm.functions.Function0, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int getMaxAttempts()
+  @NotNull
+  public final kotlin.jvm.functions.Function0<kotlin.Unit> getOnDisconnect()
+  @NotNull
+  public final kotlin.jvm.functions.Function0<kotlin.Unit> getOnReconnect()
+##
+public final class net.corda.client.rpc.MaxRpcRetryException extends net.corda.client.rpc.RPCException
+  public <init>(int, reflect.Method, Throwable)
+##
+public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException implements net.corda.core.ClientRelevantError, net.corda.nodeapi.exceptions.RpcSerializableError
+  public <init>(String)
+  @NotNull
+  public final String getMsg()
+##
+@DoNotImplement
+public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
+  public abstract void close()
+  public abstract void forceClose()
+  @NotNull
+  public abstract I getProxy()
+  public abstract int getServerProtocolVersion()
+  public abstract void notifyServerAndClose()
+##
+public class net.corda.client.rpc.RPCException extends net.corda.core.CordaRuntimeException
+  public <init>(String)
+  public <init>(String, Throwable)
+##
+public @interface net.corda.client.rpc.RPCSinceVersion
+  public abstract int version()
+##
+public class net.corda.client.rpc.UnrecoverableRPCException extends net.corda.client.rpc.RPCException
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
+  public static final void notUsed(rx.Observable<T>)
+##
+public final class net.corda.client.rpc.reconnect.CouldNotStartFlowException extends net.corda.client.rpc.RPCException
+  public <init>()
+  public <init>(Throwable)
+  public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.finance.test.CashSchema extends java.lang.Object
+  public static final net.corda.finance.test.CashSchema INSTANCE
+##
+public final class net.corda.finance.test.SampleCashSchemaV1 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV1 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV1$PersistentCashState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(String, long, String, String, byte[])
+  @NotNull
+  public String getCurrency()
+  @NotNull
+  public String getIssuerPartyHash()
+  @NotNull
+  public byte[] getIssuerRef()
+  @NotNull
+  public String getOwnerHash()
+  public long getPennies()
+  public void setCurrency(String)
+  public void setIssuerPartyHash(String)
+  public void setIssuerRef(byte[])
+  public void setOwnerHash(String)
+  public void setPennies(long)
+##
+public final class net.corda.finance.test.SampleCashSchemaV2 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV2 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV2$PersistentCashState extends net.corda.core.schemas.CommonSchemaV1$FungibleState
+  public <init>()
+  public <init>(String, java.util.Set<? extends net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String getCurrency()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public void setCurrency(String)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+##
+public final class net.corda.finance.test.SampleCashSchemaV3 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV3 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV3$PersistentCashState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[])
+  public <init>(java.util.Set, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public String getCurrency()
+  @Nullable
+  public net.corda.core.identity.AbstractParty getIssuer()
+  @NotNull
+  public byte[] getIssuerRef()
+  @Nullable
+  public net.corda.core.identity.AbstractParty getOwner()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public long getPennies()
+  public void setCurrency(String)
+  public void setIssuer(net.corda.core.identity.AbstractParty)
+  public void setIssuerRef(byte[])
+  public void setOwner(net.corda.core.identity.AbstractParty)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setPennies(long)
 ##
 public final class net.corda.testing.contracts.DummyContract extends java.lang.Object implements net.corda.core.contracts.Contract
   public <init>()
@@ -6913,6 +8783,10 @@ public final class net.corda.testing.contracts.DummyContractV2 extends java.lang
   @NotNull
   public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
   @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
+  @NotNull
   public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
   public void verify(net.corda.core.transactions.LedgerTransaction)
   public static final net.corda.testing.contracts.DummyContractV2$Companion Companion
@@ -6929,6 +8803,10 @@ public static final class net.corda.testing.contracts.DummyContractV2$Commands$M
 ##
 public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
 ##
 public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
   public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
@@ -6947,6 +8825,8 @@ public static final class net.corda.testing.contracts.DummyContractV2$State exte
   public int hashCode()
   @NotNull
   public String toString()
+  @NotNull
+  public final kotlin.Pair<net.corda.testing.contracts.DummyContractV2$Commands, net.corda.testing.contracts.DummyContractV2$State> withNewOwner(net.corda.core.identity.AbstractParty)
 ##
 public final class net.corda.testing.contracts.DummyContractV3 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
   public <init>()
@@ -7203,1336 +9083,6 @@ public final class net.corda.testing.core.TestUtils extends java.lang.Object
   public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
   @NotNull
   public static final net.corda.core.identity.PartyAndCertificate singleIdentityAndCert(net.corda.core.node.NodeInfo)
-##
-public final class net.corda.client.jackson.JacksonSupport extends java.lang.Object
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper()
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory)
-  @NotNull
-  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory, boolean)
-  @NotNull
-  public final com.fasterxml.jackson.databind.Module getCordaModule()
-  public static final net.corda.client.jackson.JacksonSupport INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$AmountDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @NotNull
-  public net.corda.core.contracts.Amount<?> deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-  public static final net.corda.client.jackson.JacksonSupport$AmountDeserializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$AmountSerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.contracts.Amount<?>, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$AmountSerializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @NotNull
-  public net.corda.core.identity.AnonymousParty deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.identity.AnonymousParty, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @NotNull
-  public net.corda.core.identity.CordaX500Name deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.identity.CordaX500Name, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer INSTANCE
-##
-@DoNotImplement
-public static final class net.corda.client.jackson.JacksonSupport$IdentityObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
-  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
-  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
-  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final boolean getFuzzyIdentityMatch()
-  @NotNull
-  public final net.corda.core.node.services.IdentityService getIdentityService()
-  public boolean isFullParties()
-  @Nullable
-  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
-  @NotNull
-  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
-  @Nullable
-  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @Nullable
-  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
-##
-@DoNotImplement
-public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
-  public <init>(com.fasterxml.jackson.core.JsonFactory)
-  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean)
-  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public boolean isFullParties()
-  @Nullable
-  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
-  @NotNull
-  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
-  @Nullable
-  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @Nullable
-  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
-##
-public static final class net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @NotNull
-  public net.corda.core.node.NodeInfo deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-  public static final net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$NodeInfoSerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.node.NodeInfo, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$NodeInfoSerializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @NotNull
-  public net.corda.core.utilities.OpaqueBytes deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.utilities.OpaqueBytes, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$PartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @NotNull
-  public net.corda.core.identity.Party deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-  public static final net.corda.client.jackson.JacksonSupport$PartyDeserializer INSTANCE
-##
-@DoNotImplement
-public static interface net.corda.client.jackson.JacksonSupport$PartyObjectMapper
-  public abstract boolean isFullParties()
-  @Nullable
-  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
-  @NotNull
-  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
-  @Nullable
-  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @Nullable
-  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
-##
-public static final class net.corda.client.jackson.JacksonSupport$PartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.identity.Party, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$PartySerializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @NotNull
-  public java.security.PublicKey deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-  public static final net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer INSTANCE
-##
-public static final class net.corda.client.jackson.JacksonSupport$PublicKeySerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(java.security.PublicKey, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$PublicKeySerializer INSTANCE
-##
-@DoNotImplement
-public static final class net.corda.client.jackson.JacksonSupport$RpcObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
-  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
-  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
-  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final boolean getFuzzyIdentityMatch()
-  @NotNull
-  public final net.corda.core.messaging.CordaRPCOps getRpc()
-  public boolean isFullParties()
-  @Nullable
-  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
-  @NotNull
-  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
-  @Nullable
-  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @Nullable
-  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
-##
-public static final class net.corda.client.jackson.JacksonSupport$SecureHashDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  public <init>()
-  @NotNull
-  public T deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-##
-public static final class net.corda.client.jackson.JacksonSupport$SecureHashSerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.crypto.SecureHash, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$SecureHashSerializer INSTANCE
-##
-public abstract static class net.corda.client.jackson.JacksonSupport$SignedTransactionMixin extends java.lang.Object
-  public <init>()
-  @JsonIgnore
-  @NotNull
-  public abstract net.corda.core.crypto.SecureHash getId()
-  @JsonIgnore
-  @NotNull
-  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
-  @JsonIgnore
-  @Nullable
-  public abstract net.corda.core.identity.Party getNotary()
-  @JsonIgnore
-  @NotNull
-  public abstract net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
-  @JsonIgnore
-  @NotNull
-  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
-  @JsonProperty
-  @NotNull
-  protected abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
-  @JsonProperty
-  @NotNull
-  protected abstract net.corda.core.transactions.CoreTransaction getTransaction()
-  @JsonIgnore
-  @NotNull
-  public abstract net.corda.core.transactions.WireTransaction getTx()
-  @JsonIgnore
-  @NotNull
-  public abstract net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
-##
-public static final class net.corda.client.jackson.JacksonSupport$ToStringSerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-  public static final net.corda.client.jackson.JacksonSupport$ToStringSerializer INSTANCE
-##
-public abstract static class net.corda.client.jackson.JacksonSupport$WireTransactionMixin extends java.lang.Object
-  public <init>()
-  @JsonIgnore
-  @NotNull
-  public abstract java.util.List<net.corda.core.crypto.SecureHash> getAvailableComponentHashes()
-  @JsonIgnore
-  @NotNull
-  public abstract java.util.List<Object> getAvailableComponents()
-  @JsonIgnore
-  @NotNull
-  public abstract net.corda.core.crypto.MerkleTree getMerkleTree()
-  @JsonIgnore
-  @NotNull
-  public abstract java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
-##
-@ThreadSafe
-public class net.corda.client.jackson.StringToMethodCallParser extends java.lang.Object
-  public <init>(Class<? extends T>)
-  public <init>(Class<? extends T>, com.fasterxml.jackson.databind.ObjectMapper)
-  public <init>(Class, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(kotlin.reflect.KClass<? extends T>)
-  @NotNull
-  public final java.util.Map<String, String> getAvailableCommands()
-  @NotNull
-  protected final com.google.common.collect.Multimap<String, reflect.Method> getMethodMap()
-  @NotNull
-  public final java.util.Map<String, java.util.List<String>> getMethodParamNames()
-  @NotNull
-  public java.util.List<String> paramNamesFromConstructor(reflect.Constructor<?>)
-  @NotNull
-  public java.util.List<String> paramNamesFromMethod(reflect.Method)
-  @NotNull
-  public final net.corda.client.jackson.StringToMethodCallParser<T>.ParsedMethodCall parse(T, String)
-  @NotNull
-  public final Object[] parseArguments(String, java.util.List<? extends kotlin.Pair<String, ? extends reflect.Type>>, String)
-  public static final net.corda.client.jackson.StringToMethodCallParser$Companion Companion
-##
-public static final class net.corda.client.jackson.StringToMethodCallParser$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public final class net.corda.client.jackson.StringToMethodCallParser$ParsedMethodCall extends java.lang.Object implements java.util.concurrent.Callable
-  public <init>(net.corda.client.jackson.StringToMethodCallParser, T, reflect.Method, Object[])
-  @Nullable
-  public Object call()
-  @NotNull
-  public final Object[] getArgs()
-  @NotNull
-  public final reflect.Method getMethod()
-  @Nullable
-  public final Object invoke()
-##
-public static class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException extends net.corda.core.CordaException
-  public <init>(String, Throwable)
-  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$FailedParse extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
-  public <init>(Exception)
-##
-public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$MissingParameter extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
-  public <init>(String, String, String)
-  @NotNull
-  public final String getParamName()
-##
-public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$ReflectionDataMissing extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
-  public <init>(String, int)
-##
-public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$TooManyParameters extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
-  public <init>(String, String)
-##
-public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$UnknownMethod extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
-  public <init>(String)
-  @NotNull
-  public final String getMethodName()
-##
-public final class net.corda.testing.driver.Driver extends java.lang.Object
-  public static final A driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1<? super net.corda.testing.driver.DriverDSL, ? extends A>)
-##
-@DoNotImplement
-public interface net.corda.testing.driver.DriverDSL
-  @NotNull
-  public abstract java.nio.file.Path baseDirectory(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public abstract net.corda.testing.driver.NotaryHandle getDefaultNotaryHandle()
-  @NotNull
-  public abstract net.corda.core.identity.Party getDefaultNotaryIdentity()
-  @NotNull
-  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> getDefaultNotaryNode()
-  @NotNull
-  public abstract java.util.List<net.corda.testing.driver.NotaryHandle> getNotaryHandles()
-  @NotNull
-  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode()
-  @NotNull
-  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters)
-  @NotNull
-  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
-  @NotNull
-  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle)
-  @NotNull
-  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle, String)
-##
-public final class net.corda.testing.driver.DriverParameters extends java.lang.Object
-  public <init>()
-  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
-  public final boolean component1()
-  @NotNull
-  public final java.util.List<String> component10()
-  @NotNull
-  public final net.corda.testing.driver.JmxPolicy component11()
-  @NotNull
-  public final net.corda.core.node.NetworkParameters component12()
-  @NotNull
-  public final java.util.Map<String, Object> component13()
-  public final boolean component14()
-  @Nullable
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> component15()
-  @NotNull
-  public final java.nio.file.Path component2()
-  @NotNull
-  public final net.corda.testing.driver.PortAllocation component3()
-  @NotNull
-  public final net.corda.testing.driver.PortAllocation component4()
-  @NotNull
-  public final java.util.Map<String, String> component5()
-  public final boolean component6()
-  public final boolean component7()
-  public final boolean component8()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.NotarySpec> component9()
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
-  public boolean equals(Object)
-  @Nullable
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
-  @NotNull
-  public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
-  @NotNull
-  public final java.nio.file.Path getDriverDirectory()
-  @NotNull
-  public final java.util.List<String> getExtraCordappPackagesToScan()
-  public final boolean getInMemoryDB()
-  @NotNull
-  public final net.corda.testing.driver.JmxPolicy getJmxPolicy()
-  @NotNull
-  public final net.corda.core.node.NetworkParameters getNetworkParameters()
-  @NotNull
-  public final java.util.Map<String, Object> getNotaryCustomOverrides()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
-  @NotNull
-  public final net.corda.testing.driver.PortAllocation getPortAllocation()
-  public final boolean getStartNodesInProcess()
-  @NotNull
-  public final java.util.Map<String, String> getSystemProperties()
-  public final boolean getUseTestClock()
-  public final boolean getWaitForAllNodesToFinish()
-  public int hashCode()
-  public final boolean isDebug()
-  @NotNull
-  public String toString()
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(java.util.List<String>)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withInMemoryDB(boolean)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withIsDebug(boolean)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withJmxPolicy(net.corda.testing.driver.JmxPolicy)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withNotaryCustomOverrides(java.util.Map<String, ?>)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withPortAllocation(net.corda.testing.driver.PortAllocation)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withStartNodesInProcess(boolean)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withSystemProperties(java.util.Map<String, String>)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withUseTestClock(boolean)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withWaitForAllNodesToFinish(boolean)
-##
-@DoNotImplement
-public interface net.corda.testing.driver.InProcess extends net.corda.testing.driver.NodeHandle
-  @NotNull
-  public abstract net.corda.core.node.ServiceHub getServices()
-  @NotNull
-  public abstract rx.Observable<T> registerInitiatedFlow(Class<T>)
-  @NotNull
-  public abstract net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
-##
-public final class net.corda.testing.driver.JmxPolicy extends java.lang.Object
-  public <init>()
-  public <init>(net.corda.testing.driver.PortAllocation)
-  public <init>(boolean, net.corda.testing.driver.PortAllocation)
-  public <init>(boolean, net.corda.testing.driver.PortAllocation, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final boolean component1()
-  @NotNull
-  public final net.corda.testing.driver.PortAllocation component2()
-  @NotNull
-  public final net.corda.testing.driver.JmxPolicy copy(boolean, net.corda.testing.driver.PortAllocation)
-  @NotNull
-  public static final net.corda.testing.driver.JmxPolicy defaultEnabled()
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.testing.driver.PortAllocation getJmxHttpServerPortAllocation()
-  public final boolean getStartJmxHttpServer()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  public static final net.corda.testing.driver.JmxPolicy$Companion Companion
-##
-public static final class net.corda.testing.driver.JmxPolicy$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.testing.driver.JmxPolicy defaultEnabled()
-##
-@DoNotImplement
-public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoCloseable
-  @NotNull
-  public abstract java.nio.file.Path getBaseDirectory()
-  @Nullable
-  public abstract net.corda.core.utilities.NetworkHostAndPort getJmxAddress()
-  @NotNull
-  public abstract net.corda.core.node.NodeInfo getNodeInfo()
-  @NotNull
-  public abstract net.corda.core.utilities.NetworkHostAndPort getP2pAddress()
-  @NotNull
-  public abstract net.corda.core.messaging.CordaRPCOps getRpc()
-  @NotNull
-  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAddress()
-  @NotNull
-  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAdminAddress()
-  @NotNull
-  public abstract java.util.List<net.corda.testing.node.User> getRpcUsers()
-  public abstract void stop()
-##
-public final class net.corda.testing.driver.NodeParameters extends java.lang.Object
-  public <init>()
-  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
-  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
-  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @Nullable
-  public final net.corda.core.identity.CordaX500Name component1()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.User> component2()
-  @NotNull
-  public final net.corda.testing.driver.VerifierType component3()
-  @NotNull
-  public final java.util.Map<String, Object> component4()
-  @Nullable
-  public final Boolean component5()
-  @NotNull
-  public final String component6()
-  @NotNull
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> component7()
-  @NotNull
-  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> component8()
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
-  public boolean equals(Object)
-  @NotNull
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
-  @NotNull
-  public final java.util.Map<String, Object> getCustomOverrides()
-  @NotNull
-  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> getFlowOverrides()
-  @NotNull
-  public final String getMaximumHeapSize()
-  @Nullable
-  public final net.corda.core.identity.CordaX500Name getProvidedName()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
-  @Nullable
-  public final Boolean getStartInSameProcess()
-  @NotNull
-  public final net.corda.testing.driver.VerifierType getVerifierType()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withAdditionalCordapps(java.util.Set<? extends net.corda.testing.node.TestCordapp>)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withCustomOverrides(java.util.Map<String, ?>)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withFlowOverrides(java.util.Map<Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withProvidedName(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withRpcUsers(java.util.List<net.corda.testing.node.User>)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withStartInSameProcess(Boolean)
-  @NotNull
-  public final net.corda.testing.driver.NodeParameters withVerifierType(net.corda.testing.driver.VerifierType)
-##
-public final class net.corda.testing.driver.NotaryHandle extends java.lang.Object
-  public <init>(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
-  @NotNull
-  public final net.corda.core.identity.Party component1()
-  public final boolean component2()
-  @NotNull
-  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> component3()
-  @NotNull
-  public final net.corda.testing.driver.NotaryHandle copy(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.core.identity.Party getIdentity()
-  @NotNull
-  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> getNodeHandles()
-  public final boolean getValidating()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@DoNotImplement
-public interface net.corda.testing.driver.OutOfProcess extends net.corda.testing.driver.NodeHandle
-  @NotNull
-  public abstract Process getProcess()
-##
-@DoNotImplement
-public abstract class net.corda.testing.driver.PortAllocation extends java.lang.Object
-  public <init>()
-  @NotNull
-  public final net.corda.core.utilities.NetworkHostAndPort nextHostAndPort()
-  public abstract int nextPort()
-##
-@DoNotImplement
-public static class net.corda.testing.driver.PortAllocation$Incremental extends net.corda.testing.driver.PortAllocation
-  public <init>(int)
-  @NotNull
-  public final java.util.concurrent.atomic.AtomicInteger getPortCounter()
-  public int nextPort()
-##
-public final class net.corda.testing.driver.VerifierType extends java.lang.Enum
-  public static net.corda.testing.driver.VerifierType valueOf(String)
-  public static net.corda.testing.driver.VerifierType[] values()
-##
-public final class net.corda.testing.driver.WebserverHandle extends java.lang.Object
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Process)
-  @NotNull
-  public final net.corda.core.utilities.NetworkHostAndPort component1()
-  @NotNull
-  public final Process component2()
-  @NotNull
-  public final net.corda.testing.driver.WebserverHandle copy(net.corda.core.utilities.NetworkHostAndPort, Process)
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.core.utilities.NetworkHostAndPort getListenAddress()
-  @NotNull
-  public final Process getProcess()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@DoNotImplement
-public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
-  public <init>()
-  public abstract int getClusterSize()
-##
-@DoNotImplement
-public static final class net.corda.testing.node.ClusterSpec$Raft extends net.corda.testing.node.ClusterSpec
-  public <init>(int)
-  public final int component1()
-  @NotNull
-  public final net.corda.testing.node.ClusterSpec$Raft copy(int)
-  public boolean equals(Object)
-  public int getClusterSize()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@ThreadSafe
-public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.corda.core.serialization.SingletonSerializeAsToken
-  public <init>(boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, org.apache.activemq.artemis.utils.ReusableLatch, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final synchronized java.util.List<net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService> getEndpointsExternal()
-  @NotNull
-  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getReceivedMessages()
-  @NotNull
-  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getSentMessages()
-  @Nullable
-  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpSend(boolean)
-  public final void stop()
-  public static final net.corda.testing.node.InMemoryMessagingNetwork$Companion Companion
-##
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-@CordaSerializable
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle extends java.lang.Object implements net.corda.core.messaging.MessageRecipientGroup
-  public <init>(net.corda.core.identity.Party)
-  @NotNull
-  public final net.corda.core.identity.Party component1()
-  @NotNull
-  public final net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle copy(net.corda.core.identity.Party)
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.core.identity.Party getParty()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-public static interface net.corda.testing.node.InMemoryMessagingNetwork$LatencyCalculator
-  @NotNull
-  public abstract java.time.Duration between(net.corda.core.messaging.SingleMessageRecipient, net.corda.core.messaging.SingleMessageRecipient)
-##
-@CordaSerializable
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer extends java.lang.Object
-  @NotNull
-  public final net.corda.core.utilities.ByteSequence getMessageData()
-  @NotNull
-  public final net.corda.core.messaging.MessageRecipients getRecipients()
-  @NotNull
-  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle getSender()
-  @NotNull
-  public String toString()
-  public static final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion Companion
-##
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService extends java.lang.Object
-  public <init>(net.corda.testing.node.internal.MockNodeMessagingService, kotlin.jvm.internal.DefaultConstructorMarker)
-  @Nullable
-  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
-  public static final net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion Companion
-##
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-@CordaSerializable
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle extends java.lang.Object implements net.corda.core.messaging.SingleMessageRecipient
-  public <init>(int, net.corda.core.identity.CordaX500Name)
-  public final int component1()
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name component2()
-  @NotNull
-  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle copy(int, net.corda.core.identity.CordaX500Name)
-  public boolean equals(Object)
-  public final int getId()
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name getName()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@DoNotImplement
-public abstract static class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  public abstract A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
-##
-@DoNotImplement
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$Random extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
-  public <init>()
-  public <init>(java.util.SplittableRandom)
-  public <init>(java.util.SplittableRandom, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final java.util.SplittableRandom getRandom()
-  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
-##
-@DoNotImplement
-public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
-  public <init>()
-  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
-##
-public final class net.corda.testing.node.MockNetFlowTimeOut extends java.lang.Object
-  public <init>(java.time.Duration, int, double)
-  public final double getBackoffBase()
-  public final int getMaxRestartCount()
-  @NotNull
-  public final java.time.Duration getTimeout()
-##
-public final class net.corda.testing.node.MockNetNotaryConfig extends java.lang.Object
-  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name)
-  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @Nullable
-  public final String getClassName()
-  @Nullable
-  public final com.typesafe.config.Config getExtraConfig()
-  @Nullable
-  public final net.corda.core.identity.CordaX500Name getServiceLegalName()
-  public final boolean getValidating()
-##
-public class net.corda.testing.node.MockNetwork extends java.lang.Object
-  public <init>(java.util.List<String>)
-  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters)
-  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
-  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.testing.node.MockNetworkParameters)
-  @NotNull
-  public final java.nio.file.Path baseDirectory(int)
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode createNode()
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode()
-  @NotNull
-  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
-  @NotNull
-  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
-  @NotNull
-  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
-  @NotNull
-  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
-  @NotNull
-  public final java.util.List<String> getCordappPackages()
-  @NotNull
-  public final net.corda.core.identity.Party getDefaultNotaryIdentity()
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode getDefaultNotaryNode()
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters getDefaultParameters()
-  @NotNull
-  public final net.corda.core.node.NetworkParameters getNetworkParameters()
-  public final boolean getNetworkSendManuallyPumped()
-  public final int getNextNodeId()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.StartedMockNode> getNotaryNodes()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
-  @NotNull
-  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
-  public final boolean getThreadPerNode()
-  public final void runNetwork()
-  public final void runNetwork(int)
-  public final void startNodes()
-  public final void stopNodes()
-  public final void waitQuiescent()
-##
-public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lang.Object
-  public <init>(net.corda.core.identity.CordaX500Name)
-  public <init>(net.corda.core.identity.CordaX500Name, boolean)
-  public <init>(net.corda.core.identity.CordaX500Name, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name component1()
-  public final boolean component2()
-  @NotNull
-  public final net.corda.testing.node.MockNetworkNotarySpec copy(net.corda.core.identity.CordaX500Name, boolean)
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name getName()
-  public final boolean getValidating()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-public final class net.corda.testing.node.MockNetworkParameters extends java.lang.Object
-  public <init>()
-  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
-  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final boolean component1()
-  public final boolean component2()
-  @NotNull
-  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy component3()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> component4()
-  @NotNull
-  public final net.corda.core.node.NetworkParameters component5()
-  @NotNull
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> component6()
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  public boolean equals(Object)
-  @NotNull
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
-  @NotNull
-  public final net.corda.core.node.NetworkParameters getNetworkParameters()
-  public final boolean getNetworkSendManuallyPumped()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
-  @NotNull
-  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
-  public final boolean getThreadPerNode()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters withNetworkSendManuallyPumped(boolean)
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters withNotarySpecs(java.util.List<net.corda.testing.node.MockNetworkNotarySpec>)
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters withServicePeerAllocationStrategy(net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy)
-  @NotNull
-  public final net.corda.testing.node.MockNetworkParameters withThreadPerNode(boolean)
-##
-public final class net.corda.testing.node.MockNodeConfigOverrides extends java.lang.Object
-  public <init>()
-  public <init>(java.util.Map<String, String>, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut)
-  public <init>(java.util.Map, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @Nullable
-  public final java.util.Map<String, String> getExtraDataSourceProperties()
-  @Nullable
-  public final net.corda.testing.node.MockNetFlowTimeOut getFlowTimeout()
-  @Nullable
-  public final net.corda.testing.node.MockNetNotaryConfig getNotary()
-##
-public final class net.corda.testing.node.MockNodeParameters extends java.lang.Object
-  public <init>()
-  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
-  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @Nullable
-  public final Integer component1()
-  @Nullable
-  public final net.corda.core.identity.CordaX500Name component2()
-  @NotNull
-  public final java.math.BigInteger component3()
-  @Nullable
-  public final net.corda.testing.node.MockNodeConfigOverrides component4()
-  @NotNull
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> component5()
-  @NotNull
-  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
-  @NotNull
-  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  public boolean equals(Object)
-  @NotNull
-  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
-  @Nullable
-  public final net.corda.testing.node.MockNodeConfigOverrides getConfigOverrides()
-  @NotNull
-  public final java.math.BigInteger getEntropyRoot()
-  @Nullable
-  public final Integer getForcedID()
-  @Nullable
-  public final net.corda.core.identity.CordaX500Name getLegalName()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  @NotNull
-  public final net.corda.testing.node.MockNodeParameters withAdditionalCordapps(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
-  @NotNull
-  public final net.corda.testing.node.MockNodeParameters withConfigOverrides(net.corda.testing.node.MockNodeConfigOverrides)
-  @NotNull
-  public final net.corda.testing.node.MockNodeParameters withEntropyRoot(java.math.BigInteger)
-  @NotNull
-  public final net.corda.testing.node.MockNodeParameters withForcedID(Integer)
-  @NotNull
-  public final net.corda.testing.node.MockNodeParameters withLegalName(net.corda.core.identity.CordaX500Name)
-##
-public class net.corda.testing.node.MockServices extends java.lang.Object implements net.corda.core.node.ServiceHub
-  public <init>()
-  public <init>(Iterable<String>)
-  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name)
-  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
-  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
-  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
-  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
-  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
-  public <init>(Iterable, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
-  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters)
-  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair)
-  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
-  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
-  public <init>(net.corda.core.identity.CordaX500Name)
-  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
-  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
-  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
-  public <init>(net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
-  public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
-  public final void addMockCordapp(String)
-  @NotNull
-  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
-  @NotNull
-  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @NotNull
-  public T cordaService(Class<T>)
-  @NotNull
-  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
-  @NotNull
-  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
-  @NotNull
-  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
-  @NotNull
-  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @NotNull
-  public net.corda.core.cordapp.CordappContext getAppContext()
-  @NotNull
-  public final net.corda.testing.services.MockAttachmentStorage getAttachments()
-  @NotNull
-  public net.corda.testing.node.TestClock getClock()
-  @NotNull
-  public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
-  @NotNull
-  public final ClassLoader getCordappClassloader()
-  @NotNull
-  public net.corda.core.cordapp.CordappProvider getCordappProvider()
-  @NotNull
-  public net.corda.core.node.services.IdentityService getIdentityService()
-  @NotNull
-  public net.corda.core.node.services.KeyManagementService getKeyManagementService()
-  @NotNull
-  public net.corda.core.node.NodeInfo getMyInfo()
-  @NotNull
-  public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
-  @NotNull
-  public net.corda.core.node.NetworkParameters getNetworkParameters()
-  @NotNull
-  public net.corda.core.node.services.NetworkParametersService getNetworkParametersService()
-  @NotNull
-  protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
-  @NotNull
-  public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
-  @NotNull
-  public net.corda.core.node.services.TransactionStorage getValidatedTransactions()
-  @NotNull
-  public net.corda.core.node.services.VaultService getVaultService()
-  @NotNull
-  public java.sql.Connection jdbcSession()
-  @NotNull
-  public net.corda.core.contracts.Attachment loadContractAttachment(net.corda.core.contracts.StateRef)
-  @NotNull
-  public net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
-  @NotNull
-  public java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
-  @NotNull
-  public static final java.util.Properties makeTestDataSourceProperties(String)
-  @NotNull
-  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
-  @NotNull
-  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
-  public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
-  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
-  public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
-  public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  @NotNull
-  public Void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
-  public void setNetworkParametersService(net.corda.core.node.services.NetworkParametersService)
-  @NotNull
-  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
-  @NotNull
-  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
-  @NotNull
-  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
-  @NotNull
-  public net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
-  public void withEntityManager(java.util.function.Consumer<javax.persistence.EntityManager>)
-  public T withEntityManager(kotlin.jvm.functions.Function1<? super javax.persistence.EntityManager, ? extends T>)
-  public static final net.corda.testing.node.MockServices$Companion Companion
-##
-public static final class net.corda.testing.node.MockServices$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final java.util.Properties makeTestDataSourceProperties(String)
-  @NotNull
-  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
-  @NotNull
-  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
-##
-public final class net.corda.testing.node.MockServicesKt extends java.lang.Object
-  @NotNull
-  public static final T createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1<? super net.corda.core.node.AppServiceHub, ? extends T>)
-  @NotNull
-  public static final net.corda.core.node.services.IdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
-##
-public final class net.corda.testing.node.NodeTestUtils extends java.lang.Object
-  @NotNull
-  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
-  @NotNull
-  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
-  @NotNull
-  public static final net.corda.core.context.Actor testActor(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public static final net.corda.core.context.InvocationContext testContext(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
-  @NotNull
-  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
-##
-public final class net.corda.testing.node.NotarySpec extends java.lang.Object
-  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
-  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String)
-  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name component1()
-  public final boolean component2()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.User> component3()
-  @NotNull
-  public final net.corda.testing.driver.VerifierType component4()
-  @Nullable
-  public final net.corda.testing.node.ClusterSpec component5()
-  @NotNull
-  public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
-  public boolean equals(Object)
-  @Nullable
-  public final net.corda.testing.node.ClusterSpec getCluster()
-  @NotNull
-  public final String getMaximumHeapSize()
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name getName()
-  @NotNull
-  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
-  public final boolean getValidating()
-  @NotNull
-  public final net.corda.testing.driver.VerifierType getVerifierType()
-  public int hashCode()
-  public final void setMaximumHeapSize(String)
-  @NotNull
-  public String toString()
-##
-public final class net.corda.testing.node.StartedMockNode extends java.lang.Object
-  public <init>(net.corda.testing.node.internal.TestStartedNode, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final java.util.List<kotlin.Pair<F, net.corda.core.concurrent.CordaFuture<?>>> findStateMachines(Class<F>)
-  public final int getId()
-  @NotNull
-  public final net.corda.core.node.NodeInfo getInfo()
-  @NotNull
-  public final net.corda.core.node.ServiceHub getServices()
-  @Nullable
-  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
-  @NotNull
-  public final rx.Observable<F> registerInitiatedFlow(Class<F>)
-  @NotNull
-  public final rx.Observable<F> registerInitiatedFlow(Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<F>)
-  @NotNull
-  public final net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
-  public final void stop()
-  public final T transaction(kotlin.jvm.functions.Function0<? extends T>)
-  public static final net.corda.testing.node.StartedMockNode$Companion Companion
-##
-public static final class net.corda.testing.node.StartedMockNode$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-@ThreadSafe
-public final class net.corda.testing.node.TestClock extends net.corda.node.MutableClock
-  public <init>(java.time.Clock)
-  public final synchronized void advanceBy(java.time.Duration)
-  public final synchronized void setTo(java.time.Instant)
-##
-@DoNotImplement
-public abstract class net.corda.testing.node.TestCordapp extends java.lang.Object
-  public <init>()
-  @NotNull
-  public static final net.corda.testing.node.TestCordapp findCordapp(String)
-  @NotNull
-  public abstract java.util.Map<String, Object> getConfig()
-  @NotNull
-  public abstract net.corda.testing.node.TestCordapp withConfig(java.util.Map<String, ?>)
-  public static final net.corda.testing.node.TestCordapp$Companion Companion
-##
-public static final class net.corda.testing.node.TestCordapp$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.testing.node.TestCordapp findCordapp(String)
-##
-public final class net.corda.testing.node.UnstartedMockNode extends java.lang.Object
-  public <init>(net.corda.testing.node.internal.InternalMockNetwork$MockNode, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final int getId()
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode getStarted()
-  public final boolean isStarted()
-  @NotNull
-  public final net.corda.testing.node.StartedMockNode start()
-  public static final net.corda.testing.node.UnstartedMockNode$Companion Companion
-##
-public static final class net.corda.testing.node.UnstartedMockNode$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public final class net.corda.testing.node.User extends java.lang.Object
-  public <init>(String, String, java.util.Set<String>)
-  @NotNull
-  public final String component1()
-  @NotNull
-  public final String component2()
-  @NotNull
-  public final java.util.Set<String> component3()
-  @NotNull
-  public final net.corda.testing.node.User copy(String, String, java.util.Set<String>)
-  public boolean equals(Object)
-  @NotNull
-  public final String getPassword()
-  @NotNull
-  public final java.util.Set<String> getPermissions()
-  @NotNull
-  public final String getUsername()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-public class net.corda.client.rpc.ConnectionFailureException extends net.corda.client.rpc.RPCException
-  public <init>()
-  public <init>(Throwable)
-  public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(java.util.List, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCConnection start(String, String)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.identity.CordaX500Name)
-  public final A use(String, String, kotlin.jvm.functions.Function1<? super net.corda.client.rpc.CordaRPCConnection, ? extends A>)
-  public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
-##
-public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
-  public <init>()
-  public <init>(java.time.Duration)
-  public <init>(java.time.Duration, int)
-  public <init>(java.time.Duration, int, boolean)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final java.time.Duration component1()
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy()
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
-  @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
-  public boolean equals(Object)
-  public int getCacheConcurrencyLevel()
-  @NotNull
-  public java.time.Duration getConnectionMaxRetryInterval()
-  @NotNull
-  public java.time.Duration getConnectionRetryInterval()
-  public double getConnectionRetryIntervalMultiplier()
-  @NotNull
-  public java.time.Duration getDeduplicationCacheExpiry()
-  public int getMaxFileSize()
-  public int getMaxReconnectAttempts()
-  public int getMinimumServerProtocolVersion()
-  public int getObservationExecutorPoolSize()
-  @NotNull
-  public java.time.Duration getReapInterval()
-  public boolean getTrackRpcCallSites()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
-  @NotNull
-  public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
-##
-public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-@DoNotImplement
-public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
-  public <init>(net.corda.client.rpc.RPCConnection<? extends net.corda.core.messaging.CordaRPCOps>)
-  public void close()
-  public void forceClose()
-  @NotNull
-  public net.corda.core.messaging.CordaRPCOps getProxy()
-  public int getServerProtocolVersion()
-  public void notifyServerAndClose()
-##
-public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException implements net.corda.core.ClientRelevantError, net.corda.nodeapi.exceptions.RpcSerializableError
-  public <init>(String)
-  @NotNull
-  public final String getMsg()
-##
-@DoNotImplement
-public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
-  public abstract void forceClose()
-  @NotNull
-  public abstract I getProxy()
-  public abstract int getServerProtocolVersion()
-  public abstract void notifyServerAndClose()
-##
-public class net.corda.client.rpc.RPCException extends net.corda.core.CordaRuntimeException
-  public <init>(String)
-  public <init>(String, Throwable)
-##
-public @interface net.corda.client.rpc.RPCSinceVersion
-  public abstract int version()
-##
-public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
-  public static final void notUsed(rx.Observable<T>)
-##
-public final class net.corda.finance.test.CashSchema extends java.lang.Object
-  public static final net.corda.finance.test.CashSchema INSTANCE
-##
-public final class net.corda.finance.test.SampleCashSchemaV1 extends net.corda.core.schemas.MappedSchema
-  public static final net.corda.finance.test.SampleCashSchemaV1 INSTANCE
-##
-@Entity
-@Table
-public static class net.corda.finance.test.SampleCashSchemaV1$PersistentCashState extends net.corda.core.schemas.PersistentState
-  public <init>()
-  public <init>(String, long, String, String, byte[])
-  @NotNull
-  public String getCurrency()
-  @NotNull
-  public String getIssuerPartyHash()
-  @NotNull
-  public byte[] getIssuerRef()
-  @NotNull
-  public String getOwnerHash()
-  public long getPennies()
-  public void setCurrency(String)
-  public void setIssuerPartyHash(String)
-  public void setIssuerRef(byte[])
-  public void setOwnerHash(String)
-  public void setPennies(long)
-##
-public final class net.corda.finance.test.SampleCashSchemaV2 extends net.corda.core.schemas.MappedSchema
-  public static final net.corda.finance.test.SampleCashSchemaV2 INSTANCE
-##
-@Entity
-@Table
-public static class net.corda.finance.test.SampleCashSchemaV2$PersistentCashState extends net.corda.core.schemas.CommonSchemaV1$FungibleState
-  public <init>()
-  public <init>(String, java.util.Set<? extends net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
-  @NotNull
-  public String getCurrency()
-  @Nullable
-  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
-  public void setCurrency(String)
-  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
-##
-public final class net.corda.finance.test.SampleCashSchemaV3 extends net.corda.core.schemas.MappedSchema
-  public static final net.corda.finance.test.SampleCashSchemaV3 INSTANCE
-##
-@Entity
-@Table
-public static class net.corda.finance.test.SampleCashSchemaV3$PersistentCashState extends net.corda.core.schemas.PersistentState
-  public <init>()
-  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[])
-  public <init>(java.util.Set, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[], int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public String getCurrency()
-  @Nullable
-  public net.corda.core.identity.AbstractParty getIssuer()
-  @NotNull
-  public byte[] getIssuerRef()
-  @Nullable
-  public net.corda.core.identity.AbstractParty getOwner()
-  @Nullable
-  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
-  public long getPennies()
-  public void setCurrency(String)
-  public void setIssuer(net.corda.core.identity.AbstractParty)
-  public void setIssuerRef(byte[])
-  public void setOwner(net.corda.core.identity.AbstractParty)
-  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
-  public void setPennies(long)
 ##
 public final class net.corda.testing.dsl.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -7215,6 +7215,402 @@ public static final class net.corda.core.utilities.UuidGenerator$Companion exten
 public interface net.corda.core.utilities.VariablePropertyDelegate extends net.corda.core.utilities.PropertyDelegate
   public abstract void setValue(Object, kotlin.reflect.KProperty<?>, T)
 ##
+public final class net.corda.testing.contracts.DummyContract extends java.lang.Object implements net.corda.core.contracts.Contract
+  public <init>()
+  public <init>(Object)
+  public <init>(Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final Object component1()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract copy(Object)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @Nullable
+  public final Object getBlank()
+  @NotNull
+  public final String getPROGRAM_ID()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public String toString()
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContract$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContract"
+##
+public static interface net.corda.testing.contracts.DummyContract$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContract$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContract$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContract$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
+##
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$MultiOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$MultiOwnerState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$SingleOwnerState extends java.lang.Object implements net.corda.core.contracts.OwnableState, net.corda.testing.contracts.DummyContract$State
+  public <init>(int, net.corda.core.identity.AbstractParty)
+  public <init>(int, net.corda.core.identity.AbstractParty, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final net.corda.core.identity.AbstractParty component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$SingleOwnerState copy(int, net.corda.core.identity.AbstractParty)
+  public boolean equals(Object)
+  public int getMagicNumber()
+  @NotNull
+  public net.corda.core.identity.AbstractParty getOwner()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
+##
+@DoNotImplement
+public static interface net.corda.testing.contracts.DummyContract$State extends net.corda.core.contracts.ContractState
+  public abstract int getMagicNumber()
+##
+public final class net.corda.testing.contracts.DummyContractV2 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
+  public <init>()
+  @NotNull
+  public String getLegacyContract()
+  @NotNull
+  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContractV2$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV2"
+##
+public static interface net.corda.testing.contracts.DummyContractV2$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
+##
+public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContractV2$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final kotlin.Pair<net.corda.testing.contracts.DummyContractV2$Commands, net.corda.testing.contracts.DummyContractV2$State> withNewOwner(net.corda.core.identity.AbstractParty)
+##
+public final class net.corda.testing.contracts.DummyContractV3 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
+  public <init>()
+  @NotNull
+  public String getLegacyContract()
+  @NotNull
+  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+  @NotNull
+  public net.corda.testing.contracts.DummyContractV3$State upgrade(net.corda.testing.contracts.DummyContractV2$State)
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContractV3$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV3"
+##
+public static interface net.corda.testing.contracts.DummyContractV3$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.contracts.DummyContractV3$State extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContractV3$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@BelongsToContract
+public final class net.corda.testing.contracts.DummyState extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>()
+  public <init>(int)
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int)
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.core.DummyCommandData extends net.corda.core.contracts.TypeOnlyCommandData
+  public static final net.corda.testing.core.DummyCommandData INSTANCE
+##
+public final class net.corda.testing.core.Expect extends java.lang.Object
+  public <init>(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  @NotNull
+  public final Class<T> component1()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> component2()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> component3()
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> copy(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  public boolean equals(Object)
+  @NotNull
+  public final Class<T> getClazz()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> getExpectClosure()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> getMatch()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public abstract class net.corda.testing.core.ExpectCompose extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Parallel extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getParallel()
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Sequential extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getSequence()
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Single extends net.corda.testing.core.ExpectCompose
+  public <init>(net.corda.testing.core.Expect<? extends E, T>)
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> getExpect()
+##
+public static final class net.corda.testing.core.ExpectComposeState$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> fromExpectCompose(net.corda.testing.core.ExpectCompose<? extends E>)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Finished extends net.corda.testing.core.ExpectComposeState
+  public <init>()
+  @NotNull
+  public java.util.List<Class<E>> getExpectedEvents()
+  @Nullable
+  public Void nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Parallel extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Parallel<? extends E>, java.util.List<? extends net.corda.testing.core.ExpectComposeState<E>>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Parallel<E> getParallel()
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectComposeState<E>> getStates()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Sequential extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Sequential<? extends E>, int, net.corda.testing.core.ExpectComposeState<E>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
+  public final int getIndex()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Sequential<E> getSequential()
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> getState()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Single extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Single<? extends E, T>)
+  @NotNull
+  public java.util.List<Class<T>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Single<E, T> getSingle()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public final class net.corda.testing.core.ExpectKt extends java.lang.Object
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> expect(Class<E>, kotlin.jvm.functions.Function1<? super E, Boolean>, kotlin.jvm.functions.Function1<? super E, kotlin.Unit>)
+  public static final void expectEvents(Iterable<? extends E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void expectEvents(rx.Observable<E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void genericExpectEvents(S, boolean, kotlin.jvm.functions.Function2<? super S, ? super kotlin.jvm.functions.Function1<? super E, kotlin.Unit>, kotlin.Unit>, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(net.corda.testing.core.ExpectCompose<? extends E>...)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> replicate(int, kotlin.jvm.functions.Function1<? super Integer, ? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(net.corda.testing.core.ExpectCompose<? extends E>...)
+##
+public final class net.corda.testing.core.SerializationEnvironmentRule extends java.lang.Object implements org.junit.rules.TestRule
+  public <init>()
+  public <init>(boolean)
+  public <init>(boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement, org.junit.runner.Description)
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getSerializationFactory()
+  public static final net.corda.testing.core.SerializationEnvironmentRule$Companion Companion
+##
+public static final class net.corda.testing.core.SerializationEnvironmentRule$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.testing.core.TestConstants extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.contracts.Command<net.corda.core.contracts.TypeOnlyCommandData> dummyCommand(java.security.PublicKey...)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name ALICE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOB_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOC_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
+  public static final int MAX_MESSAGE_SIZE = 10485760
+##
+public final class net.corda.testing.core.TestIdentity extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, long)
+  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme)
+  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public static final net.corda.testing.core.TestIdentity fresh(String)
+  @NotNull
+  public static final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate getIdentity()
+  @NotNull
+  public final java.security.KeyPair getKeyPair()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  @NotNull
+  public final java.security.PublicKey getPublicKey()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference ref(byte...)
+  public static final net.corda.testing.core.TestIdentity$Companion Companion
+##
+public static final class net.corda.testing.core.TestIdentity$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.core.TestIdentity fresh(String)
+  @NotNull
+  public final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
+##
+public final class net.corda.testing.core.TestUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.utilities.NetworkHostAndPort freeLocalHostAndPort()
+  public static final int freePort()
+  @NotNull
+  public static final net.corda.core.contracts.StateRef generateStateRef()
+  @NotNull
+  public static final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getFreeLocalPorts(String, int)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.Party)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name makeUnique(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate singleIdentityAndCert(net.corda.core.node.NodeInfo)
+##
 public final class net.corda.client.jackson.JacksonSupport extends java.lang.Object
   @NotNull
   public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps)
@@ -8687,402 +9083,6 @@ public static class net.corda.finance.test.SampleCashSchemaV3$PersistentCashStat
   public void setOwner(net.corda.core.identity.AbstractParty)
   public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
   public void setPennies(long)
-##
-public final class net.corda.testing.contracts.DummyContract extends java.lang.Object implements net.corda.core.contracts.Contract
-  public <init>()
-  public <init>(Object)
-  public <init>(Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @Nullable
-  public final Object component1()
-  @NotNull
-  public final net.corda.testing.contracts.DummyContract copy(Object)
-  public boolean equals(Object)
-  @NotNull
-  public static final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
-  @Nullable
-  public final Object getBlank()
-  @NotNull
-  public final String getPROGRAM_ID()
-  public int hashCode()
-  @NotNull
-  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
-  @NotNull
-  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
-  @NotNull
-  public String toString()
-  public void verify(net.corda.core.transactions.LedgerTransaction)
-  public static final net.corda.testing.contracts.DummyContract$Companion Companion
-  @NotNull
-  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContract"
-##
-public static interface net.corda.testing.contracts.DummyContract$Commands extends net.corda.core.contracts.CommandData
-##
-public static final class net.corda.testing.contracts.DummyContract$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
-  public <init>()
-##
-public static final class net.corda.testing.contracts.DummyContract$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
-  public <init>()
-##
-public static final class net.corda.testing.contracts.DummyContract$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
-  @NotNull
-  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
-  @NotNull
-  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
-##
-@DoNotImplement
-public static final class net.corda.testing.contracts.DummyContract$MultiOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State
-  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final int component1()
-  @NotNull
-  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
-  @NotNull
-  public final net.corda.testing.contracts.DummyContract$MultiOwnerState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public boolean equals(Object)
-  public int getMagicNumber()
-  @NotNull
-  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
-  @NotNull
-  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@DoNotImplement
-public static final class net.corda.testing.contracts.DummyContract$SingleOwnerState extends java.lang.Object implements net.corda.core.contracts.OwnableState, net.corda.testing.contracts.DummyContract$State
-  public <init>(int, net.corda.core.identity.AbstractParty)
-  public <init>(int, net.corda.core.identity.AbstractParty, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final int component1()
-  @NotNull
-  public final net.corda.core.identity.AbstractParty component2()
-  @NotNull
-  public final net.corda.testing.contracts.DummyContract$SingleOwnerState copy(int, net.corda.core.identity.AbstractParty)
-  public boolean equals(Object)
-  public int getMagicNumber()
-  @NotNull
-  public net.corda.core.identity.AbstractParty getOwner()
-  @NotNull
-  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  @NotNull
-  public net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
-##
-@DoNotImplement
-public static interface net.corda.testing.contracts.DummyContract$State extends net.corda.core.contracts.ContractState
-  public abstract int getMagicNumber()
-##
-public final class net.corda.testing.contracts.DummyContractV2 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
-  public <init>()
-  @NotNull
-  public String getLegacyContract()
-  @NotNull
-  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
-  @NotNull
-  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
-  @NotNull
-  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
-  @NotNull
-  public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
-  public void verify(net.corda.core.transactions.LedgerTransaction)
-  public static final net.corda.testing.contracts.DummyContractV2$Companion Companion
-  @NotNull
-  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV2"
-##
-public static interface net.corda.testing.contracts.DummyContractV2$Commands extends net.corda.core.contracts.CommandData
-##
-public static final class net.corda.testing.contracts.DummyContractV2$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
-  public <init>()
-##
-public static final class net.corda.testing.contracts.DummyContractV2$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
-  public <init>()
-##
-public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
-  @NotNull
-  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
-##
-public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
-  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final int component1()
-  @NotNull
-  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
-  @NotNull
-  public final net.corda.testing.contracts.DummyContractV2$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public boolean equals(Object)
-  public final int getMagicNumber()
-  @NotNull
-  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
-  @NotNull
-  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  @NotNull
-  public final kotlin.Pair<net.corda.testing.contracts.DummyContractV2$Commands, net.corda.testing.contracts.DummyContractV2$State> withNewOwner(net.corda.core.identity.AbstractParty)
-##
-public final class net.corda.testing.contracts.DummyContractV3 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
-  public <init>()
-  @NotNull
-  public String getLegacyContract()
-  @NotNull
-  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
-  @NotNull
-  public net.corda.testing.contracts.DummyContractV3$State upgrade(net.corda.testing.contracts.DummyContractV2$State)
-  public void verify(net.corda.core.transactions.LedgerTransaction)
-  public static final net.corda.testing.contracts.DummyContractV3$Companion Companion
-  @NotNull
-  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV3"
-##
-public static interface net.corda.testing.contracts.DummyContractV3$Commands extends net.corda.core.contracts.CommandData
-##
-public static final class net.corda.testing.contracts.DummyContractV3$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
-  public <init>()
-##
-public static final class net.corda.testing.contracts.DummyContractV3$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
-  public <init>()
-##
-public static final class net.corda.testing.contracts.DummyContractV3$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public static final class net.corda.testing.contracts.DummyContractV3$State extends java.lang.Object implements net.corda.core.contracts.ContractState
-  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final int component1()
-  @NotNull
-  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
-  @NotNull
-  public final net.corda.testing.contracts.DummyContractV3$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public boolean equals(Object)
-  public final int getMagicNumber()
-  @NotNull
-  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
-  @NotNull
-  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@BelongsToContract
-public final class net.corda.testing.contracts.DummyState extends java.lang.Object implements net.corda.core.contracts.ContractState
-  public <init>()
-  public <init>(int)
-  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final int component1()
-  @NotNull
-  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
-  @NotNull
-  public final net.corda.testing.contracts.DummyState copy(int)
-  @NotNull
-  public final net.corda.testing.contracts.DummyState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
-  public boolean equals(Object)
-  public final int getMagicNumber()
-  @NotNull
-  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-public final class net.corda.testing.core.DummyCommandData extends net.corda.core.contracts.TypeOnlyCommandData
-  public static final net.corda.testing.core.DummyCommandData INSTANCE
-##
-public final class net.corda.testing.core.Expect extends java.lang.Object
-  public <init>(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
-  @NotNull
-  public final Class<T> component1()
-  @NotNull
-  public final kotlin.jvm.functions.Function1<T, Boolean> component2()
-  @NotNull
-  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> component3()
-  @NotNull
-  public final net.corda.testing.core.Expect<E, T> copy(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
-  public boolean equals(Object)
-  @NotNull
-  public final Class<T> getClazz()
-  @NotNull
-  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> getExpectClosure()
-  @NotNull
-  public final kotlin.jvm.functions.Function1<T, Boolean> getMatch()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@DoNotImplement
-public abstract class net.corda.testing.core.ExpectCompose extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-@DoNotImplement
-public static final class net.corda.testing.core.ExpectCompose$Parallel extends net.corda.testing.core.ExpectCompose
-  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  @NotNull
-  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getParallel()
-##
-@DoNotImplement
-public static final class net.corda.testing.core.ExpectCompose$Sequential extends net.corda.testing.core.ExpectCompose
-  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  @NotNull
-  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getSequence()
-##
-@DoNotImplement
-public static final class net.corda.testing.core.ExpectCompose$Single extends net.corda.testing.core.ExpectCompose
-  public <init>(net.corda.testing.core.Expect<? extends E, T>)
-  @NotNull
-  public final net.corda.testing.core.Expect<E, T> getExpect()
-##
-public static final class net.corda.testing.core.ExpectComposeState$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.testing.core.ExpectComposeState<E> fromExpectCompose(net.corda.testing.core.ExpectCompose<? extends E>)
-##
-public static final class net.corda.testing.core.ExpectComposeState$Finished extends net.corda.testing.core.ExpectComposeState
-  public <init>()
-  @NotNull
-  public java.util.List<Class<E>> getExpectedEvents()
-  @Nullable
-  public Void nextState(E)
-##
-public static final class net.corda.testing.core.ExpectComposeState$Parallel extends net.corda.testing.core.ExpectComposeState
-  public <init>(net.corda.testing.core.ExpectCompose$Parallel<? extends E>, java.util.List<? extends net.corda.testing.core.ExpectComposeState<E>>)
-  @NotNull
-  public java.util.List<Class<? extends E>> getExpectedEvents()
-  @NotNull
-  public final net.corda.testing.core.ExpectCompose$Parallel<E> getParallel()
-  @NotNull
-  public final java.util.List<net.corda.testing.core.ExpectComposeState<E>> getStates()
-  @Nullable
-  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
-##
-public static final class net.corda.testing.core.ExpectComposeState$Sequential extends net.corda.testing.core.ExpectComposeState
-  public <init>(net.corda.testing.core.ExpectCompose$Sequential<? extends E>, int, net.corda.testing.core.ExpectComposeState<E>)
-  @NotNull
-  public java.util.List<Class<? extends E>> getExpectedEvents()
-  public final int getIndex()
-  @NotNull
-  public final net.corda.testing.core.ExpectCompose$Sequential<E> getSequential()
-  @NotNull
-  public final net.corda.testing.core.ExpectComposeState<E> getState()
-  @Nullable
-  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
-##
-public static final class net.corda.testing.core.ExpectComposeState$Single extends net.corda.testing.core.ExpectComposeState
-  public <init>(net.corda.testing.core.ExpectCompose$Single<? extends E, T>)
-  @NotNull
-  public java.util.List<Class<T>> getExpectedEvents()
-  @NotNull
-  public final net.corda.testing.core.ExpectCompose$Single<E, T> getSingle()
-  @Nullable
-  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
-##
-public final class net.corda.testing.core.ExpectKt extends java.lang.Object
-  @NotNull
-  public static final net.corda.testing.core.ExpectCompose<E> expect(Class<E>, kotlin.jvm.functions.Function1<? super E, Boolean>, kotlin.jvm.functions.Function1<? super E, kotlin.Unit>)
-  public static final void expectEvents(Iterable<? extends E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  public static final void expectEvents(rx.Observable<E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  public static final void genericExpectEvents(S, boolean, kotlin.jvm.functions.Function2<? super S, ? super kotlin.jvm.functions.Function1<? super E, kotlin.Unit>, kotlin.Unit>, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  @NotNull
-  public static final net.corda.testing.core.ExpectCompose<E> parallel(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  @NotNull
-  public static final net.corda.testing.core.ExpectCompose<E> parallel(net.corda.testing.core.ExpectCompose<? extends E>...)
-  @NotNull
-  public static final net.corda.testing.core.ExpectCompose<E> replicate(int, kotlin.jvm.functions.Function1<? super Integer, ? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  @NotNull
-  public static final net.corda.testing.core.ExpectCompose<E> sequence(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
-  @NotNull
-  public static final net.corda.testing.core.ExpectCompose<E> sequence(net.corda.testing.core.ExpectCompose<? extends E>...)
-##
-public final class net.corda.testing.core.SerializationEnvironmentRule extends java.lang.Object implements org.junit.rules.TestRule
-  public <init>()
-  public <init>(boolean)
-  public <init>(boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement, org.junit.runner.Description)
-  @NotNull
-  public final net.corda.core.serialization.SerializationFactory getSerializationFactory()
-  public static final net.corda.testing.core.SerializationEnvironmentRule$Companion Companion
-##
-public static final class net.corda.testing.core.SerializationEnvironmentRule$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-##
-public final class net.corda.testing.core.TestConstants extends java.lang.Object
-  @NotNull
-  public static final net.corda.core.contracts.Command<net.corda.core.contracts.TypeOnlyCommandData> dummyCommand(java.security.PublicKey...)
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name ALICE_NAME
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name BOB_NAME
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name BOC_NAME
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
-  public static final int MAX_MESSAGE_SIZE = 10485760
-##
-public final class net.corda.testing.core.TestIdentity extends java.lang.Object
-  public <init>(net.corda.core.identity.CordaX500Name)
-  public <init>(net.corda.core.identity.CordaX500Name, long)
-  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme)
-  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair)
-  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme)
-  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public static final net.corda.testing.core.TestIdentity fresh(String)
-  @NotNull
-  public static final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
-  @NotNull
-  public final net.corda.core.identity.PartyAndCertificate getIdentity()
-  @NotNull
-  public final java.security.KeyPair getKeyPair()
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name getName()
-  @NotNull
-  public final net.corda.core.identity.Party getParty()
-  @NotNull
-  public final java.security.PublicKey getPublicKey()
-  @NotNull
-  public final net.corda.core.contracts.PartyAndReference ref(byte...)
-  public static final net.corda.testing.core.TestIdentity$Companion Companion
-##
-public static final class net.corda.testing.core.TestIdentity$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.testing.core.TestIdentity fresh(String)
-  @NotNull
-  public final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
-##
-public final class net.corda.testing.core.TestUtils extends java.lang.Object
-  @NotNull
-  public static final net.corda.core.utilities.NetworkHostAndPort freeLocalHostAndPort()
-  public static final int freePort()
-  @NotNull
-  public static final net.corda.core.contracts.StateRef generateStateRef()
-  @NotNull
-  public static final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getFreeLocalPorts(String, int)
-  @NotNull
-  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
-  @NotNull
-  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.Party)
-  @NotNull
-  public static final net.corda.core.identity.CordaX500Name makeUnique(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
-  @NotNull
-  public static final net.corda.core.identity.PartyAndCertificate singleIdentityAndCert(net.corda.core.node.NodeInfo)
 ##
 public final class net.corda.testing.dsl.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)


### PR DESCRIPTION
Corda 4.5 did not receive an api-current update when the release branch was created. This PR is to perform the update now.

Steps taken:
- Generate api-current on the 4.4 branch
- Replace the 4.5 api-current with the generated 4.4 version
- Go through all PRs affecting api-current on the 4.5 branch and reapply changes
- Track down remaining changes that trigger a build failure and identify PR that introduced them - _Not needed_

PRs that update api-current:
- PR #5998

The build succeeded after PR #5998 changes were included.

The changes that remain in this PR are the changes that were introduced in the 4.5 work that do not trigger an api-check build failure.
