### PR TITLE
ENT-5492: Don't do reconnect logic on illegal argument for attachments

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -320,7 +320,7 @@ class ReconnectingCordaRPCOps private constructor(
             checkIfClosed()
             var remainingAttempts = maxNumberOfAttempts
             var lastException: Throwable? = null
-            while (remainingAttempts != 0 && !reconnectingRPCConnection.isClosed()) {
+            loop@ while (remainingAttempts != 0 && !reconnectingRPCConnection.isClosed()) {
                 try {
                     log.debug { "Invoking RPC $method..." }
                     return method.invoke(reconnectingRPCConnection.proxy, *(args ?: emptyArray())).also {
@@ -352,6 +352,10 @@ class ReconnectingCordaRPCOps private constructor(
                         }
                         is PermissionException -> {
                             throw RPCException("User does not have permission to perform operation ${method.name}.", e)
+                        }
+                        is IllegalArgumentException -> {
+                            log.warn("Failed to perform operation ${method.name}.", e)
+                            break@loop
                         }
                         else -> {
                             log.warn("Failed to perform operation ${method.name}.", e)

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -38,6 +38,7 @@ import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.seconds
+import net.corda.nodeapi.exceptions.MissingAttachmentException
 import net.corda.nodeapi.exceptions.RejectedCommandException
 import org.apache.activemq.artemis.api.core.ActiveMQConnectionTimedOutException
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
@@ -353,7 +354,7 @@ class ReconnectingCordaRPCOps private constructor(
                         is PermissionException -> {
                             throw RPCException("User does not have permission to perform operation ${method.name}.", e)
                         }
-                        is IllegalArgumentException -> {
+                        is MissingAttachmentException -> {
                             log.warn("Failed to perform operation ${method.name}.", e)
                             break@loop
                         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
@@ -36,6 +36,12 @@ class RejectedCommandException(message: String) :
         @Suppress("DEPRECATION") net.corda.core.ClientRelevantError
 
 /**
+ * Thrown to indicate that the command was rejected by the node, typically due to a special temporary mode.
+ */
+class MissingAttachmentException(message: String) :
+        CordaRuntimeException(message)
+
+/**
  * Allows an implementing [Throwable] to be propagated to RPC clients.
  */
 @Deprecated("Use ClientRelevantError instead.", replaceWith = ReplaceWith("ClientRelevantError"))

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -56,6 +56,7 @@ import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.rpc.CheckpointDumperImpl
 import net.corda.node.services.rpc.context
 import net.corda.node.services.statemachine.StateMachineManager
+import net.corda.nodeapi.exceptions.MissingAttachmentException
 import net.corda.nodeapi.exceptions.NonRpcFlowException
 import net.corda.nodeapi.exceptions.RejectedCommandException
 import rx.Observable
@@ -287,7 +288,7 @@ internal class CordaRPCOpsImpl(
 
     override fun openAttachment(id: SecureHash): InputStream {
         return services.attachments.openAttachment(id)?.open() ?:
-            throw IllegalArgumentException("Unable to open attachment with id: $id")
+            throw MissingAttachmentException("Unable to open attachment with id: $id")
     }
 
     override fun uploadAttachment(jar: InputStream): SecureHash {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.node.internal
 
-import net.corda.client.rpc.RPCException
 import net.corda.client.rpc.notUsed
 import net.corda.common.logging.CordaVersion
 import net.corda.core.CordaRuntimeException
@@ -288,7 +287,7 @@ internal class CordaRPCOpsImpl(
 
     override fun openAttachment(id: SecureHash): InputStream {
         return services.attachments.openAttachment(id)?.open() ?:
-            throw RPCException("Unable to open attachment with id: $id")
+            throw IllegalArgumentException("Unable to open attachment with id: $id")
     }
 
     override fun uploadAttachment(jar: InputStream): SecureHash {

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -40,6 +40,7 @@ import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.node.services.rpc.CURRENT_RPC_CONTEXT
 import net.corda.node.services.rpc.RpcAuthContext
+import net.corda.nodeapi.exceptions.MissingAttachmentException
 import net.corda.nodeapi.exceptions.NonRpcFlowException
 import net.corda.nodeapi.internal.config.User
 import net.corda.testing.core.ALICE_NAME
@@ -360,7 +361,7 @@ class CordaRPCOpsImplTest {
         withPermissions(invokeRpc(CordaRPCOps::openAttachment)) {
             assertThatThrownBy {
                 rpc.openAttachment(SecureHash.zeroHash)
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(MissingAttachmentException::class.java)
                     .withFailMessage("Unable to open attachment with id: ${SecureHash.zeroHash}")
         }
     }

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -2,7 +2,6 @@ package net.corda.node
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.client.rpc.PermissionException
-import net.corda.client.rpc.RPCException
 import net.corda.core.context.AuthServiceId
 import net.corda.core.context.InvocationContext
 import net.corda.core.contracts.Amount
@@ -361,7 +360,7 @@ class CordaRPCOpsImplTest {
         withPermissions(invokeRpc(CordaRPCOps::openAttachment)) {
             assertThatThrownBy {
                 rpc.openAttachment(SecureHash.zeroHash)
-            }.isInstanceOf(RPCException::class.java)
+            }.isInstanceOf(IllegalArgumentException::class.java)
                     .withFailMessage("Unable to open attachment with id: ${SecureHash.zeroHash}")
         }
     }


### PR DESCRIPTION
There's no point for these errors as they're always going to fail.

So now we'll warn about the error and be done with it.