### PR TITLE
CORDA-3924: Add a missing exit code for graceful shutdowns

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -643,7 +643,9 @@ object InteractiveShell {
     }
 
     @JvmStatic
-    fun gracefulShutdown(userSessionOut: RenderPrintWriter, cordaRPCOps: CordaRPCOps) {
+    fun gracefulShutdown(userSessionOut: RenderPrintWriter, cordaRPCOps: CordaRPCOps): Int {
+
+        var result = 0 // assume it all went well
 
         fun display(statements: RenderPrintWriter.() -> Unit) {
             statements.invoke(userSessionOut)
@@ -688,13 +690,16 @@ object InteractiveShell {
                 // Cancelled whilst draining flows.  So let's carry on from here
                 cordaRPCOps.setFlowsDrainingModeEnabled(false)
                 display { println("...cancelled clean shutdown.") }
+                result = 1
             }
         } catch (e: Exception) {
             display { println("RPC failed: ${e.rootCause}", Color.red) }
+            result = 1
         } finally {
             InputStreamSerializer.invokeContext = null
             InputStreamDeserializer.closeAll()
         }
+        return result;
     }
 
     private fun printAndFollowRPCResponse(


### PR DESCRIPTION
This helps with QA testing the results.  I had a quick check and didn't see other places where we were forgetting to return a code.

Example before and after in the screenshot:

![image](https://user-images.githubusercontent.com/8395358/92600626-bc3e1e00-f2a3-11ea-9ab8-62d9da4b2e83.png)
