### PR TITLE
Infra-656 - NoSuchFileException in NodeInfoWatcher fix

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -41,17 +41,20 @@ class NodeInfoWatcher(private val nodePath: Path,
         private val logger = contextLogger()
 
         // TODO This method doesn't belong in this class
-        fun saveToFile(path: Path, nodeInfoAndSigned: NodeInfoAndSigned) {
+        fun saveToFile(path: Path, nodeInfoAndSigned: NodeInfoAndSigned): Path {
             // By using the hash of the node's first name we ensure:
             // 1) node info files for the same node map to the same filename and thus avoid having duplicate files for
             //    the same node
             // 2) avoid having to deal with characters in the X.500 name which are incompatible with the local filesystem
             val fileNameHash = nodeInfoAndSigned.nodeInfo.legalIdentities[0].name.serialize().hash
+            val target = path / "${NodeInfoFilesCopier.NODE_INFO_FILE_NAME_PREFIX}$fileNameHash"
             nodeInfoAndSigned
                     .signed
                     .serialize()
                     .open()
-                    .copyTo(path / "${NodeInfoFilesCopier.NODE_INFO_FILE_NAME_PREFIX}$fileNameHash", REPLACE_EXISTING)
+                    .copyTo(target, REPLACE_EXISTING)
+
+            return target
         }
     }
 
@@ -85,7 +88,7 @@ class NodeInfoWatcher(private val nodePath: Path,
                         logger.debug { "Examining $it" }
                         true
                     }
-                    .filter { !it.endsWith(".tmp") }
+                    .filter { !it.toString().endsWith(".tmp") }
                     .filter { it.isRegularFile() }
                     .filter { file ->
                         val lastModifiedTime = file.lastModifiedTime()

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -85,6 +85,7 @@ class NodeInfoWatcher(private val nodePath: Path,
                         logger.debug { "Examining $it" }
                         true
                     }
+                    .filter { !it.endsWith(".tmp") }
                     .filter { it.isRegularFile() }
                     .filter { file ->
                         val lastModifiedTime = file.lastModifiedTime()

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -4,15 +4,14 @@ import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import net.corda.core.internal.NODE_INFO_DIRECTORY
 import net.corda.core.internal.createDirectories
-import net.corda.core.internal.createFile
 import net.corda.core.internal.div
 import net.corda.core.internal.size
 import net.corda.core.node.services.KeyManagementService
+import net.corda.coretesting.internal.createNodeInfoAndSigned
 import net.corda.nodeapi.internal.NodeInfoAndSigned
 import net.corda.nodeapi.internal.network.NodeInfoFilesCopier
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
-import net.corda.coretesting.internal.createNodeInfoAndSigned
 import net.corda.testing.node.internal.MockKeyManagementService
 import net.corda.testing.node.makeTestIdentityService
 import org.assertj.core.api.Assertions.assertThat

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -4,6 +4,7 @@ import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import net.corda.core.internal.NODE_INFO_DIRECTORY
 import net.corda.core.internal.createDirectories
+import net.corda.core.internal.createFile
 import net.corda.core.internal.div
 import net.corda.core.internal.size
 import net.corda.core.node.services.KeyManagementService
@@ -21,7 +22,9 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import rx.observers.TestSubscriber
 import rx.schedulers.TestScheduler
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -127,6 +130,31 @@ class NodeInfoWatcherTest {
             // The same folder can be reported more than once, so take unique values.
             val readNodes = testSubscriber.onNextEvents.distinct().flatten()
             assertEquals(nodeInfoAndSigned.nodeInfo, (readNodes.first() as? NodeInfoUpdate.Add)?.nodeInfo)
+        } finally {
+            subscription.unsubscribe()
+        }
+    }
+
+    @Test(timeout=300_000)
+    fun `ignore tmp files`() {
+        nodeInfoPath.createDirectories()
+
+        // Start polling with an empty folder.
+        val subscription = nodeInfoWatcher.nodeInfoUpdates().subscribe(testSubscriber)
+        try {
+            // Ensure the watch service is started.
+            advanceTime()
+
+
+            // create file
+            // boohoo, we shouldn't create real files, instead mock Path
+            val file = NodeInfoWatcher.saveToFile(nodeInfoPath, nodeInfoAndSigned)
+            Files.move(file, Paths.get("$file.tmp"))
+
+            advanceTime()
+
+            // Check no nodeInfos are read.
+            assertEquals(0, testSubscriber.onNextEvents.distinct().flatten().size)
         } finally {
             subscription.unsubscribe()
         }


### PR DESCRIPTION
Second attempt to fix this.
Included test this time.

Changed signature of NodeInfoWatcher.saveToFile to return generated file name so to be able to test this.