### PR TITLE
NOTICK - Fix flow framework tests

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -147,6 +147,8 @@ class FlowFrameworkTests {
 
         SuspendingFlow.hookBeforeCheckpoint = {}
         SuspendingFlow.hookAfterCheckpoint = {}
+//        StaffedFlowHospital.onFlowKeptForOvernightObservation.clear()
+//        StaffedFlowHospital.onFlowResuscitated.clear()
     }
 
     @Test(timeout=300_000)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -147,8 +147,8 @@ class FlowFrameworkTests {
 
         SuspendingFlow.hookBeforeCheckpoint = {}
         SuspendingFlow.hookAfterCheckpoint = {}
-//        StaffedFlowHospital.onFlowKeptForOvernightObservation.clear()
-//        StaffedFlowHospital.onFlowResuscitated.clear()
+        StaffedFlowHospital.onFlowResuscitated.clear()
+        StaffedFlowHospital.onFlowKeptForOvernightObservation.clear()
     }
 
     @Test(timeout=300_000)


### PR DESCRIPTION
Clear hospital hooks after tests; should be fixing tests hanging.