### PR TITLE
ENT-5662: Updated CLI usage error

### DIFF
--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -92,8 +92,9 @@ open class SharedNodeCmdLineOptions {
         return """
                 Unable to load the node config file from '$configFile'.
                 ${cause?.message?.let { "Cause: $it" } ?: ""}
-
-                Try setting the --base-directory flag to change which directory the node
+                
+                Ensure that the [COMMAND] precedes all options. Alternatively, try
+                setting the --base-directory flag to change which directory the node
                 is looking in, or use the --config-file flag to specify it explicitly.
             """.trimIndent()
     }


### PR DESCRIPTION
Updates the error message displayed when a config file is not found to alert a user to check that command precedes the options