### PR TITLE
CORDA-3908: Update corda-4.7 .ci/api-current.txt to match the previous release (corda-4.6)

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -9218,11 +9218,6 @@ public final class net.corda.client.rpc.reconnect.CouldNotStartFlowException ext
   public <init>(Throwable)
   public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
 ##
-public final class net.corda.client.rpc.reconnect.CouldNotStartFlowException extends net.corda.client.rpc.RPCException
-  public <init>()
-  public <init>(Throwable)
-  public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
-##
 public final class net.corda.finance.test.CashSchema extends java.lang.Object
   public static final net.corda.finance.test.CashSchema INSTANCE
 ##

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -8237,8 +8237,8 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
   public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
   public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String)
-  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String, net.corda.core.utilities.NetworkHostAndPort)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, String, net.corda.core.utilities.NetworkHostAndPort, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.core.identity.CordaX500Name component1()
   @NotNull
@@ -8262,7 +8262,7 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   @NotNull
   public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
   @NotNull
-  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String)
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String, net.corda.core.utilities.NetworkHostAndPort)
   public boolean equals(Object)
   @NotNull
   public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -155,6 +155,8 @@ public final class net.corda.core.context.AuthServiceId extends java.lang.Object
 public final class net.corda.core.context.InvocationContext extends java.lang.Object
   public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
   public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>, String)
+  public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.InvocationOrigin component1()
   @NotNull
@@ -165,11 +167,21 @@ public final class net.corda.core.context.InvocationContext extends java.lang.Ob
   public final net.corda.core.context.Trace component4()
   @Nullable
   public final net.corda.core.context.Actor component5()
+  @Nullable
+  public final java.util.List<Object> component6()
+  @Nullable
+  public final String component7()
   @NotNull
   public final net.corda.core.context.InvocationContext copy(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext copy(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>, String)
   public boolean equals(Object)
   @Nullable
   public final net.corda.core.context.Actor getActor()
+  @Nullable
+  public final java.util.List<Object> getArguments()
+  @Nullable
+  public final String getClientId()
   @Nullable
   public final net.corda.core.context.Trace getExternalTrace()
   @Nullable
@@ -180,13 +192,33 @@ public final class net.corda.core.context.InvocationContext extends java.lang.Ob
   public final net.corda.core.context.Trace getTrace()
   public int hashCode()
   @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace)
+  @NotNull
   public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>, String)
   @NotNull
   public static final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
   @NotNull
   public final java.security.Principal principal()
   @NotNull
+  public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
   public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>)
   @NotNull
   public static final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
   @NotNull
@@ -200,11 +232,31 @@ public final class net.corda.core.context.InvocationContext extends java.lang.Ob
 public static final class net.corda.core.context.InvocationContext$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace)
+  @NotNull
   public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>, String)
   @NotNull
   public final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
   @NotNull
+  public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
   public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor, java.util.List<?>)
   @NotNull
   public final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
   @NotNull
@@ -478,6 +530,8 @@ public interface net.corda.core.contracts.Attachment extends net.corda.core.cont
 public interface net.corda.core.contracts.AttachmentConstraint
   public abstract boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
 ##
+public final class net.corda.core.contracts.AttachmentConstraintKt extends java.lang.Object
+##
 @CordaSerializable
 public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)
@@ -498,6 +552,12 @@ public final class net.corda.core.contracts.AutomaticPlaceholderConstraint exten
 ##
 public @interface net.corda.core.contracts.BelongsToContract
   public abstract Class<? extends net.corda.core.contracts.Contract> value()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.BrokenAttachmentException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
 ##
 @CordaSerializable
 public final class net.corda.core.contracts.Command extends java.lang.Object
@@ -569,6 +629,7 @@ public interface net.corda.core.contracts.Contract
   public abstract void verify(net.corda.core.transactions.LedgerTransaction)
 ##
 @DoNotImplement
+@CordaSerializable
 public final class net.corda.core.contracts.ContractAttachment extends java.lang.Object implements net.corda.core.contracts.Attachment
   public <init>(net.corda.core.contracts.Attachment, String)
   public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>)
@@ -647,6 +708,11 @@ public final class net.corda.core.contracts.HashAttachmentConstraint extends jav
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   @NotNull
   public String toString()
+  public static final net.corda.core.contracts.HashAttachmentConstraint$Companion Companion
+##
+public static final class net.corda.core.contracts.HashAttachmentConstraint$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getDisableHashConstraints()
 ##
 @CordaSerializable
 public final class net.corda.core.contracts.InsufficientBalanceException extends net.corda.core.flows.FlowException
@@ -675,15 +741,20 @@ public final class net.corda.core.contracts.Issued extends java.lang.Object
 public @interface net.corda.core.contracts.LegalProseReference
   public abstract String uri()
 ##
+@DoNotImplement
 @CordaSerializable
 public final class net.corda.core.contracts.LinearPointer extends net.corda.core.contracts.StatePointer
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.contracts.UniqueIdentifier, Class<T>)
+  public <init>(net.corda.core.contracts.UniqueIdentifier, Class<T>, boolean)
+  public <init>(net.corda.core.contracts.UniqueIdentifier, Class, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public boolean equals(Object)
   @NotNull
   public net.corda.core.contracts.UniqueIdentifier getPointer()
   @NotNull
   public Class<T> getType()
   public int hashCode()
+  public boolean isResolved()
   @NotNull
   public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
@@ -871,6 +942,7 @@ public final class net.corda.core.contracts.StateAndRef extends java.lang.Object
   @NotNull
   public String toString()
 ##
+@DoNotImplement
 @CordaSerializable
 public abstract class net.corda.core.contracts.StatePointer extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
@@ -878,10 +950,15 @@ public abstract class net.corda.core.contracts.StatePointer extends java.lang.Ob
   public abstract Object getPointer()
   @NotNull
   public abstract Class<T> getType()
+  public abstract boolean isResolved()
   @NotNull
   public abstract net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
   public abstract net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.core.contracts.StatePointer$Companion Companion
+##
+public static final class net.corda.core.contracts.StatePointer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public final class net.corda.core.contracts.StateRef extends java.lang.Object
@@ -899,15 +976,20 @@ public final class net.corda.core.contracts.StateRef extends java.lang.Object
   @NotNull
   public String toString()
 ##
+@DoNotImplement
 @CordaSerializable
 public final class net.corda.core.contracts.StaticPointer extends net.corda.core.contracts.StatePointer
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.contracts.StateRef, Class<T>)
+  public <init>(net.corda.core.contracts.StateRef, Class<T>, boolean)
+  public <init>(net.corda.core.contracts.StateRef, Class, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public boolean equals(Object)
   @NotNull
   public net.corda.core.contracts.StateRef getPointer()
   @NotNull
   public Class<T> getType()
   public int hashCode()
+  public boolean isResolved()
   @NotNull
   public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
@@ -1010,10 +1092,15 @@ public final class net.corda.core.contracts.TransactionState extends java.lang.O
 ##
 public final class net.corda.core.contracts.TransactionStateKt extends java.lang.Object
 ##
+@CordaSerializable
 public abstract class net.corda.core.contracts.TransactionVerificationException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
   @NotNull
   public final net.corda.core.crypto.SecureHash getTxId()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$BrokenTransactionException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ConflictingAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
@@ -1023,6 +1110,7 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ConstraintPropagationRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, String, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.AttachmentConstraint)
   @NotNull
   public final String getContractClass()
@@ -1035,6 +1123,7 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ContractCreationError extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
   public <init>(net.corda.core.crypto.SecureHash, String, Throwable, String)
   @NotNull
   public final String getContractClass()
@@ -1052,10 +1141,30 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   public static net.corda.core.contracts.TransactionVerificationException$Direction[] values()
 ##
 @CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.Attachment)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachmentId()
+##
+@CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateInputStates extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
   @NotNull
   public final net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef> getDuplicates()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$InvalidAttachmentException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentHash()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$InvalidConstraintRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, String)
+  @NotNull
+  public final String getContractClass()
+  @NotNull
+  public final String getReason()
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$InvalidNotaryChange extends net.corda.core.contracts.TransactionVerificationException
@@ -1066,6 +1175,11 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   public <init>(net.corda.core.crypto.SecureHash, String)
   @NotNull
   public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MissingNetworkParametersException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SecureHash)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$MoreThanOneNotary extends net.corda.core.contracts.TransactionVerificationException
@@ -1082,6 +1196,8 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$OverlappingAttachmentsException extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getPath()
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$PackageOwnershipException extends net.corda.core.contracts.TransactionVerificationException
@@ -1101,11 +1217,13 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionContractConflictException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionDuplicateEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, int)
+  public <init>(net.corda.core.crypto.SecureHash, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionMissingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
@@ -1115,16 +1233,36 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   public final int getMissing()
 ##
 @CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNetworkParameterOrderingException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.StateRef, net.corda.core.node.NetworkParameters, net.corda.core.node.NetworkParameters)
+##
+@CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNonMatchingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, java.util.Collection<Integer>)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNotaryMismatchEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, int, int, net.corda.core.identity.Party, net.corda.core.identity.Party)
+  public <init>(net.corda.core.crypto.SecureHash, String)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionRequiredContractUnspecifiedException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$UnsupportedClassVersionError extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$UntrustedAttachmentsException extends net.corda.core.CordaException
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
 ##
 @CordaSerializable
 public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.lang.Object implements net.corda.core.contracts.CommandData
@@ -1182,6 +1320,8 @@ public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstrain
 public interface net.corda.core.cordapp.Cordapp
   @NotNull
   public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getAllFlows()
+  @NotNull
+  public abstract java.util.List<net.corda.core.serialization.CheckpointCustomSerializer<?, ?>> getCheckpointCustomSerializers()
   @NotNull
   public abstract java.util.List<String> getContractClassNames()
   @NotNull
@@ -1367,6 +1507,48 @@ public final class net.corda.core.cordapp.CordappContext extends java.lang.Objec
 public static final class net.corda.core.cordapp.CordappContext$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
+@CordaSerializable
+public final class net.corda.core.cordapp.CordappInfo extends java.lang.Object
+  public <init>(String, String, String, int, int, String, String, String, net.corda.core.crypto.SecureHash$SHA256)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final String component3()
+  public final int component4()
+  public final int component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final String component7()
+  @NotNull
+  public final String component8()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 component9()
+  @NotNull
+  public final net.corda.core.cordapp.CordappInfo copy(String, String, String, int, int, String, String, String, net.corda.core.crypto.SecureHash$SHA256)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getJarHash()
+  @NotNull
+  public final String getLicence()
+  public final int getMinimumPlatformVersion()
+  @NotNull
+  public final String getName()
+  @NotNull
+  public final String getShortName()
+  public final int getTargetPlatformVersion()
+  @NotNull
+  public final String getType()
+  @NotNull
+  public final String getVendor()
+  @NotNull
+  public final String getVersion()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
 @DoNotImplement
 public interface net.corda.core.cordapp.CordappProvider
   @NotNull
@@ -1528,6 +1710,8 @@ public final class net.corda.core.crypto.CordaObjectIdentifier extends java.lang
 ##
 public final class net.corda.core.crypto.CordaSecurityProvider extends java.security.Provider
   public <init>()
+  @Nullable
+  public java.security.Provider$Service getService(String, String)
   public static final net.corda.core.crypto.CordaSecurityProvider$Companion Companion
   @NotNull
   public static final String PROVIDER_NAME = "Corda"
@@ -1679,6 +1863,9 @@ public static class net.corda.core.crypto.DigitalSignature$WithKey extends net.c
   public final boolean verify(byte[])
   @NotNull
   public final net.corda.core.crypto.DigitalSignature withoutKey()
+##
+public final class net.corda.core.crypto.DummySecureRandom extends java.security.SecureRandom
+  public static final net.corda.core.crypto.DummySecureRandom INSTANCE
 ##
 public abstract class net.corda.core.crypto.MerkleTree extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
@@ -1860,6 +2047,8 @@ public static final class net.corda.core.crypto.SecureHash$Companion extends jav
 @CordaSerializable
 public static final class net.corda.core.crypto.SecureHash$SHA256 extends net.corda.core.crypto.SecureHash
   public <init>(byte[])
+  public boolean equals(Object)
+  public int hashCode()
 ##
 public final class net.corda.core.crypto.SecureHashKt extends java.lang.Object
   @NotNull
@@ -2154,11 +2343,17 @@ public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.F
   @Suspendable
   protected void verifyDataRequest(net.corda.core.internal.FetchDataFlow$Request$Data)
 ##
+@DoNotImplement
+public interface net.corda.core.flows.Destination
+##
 @InitiatingFlow
 public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.node.StatesToRecord, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>)
@@ -2315,7 +2510,11 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public final R await(net.corda.core.flows.FlowExternalOperation<R>)
   @Suspendable
   public abstract T call()
+  public final void checkFlowIsNotKilled()
+  public final void checkFlowIsNotKilled(kotlin.jvm.functions.Function0<?>)
   public final void checkFlowPermission(String, java.util.Map<String, String>)
+  @Suspendable
+  public final void close(net.corda.core.utilities.NonEmptySet<net.corda.core.flows.FlowSession>)
   @Suspendable
   @Nullable
   public final net.corda.core.flows.FlowStackSnapshot flowStackSnapshot()
@@ -2338,7 +2537,11 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public final net.corda.core.node.ServiceHub getServiceHub()
   @Suspendable
   @NotNull
+  public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.flows.Destination)
+  @Suspendable
+  @NotNull
   public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.identity.Party)
+  public final boolean isKilled()
   @Suspendable
   public final void persistFlowStackSnapshot()
   @Suspendable
@@ -2359,6 +2562,14 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public final void recordAuditEvent(String, String, java.util.Map<String, String>)
   @Suspendable
   public void send(net.corda.core.identity.Party, Object)
+  @Suspendable
+  public final void sendAll(Object, java.util.Set<? extends net.corda.core.flows.FlowSession>)
+  @Suspendable
+  public final void sendAll(Object, java.util.Set<? extends net.corda.core.flows.FlowSession>, boolean)
+  @Suspendable
+  public final void sendAllMap(java.util.Map<net.corda.core.flows.FlowSession, ?>)
+  @Suspendable
+  public final void sendAllMap(java.util.Map<net.corda.core.flows.FlowSession, ?>, boolean)
   @Suspendable
   @NotNull
   public net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, net.corda.core.identity.Party, Object)
@@ -2409,6 +2620,8 @@ public interface net.corda.core.flows.FlowLogicRefFactory
 @DoNotImplement
 public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
   public <init>()
+  @Suspendable
+  public abstract void close()
   @NotNull
   public abstract net.corda.core.identity.Party getCounterparty()
   @Suspendable
@@ -2417,6 +2630,8 @@ public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
   @Suspendable
   @NotNull
   public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo(boolean)
+  @NotNull
+  public abstract net.corda.core.flows.Destination getDestination()
   @Suspendable
   @NotNull
   public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>)
@@ -2472,6 +2687,13 @@ public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends j
   @NotNull
   public String toString()
 ##
+@CordaSerializable
+public class net.corda.core.flows.HospitalizeFlowException extends net.corda.core.CordaRuntimeException
+  public <init>()
+  public <init>(String)
+  public <init>(String, Throwable)
+  public <init>(Throwable)
+##
 public interface net.corda.core.flows.IdentifiableException
   @Nullable
   public Long getErrorId()
@@ -2487,6 +2709,29 @@ public @interface net.corda.core.flows.InitiatedBy
 ##
 public @interface net.corda.core.flows.InitiatingFlow
   public abstract int version()
+##
+@CordaSerializable
+public final class net.corda.core.flows.KilledFlowException extends net.corda.core.CordaRuntimeException
+  public <init>(net.corda.core.flows.StateMachineRunId)
+  public <init>(net.corda.core.flows.StateMachineRunId, String)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getId()
+##
+@CordaSerializable
+public final class net.corda.core.flows.MaybeSerializedSignedTransaction extends java.lang.Object implements net.corda.core.contracts.NamedByHash
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction)
+  @Nullable
+  public final net.corda.core.transactions.SignedTransaction get()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @Nullable
+  public final net.corda.core.transactions.SignedTransaction getNonSerialised()
+  @Nullable
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.SignedTransaction> getSerialized()
+  public final boolean isNull()
+  @NotNull
+  public final String payloadContentDescription()
+  public final int serializedByteCount()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.NotarisationPayload extends java.lang.Object
@@ -2561,6 +2806,11 @@ public final class net.corda.core.flows.NotaryChangeFlow extends net.corda.core.
 ##
 @CordaSerializable
 public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public static final net.corda.core.flows.NotaryError$Companion Companion
+  public static final int NUM_STATES = 5
+##
+public static final class net.corda.core.flows.NotaryError$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
@@ -2668,6 +2918,10 @@ public final class net.corda.core.flows.NotaryFlow extends java.lang.Object
 public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.internal.BackpressureAwareTimedFlow
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker, boolean)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.transactions.SignedTransaction, boolean)
+  public <init>(net.corda.core.transactions.SignedTransaction, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public java.util.List<net.corda.core.crypto.TransactionSignature> call()
@@ -2720,6 +2974,10 @@ public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.
   public net.corda.core.transactions.SignedTransaction call()
   @Suspendable
   protected void checkBeforeRecording(net.corda.core.transactions.SignedTransaction)
+##
+@CordaSerializable
+public final class net.corda.core.flows.ResultSerializationException extends net.corda.core.CordaRuntimeException
+  public <init>(net.corda.core.serialization.internal.MissingSerializerException)
 ##
 public @interface net.corda.core.flows.SchedulableFlow
 ##
@@ -2983,6 +3241,7 @@ public final class net.corda.core.identity.IdentityUtils extends java.lang.Objec
   public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>)
   @NotNull
   public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>, boolean)
+  public static final boolean x500Matches(String, boolean, net.corda.core.identity.CordaX500Name)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -3058,6 +3317,8 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   @NotNull
   public abstract java.time.Instant currentNodeTime()
   @NotNull
+  public abstract java.util.Map<String, Boolean> finishedFlowsWithClientIds()
+  @NotNull
   public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
   public abstract Iterable<String> getVaultTransactionNotes(net.corda.core.crypto.SecureHash)
@@ -3078,6 +3339,8 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<net.corda.core.messaging.ParametersUpdateInfo, net.corda.core.messaging.ParametersUpdateInfo> networkParametersFeed()
   @NotNull
+  public abstract net.corda.core.node.NodeDiagnosticInfo nodeDiagnosticInfo()
+  @NotNull
   public abstract net.corda.core.node.NodeInfo nodeInfo()
   @Nullable
   public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
@@ -3093,14 +3356,21 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
   @NotNull
   public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+  @RPCReturnsObservables
+  @Nullable
+  public abstract net.corda.core.messaging.FlowHandleWithClientId<T> reattachFlowWithClientId(String)
   public abstract void refreshNetworkMapCache()
   @NotNull
   public abstract java.util.List<String> registeredFlows()
+  public abstract boolean removeClientId(String)
   public abstract void setFlowsDrainingModeEnabled(boolean)
   public abstract void shutdown()
   @RPCReturnsObservables
   @NotNull
   public abstract net.corda.core.messaging.FlowHandle<T> startFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.FlowHandleWithClientId<T> startFlowDynamicWithClientId(String, Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
   @RPCReturnsObservables
   @NotNull
   public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
@@ -3190,6 +3460,36 @@ public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Obj
   @NotNull
   public final net.corda.core.messaging.FlowHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>)
   public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.messaging.FlowHandleWithClientId extends net.corda.core.messaging.FlowHandle
+  @NotNull
+  public abstract String getClientId()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.messaging.FlowHandleWithClientIdImpl extends java.lang.Object implements net.corda.core.messaging.FlowHandleWithClientId
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, String)
+  public void close()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<A> component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final net.corda.core.messaging.FlowHandleWithClientIdImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, String)
+  public boolean equals(Object)
+  @NotNull
+  public String getClientId()
   @NotNull
   public net.corda.core.flows.StateMachineRunId getId()
   @NotNull
@@ -3382,9 +3682,22 @@ public static final class net.corda.core.messaging.StateMachineUpdate$Removed ex
 @DoNotImplement
 public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.ServiceHub
   @NotNull
+  public abstract net.corda.core.node.services.vault.CordaTransactionSupport getDatabase()
+  public abstract void register(int, kotlin.jvm.functions.Function1<? super net.corda.core.node.services.ServiceLifecycleEvent, ? extends T>)
+  public abstract void register(int, net.corda.core.node.services.ServiceLifecycleObserver)
+  @NotNull
   public abstract net.corda.core.messaging.FlowHandle<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
   @NotNull
   public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  public static final net.corda.core.node.AppServiceHub$Companion Companion
+  public static final int SERVICE_PRIORITY_HIGH = 200
+  public static final int SERVICE_PRIORITY_LOW = 20
+  public static final int SERVICE_PRIORITY_NORMAL = 100
+##
+public static final class net.corda.core.node.AppServiceHub$Companion extends java.lang.Object
+  public static final int SERVICE_PRIORITY_HIGH = 200
+  public static final int SERVICE_PRIORITY_LOW = 20
+  public static final int SERVICE_PRIORITY_NORMAL = 100
 ##
 public @interface net.corda.core.node.AutoAcceptable
 ##
@@ -3435,6 +3748,34 @@ public final class net.corda.core.node.NetworkParameters extends java.lang.Objec
   public String toString()
 ##
 @CordaSerializable
+public final class net.corda.core.node.NodeDiagnosticInfo extends java.lang.Object
+  public <init>(String, String, int, String, java.util.List<net.corda.core.cordapp.CordappInfo>)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final java.util.List<net.corda.core.cordapp.CordappInfo> component5()
+  @NotNull
+  public final net.corda.core.node.NodeDiagnosticInfo copy(String, String, int, String, java.util.List<net.corda.core.cordapp.CordappInfo>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.cordapp.CordappInfo> getCordapps()
+  public final int getPlatformVersion()
+  @NotNull
+  public final String getRevision()
+  @NotNull
+  public final String getVendor()
+  @NotNull
+  public final String getVersion()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
 public final class net.corda.core.node.NodeInfo extends java.lang.Object
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
   @NotNull
@@ -3459,6 +3800,7 @@ public final class net.corda.core.node.NodeInfo extends java.lang.Object
   public final net.corda.core.identity.PartyAndCertificate identityAndCertFromX500Name(net.corda.core.identity.CordaX500Name)
   @NotNull
   public final net.corda.core.identity.Party identityFromX500Name(net.corda.core.identity.CordaX500Name)
+  public final boolean isLegalIdentity(net.corda.core.identity.CordaX500Name)
   public final boolean isLegalIdentity(net.corda.core.identity.Party)
   @NotNull
   public String toString()
@@ -3501,6 +3843,8 @@ public interface net.corda.core.node.ServiceHub extends net.corda.core.node.Serv
   public abstract java.time.Clock getClock()
   @NotNull
   public abstract net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public abstract net.corda.core.node.services.diagnostics.DiagnosticsService getDiagnosticsService()
   @NotNull
   public abstract net.corda.core.node.services.KeyManagementService getKeyManagementService()
   @NotNull
@@ -3550,6 +3894,8 @@ public interface net.corda.core.node.ServicesForResolution
   public abstract net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
   @NotNull
   public abstract java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public net.corda.core.transactions.LedgerTransaction specialise(net.corda.core.transactions.LedgerTransaction)
 ##
 public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
   public static net.corda.core.node.StatesToRecord valueOf(String)
@@ -3588,11 +3934,18 @@ public interface net.corda.core.node.services.ContractUpgradeService
 ##
 public @interface net.corda.core.node.services.CordaService
 ##
+public final class net.corda.core.node.services.CordaServiceCriticalFailureException extends java.lang.Exception
+  public <init>(String)
+  public <init>(String, Throwable)
+##
 @DoNotImplement
 public interface net.corda.core.node.services.IdentityService
   public abstract void assertOwnership(net.corda.core.identity.Party, net.corda.core.identity.AnonymousParty)
   @Nullable
   public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
+  @Suspendable
+  @Nullable
+  public abstract java.util.UUID externalIdForPublicKey(java.security.PublicKey)
   @NotNull
   public abstract Iterable<net.corda.core.identity.PartyAndCertificate> getAllIdentities()
   @NotNull
@@ -3606,6 +3959,9 @@ public interface net.corda.core.node.services.IdentityService
   @Nullable
   public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
   @NotNull
+  public abstract Iterable<java.security.PublicKey> publicKeysForExternalId(java.util.UUID)
+  public abstract void registerKey(java.security.PublicKey, net.corda.core.identity.Party, java.util.UUID)
+  @NotNull
   public abstract net.corda.core.identity.Party requireWellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
   @Nullable
   public abstract net.corda.core.identity.PartyAndCertificate verifyAndRegisterIdentity(net.corda.core.identity.PartyAndCertificate)
@@ -3615,6 +3971,9 @@ public interface net.corda.core.node.services.IdentityService
   public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
   @Nullable
   public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  public static final net.corda.core.node.services.IdentityService$Companion Companion
+##
+public static final class net.corda.core.node.services.IdentityService$Companion extends java.lang.Object
 ##
 @DoNotImplement
 public interface net.corda.core.node.services.KeyManagementService
@@ -3625,7 +3984,13 @@ public interface net.corda.core.node.services.KeyManagementService
   public abstract java.security.PublicKey freshKey()
   @Suspendable
   @NotNull
+  public abstract java.security.PublicKey freshKey(java.util.UUID)
+  @Suspendable
+  @NotNull
   public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean, java.util.UUID)
   @NotNull
   public abstract java.util.Set<java.security.PublicKey> getKeys()
   @Suspendable
@@ -3767,6 +4132,10 @@ public static final class net.corda.core.node.services.PartyInfo$SingleNode exte
   public int hashCode()
   @NotNull
   public String toString()
+##
+public final class net.corda.core.node.services.ServiceLifecycleEvent extends java.lang.Enum
+  public static net.corda.core.node.services.ServiceLifecycleEvent valueOf(String)
+  public static net.corda.core.node.services.ServiceLifecycleEvent[] values()
 ##
 public interface net.corda.core.node.services.ServiceLifecycleObserver
   public abstract void onServiceLifecycleEvent(net.corda.core.node.services.ServiceLifecycleEvent)
@@ -3996,6 +4365,8 @@ public static final class net.corda.core.node.services.Vault$UpdateType extends 
 @CordaSerializable
 public final class net.corda.core.node.services.VaultQueryException extends net.corda.core.flows.FlowException
   public <init>(String)
+  public <init>(String, Exception)
+  public <init>(String, Exception, int, kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 public interface net.corda.core.node.services.VaultService
@@ -4045,6 +4416,34 @@ public interface net.corda.core.node.services.VaultService
 public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
   public static final int MAX_CONSTRAINT_DATA_SIZE = 20000
 ##
+@DoNotImplement
+public interface net.corda.core.node.services.diagnostics.DiagnosticsService
+  @NotNull
+  public abstract net.corda.core.node.services.diagnostics.NodeVersionInfo nodeVersionInfo()
+##
+public final class net.corda.core.node.services.diagnostics.NodeVersionInfo extends java.lang.Object
+  public <init>(String, String, int, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.node.services.diagnostics.NodeVersionInfo copy(String, String, int, String)
+  public boolean equals(Object)
+  public final int getPlatformVersion()
+  @NotNull
+  public final String getReleaseVersion()
+  @NotNull
+  public final String getRevision()
+  @NotNull
+  public final String getVendor()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
 @CordaSerializable
 public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum
   public static net.corda.core.node.services.vault.AggregateFunctionType valueOf(String)
@@ -4071,9 +4470,13 @@ public static final class net.corda.core.node.services.vault.AttachmentQueryCrit
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria extends net.corda.core.node.services.vault.AttachmentQueryCriteria
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>, net.corda.core.node.services.vault.ColumnPredicate<Integer>)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
@@ -4582,6 +4985,10 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Nul
   @NotNull
   public String toString()
 ##
+@DoNotImplement
+public interface net.corda.core.node.services.vault.CordaTransactionSupport
+  public abstract T transaction(kotlin.jvm.functions.Function1<? super net.corda.core.node.services.vault.SessionScope, ? extends T>)
+##
 @CordaSerializable
 public abstract class net.corda.core.node.services.vault.CriteriaExpression extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
@@ -4779,6 +5186,10 @@ public abstract static class net.corda.core.node.services.vault.QueryCriteria$Co
   @Nullable
   public abstract java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
   @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
+  @NotNull
+  public java.util.List<java.util.UUID> getExternalIds()
+  @Nullable
   public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   @NotNull
   public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
@@ -4789,17 +5200,30 @@ public abstract static class net.corda.core.node.services.vault.QueryCriteria$Co
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  @DeprecatedConstructorForDeserialization
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component1()
   @Nullable
@@ -4816,13 +5240,19 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component7()
   @NotNull
   public final net.corda.core.node.services.Vault$RelevancyStatus component8()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component9()
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> getIssuer()
   @Nullable
@@ -4844,6 +5274,8 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withExactParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withIssuer(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
@@ -4905,18 +5337,33 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  @DeprecatedConstructorForDeserialization
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component1()
@@ -4930,13 +5377,19 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Linea
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component5()
   @NotNull
   public final net.corda.core.node.services.Vault$RelevancyStatus component6()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component7()
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
   @Nullable
   public final java.util.List<String> getExternalId()
   @Nullable
@@ -4954,6 +5407,8 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Linea
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withExactParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withExternalId(java.util.List<String>)
   @NotNull
@@ -5024,9 +5479,13 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$TimeI
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
   public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
@@ -5068,19 +5527,38 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
   public <init>()
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @DeprecatedConstructorForDeserialization
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  @DeprecatedConstructorForDeserialization
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, java.util.List, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.Vault$StateStatus component1()
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component10()
+  @NotNull
+  public final java.util.List<java.util.UUID> component11()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component12()
   @Nullable
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component2()
   @Nullable
@@ -5101,6 +5579,10 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   @NotNull
   public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo$Type> getConstraintTypes()
@@ -5108,6 +5590,10 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo> getConstraints()
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getExactParticipants()
+  @NotNull
+  public java.util.List<java.util.UUID> getExternalIds()
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> getNotary()
   @Nullable
@@ -5133,6 +5619,10 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withConstraints(java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withExactParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withExternalIds(java.util.List<java.util.UUID>)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withNotary(java.util.List<? extends net.corda.core.identity.AbstractParty>)
   @NotNull
@@ -5161,6 +5651,11 @@ public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends
   public static final int DEFAULT_PAGE_NUM = 1
   public static final int DEFAULT_PAGE_SIZE = 200
   public static final int MAX_PAGE_SIZE = 2147483646
+##
+@DoNotImplement
+public interface net.corda.core.node.services.vault.SessionScope
+  @NotNull
+  public abstract org.hibernate.Session getSession()
 ##
 @CordaSerializable
 public final class net.corda.core.node.services.vault.Sort extends net.corda.core.node.services.vault.BaseSort
@@ -5273,6 +5768,10 @@ public static final class net.corda.core.node.services.vault.SortAttribute$Stand
   public int hashCode()
   @NotNull
   public String toString()
+##
+public final class net.corda.core.observable.Observables extends java.lang.Object
+  @NotNull
+  public static final rx.Observable<T> continueOnError(rx.Observable<T>)
 ##
 public final class net.corda.core.schemas.CommonSchema extends java.lang.Object
   public static final net.corda.core.schemas.CommonSchema INSTANCE
@@ -5441,6 +5940,14 @@ public final class net.corda.core.serialization.MissingAttachmentsException exte
   @NotNull
   public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
 ##
+@CordaSerializable
+public final class net.corda.core.serialization.MissingAttachmentsRuntimeException extends net.corda.core.CordaRuntimeException
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>, String)
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>, String, Throwable)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
+##
 public final class net.corda.core.serialization.ObjectWithCompatibleContext extends java.lang.Object
   public <init>(T, net.corda.core.serialization.SerializationContext)
   @NotNull
@@ -5468,6 +5975,7 @@ public final class net.corda.core.serialization.SerializationAPIKt extends java.
 ##
 @DoNotImplement
 public interface net.corda.core.serialization.SerializationContext
+  public abstract boolean getCarpenterDisabled()
   @NotNull
   public abstract java.util.Set<net.corda.core.serialization.SerializationCustomSerializer<?, ?>> getCustomSerializers()
   @NotNull
@@ -5507,6 +6015,8 @@ public interface net.corda.core.serialization.SerializationContext
   public abstract net.corda.core.serialization.SerializationContext withProperty(Object, Object)
   @NotNull
   public abstract net.corda.core.serialization.SerializationContext withWhitelisted(Class<?>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withoutCarpenter()
   @NotNull
   public abstract net.corda.core.serialization.SerializationContext withoutReferences()
 ##
@@ -5710,6 +6220,7 @@ public static final class net.corda.core.transactions.ContractUpgradeFilteredTra
 @DoNotImplement
 public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List, net.corda.core.node.NetworkParameters, net.corda.core.contracts.UpgradedContract, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
   @NotNull
@@ -5760,6 +6271,10 @@ public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction 
   public int hashCode()
   @NotNull
   public String toString()
+  public static final net.corda.core.transactions.ContractUpgradeLedgerTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.ContractUpgradeLedgerTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -5893,6 +6408,7 @@ public abstract class net.corda.core.transactions.FullTransaction extends net.co
 public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters, java.util.List, java.util.List, java.util.List, java.util.List, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function2, net.corda.core.serialization.internal.AttachmentsClassLoaderCache, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.Command<T>> commandsOfType(Class<T>)
   @NotNull
@@ -6208,6 +6724,7 @@ public final class net.corda.core.transactions.SignedTransaction extends java.la
   public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable<net.corda.core.crypto.TransactionSignature>)
   public static final net.corda.core.transactions.SignedTransaction$Companion Companion
 ##
+@CordaSerializable
 public static final class net.corda.core.transactions.SignedTransaction$SignaturesMissingException extends java.security.SignatureException implements net.corda.core.CordaThrowable, net.corda.core.contracts.NamedByHash
   public <init>(java.util.Set<? extends java.security.PublicKey>, java.util.List<String>, net.corda.core.crypto.SecureHash)
   public void addSuppressed(Throwable[])
@@ -6254,6 +6771,8 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, net.corda.core.contracts.AttachmentConstraint)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, net.corda.core.identity.Party)
   @NotNull
@@ -6501,6 +7020,8 @@ public final class net.corda.core.utilities.KotlinUtilsKt extends java.lang.Obje
   @NotNull
   public static final org.slf4j.Logger contextLogger(Object)
   public static final void debug(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
+  @NotNull
+  public static final org.slf4j.Logger detailedLogger()
   public static final int exactAdd(int, int)
   public static final long exactAdd(long, long)
   @NotNull
@@ -6647,6 +7168,7 @@ public final class net.corda.core.utilities.ProgressTracker extends java.lang.Ob
   public final net.corda.core.utilities.ProgressTracker$Step nextStep()
   public final void setChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step, net.corda.core.utilities.ProgressTracker)
   public final void setCurrentStep(net.corda.core.utilities.ProgressTracker$Step)
+  public static final net.corda.core.utilities.ProgressTracker$Companion Companion
 ##
 @CordaSerializable
 public abstract static class net.corda.core.utilities.ProgressTracker$Change extends java.lang.Object
@@ -6723,12 +7245,14 @@ public static class net.corda.core.utilities.ProgressTracker$Step extends java.l
   public <init>(String)
   @Nullable
   public net.corda.core.utilities.ProgressTracker childProgressTracker()
+  public boolean equals(Object)
   @NotNull
   public rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
   @NotNull
   public java.util.Map<String, String> getExtraAuditData()
   @NotNull
   public String getLabel()
+  public int hashCode()
 ##
 @CordaSerializable
 public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED extends net.corda.core.utilities.ProgressTracker$Step
@@ -6737,6 +7261,10 @@ public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED ext
 ##
 public interface net.corda.core.utilities.PropertyDelegate
   public abstract T getValue(Object, kotlin.reflect.KProperty<?>)
+##
+public final class net.corda.core.utilities.SgxSupport extends java.lang.Object
+  public static final boolean isInsideEnclave()
+  public static final net.corda.core.utilities.SgxSupport INSTANCE
 ##
 @CordaSerializable
 public abstract class net.corda.core.utilities.Try extends java.lang.Object
@@ -6917,6 +7445,10 @@ public final class net.corda.testing.contracts.DummyContractV2 extends java.lang
   @NotNull
   public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
   @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
+  @NotNull
   public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
   public void verify(net.corda.core.transactions.LedgerTransaction)
   public static final net.corda.testing.contracts.DummyContractV2$Companion Companion
@@ -6933,6 +7465,10 @@ public static final class net.corda.testing.contracts.DummyContractV2$Commands$M
 ##
 public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContractV2$State>, net.corda.core.identity.AbstractParty)
 ##
 public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
   public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
@@ -6951,6 +7487,8 @@ public static final class net.corda.testing.contracts.DummyContractV2$State exte
   public int hashCode()
   @NotNull
   public String toString()
+  @NotNull
+  public final kotlin.Pair<net.corda.testing.contracts.DummyContractV2$Commands, net.corda.testing.contracts.DummyContractV2$State> withNewOwner(net.corda.core.identity.AbstractParty)
 ##
 public final class net.corda.testing.contracts.DummyContractV3 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
   public <init>()
@@ -7439,6 +7977,7 @@ public class net.corda.client.jackson.StringToMethodCallParser extends java.lang
   public final net.corda.client.jackson.StringToMethodCallParser<T>.ParsedMethodCall parse(T, String)
   @NotNull
   public final Object[] parseArguments(String, java.util.List<? extends kotlin.Pair<String, ? extends reflect.Type>>, String)
+  public final void validateIsMatchingCtor(String, java.util.List<? extends kotlin.Pair<String, ? extends reflect.Type>>, String)
   public static final net.corda.client.jackson.StringToMethodCallParser$Companion Companion
 ##
 public static final class net.corda.client.jackson.StringToMethodCallParser$Companion extends java.lang.Object
@@ -7467,6 +8006,9 @@ public static final class net.corda.client.jackson.StringToMethodCallParser$Unpa
   @NotNull
   public final String getParamName()
 ##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$NoSuchFile extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String)
+##
 public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$ReflectionDataMissing extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
   public <init>(String, int)
 ##
@@ -7480,6 +8022,8 @@ public static final class net.corda.client.jackson.StringToMethodCallParser$Unpa
 ##
 public final class net.corda.testing.driver.Driver extends java.lang.Object
   public static final A driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1<? super net.corda.testing.driver.DriverDSL, ? extends A>)
+  @NotNull
+  public static final java.io.File logFile(net.corda.testing.driver.NodeHandle)
 ##
 @DoNotImplement
 public interface net.corda.testing.driver.DriverDSL
@@ -7493,12 +8037,15 @@ public interface net.corda.testing.driver.DriverDSL
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> getDefaultNotaryNode()
   @NotNull
   public abstract java.util.List<net.corda.testing.driver.NotaryHandle> getNotaryHandles()
+  public abstract int nextPort()
   @NotNull
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode()
   @NotNull
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters)
   @NotNull
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, String)
   @NotNull
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle)
   @NotNull
@@ -7512,6 +8059,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
   public final boolean component1()
   @NotNull
@@ -7525,6 +8074,13 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final boolean component14()
   @Nullable
   public final java.util.Collection<net.corda.testing.node.TestCordapp> component15()
+  @Nullable
+  public final java.nio.file.Path component16()
+  @NotNull
+  public final java.util.List<java.nio.file.Path> component17()
+  @NotNull
+  public final java.util.Map<String, String> component18()
+  public final boolean component19()
   @NotNull
   public final java.nio.file.Path component2()
   @NotNull
@@ -7543,14 +8099,23 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean)
+  @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
   public boolean equals(Object)
+  public final boolean getAllowHibernateToManageAppSchema()
   @Nullable
   public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
   @NotNull
   public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
+  @Nullable
+  public final java.nio.file.Path getDjvmBootstrapSource()
+  @NotNull
+  public final java.util.List<java.nio.file.Path> getDjvmCordaSource()
   @NotNull
   public final java.nio.file.Path getDriverDirectory()
+  @NotNull
+  public final java.util.Map<String, String> getEnvironmentVariables()
   @NotNull
   public final java.util.List<String> getExtraCordappPackagesToScan()
   public final boolean getInMemoryDB()
@@ -7574,11 +8139,19 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   @NotNull
   public String toString()
   @NotNull
+  public final net.corda.testing.driver.DriverParameters withAllowHibernateToManageAppSchema(boolean)
+  @NotNull
   public final net.corda.testing.driver.DriverParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
   @NotNull
+  public final net.corda.testing.driver.DriverParameters withDjvmBootstrapSource(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDjvmCordaSource(java.util.List<? extends java.nio.file.Path>)
+  @NotNull
   public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withEnvironmentVariables(java.util.Map<String, String>)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(java.util.List<String>)
   @NotNull
@@ -7664,6 +8237,8 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
   public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
   public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.core.identity.CordaX500Name component1()
   @NotNull
@@ -7680,10 +8255,14 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   public final java.util.Collection<net.corda.testing.node.TestCordapp> component7()
   @NotNull
   public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> component8()
+  @Nullable
+  public final String component9()
   @NotNull
   public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
   @NotNull
   public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>, String)
   public boolean equals(Object)
   @NotNull
   public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
@@ -7691,6 +8270,8 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   public final java.util.Map<String, Object> getCustomOverrides()
   @NotNull
   public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> getFlowOverrides()
+  @Nullable
+  public final String getLogLevelOverride()
   @NotNull
   public final String getMaximumHeapSize()
   @Nullable
@@ -7710,6 +8291,8 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   public final net.corda.testing.driver.NodeParameters withCustomOverrides(java.util.Map<String, ?>)
   @NotNull
   public final net.corda.testing.driver.NodeParameters withFlowOverrides(java.util.Map<Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withLogLevelOverride(String)
   @NotNull
   public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
   @NotNull
@@ -7749,8 +8332,18 @@ public interface net.corda.testing.driver.OutOfProcess extends net.corda.testing
 public abstract class net.corda.testing.driver.PortAllocation extends java.lang.Object
   public <init>()
   @NotNull
+  public static final net.corda.testing.driver.PortAllocation getDefaultAllocator()
+  @NotNull
   public final net.corda.core.utilities.NetworkHostAndPort nextHostAndPort()
   public abstract int nextPort()
+  public static final net.corda.testing.driver.PortAllocation$Companion Companion
+  public static final int DEFAULT_START_PORT = 10000
+  public static final int FIRST_EPHEMERAL_PORT = 30000
+##
+public static final class net.corda.testing.driver.PortAllocation$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getDefaultAllocator()
 ##
 @DoNotImplement
 public static class net.corda.testing.driver.PortAllocation$Incremental extends net.corda.testing.driver.PortAllocation
@@ -7758,6 +8351,11 @@ public static class net.corda.testing.driver.PortAllocation$Incremental extends 
   @NotNull
   public final java.util.concurrent.atomic.AtomicInteger getPortCounter()
   public int nextPort()
+##
+@DoNotImplement
+public class net.corda.testing.driver.SharedMemoryIncremental extends net.corda.testing.driver.PortAllocation
+  public int nextPort()
+  public static net.corda.testing.driver.SharedMemoryIncremental INSTANCE
 ##
 public final class net.corda.testing.driver.VerifierType extends java.lang.Enum
   public static net.corda.testing.driver.VerifierType valueOf(String)
@@ -7779,6 +8377,22 @@ public final class net.corda.testing.driver.WebserverHandle extends java.lang.Ob
   public int hashCode()
   @NotNull
   public String toString()
+##
+public final class net.corda.testing.flows.FlowTestsUtilsKt extends java.lang.Object
+  @NotNull
+  public static final kotlin.Pair<net.corda.core.flows.FlowSession, T> from(T, net.corda.core.flows.FlowSession)
+  @NotNull
+  public static final R from(java.util.Map<net.corda.core.flows.FlowSession, ? extends net.corda.core.utilities.UntrustworthyData<?>>, net.corda.core.flows.FlowSession)
+  @NotNull
+  public static final kotlin.Pair<net.corda.core.flows.FlowSession, Class<T>> from(kotlin.reflect.KClass<T>, net.corda.core.flows.FlowSession)
+  @Suspendable
+  @NotNull
+  public static final java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(net.corda.core.flows.FlowLogic<?>, Class<R>, net.corda.core.flows.FlowSession, net.corda.core.flows.FlowSession...)
+  @Suspendable
+  @NotNull
+  public static final java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAll(net.corda.core.flows.FlowLogic<?>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>...)
+  @NotNull
+  public static final rx.Observable<T> registerCoreFlowFactory(net.corda.testing.node.internal.TestStartedNode, Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<T>, kotlin.jvm.functions.Function1<? super net.corda.core.flows.FlowSession, ? extends T>, boolean)
 ##
 @DoNotImplement
 public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
@@ -7973,16 +8587,21 @@ public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lan
   public <init>(net.corda.core.identity.CordaX500Name)
   public <init>(net.corda.core.identity.CordaX500Name, boolean)
   public <init>(net.corda.core.identity.CordaX500Name, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, String)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.identity.CordaX500Name component1()
   public final boolean component2()
   @NotNull
   public final net.corda.testing.node.MockNetworkNotarySpec copy(net.corda.core.identity.CordaX500Name, boolean)
   public boolean equals(Object)
+  @Nullable
+  public final String getClassName()
   @NotNull
   public final net.corda.core.identity.CordaX500Name getName()
   public final boolean getValidating()
   public int hashCode()
+  public final void setClassName(String)
   @NotNull
   public String toString()
 ##
@@ -8099,6 +8718,7 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
   public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair[], net.corda.core.node.services.KeyManagementService)
   public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
   public <init>(Iterable, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
@@ -8111,6 +8731,8 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.nodeapi.internal.cordapp.CordappLoader, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity, java.security.KeyPair[], net.corda.core.node.services.KeyManagementService, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
   public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
   public final void addMockCordapp(String)
@@ -8140,6 +8762,8 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public final ClassLoader getCordappClassloader()
   @NotNull
   public net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public net.corda.core.node.services.diagnostics.DiagnosticsService getDiagnosticsService()
   @NotNull
   public net.corda.core.node.services.IdentityService getIdentityService()
   @NotNull
@@ -8174,6 +8798,12 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
   @NotNull
   public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>, net.corda.testing.internal.TestingNamedCacheFactory)
   public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
   public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
   public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
@@ -8202,6 +8832,12 @@ public static final class net.corda.testing.node.MockServices$Companion extends 
   public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
   @NotNull
   public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>, net.corda.testing.internal.TestingNamedCacheFactory)
 ##
 public final class net.corda.testing.node.MockServicesKt extends java.lang.Object
   @NotNull
@@ -8228,6 +8864,10 @@ public final class net.corda.testing.node.NotarySpec extends java.lang.Object
   public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String)
   public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String, boolean)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, boolean)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.identity.CordaX500Name component1()
   public final boolean component2()
@@ -8237,8 +8877,11 @@ public final class net.corda.testing.node.NotarySpec extends java.lang.Object
   public final net.corda.testing.driver.VerifierType component4()
   @Nullable
   public final net.corda.testing.node.ClusterSpec component5()
+  public final boolean component6()
   @NotNull
   public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  @NotNull
+  public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, boolean)
   public boolean equals(Object)
   @Nullable
   public final net.corda.testing.node.ClusterSpec getCluster()
@@ -8248,6 +8891,7 @@ public final class net.corda.testing.node.NotarySpec extends java.lang.Object
   public final net.corda.core.identity.CordaX500Name getName()
   @NotNull
   public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  public final boolean getStartInProcess()
   public final boolean getValidating()
   @NotNull
   public final net.corda.testing.driver.VerifierType getVerifierType()
@@ -8307,6 +8951,8 @@ public final class net.corda.testing.node.UnstartedMockNode extends java.lang.Ob
   public final int getId()
   @NotNull
   public final net.corda.testing.node.StartedMockNode getStarted()
+  @NotNull
+  public final T installCordaService(Class<T>)
   public final boolean isStarted()
   @NotNull
   public final net.corda.testing.node.StartedMockNode start()
@@ -8343,28 +8989,46 @@ public class net.corda.client.rpc.ConnectionFailureException extends net.corda.c
 ##
 public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
   public <init>(java.util.List, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(java.util.List, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
   public <init>(net.corda.core.utilities.NetworkHostAndPort)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.client.rpc.CordaRPCConnection start(String, String)
   @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.client.rpc.GracefulReconnect)
+  @NotNull
   public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.client.rpc.GracefulReconnect)
   @NotNull
   public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
   @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name, net.corda.client.rpc.GracefulReconnect)
+  @NotNull
   public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.identity.CordaX500Name, net.corda.client.rpc.GracefulReconnect)
   public final A use(String, String, kotlin.jvm.functions.Function1<? super net.corda.client.rpc.CordaRPCConnection, ? extends A>)
   public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
 ##
@@ -8440,12 +9104,33 @@ public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Compa
 @DoNotImplement
 public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
   public <init>(net.corda.client.rpc.RPCConnection<? extends net.corda.core.messaging.CordaRPCOps>)
+  public <init>(net.corda.client.rpc.RPCConnection, java.util.concurrent.ExecutorService, net.corda.client.rpc.internal.ReconnectingCordaRPCOps, kotlin.jvm.internal.DefaultConstructorMarker)
   public void close()
   public void forceClose()
   @NotNull
   public net.corda.core.messaging.CordaRPCOps getProxy()
   public int getServerProtocolVersion()
   public void notifyServerAndClose()
+  public static final net.corda.client.rpc.CordaRPCConnection$Companion Companion
+##
+public static final class net.corda.client.rpc.CordaRPCConnection$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.rpc.GracefulReconnect extends java.lang.Object
+  public <init>()
+  public <init>(Runnable, Runnable)
+  public <init>(Runnable, Runnable, int)
+  public <init>(Runnable, Runnable, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(kotlin.jvm.functions.Function0<kotlin.Unit>, kotlin.jvm.functions.Function0<kotlin.Unit>, int)
+  public <init>(kotlin.jvm.functions.Function0, kotlin.jvm.functions.Function0, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int getMaxAttempts()
+  @NotNull
+  public final kotlin.jvm.functions.Function0<kotlin.Unit> getOnDisconnect()
+  @NotNull
+  public final kotlin.jvm.functions.Function0<kotlin.Unit> getOnReconnect()
+##
+public final class net.corda.client.rpc.MaxRpcRetryException extends net.corda.client.rpc.RPCException
+  public <init>(int, reflect.Method, Throwable)
 ##
 public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException implements net.corda.core.ClientRelevantError, net.corda.nodeapi.exceptions.RpcSerializableError
   public <init>(String)
@@ -8454,6 +9139,7 @@ public final class net.corda.client.rpc.PermissionException extends net.corda.co
 ##
 @DoNotImplement
 public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
+  public abstract void close()
   public abstract void forceClose()
   @NotNull
   public abstract I getProxy()
@@ -8473,59 +9159,6 @@ public class net.corda.client.rpc.UnrecoverableRPCException extends net.corda.cl
 ##
 public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
   public static final void notUsed(rx.Observable<T>)
-##
-public final class net.corda.client.rpc.ext.MultiRPCClient extends java.lang.Object implements java.lang.AutoCloseable
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
-  public <init>(java.util.List, Class, String, String, java.util.Set, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
-  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(java.util.List, Class, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, ClassLoader, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, ClassLoader, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, java.util.Set, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public final boolean addConnectionListener(net.corda.client.rpc.ext.RPCConnectionListener<I>)
-  public void close()
-  public final boolean removeConnectionListener(net.corda.client.rpc.ext.RPCConnectionListener<I>)
-  @NotNull
-  public final java.util.concurrent.CompletableFuture<net.corda.client.rpc.RPCConnection<I>> start()
-  public final void stop()
-  public static final net.corda.client.rpc.ext.MultiRPCClient$Companion Companion
-##
-public interface net.corda.client.rpc.ext.RPCConnectionListener
-  public abstract void onConnect(net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext<I>)
-  public abstract void onDisconnect(net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext<I>)
-  public abstract void onPermanentFailure(net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext<I>)
-##
-public static interface net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext
-  @Nullable
-  public abstract net.corda.client.rpc.RPCConnection<I> getConnectionOpt()
-  @Nullable
-  public abstract Throwable getThrowableOpt()
-  @NotNull
-  public abstract String getUserName()
 ##
 public final class net.corda.client.rpc.reconnect.CouldNotStartFlowException extends net.corda.client.rpc.RPCException
   public <init>()

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -9160,6 +9160,64 @@ public class net.corda.client.rpc.UnrecoverableRPCException extends net.corda.cl
 public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
   public static final void notUsed(rx.Observable<T>)
 ##
+public final class net.corda.client.rpc.ext.MultiRPCClient extends java.lang.Object implements java.lang.AutoCloseable
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
+  public <init>(java.util.List, Class, String, String, java.util.Set, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(java.util.List, Class, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, ClassLoader, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, ClassLoader, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, java.util.Set, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class<I>, String, String, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Class, String, String, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean addConnectionListener(net.corda.client.rpc.ext.RPCConnectionListener<I>)
+  public void close()
+  public final boolean removeConnectionListener(net.corda.client.rpc.ext.RPCConnectionListener<I>)
+  @NotNull
+  public final java.util.concurrent.CompletableFuture<net.corda.client.rpc.RPCConnection<I>> start()
+  public final void stop()
+  public static final net.corda.client.rpc.ext.MultiRPCClient$Companion Companion
+##
+public interface net.corda.client.rpc.ext.RPCConnectionListener
+  public abstract void onConnect(net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext<I>)
+  public abstract void onDisconnect(net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext<I>)
+  public abstract void onPermanentFailure(net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext<I>)
+##
+public static interface net.corda.client.rpc.ext.RPCConnectionListener$ConnectionContext
+  @Nullable
+  public abstract net.corda.client.rpc.RPCConnection<I> getConnectionOpt()
+  @Nullable
+  public abstract Throwable getThrowableOpt()
+  @NotNull
+  public abstract String getUserName()
+##
+public final class net.corda.client.rpc.reconnect.CouldNotStartFlowException extends net.corda.client.rpc.RPCException
+  public <init>()
+  public <init>(Throwable)
+  public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
 public final class net.corda.client.rpc.reconnect.CouldNotStartFlowException extends net.corda.client.rpc.RPCException
   public <init>()
   public <init>(Throwable)


### PR DESCRIPTION
Corda 4.7 did not receive an api-current update when the release branch was created. This PR is to perform the update now.

Steps taken:
- Generate api-current on the 4.6 branch
- Replace the 4.7 api-current with the generated 4.6 version
- Go through all PRs affecting api-current on the 4.7 branch and reapply changes
- Track down remaining changes that trigger a build failure and identify PR that introduced them

PRs that update api-current:
- PR #6644

One PR was found to trigger the API check:
- PR #6644 - NodeParameters gained 1 new parameter
