### PR TITLE
NOTICK hacking in flow awaiting for testing

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -133,6 +133,7 @@ import net.corda.node.services.statemachine.FlowLogicRefFactoryImpl
 import net.corda.node.services.statemachine.FlowMonitor
 import net.corda.node.services.statemachine.FlowOperator
 import net.corda.node.services.statemachine.FlowStateMachineImpl
+import net.corda.node.services.statemachine.LockingRpc
 import net.corda.node.services.statemachine.SingleThreadedStateMachineManager
 import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.node.services.transactions.BasicVerifierFactoryService
@@ -411,7 +412,9 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
 
         val attachmentTrustInfoRPCOps = Pair(AttachmentTrustInfoRPCOps::class.java, AttachmentTrustInfoRPCOpsImpl(services.attachmentTrustCalculator))
 
-        return listOf(cordaRPCOpsImpl, checkpointRPCOpsImpl, attachmentTrustInfoRPCOps).map { rpcOpsImplPair ->
+        val lockingRpcOps = Pair(LockingRpc::class.java, smm)
+
+        return listOf(cordaRPCOpsImpl, checkpointRPCOpsImpl, attachmentTrustInfoRPCOps, lockingRpcOps).map { rpcOpsImplPair ->
             // Mind that order of proxies is important
             val targetInterface = rpcOpsImplPair.first
             val stage1Proxy = AuthenticatedRpcOpsProxy.proxy(rpcOpsImplPair.second, targetInterface)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -121,6 +121,10 @@ interface StateMachineManager : LockingRpc {
      * @return whether the mapping was removed.
      */
     fun removeClientId(clientId: String): Boolean
+
+    // would go onto its interface
+//    fun await(id: StateMachineRunId, status: Checkpoint.FlowStatus): CordaFuture<Checkpoint.FlowStatus>
+//    fun release(id: StateMachineRunId): Boolean
 }
 
 interface LockingRpc : RPCOps {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/LockingInterceptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/LockingInterceptor.kt
@@ -1,0 +1,60 @@
+package net.corda.node.services.statemachine.interceptors
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.concurrent.CordaFuture
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.internal.concurrent.OpenFuture
+import net.corda.core.utilities.contextLogger
+import net.corda.node.services.statemachine.ActionExecutor
+import net.corda.node.services.statemachine.Checkpoint
+import net.corda.node.services.statemachine.ErrorState
+import net.corda.node.services.statemachine.Event
+import net.corda.node.services.statemachine.FlowFiber
+import net.corda.node.services.statemachine.StaffedFlowHospital
+import net.corda.node.services.statemachine.StateMachineInnerState
+import net.corda.node.services.statemachine.StateMachineState
+import net.corda.node.services.statemachine.TransitionExecutor
+import net.corda.node.services.statemachine.transitions.FlowContinuation
+import net.corda.node.services.statemachine.transitions.TransitionResult
+import java.util.concurrent.Semaphore
+import kotlin.reflect.full.functions
+
+/**
+ * This interceptor notifies the passed in [flowHospital] in case a flow went through a clean->errored or a errored->clean
+ * transition.
+ */
+internal class LockingInterceptor(
+    private val locks: MutableMap<StateMachineRunId, Pair<Checkpoint.FlowStatus, OpenFuture<Checkpoint.FlowStatus>>>,
+    private val delegate: TransitionExecutor
+) : TransitionExecutor {
+
+    private companion object {
+        val log = contextLogger()
+    }
+
+    @Suspendable
+    override fun executeTransition(
+        fiber: FlowFiber,
+        previousState: StateMachineState,
+        event: Event,
+        transition: TransitionResult,
+        actionExecutor: ActionExecutor
+    ): Pair<FlowContinuation, StateMachineState> {
+
+        val (continuation, nextState) = delegate.executeTransition(fiber, previousState, event, transition, actionExecutor)
+
+
+        locks[fiber.id]?.let { (status, future) ->
+            if (status == nextState.checkpoint.status) {
+                log.info("Draining permits for flow ${fiber.id} / available: ${nextState.lock.availablePermits()}")
+                nextState.lock.drainPermits()
+                val method = Semaphore::class.java.getDeclaredMethod("reducePermits", Int::class.java)
+                method.isAccessible = true
+                method.invoke(nextState.lock, 1)
+                future.set(status)
+            }
+        }
+
+        return Pair(continuation, nextState)
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.statemachine.transitions
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.KilledFlowException
 import net.corda.node.services.statemachine.Action
+import net.corda.node.services.statemachine.Checkpoint
 import net.corda.node.services.statemachine.DeduplicationId
 import net.corda.node.services.statemachine.ErrorSessionMessage
 import net.corda.node.services.statemachine.Event
@@ -29,7 +30,7 @@ class KilledFlowTransition(
                 startingState.checkpoint.checkpointState.sessions,
                 errorMessages
             )
-            val newCheckpoint = startingState.checkpoint.setSessions(sessions = newSessions)
+            val newCheckpoint = startingState.checkpoint.copy(status = Checkpoint.FlowStatus.KILLED).setSessions(sessions = newSessions)
             currentState = currentState.copy(checkpoint = newCheckpoint)
             actions.add(
                 Action.PropagateErrors(


### PR DESCRIPTION
Add `await` + `release` functions to node to be able to wait for a flow
to enter a input status. Once it does, it decreases the permits in the
flow's semaphore, preventing the flow from continuing (blocks the flow
thread).

The permit is decreased inside of `LockingInterceptor`, which checks the
output state of a transition to determine whether to decrease the flow
locks permit count.

`release` calls `Semaphore.release` to put the lock back into a
uncontested state so that the flow can do the next transition.

`acquire` was not used, because it would block the calling thread. This
would decrease the usefulness in tests, as the test thread would be
blocked here.

A `Future` is returned by `await`, allowing the calling thread to do
other things, and then call `get` to block itself when it needs wait for
flow to reach the desired status.

Currently this is hard coded into the node, but it could be changed to
only be enabled in dev mode or something like that. It is accessed via
the `MultiRPCClient`.

I'll tidy it up if we are happy with the idea. A.k.a, remove the
reflection and not shove everything into
`SingleThreadedStateMachineManager`.
