### PR TITLE
EG-3402 - Fixed an issue in the irs-demo project that would make builds to always fail

### DIFF
--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -50,6 +50,9 @@ repositories {
     }
 }
 
+evaluationDependsOn("cordapp")
+evaluationDependsOn("web")
+
 dependencies {
     compile "commons-io:commons-io:$commons_io_version"
     compile project(":samples:irs-demo:web")
@@ -83,9 +86,6 @@ task slowIntegrationTest(type: Test, dependsOn: []) {
     testClassesDirs = sourceSets.slowIntegrationTest.output.classesDirs
     classpath = sourceSets.slowIntegrationTest.runtimeClasspath
 }
-
-evaluationDependsOn("cordapp")
-evaluationDependsOn("web")
 
 task systemTest(type: Test, dependsOn: ["cordapp:prepareDockerNodes", "web:generateDockerCompose"]) {
     testClassesDirs = sourceSets.systemTest.output.classesDirs

--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -92,6 +92,7 @@ dependencies {
 jar {
     from sourceSets.main.output
     dependsOn clientInstall
+    archiveClassifier = 'thin'
 }
 
 def docker_dir = file("$project.buildDir/docker")


### PR DESCRIPTION
**Bug Reported**
It has been reported that the build command _"./gradlew clean build slowIntegrationTest"_ would always fail with error:
`> Task :samples:irs-demo:compileSlowIntegrationTestKotlin FAILED
e: ./enterprise/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt: (24, 26): Unresolved reference: IrsDemoWebApplication
e: ./enterprise/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt: (85, 39): Unresolved reference: IrsDemoWebApplicationFAILURE: Build failed with an exception.`

**Bug Summary**
After some investigation and discussion with other Corda engineers, it was concluded that the issue was being caused by Spring Boot. In more detail, the build would fail because Spring Boot was overriding the :samples:irs-demo:web jar causing problems to the slowIntegrationTest.

The solution was to use the archiveClassifier gradle property. This property accepts a string that is appended to the jar filename. This successfully prevents the Spring Boot from overwriting the jar.

**Test Cases**
- Run the command _"./gradlew clean build slowIntegrationTest"_  several times from the irs-demo directory and ensure it runs successfully. This will prove the issue is resolved.
- Run the same command again several times but from the root directory of the project and ensure it runs successfully. This proves the issue is resolved and nothing else was broken by the fix.