### PR TITLE
CORDA-3761 [POC]: Notary identity rotation without changing network parameters

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -83,7 +83,7 @@ class NotaryFlow {
         protected fun checkTransaction(): Party {
             val notaryParty = stx.notary ?: throw IllegalStateException("Transaction does not specify a Notary")
             check(serviceHub.networkMapCache.isNotary(notaryParty)) { "$notaryParty is not a notary on the network" }
-            check(serviceHub.loadStates(stx.inputs.toSet() + stx.references.toSet()).all { it.state.notary == notaryParty }) {
+            check(serviceHub.loadStates(stx.inputs.toSet() + stx.references.toSet()).all { it.state.notary.name == notaryParty.name }) {
                 "Input states and reference input states must have the same Notary"
             }
 

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -116,7 +116,7 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
     private fun checkNoNotaryChange() {
         if (ltx.notary != null && (ltx.inputs.isNotEmpty() || ltx.references.isNotEmpty())) {
             ltx.outputs.forEach {
-                if (it.notary != ltx.notary) {
+                if (it.notary.name != ltx.notary?.name) {
                     throw TransactionVerificationException.NotaryChangeInWrongTransactionType(ltx.id, ltx.notary, it.notary)
                 }
             }
@@ -227,7 +227,7 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
     private tailrec fun checkNotary(index: Int, indicesAlreadyChecked: HashSet<Int>) {
         if (indicesAlreadyChecked.add(index)) {
             val encumbranceIndex = ltx.outputs[index].encumbrance!!
-            if (ltx.outputs[index].notary != ltx.outputs[encumbranceIndex].notary) {
+            if (ltx.outputs[index].notary.name != ltx.outputs[encumbranceIndex].notary.name) {
                 throw TransactionVerificationException.TransactionNotaryMismatchEncumbranceException(
                         ltx.id,
                         index,

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -116,7 +116,7 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
     private fun checkNoNotaryChange() {
         if (ltx.notary != null && (ltx.inputs.isNotEmpty() || ltx.references.isNotEmpty())) {
             ltx.outputs.forEach {
-                if (it.notary.name != ltx.notary?.name) {
+                if (it.notary.name != ltx.notary.name) {
                     throw TransactionVerificationException.NotaryChangeInWrongTransactionType(ltx.id, ltx.notary, it.notary)
                 }
             }

--- a/core/src/main/kotlin/net/corda/core/internal/notary/NotaryService.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/NotaryService.kt
@@ -12,7 +12,8 @@ import java.security.PublicKey
 @DeleteForDJVM
 abstract class NotaryService : SingletonSerializeAsToken() {
     abstract val services: ServiceHub
-    abstract val notaryIdentityKey: PublicKey
+    abstract val notaryIdentity: Party
+    val notaryIdentityKey: PublicKey get() = notaryIdentity.owningKey
 
     /**
      * Interfaces for the request and result formats of queries supported by notary services. To

--- a/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
@@ -107,8 +107,8 @@ abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service:
     /** Check if transaction is intended to be signed by this notary. */
     @Suspendable
     private fun checkNotary(notary: Party?) {
-        require(notary?.owningKey == service.notaryIdentityKey) {
-            "The notary specified on the transaction: [$notary] does not match the notary service's identity: [${service.notaryIdentityKey}] "
+        require(notary?.name == service.notaryIdentity.name) {
+            "The notary specified on the transaction: [$notary] does not match the notary service's identity: [${service.notaryIdentity}] "
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -120,7 +120,7 @@ interface NetworkMapCacheBase {
     // DOCEND 2
 
     /** Returns true if and only if the given [Party] is a notary, which is defined by the network parameters. */
-    fun isNotary(party: Party): Boolean = party in notaryIdentities
+    fun isNotary(party: Party): Boolean
 
     /**
      * Returns true if and only if the given [Party] is validating notary. For every party that is a validating notary,

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -42,9 +42,9 @@ abstract class FullTransaction : BaseTransaction() {
 
     private fun checkInputsAndReferencesHaveSameNotary() {
         if (inputs.isEmpty() && references.isEmpty()) return
-        val notaries = (inputs + references).map { it.state.notary }.toHashSet()
+        val notaries = (inputs + references).map { it.state.notary.name }.toHashSet()
         check(notaries.size == 1) { "All inputs and reference inputs must point to the same notary" }
-        check(notaries.single() == notary) { "The specified notary must be the one specified by all inputs and input references" }
+        check(notaries.single() == notary?.name) { "The specified notary must be the one specified by all inputs and input references" }
     }
 
     /** Make sure the assigned notary is part of the network parameter whitelist. */
@@ -52,8 +52,8 @@ abstract class FullTransaction : BaseTransaction() {
         notary?.let { notaryParty ->
             // Network parameters will never be null if the transaction is resolved from a CoreTransaction rather than constructed directly.
             networkParameters?.let { parameters ->
-                val notaryWhitelist = parameters.notaries.map { it.identity }
-                check(notaryParty in notaryWhitelist) {
+                val notaryWhitelist = parameters.notaries.map { it.identity.name }
+                check(notaryParty.name in notaryWhitelist) {
                     "Notary ($notaryParty) specified by the transaction is not on the network parameter whitelist: [${notaryWhitelist.joinToString()}]"
                 }
             }

--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -154,8 +154,8 @@ private constructor(
      */
     private fun checkNewNotaryWhitelisted() {
         networkParameters?.let { parameters ->
-            val notaryWhitelist = parameters.notaries.map { it.identity }
-            check(newNotary in notaryWhitelist) {
+            val notaryWhitelist = parameters.notaries.map { it.identity.name }
+            check(newNotary.name in notaryWhitelist) {
                 "The output notary $newNotary is not whitelisted in the attached network parameters."
             }
         }

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -635,7 +635,7 @@ open class TransactionBuilder(
 
     private fun checkNotary(stateAndRef: StateAndRef<*>) {
         val notary = stateAndRef.state.notary
-        require(notary == this.notary) {
+        require(notary.name == this.notary?.name) {
             "Input state requires notary \"$notary\" which does not match the transaction notary \"${this.notary}\"."
         }
     }
@@ -648,7 +648,7 @@ open class TransactionBuilder(
         }
     }
 
-    private fun checkReferencesUseSameNotary() = referencesWithTransactionState.map { it.notary }.toSet().size == 1
+    private fun checkReferencesUseSameNotary() = referencesWithTransactionState.map { it.notary.name }.toSet().size == 1
 
     /**
      * If any inputs or outputs added to the [TransactionBuilder] contain [StatePointer]s, then this method is used

--- a/finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt
+++ b/finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt
@@ -264,7 +264,7 @@ abstract class OnLedgerAsset<T : Any, out C : CommandData, S : FungibleAsset<T>>
             // TODO: We should be prepared to produce multiple transactions exiting inputs from
             // different notaries, or at least group states by notary and take the set with the
             // highest total value
-            acceptableCoins = acceptableCoins.filter { it.state.notary == tx.notary }
+            acceptableCoins = acceptableCoins.filter { it.state.notary.name == tx.notary?.name }
 
             val (gathered, gatheredAmount) = gatherCoins(acceptableCoins, amount)
             val takeChangeFrom = gathered.lastOrNull()

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
@@ -62,6 +62,8 @@ class CashExitFlow(private val amount: Amount<Currency>,
         } catch (e: InsufficientBalanceException) {
             throw CashException("Exiting more cash than exists", e)
         }
+        /** Make sure that we don't use stale notary identity after key rotation. TODO: look for better solution. */
+        builder.notary = serviceHub.networkMapCache.notaryIdentities.first { it.name == builder.notary?.name }
 
         // Work out who the owners of the burnt states were (specify page size so we don't silently drop any if > DEFAULT_PAGE_SIZE)
         val inputStates = serviceHub.vaultService.queryBy<Cash.State>(VaultQueryCriteria(stateRefs = builder.inputStates()),

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -74,6 +74,8 @@ open class CashPaymentFlow(
         } catch (e: InsufficientBalanceException) {
             throw CashException("Insufficient cash for spend: ${e.message}", e)
         }
+        /** Make sure that we don't use stale notary identity after key rotation. TODO: look for better solution. */
+        builder.notary = serviceHub.networkMapCache.notaryIdentities.first { it.name == builder.notary?.name }
 
         progressTracker.currentStep = SIGNING_TX
         logger.info("Signing transaction for: ${spendTX.lockId}")

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/ObligationUtils.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/ObligationUtils.kt
@@ -198,9 +198,9 @@ object ObligationUtils {
         val obligationOwner = states.first().data.beneficiary
 
         requireThat {
-            "all fungible asset states use the same notary" using (assetStatesAndRefs.all { it.state.notary == notary })
+            "all fungible asset states use the same notary" using (assetStatesAndRefs.all { it.state.notary.name == notary.name })
             "all obligation states are in the normal state" using (statesAndRefs.all { it.state.data.lifecycle == Obligation.Lifecycle.NORMAL })
-            "all obligation states use the same notary" using (statesAndRefs.all { it.state.notary == notary })
+            "all obligation states use the same notary" using (statesAndRefs.all { it.state.notary.name == notary.name })
             "all obligation states have the same obligor" using (statesAndRefs.all { it.state.data.obligor == obligationIssuer })
             "all obligation states have the same beneficiary" using (statesAndRefs.all { it.state.data.beneficiary == obligationOwner })
         }

--- a/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
@@ -117,11 +117,11 @@ class DBNetworkParametersStorage(
     override fun getHistoricNotary(party: Party): NotaryInfo? {
         val currentParameters = lookup(currentHash)
                 ?: throw IllegalStateException("Unable to obtain NotaryInfo – current network parameters not set.")
-        val inCurrentParams = currentParameters.notaries.singleOrNull { it.identity == party }
+        val inCurrentParams = currentParameters.notaries.singleOrNull { it.identity.name == party.name }
         if (inCurrentParams != null) return inCurrentParams
         return hashToParameters.allPersisted.use {
             it.flatMap { (_, signedNetParams) -> signedNetParams.raw.deserialize().notaries.stream() }
-                    .filter { it.identity == party }
+                    .filter { it.identity.name == party.name }
                     .findFirst()
                     .orElse(null)
         }

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -57,7 +57,9 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
     @Volatile
     private lateinit var notaries: List<NotaryInfo>
 
-    override val notaryIdentities: List<Party> get() = notaries.map { it.identity }
+    // Notary whitelist in the network parameters may contain stale entries after certificate rotation.
+    // We need to obtain active notary identities by X.500 name from network map cache.
+    override val notaryIdentities: List<Party> get() = notaries.map { getPeerCertificateByLegalName(it.identity.name)?.party ?: it.identity }
 
     override val allNodeHashes: List<SecureHash>
         get() {
@@ -97,7 +99,9 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
         }
     }
 
-    override fun isValidatingNotary(party: Party): Boolean = notaries.any { it.validating && it.identity == party }
+    override fun isNotary(party: Party): Boolean = notaries.any { it.identity.name == party.name }
+
+    override fun isValidatingNotary(party: Party): Boolean = notaries.any { it.validating && it.identity.name == party.name }
 
     override fun getPartyInfo(party: Party): PartyInfo? {
         val nodes = getNodesByLegalIdentityKey(party.owningKey)

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -88,9 +88,9 @@ class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePart
     }
 
     private fun checkInWhitelist(networkParameters: NetworkParameters, notary: Party) {
-        val notaryWhitelist = networkParameters.notaries.map { it.identity }
+        val notaryWhitelist = networkParameters.notaries.map { it.identity.name }
 
-        check(notary in notaryWhitelist) {
+        check(notary.name in notaryWhitelist) {
             "Notary specified by the transaction ($notary) is not on the network parameter whitelist: ${notaryWhitelist.joinToString()}"
         }
     }

--- a/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmartNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmartNotaryService.kt
@@ -37,7 +37,7 @@ import kotlin.concurrent.thread
  */
 class BFTSmartNotaryService(
         override val services: ServiceHubInternal,
-        override val notaryIdentityKey: PublicKey
+        override val notaryIdentity: Party
 ) : NotaryService() {
     companion object {
         private val log = contextLogger()

--- a/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftNotaryService.kt
@@ -1,18 +1,18 @@
 package net.corda.notary.experimental.raft
 
 import net.corda.core.flows.FlowSession
+import net.corda.core.identity.Party
 import net.corda.core.internal.notary.NotaryServiceFlow
 import net.corda.core.internal.notary.SinglePartyNotaryService
 import net.corda.core.utilities.seconds
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.transactions.NonValidatingNotaryFlow
 import net.corda.node.services.transactions.ValidatingNotaryFlow
-import java.security.PublicKey
 
 /** A highly available notary service using the Raft algorithm to achieve consensus. */
 class RaftNotaryService(
         override val services: ServiceHubInternal,
-        override val notaryIdentityKey: PublicKey
+        override val notaryIdentity: Party
 ) : SinglePartyNotaryService() {
     private val notaryConfig = services.configuration.notary
             ?: throw IllegalArgumentException("Failed to register ${RaftNotaryService::class.java}: notary configuration not present")

--- a/node/src/main/kotlin/net/corda/notary/jpa/JPANotaryService.kt
+++ b/node/src/main/kotlin/net/corda/notary/jpa/JPANotaryService.kt
@@ -2,6 +2,7 @@ package net.corda.notary.jpa
 
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowSession
+import net.corda.core.identity.Party
 import net.corda.core.internal.notary.NotaryServiceFlow
 import net.corda.core.internal.notary.SinglePartyNotaryService
 import net.corda.core.utilities.seconds
@@ -10,12 +11,11 @@ import net.corda.node.services.transactions.NonValidatingNotaryFlow
 import net.corda.node.services.transactions.ValidatingNotaryFlow
 import net.corda.nodeapi.internal.config.parseAs
 import net.corda.notary.common.signBatch
-import java.security.PublicKey
 
 /** Notary service backed by a relational database. */
 class JPANotaryService(
         override val services: ServiceHubInternal,
-        override val notaryIdentityKey: PublicKey) : SinglePartyNotaryService() {
+        override val notaryIdentity: Party) : SinglePartyNotaryService() {
 
     private val notaryConfig = services.configuration.notary
             ?: throw IllegalArgumentException("Failed to register ${this::class.java}: notary configuration not present")

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -43,7 +43,6 @@ import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import java.security.PublicKey
 import java.time.Duration
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -267,7 +266,7 @@ class TimedFlowTests {
      * A test notary service that will just stop forever the first time you invoke its commitInputStates method and will succeed the
      * second time around.
      */
-    private class TestNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : SinglePartyNotaryService() {
+    private class TestNotaryService(override val services: ServiceHubInternal, override val notaryIdentity: Party) : SinglePartyNotaryService() {
         override val uniquenessProvider = object : UniquenessProvider {
             /** A dummy commit method that immediately returns a success message. */
             override fun commit(states: List<StateRef>, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature, timeWindow: TimeWindow?, references: List<StateRef>): CordaFuture<UniquenessProvider.Result> {

--- a/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt
+++ b/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt
@@ -5,6 +5,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.NotarisationPayload
 import net.corda.core.flows.NotaryError
+import net.corda.core.identity.Party
 import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.internal.notary.NotaryInternalException
 import net.corda.core.internal.notary.SinglePartyNotaryService
@@ -24,7 +25,7 @@ import java.security.PublicKey
 // START 1
 class MyCustomValidatingNotaryService(
         override val services: ServiceHubInternal,
-        override val notaryIdentityKey: PublicKey)
+        override val notaryIdentity: Party)
     : SinglePartyNotaryService() {
     override val uniquenessProvider = PersistentUniquenessProvider(
             services.clock,

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt
@@ -17,7 +17,6 @@ import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import java.security.PublicKey
 import java.util.*
 
 class CustomNotaryTest {
@@ -59,7 +58,7 @@ class CustomNotaryTest {
         future.getOrThrow()
     }
 
-    class CustomNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : NotaryService() {
+    class CustomNotaryService(override val services: ServiceHubInternal, override val notaryIdentity: Party) : NotaryService() {
 
         override fun createServiceFlow(otherPartySession: FlowSession): FlowLogic<Void?> =
                 object : FlowLogic<Void?>() {


### PR DESCRIPTION
POC for notary certificate rotation without network parameters change.
👮🏻👮🏻👮🏻 !!!! DO NOT MERGE !!!! 👮🏻👮🏻👮🏻

This is an attempt to implement a solution discussed 2 weeks ago:
- Notary identity can be rotated without changing network parameters
- Notary whitelist hence will contain only "indicative" public keys (but real X.500 names)
- Real notary public keys will be resolved from network map cache using X.500 names from the notary whitelist

The PR mainly contains loosening validation of notary comparisons (i.e. comparing names instead of keys) and "refreshing" whitelisted notaries (`NetworkMapCache.notaryIdentities` ) using network map cache.

There was, however, an issue discovered with Corda Finance cash selection utils (and may potentially affect other apps). Transaction notary is automatically taken from existing states, so the transaction may contain stale notary identity.

For the purpose of POC, the workaround was to "refresh" notary identity directly in the Corda Finance flow implementations. Though, this may be not acceptable for production apps. Other alternatives:

1. Make `TransactionBuilder` to "refresh" notary somewhere inside `toWireTransaction()`
2. Combine "keep old key" approach with this one, i.e. notary will sign old states with old keys, but network parameters change won't be needed
3. Map old notary key to a new one during signature verification, though it doesn't always look feasible, as objects may contain key without party.
