### PR TITLE
INFRA-687 Change to use an out of process node

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
@@ -99,7 +99,7 @@ class ScheduledFlowIntegrationTests {
     @Test(timeout=300_000)
 	fun `test that when states are being spent at the same time that schedules trigger everything is processed`() {
         driver(DriverParameters(
-                startNodesInProcess = true,
+                startNodesInProcess = false,
                 cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, cordappWithPackages("net.corda.testMessage"), enclosedCordapp())
         )) {
             val N = 23

--- a/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
@@ -89,10 +89,7 @@ class ScheduledFlowIntegrationTests {
 
     private fun MutableList<CordaFuture<*>>.getOrThrowAll() {
         forEach {
-            try {
-                it.getOrThrow()
-            } catch (ex: Exception) {
-            }
+            it.getOrThrow()
         }
     }
 
@@ -100,7 +97,7 @@ class ScheduledFlowIntegrationTests {
 	fun `test that when states are being spent at the same time that schedules trigger everything is processed`() {
         driver(DriverParameters(
                 startNodesInProcess = false,
-                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, cordappWithPackages("net.corda.testMessage"), enclosedCordapp())
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, cordappWithPackages("net.corda.testMessage", "net.corda.testing.core"), enclosedCordapp())
         )) {
             val N = 23
             val rpcUser = User("admin", "admin", setOf("ALL"))
@@ -127,6 +124,7 @@ class ScheduledFlowIntegrationTests {
                         scheduledFor
                 ).returnValue)
             }
+
             initialiseFutures.getOrThrowAll()
 
             val spendAttemptFutures = mutableListOf<CordaFuture<*>>()
@@ -134,6 +132,7 @@ class ScheduledFlowIntegrationTests {
                 spendAttemptFutures.add(aliceClient.proxy.startFlow(::AnotherFlow, (i).toString()).returnValue)
                 spendAttemptFutures.add(bobClient.proxy.startFlow(::AnotherFlow, (i + 100).toString()).returnValue)
             }
+
             spendAttemptFutures.getOrThrowAll()
 
             // TODO: the queries below are not atomic so we need to allow enough time for the scheduler to finish.  Would be better to query scheduler.
@@ -144,7 +143,7 @@ class ScheduledFlowIntegrationTests {
 
             val bobStates = bobClient.proxy.vaultQuery(ScheduledState::class.java).states.filter { it.state.data.processed }
             val bobSpentStates = bobClient.proxy.vaultQuery(SpentState::class.java).states
-
+            
             assertEquals(aliceStates.count() + aliceSpentStates.count(), N * 2)
             assertEquals(bobStates.count() + bobSpentStates.count(), N * 2)
             assertEquals(aliceSpentStates.count(), bobSpentStates.count())


### PR DESCRIPTION
Investigation as part of ongoing temperamental failures relating to dirty AMPQ disconnects
[Ticket](https://r3-cev.atlassian.net/browse/INFRA-687)

- https://ci02.dev.r3.com/blue/organizations/jenkins/Corda-Enterprise%2FCorda%20Private%20Pull%20Requests%2Fenterprise/detail/PR-3820/3/pipeline/
- https://ci01.dev.r3.com/job/Corda-Open-Source/job/Corda-OS-linear-builds/job/corda-release-linear-run-4.6/109/execution/node/30/log/