### PR TITLE
NOTICK remove test dependency cycle

### DIFF
--- a/common/logging/build.gradle
+++ b/common/logging/build.gradle
@@ -15,10 +15,16 @@ dependencies {
 
     compile "com.jcabi:jcabi-manifests:$jcabi_manifests_version"
 
-    testCompile project(":test-utils")
-    testCompile "com.nhaarman:mockito-kotlin:$mockito_kotlin_version"
+    // Need to depend on one other Corda project in order to get hold of a valid manifest for the tests
+    testCompile project(":common-validation")
+
+    // test dependencies
+    testImplementation "junit:junit:$junit_version"
+    testCompile group: "org.jetbrains.kotlin", name: "kotlin-test", version: kotlin_version
     testCompile "org.mockito:mockito-core:$mockito_version"
+    testCompile "com.natpryce:hamkrest:$hamkrest_version"
 }
+
 
 
 task generateSource(type: Copy) {

--- a/common/validation/build.gradle
+++ b/common/validation/build.gradle
@@ -6,8 +6,6 @@ apply plugin: 'com.jfrog.artifactory'
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-
-    testCompile project(":test-utils")
 }
 
 jar {


### PR DESCRIPTION
Make all the projects under common not depend on anything Corda (test-utils pulls in a lot of stuff these should not know anything about).
Merging to 4.7 for now.