### PR TITLE
NOTICK Create a transition interceptor for testing

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/CustomTransitionInterceptorTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/CustomTransitionInterceptorTest.kt
@@ -1,0 +1,94 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.CordaRuntimeException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.internal.concurrent.transpose
+import net.corda.core.messaging.startFlow
+import net.corda.core.node.AppServiceHub
+import net.corda.core.node.services.CordaService
+import net.corda.core.serialization.SingletonSerializeAsToken
+import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.config.NodeConfiguration
+import net.corda.node.services.statemachine.Checkpoint
+import net.corda.node.services.statemachine.Event
+import net.corda.node.services.statemachine.FlowFiber
+import net.corda.node.services.statemachine.StateMachineState
+import net.corda.node.services.statemachine.interceptors.CustomTransitionInterceptor
+import net.corda.node.services.statemachine.transitions.FlowContinuation
+import net.corda.node.services.statemachine.transitions.TransitionResult
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.internal.enclosedCordapp
+import org.junit.Test
+import kotlin.reflect.jvm.jvmName
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CustomTransitionInterceptorTest {
+
+    @Test
+    fun `can register custom interceptor`() {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = listOf(enclosedCordapp()))) {
+
+            val (nodeAHandle, nodeBHandle) = listOf(ALICE_NAME, BOB_NAME)
+                .map { startNode(providedName = it, customOverrides = mapOf(NodeConfiguration::customTransitionInterceptor.name to MyInterceptor::class.jvmName)) }
+                .transpose()
+                .getOrThrow()
+
+            nodeAHandle.rpc.startFlow(
+                ::MyFlow,
+                nodeBHandle.nodeInfo.singleIdentity()
+            ).returnValue.getOrThrow()
+        }
+    }
+
+    @CordaService
+    class MyInterceptor(services: AppServiceHub) : SingletonSerializeAsToken(), CustomTransitionInterceptor {
+
+        private companion object {
+            val log = contextLogger()
+        }
+
+        override fun intercept(
+            fiber: FlowFiber,
+            previousState: StateMachineState,
+            event: Event,
+            transition: TransitionResult,
+            nextState: StateMachineState,
+            continuation: FlowContinuation
+        ) {
+            log.info("HIT MY INTERCEPTOR")
+        }
+    }
+
+    @StartableByRPC
+    @InitiatingFlow
+    class MyFlow(private val party: Party) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            val session = initiateFlow(party)
+            session.sendAndReceive<String>("respond to me please")
+        }
+    }
+
+    @InitiatedBy(MyFlow::class)
+    class MyResponder(private val session: FlowSession) : FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            session.receive<String>()
+            session.send("here is a reply")
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -95,6 +95,8 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
 
     val reloadCheckpointAfterSuspend: Boolean
 
+    val customTransitionInterceptor: String?
+
     companion object {
         // default to at least 8MB and a bit extra for larger heap sizes
         val defaultTransactionCacheSize: Long = 8.MB + getAdditionalCacheMemory()

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -84,7 +84,8 @@ data class NodeConfigurationImpl(
         override val configurationWithOptions: ConfigurationWithOptions,
         override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize,
         override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages,
-        override val reloadCheckpointAfterSuspend: Boolean = Defaults.reloadCheckpointAfterSuspend
+        override val reloadCheckpointAfterSuspend: Boolean = Defaults.reloadCheckpointAfterSuspend,
+        override val customTransitionInterceptor: String? = Defaults.customTransitionInterceptor
 
 ) : NodeConfiguration {
     internal object Defaults {
@@ -125,6 +126,7 @@ data class NodeConfigurationImpl(
         const val flowExternalOperationThreadPoolSize: Int = 1
         val quasarExcludePackages: List<String> = emptyList()
         val reloadCheckpointAfterSuspend: Boolean = System.getProperty("reloadCheckpointAfterSuspend", "false")!!.toBoolean()
+        val customTransitionInterceptor: String? = null
 
         fun cordappsDirectories(baseDirectory: Path) = listOf(baseDirectory / CORDAPPS_DIR_NAME_DEFAULT)
 

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -68,6 +68,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
     private val flowExternalOperationThreadPoolSize by int().optional().withDefaultValue(Defaults.flowExternalOperationThreadPoolSize)
     private val quasarExcludePackages by string().list().optional().withDefaultValue(Defaults.quasarExcludePackages)
     private val reloadCheckpointAfterSuspend by boolean().optional().withDefaultValue(Defaults.reloadCheckpointAfterSuspend)
+    private val customTransitionInterceptor by string().optional()
     @Suppress("unused")
     private val custom by nestedObject().optional()
     @Suppress("unused")
@@ -136,7 +137,8 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     configurationWithOptions = ConfigurationWithOptions(configuration, Configuration.Options.defaults),
                     flowExternalOperationThreadPoolSize = config[flowExternalOperationThreadPoolSize],
                     quasarExcludePackages = config[quasarExcludePackages],
-                    reloadCheckpointAfterSuspend = config[reloadCheckpointAfterSuspend]
+                    reloadCheckpointAfterSuspend = config[reloadCheckpointAfterSuspend],
+                    customTransitionInterceptor = config[customTransitionInterceptor]
             ))
         } catch (e: Exception) {
             return when (e) {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -36,6 +36,8 @@ import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.messaging.DeduplicationHandler
 import net.corda.node.services.statemachine.FlowStateMachineImpl.Companion.currentStateMachine
+import net.corda.node.services.statemachine.interceptors.CustomTransitionInterceptor
+import net.corda.node.services.statemachine.interceptors.CustomTransitionInterceptorHolder
 import net.corda.node.services.statemachine.interceptors.DumpHistoryOnErrorInterceptor
 import net.corda.node.services.statemachine.interceptors.HospitalisingInterceptor
 import net.corda.node.services.statemachine.interceptors.PrintingInterceptor
@@ -57,6 +59,7 @@ import javax.annotation.concurrent.ThreadSafe
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
+import kotlin.reflect.full.isSubclassOf
 import kotlin.streams.toList
 
 /**
@@ -113,7 +116,7 @@ internal class SingleThreadedStateMachineManager(
     private lateinit var flowCreator: FlowCreator
 
     override val flowHospital: StaffedFlowHospital = makeFlowHospital()
-    private val transitionExecutor = makeTransitionExecutor()
+    private lateinit var transitionExecutor: TransitionExecutor
     private val reloadCheckpointAfterSuspend = serviceHub.configuration.reloadCheckpointAfterSuspend
 
     override val allStateMachines: List<FlowLogic<*>>
@@ -162,6 +165,7 @@ internal class SingleThreadedStateMachineManager(
                 )
         )
         this.checkpointSerializationContext = checkpointSerializationContext
+        transitionExecutor = makeTransitionExecutor()
         val actionExecutor = makeActionExecutor(checkpointSerializationContext)
         when (startMode) {
             StateMachineManager.StartMode.ExcludingPaused -> {}
@@ -906,12 +910,31 @@ internal class SingleThreadedStateMachineManager(
 
     private fun makeTransitionExecutor(): TransitionExecutor {
         val interceptors = ArrayList<TransitionInterceptor>()
-        interceptors.add { HospitalisingInterceptor(flowHospital, it) }
+        interceptors += { HospitalisingInterceptor(flowHospital, it) }
         if (serviceHub.configuration.devMode) {
-            interceptors.add { DumpHistoryOnErrorInterceptor(it) }
+            interceptors += { delegate -> DumpHistoryOnErrorInterceptor(delegate) }
         }
         if (logger.isDebugEnabled) {
-            interceptors.add { PrintingInterceptor(it) }
+            interceptors += { delegate -> PrintingInterceptor(delegate) }
+        }
+        serviceHub.configuration.customTransitionInterceptor?.let { name ->
+            val interceptorClass = serviceHub.cordappProvider.cordapps.flatMap { it.services }.singleOrNull { it.name == name }
+            interceptorClass?.let { clazz ->
+                if (clazz.kotlin.isSubclassOf(CustomTransitionInterceptor::class)) {
+                    try {
+                        interceptors += { delegate ->
+                            CustomTransitionInterceptorHolder(
+                                delegate,
+                                uncheckedCast(serviceHub.cordaService(clazz))
+                            )
+                        }
+                    } catch (e: IllegalStateException) {
+                        logger.info("Custom transition interceptor [$name] does is not annotated with @CordaService, will not load")
+                    }
+                } else {
+                    logger.info("Custom transition interceptor [$name] does not implement [${CustomTransitionInterceptor::class.qualifiedName}], will not load")
+                }
+            } ?: logger.info("Could not find custom transition interceptor [$name], will not load (OR THERE WAS MULTIPLE)")
         }
         val transitionExecutor: TransitionExecutor = TransitionExecutorImpl(secureRandom, database)
         return interceptors.fold(transitionExecutor) { executor, interceptor -> interceptor(executor) }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/CustomTransitionInterceptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/CustomTransitionInterceptor.kt
@@ -1,0 +1,44 @@
+package net.corda.node.services.statemachine.interceptors
+
+import net.corda.node.services.statemachine.ActionExecutor
+import net.corda.node.services.statemachine.Event
+import net.corda.node.services.statemachine.FlowFiber
+import net.corda.node.services.statemachine.StateMachineState
+import net.corda.node.services.statemachine.TransitionExecutor
+import net.corda.node.services.statemachine.transitions.FlowContinuation
+import net.corda.node.services.statemachine.transitions.TransitionResult
+
+interface CustomTransitionInterceptor {
+    fun intercept(
+        fiber: FlowFiber,
+        previousState: StateMachineState,
+        event: Event,
+        transition: TransitionResult,
+        nextState: StateMachineState,
+        continuation: FlowContinuation
+    )
+}
+
+internal class CustomTransitionInterceptorHolder(
+    private val delegate: TransitionExecutor,
+    private val interceptor: CustomTransitionInterceptor
+) : TransitionExecutor {
+
+    override fun executeTransition(
+        fiber: FlowFiber,
+        previousState: StateMachineState,
+        event: Event,
+        transition: TransitionResult,
+        actionExecutor: ActionExecutor
+    ): Pair<FlowContinuation, StateMachineState> {
+        return delegate.executeTransition(
+            fiber,
+            previousState,
+            event,
+            transition,
+            actionExecutor
+        ).also { (continuation, nextState) ->
+            interceptor.intercept(fiber, previousState, event, transition, nextState, continuation)
+        }
+    }
+}


### PR DESCRIPTION
Define a corda service (annotated with `@CordaService`) which implements
`CustomTransitionInterceptor`.

Specify in the node configuration that this is the interceptor you want
to add.

Because of how it is implemented, you can effect the fiber itself but
you cannot change the outcome of the transition (other than throwing an
exception).