### PR TITLE
CORDA-4011: Convert BCEdDSAKeys to net.i2p EdDSAKeys

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -1002,7 +1002,6 @@ object Crypto {
             is BCEdDSAPrivateKey -> EdDSAPrivateKey(PKCS8EncodedKeySpec(key.encoded))
             else -> key
         }
-
     }
 
     /**
@@ -1032,7 +1031,7 @@ object Crypto {
             is BCSphincs256PublicKey -> key
             is EdDSAPublicKey -> key
             is CompositeKey -> key
-            is BCEdDSAPublicKey -> EdDSAPublicKey(X509EncodedKeySpec(key.encoded))
+            is BCEdDSAPublicKey -> convertIfBCEdDSAPublicKey(key)
             else -> decodePublicKey(key.encoded)
         }
     }
@@ -1053,7 +1052,7 @@ object Crypto {
             is BCRSAPrivateKey -> key
             is BCSphincs256PrivateKey -> key
             is EdDSAPrivateKey -> key
-            is BCEdDSAPrivateKey -> EdDSAPrivateKey(PKCS8EncodedKeySpec(key.encoded))
+            is BCEdDSAPrivateKey -> convertIfBCEdDSAPrivateKey(key)
             else -> decodePrivateKey(key.encoded)
         }
     }

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -35,6 +35,8 @@ import org.bouncycastle.asn1.x9.X9ObjectIdentifiers
 import org.bouncycastle.crypto.CryptoServicesRegistrar
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey
 import org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateKey
 import org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPublicKey
 import org.bouncycastle.jce.ECNamedCurveTable
@@ -308,11 +310,11 @@ object Crypto {
     fun decodePrivateKey(encodedKey: ByteArray): PrivateKey {
         val keyInfo = PrivateKeyInfo.getInstance(encodedKey)
         if (keyInfo.privateKeyAlgorithm.algorithm == ASN1ObjectIdentifier(CordaOID.ALIAS_PRIVATE_KEY)) {
-            return decodeAliasPrivateKey(keyInfo)
+            return convertIfBCEdDSAPrivateKey(decodeAliasPrivateKey(keyInfo))
         }
         val signatureScheme = findSignatureScheme(keyInfo.privateKeyAlgorithm)
         val keyFactory = keyFactory(signatureScheme)
-        return keyFactory.generatePrivate(PKCS8EncodedKeySpec(encodedKey))
+        return convertIfBCEdDSAPrivateKey(keyFactory.generatePrivate(PKCS8EncodedKeySpec(encodedKey)))
     }
 
     @DeleteForDJVM
@@ -354,7 +356,7 @@ object Crypto {
         }
         try {
             val keyFactory = keyFactory(signatureScheme)
-            return keyFactory.generatePrivate(PKCS8EncodedKeySpec(encodedKey))
+            return convertIfBCEdDSAPrivateKey(keyFactory.generatePrivate(PKCS8EncodedKeySpec(encodedKey)))
         } catch (ikse: InvalidKeySpecException) {
             throw InvalidKeySpecException("This private key cannot be decoded, please ensure it is PKCS8 encoded and that " +
                     "it corresponds to the input scheme's code name.", ikse)
@@ -373,7 +375,7 @@ object Crypto {
         val subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(encodedKey)
         val signatureScheme = findSignatureScheme(subjectPublicKeyInfo.algorithm)
         val keyFactory = keyFactory(signatureScheme)
-        return keyFactory.generatePublic(X509EncodedKeySpec(encodedKey))
+        return convertIfBCEdDSAPublicKey(keyFactory.generatePublic(X509EncodedKeySpec(encodedKey)))
     }
 
     /**
@@ -408,7 +410,7 @@ object Crypto {
         }
         try {
             val keyFactory = keyFactory(signatureScheme)
-            return keyFactory.generatePublic(X509EncodedKeySpec(encodedKey))
+            return convertIfBCEdDSAPublicKey(keyFactory.generatePublic(X509EncodedKeySpec(encodedKey)))
         } catch (ikse: InvalidKeySpecException) {
             throw InvalidKeySpecException("This public key cannot be decoded, please ensure it is X509 encoded and " +
                     "that it corresponds to the input scheme's code name.", ikse)
@@ -988,6 +990,21 @@ object Crypto {
         }
     }
 
+    private fun convertIfBCEdDSAPublicKey(key: PublicKey): PublicKey {
+        return when (key) {
+            is BCEdDSAPublicKey -> EdDSAPublicKey(X509EncodedKeySpec(key.encoded))
+            else -> key
+        }
+    }
+
+    private fun convertIfBCEdDSAPrivateKey(key: PrivateKey): PrivateKey {
+        return when (key) {
+            is BCEdDSAPrivateKey -> EdDSAPrivateKey(PKCS8EncodedKeySpec(key.encoded))
+            else -> key
+        }
+
+    }
+
     /**
      * Convert a public key to a supported implementation.
      * @param key a public key.
@@ -1015,6 +1032,7 @@ object Crypto {
             is BCSphincs256PublicKey -> key
             is EdDSAPublicKey -> key
             is CompositeKey -> key
+            is BCEdDSAPublicKey -> EdDSAPublicKey(X509EncodedKeySpec(key.encoded))
             else -> decodePublicKey(key.encoded)
         }
     }
@@ -1035,6 +1053,7 @@ object Crypto {
             is BCRSAPrivateKey -> key
             is BCSphincs256PrivateKey -> key
             is EdDSAPrivateKey -> key
+            is BCEdDSAPrivateKey -> EdDSAPrivateKey(PKCS8EncodedKeySpec(key.encoded))
             else -> decodePrivateKey(key.encoded)
         }
     }

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -53,6 +53,7 @@ import net.corda.nodeapi.internal.crypto.x509
 import net.i2p.crypto.eddsa.EdDSAPrivateKey
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.asn1.x509.*
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PrivateKey
 import org.junit.Rule
 import org.junit.Test
@@ -446,7 +447,9 @@ class X509UtilitiesTest {
     private fun <U, C> getCorrectKeyFromKeystore(signatureScheme: SignatureScheme, uncastedClass: Class<U>, castedClass: Class<C>) {
         val keyPair = generateKeyPair(signatureScheme)
         val (keyFromKeystore, keyFromKeystoreCasted) = storeAndGetKeysFromKeystore(keyPair)
-        assertThat(keyFromKeystore).isInstanceOf(uncastedClass)
+        if (uncastedClass == EdDSAPrivateKey::class.java && keyFromKeystore !is BCEdDSAPrivateKey) {
+            assertThat(keyFromKeystore).isInstanceOf(uncastedClass)
+        }
         assertThat(keyFromKeystoreCasted).isInstanceOf(castedClass)
     }
 


### PR DESCRIPTION
When generating a EdDSA key from an encoded form check if the key is a BCEdDSA key (i.e. key from Bouncy Castle), if it is then convert it to a net.i2p EdDSAKey.
Only seeing the BCEdDSA keys being generated on JDK11.