### PR TITLE
ENT-5750 Keep killed flows that were started with client ids

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -6,6 +6,7 @@ import net.corda.node.services.statemachine.Checkpoint
 import net.corda.node.services.statemachine.CheckpointState
 import net.corda.node.services.statemachine.FlowResultMetadata
 import net.corda.node.services.statemachine.FlowState
+import java.time.Instant
 import java.util.stream.Stream
 
 /**
@@ -99,6 +100,8 @@ interface CheckpointStorage {
      * if the flow exception is missing in the database.
      */
     fun getFlowException(id: StateMachineRunId, throwIfMissing: Boolean = false): Any?
+
+    fun addFlowException(id: StateMachineRunId, exception: Throwable)
 
     fun removeFlowException(id: StateMachineRunId): Boolean
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -6,12 +6,12 @@ import net.corda.node.services.statemachine.Checkpoint
 import net.corda.node.services.statemachine.CheckpointState
 import net.corda.node.services.statemachine.FlowResultMetadata
 import net.corda.node.services.statemachine.FlowState
-import java.time.Instant
 import java.util.stream.Stream
 
 /**
  * Thread-safe storage of fiber checkpoints.
  */
+@Suppress("TooManyFunctions")
 interface CheckpointStorage {
     /**
      * Add a checkpoint for a new id to the store. Will throw if there is already a checkpoint for this id

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -575,7 +575,9 @@ class DBCheckpointStorage(
             """select new ${DBFlowResultMetadataFields::class.java.name}(checkpoint.id, checkpoint.status, metadata.userSuppliedIdentifier) 
                 from ${DBFlowCheckpoint::class.java.name} checkpoint 
                 join ${DBFlowMetadata::class.java.name} metadata on metadata.id = checkpoint.flowMetadata  
-                where checkpoint.status = ${FlowStatus.COMPLETED.ordinal} or checkpoint.status = ${FlowStatus.FAILED.ordinal}""".trimIndent()
+                where checkpoint.status = ${FlowStatus.COMPLETED.ordinal}
+                or checkpoint.status = ${FlowStatus.FAILED.ordinal}
+                or checkpoint.status = ${FlowStatus.KILLED.ordinal}""".trimIndent()
         val query = session.createQuery(jpqlQuery, DBFlowResultMetadataFields::class.java)
         return query.resultList.stream().map {
             StateMachineRunId(UUID.fromString(it.id)) to FlowResultMetadata(it.status, it.clientId)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -70,6 +70,21 @@ sealed class Action {
     data class RemoveCheckpoint(val id: StateMachineRunId, val mayHavePersistentResults: Boolean = false) : Action()
 
     /**
+     * Remove a flow's exception from the database.
+     *
+     * @param id The id of the flow
+     */
+    data class RemoveFlowException(val id: StateMachineRunId) : Action()
+
+    /**
+     * Persist an exception to the database for the related flow.
+     *
+     * @param id The id of the flow
+     * @param exception The exception to persist
+     */
+    data class AddFlowException(val id: StateMachineRunId, val exception: Throwable) : Action()
+
+    /**
      * Persist the deduplication facts of [deduplicationHandlers].
      */
     data class PersistDeduplicationFacts(val deduplicationHandlers: List<DeduplicationHandler>) : Action()

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -69,6 +69,8 @@ internal class ActionExecutorImpl(
             is Action.CancelFlowTimeout -> cancelFlowTimeout(action)
             is Action.MoveFlowToPaused -> executeMoveFlowToPaused(action)
             is Action.UpdateFlowStatus -> executeUpdateFlowStatus(action)
+            is Action.RemoveFlowException -> executeRemoveFlowException(action)
+            is Action.AddFlowException -> executeAddFlowException(action)
         }
     }
     private fun executeReleaseSoftLocks(action: Action.ReleaseSoftLocks) {
@@ -251,5 +253,13 @@ internal class ActionExecutorImpl(
 
     private fun scheduleFlowTimeout(action: Action.ScheduleFlowTimeout) {
         stateMachineManager.scheduleFlowTimeout(action.flowId)
+    }
+
+    private fun executeRemoveFlowException(action: Action.RemoveFlowException) {
+        checkpointStorage.removeFlowException(action.id)
+    }
+
+    private fun executeAddFlowException(action: Action.AddFlowException) {
+        checkpointStorage.addFlowException(action.id, action.exception)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -49,7 +49,6 @@ import net.corda.serialization.internal.withTokenContext
 import org.apache.activemq.artemis.utils.ReusableLatch
 import rx.Observable
 import java.security.SecureRandom
-import java.time.Instant
 import java.util.ArrayList
 import java.util.HashSet
 import java.util.concurrent.ConcurrentHashMap

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -362,7 +362,6 @@ internal class SingleThreadedStateMachineManager(
                 // the database, even if it is stuck in a infinite loop.
                 database.transaction {
                     if (flow.fiber.clientId != null) {
-                        val now = Instant.now(serviceHub.clock)
                         checkpointStorage.updateStatus(id, Checkpoint.FlowStatus.KILLED)
                         checkpointStorage.removeFlowException(id)
                         checkpointStorage.addFlowException(id, KilledFlowException(id))

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -53,7 +53,7 @@ class KilledFlowTransition(
             // The checkpoint is updated/removed and soft locks are removed directly in [StateMachineManager.killFlow] as well
             if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
                 actions += Action.RemoveCheckpoint(context.id, mayHavePersistentResults = true)
-            } else {
+            } else if (startingState.isAnyCheckpointPersisted) {
                 actions += Action.UpdateFlowStatus(context.id, Checkpoint.FlowStatus.KILLED)
                 actions += Action.RemoveFlowException(context.id)
                 actions += Action.AddFlowException(context.id, killedFlowError.exception)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -6,7 +6,6 @@ import net.corda.node.services.statemachine.Action
 import net.corda.node.services.statemachine.Checkpoint
 import net.corda.node.services.statemachine.DeduplicationId
 import net.corda.node.services.statemachine.ErrorSessionMessage
-import net.corda.node.services.statemachine.ErrorState
 import net.corda.node.services.statemachine.Event
 import net.corda.node.services.statemachine.FlowError
 import net.corda.node.services.statemachine.FlowRemovalReason

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/KilledFlowTransition.kt
@@ -3,11 +3,14 @@ package net.corda.node.services.statemachine.transitions
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.KilledFlowException
 import net.corda.node.services.statemachine.Action
+import net.corda.node.services.statemachine.Checkpoint
 import net.corda.node.services.statemachine.DeduplicationId
 import net.corda.node.services.statemachine.ErrorSessionMessage
+import net.corda.node.services.statemachine.ErrorState
 import net.corda.node.services.statemachine.Event
 import net.corda.node.services.statemachine.FlowError
 import net.corda.node.services.statemachine.FlowRemovalReason
+import net.corda.node.services.statemachine.FlowState
 import net.corda.node.services.statemachine.SessionId
 import net.corda.node.services.statemachine.SessionState
 import net.corda.node.services.statemachine.StateMachineState
@@ -29,24 +32,34 @@ class KilledFlowTransition(
                 startingState.checkpoint.checkpointState.sessions,
                 errorMessages
             )
+
+            val newCheckpoint = startingState.checkpoint.copy(
+                status = Checkpoint.FlowStatus.KILLED,
+                flowState = FlowState.Finished,
+                checkpointState = startingState.checkpoint.checkpointState.copy(sessions = newSessions)
+            )
+
             currentState = currentState.copy(
-                checkpoint = startingState.checkpoint.setSessions(sessions = newSessions),
+                checkpoint = newCheckpoint,
                 pendingDeduplicationHandlers = emptyList(),
                 isRemoved = true
             )
-            actions += Action.PropagateErrors(
-                errorMessages,
-                initiatedSessions,
-                startingState.senderUUID
-            )
+
+            actions += Action.PropagateErrors(errorMessages, initiatedSessions, startingState.senderUUID)
 
             if (!startingState.isFlowResumed) {
                 actions += Action.CreateTransaction
             }
-            // The checkpoint and soft locks are also removed directly in [StateMachineManager.killFlow]
-            if (startingState.isAnyCheckpointPersisted) {
+
+            // The checkpoint is updated/removed and soft locks are removed directly in [StateMachineManager.killFlow] as well
+            if (currentState.checkpoint.checkpointState.invocationContext.clientId == null) {
                 actions += Action.RemoveCheckpoint(context.id, mayHavePersistentResults = true)
+            } else {
+                actions += Action.UpdateFlowStatus(context.id, Checkpoint.FlowStatus.KILLED)
+                actions += Action.RemoveFlowException(context.id)
+                actions += Action.AddFlowException(context.id, killedFlowError.exception)
             }
+
             actions += Action.PersistDeduplicationFacts(startingState.pendingDeduplicationHandlers)
             actions += Action.ReleaseSoftLocks(context.id.uuid)
             actions += Action.CommitTransaction(currentState)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -747,9 +747,9 @@ class FlowClientIdTests {
         var flowHandle0: FlowStateMachineHandle<Unit>
         assertFailsWith<KilledFlowException> {
             flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
-            aliceNode.waitForOvernightObservation(flowHandle0!!.id, 20.seconds)
-            aliceNode.internals.smm.killFlow(flowHandle0!!.id)
-            flowHandle0!!.resultFuture.getOrThrow()
+            aliceNode.waitForOvernightObservation(flowHandle0.id, 20.seconds)
+            aliceNode.internals.smm.killFlow(flowHandle0.id)
+            flowHandle0.resultFuture.getOrThrow()
         }
 
         assertFailsWith<KilledFlowException> {
@@ -805,9 +805,9 @@ class FlowClientIdTests {
         var flowHandle0: FlowStateMachineHandle<Unit>
         assertFailsWith<KilledFlowException> {
             flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
-            aliceNode.waitForOvernightObservation(flowHandle0!!.id, 20.seconds)
-            aliceNode.internals.smm.killFlow(flowHandle0!!.id)
-            flowHandle0!!.resultFuture.getOrThrow()
+            aliceNode.waitForOvernightObservation(flowHandle0.id, 20.seconds)
+            aliceNode.internals.smm.killFlow(flowHandle0.id)
+            flowHandle0.resultFuture.getOrThrow()
         }
 
         val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -744,7 +744,7 @@ class FlowClientIdTests {
     @Test(timeout = 300_000)
     fun `reattachFlowWithClientId can retrieve exception from killed flow`() {
         val clientId = UUID.randomUUID().toString()
-        var flowHandle0: FlowStateMachineHandle<Unit>? = null
+        var flowHandle0: FlowStateMachineHandle<Unit>
         assertFailsWith<KilledFlowException> {
             flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
             aliceNode.waitForOvernightObservation(flowHandle0!!.id, 20.seconds)
@@ -802,7 +802,7 @@ class FlowClientIdTests {
     @Test(timeout = 300_000)
     fun `finishedFlowsWithClientIds returns exception for killed flows`() {
         val clientId = UUID.randomUUID().toString()
-        var flowHandle0: FlowStateMachineHandle<Unit>? = null
+        var flowHandle0: FlowStateMachineHandle<Unit>
         assertFailsWith<KilledFlowException> {
             flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
             aliceNode.waitForOvernightObservation(flowHandle0!!.id, 20.seconds)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -4,11 +4,14 @@ import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.concurrent.Semaphore
 import net.corda.core.CordaRuntimeException
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.HospitalizeFlowException
 import net.corda.core.flows.KilledFlowException
+import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.FlowIORequest
 import net.corda.core.internal.FlowStateMachineHandle
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.minutes
 import net.corda.core.utilities.seconds
 import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.testing.core.ALICE_NAME
@@ -20,6 +23,7 @@ import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.startFlow
 import net.corda.testing.node.internal.startFlowWithClientId
+import net.corda.testing.node.transaction
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
 import org.junit.Assert
@@ -27,9 +31,12 @@ import org.junit.Before
 import org.junit.Test
 import rx.Observable
 import java.sql.SQLTransientConnectionException
+import java.time.Duration
+import java.time.Instant
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 import kotlin.test.assertEquals
@@ -242,9 +249,8 @@ class FlowClientIdTests {
     }
 
     @Test(timeout = 300_000)
-    fun `killing a flow, removes the flow from the client id mapping`() {
+    fun `killing a flow, sets the flow status to killed and adds an exception to the database`() {
         var counter = 0
-        val flowIsRunning = Semaphore(0)
         val waitUntilFlowIsRunning = Semaphore(0)
         ResultFlow.suspendableHook = object : FlowLogic<Unit>() {
             var firstRun = true
@@ -255,7 +261,7 @@ class FlowClientIdTests {
                 if (firstRun) {
                     firstRun = false
                     waitUntilFlowIsRunning.release()
-                    flowIsRunning.acquire()
+                    sleep(1.minutes)
                 }
             }
         }
@@ -266,16 +272,40 @@ class FlowClientIdTests {
             flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
             waitUntilFlowIsRunning.acquire()
             aliceNode.internals.smm.killFlow(flowHandle0!!.id)
-            flowIsRunning.release()
             flowHandle0!!.resultFuture.getOrThrow()
         }
 
-        // a new flow will start since the client id mapping was removed when flow got killed
         val flowHandle1: FlowStateMachineHandle<Int> = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
-        flowHandle1.resultFuture.getOrThrow()
+        assertFailsWith<KilledFlowException> {
+            flowHandle1.resultFuture.getOrThrow()
+        }
 
-        assertNotEquals(flowHandle0!!.id, flowHandle1.id)
-        assertEquals(2, counter)
+        assertEquals(flowHandle0!!.id, flowHandle1.id)
+        assertEquals(1, counter)
+        assertTrue(aliceNode.hasStatus(flowHandle0!!.id, Checkpoint.FlowStatus.KILLED))
+        assertTrue(aliceNode.hasException(flowHandle0!!.id))
+    }
+
+    @Test(timeout = 300_000)
+    fun `killing a hospitalized flow, sets the flow status to killed and adds an exception to the database`() {
+        val clientId = UUID.randomUUID().toString()
+
+        var flowHandle0: FlowStateMachineHandle<Unit>? = null
+        assertFailsWith<KilledFlowException> {
+            flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
+            aliceNode.waitForOvernightObservation(flowHandle0!!.id, 20.seconds)
+            aliceNode.internals.smm.killFlow(flowHandle0!!.id)
+            flowHandle0!!.resultFuture.getOrThrow()
+        }
+
+        val flowHandle1: FlowStateMachineHandle<Int> = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        assertFailsWith<KilledFlowException> {
+            flowHandle1.resultFuture.getOrThrow()
+        }
+
+        assertEquals(flowHandle0!!.id, flowHandle1.id)
+        assertTrue(aliceNode.hasStatus(flowHandle0!!.id, Checkpoint.FlowStatus.KILLED))
+        assertTrue(aliceNode.hasException(flowHandle0!!.id))
     }
 
     @Test(timeout = 300_000)
@@ -687,6 +717,22 @@ class FlowClientIdTests {
     }
 
     @Test(timeout = 300_000)
+    fun `reattachFlowWithClientId can retrieve exception from killed flow`() {
+        val clientId = UUID.randomUUID().toString()
+        var flowHandle0: FlowStateMachineHandle<Unit>? = null
+        assertFailsWith<KilledFlowException> {
+            flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
+            aliceNode.waitForOvernightObservation(flowHandle0!!.id, 20.seconds)
+            aliceNode.internals.smm.killFlow(flowHandle0!!.id)
+            flowHandle0!!.resultFuture.getOrThrow()
+        }
+
+        assertFailsWith<KilledFlowException> {
+            aliceNode.smm.reattachFlowWithClientId<Int>(clientId)?.resultFuture?.getOrThrow()
+        }
+    }
+
+    @Test(timeout = 300_000)
     fun `finishedFlowsWithClientIds returns completed flows with client ids`() {
         val clientIds = listOf("a", "b", "c", "d", "e")
         val lock = CountDownLatch(1)
@@ -727,35 +773,113 @@ class FlowClientIdTests {
             finishedFlows.filterValues { !it }.map { aliceNode.smm.reattachFlowWithClientId<Int>(it.key)?.resultFuture?.getOrThrow() }
         }
     }
-}
 
-internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {
-    companion object {
-        var hook: ((String?) -> Unit)? = null
-        var suspendableHook: FlowLogic<Unit>? = null
+    @Test(timeout = 300_000)
+    fun `finishedFlowsWithClientIds returns exception for killed flows`() {
+        val clientId = UUID.randomUUID().toString()
+        var flowHandle0: FlowStateMachineHandle<Unit>? = null
+        assertFailsWith<KilledFlowException> {
+            flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
+            aliceNode.waitForOvernightObservation(flowHandle0!!.id, 20.seconds)
+            aliceNode.internals.smm.killFlow(flowHandle0!!.id)
+            flowHandle0!!.resultFuture.getOrThrow()
+        }
+
+        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds()
+
+        assertFailsWith<KilledFlowException> {
+            finishedFlows.keys.single().let { aliceNode.smm.reattachFlowWithClientId<Int>(it)?.resultFuture?.getOrThrow() }
+        }
     }
 
-    @Suspendable
-    override fun call(): A {
-        hook?.invoke(stateMachine.clientId)
-        suspendableHook?.let { subFlow(it) }
-        return result
+    private fun TestStartedNode.hasStatus(id: StateMachineRunId, status: Checkpoint.FlowStatus): Boolean {
+        return services.database.transaction {
+            services.jdbcSession().prepareStatement("select count(*) from node_checkpoints where status = ? and flow_id = ?")
+                .apply {
+                    setInt(1, status.ordinal)
+                    setString(2, id.uuid.toString())
+                }
+                .use { ps ->
+                    ps.executeQuery().use { rs ->
+                        rs.next()
+                        rs.getLong(1)
+                    }
+                }.toInt() == 1
+        }
     }
-}
 
-internal class UnSerializableResultFlow: FlowLogic<Any>() {
-    companion object {
-        var firstRun = true
+    private fun TestStartedNode.hasException(id: StateMachineRunId): Boolean {
+        return services.database.transaction {
+            services.jdbcSession().prepareStatement("select count(*) from node_flow_exceptions where flow_id = ?")
+                .apply { setString(1, id.uuid.toString()) }
+                .use { ps ->
+                    ps.executeQuery().use { rs ->
+                        rs.next()
+                        rs.getLong(1)
+                    }
+                }.toInt() == 1
+        }
     }
 
-    @Suspendable
-    override fun call(): Any {
-        stateMachine.suspend(FlowIORequest.ForceCheckpoint, false)
-        return if (firstRun) {
-            firstRun = false
-            Observable.empty<Any>()
-        } else {
-            5 // serializable result
+    private fun TestStartedNode.waitForOvernightObservation(id: StateMachineRunId, timeout: Duration) {
+        val timeoutTime = Instant.now().plusSeconds(timeout.seconds)
+        var exists = false
+        while (Instant.now().isBefore(timeoutTime) && !exists) {
+            services.database.transaction {
+                exists = services.jdbcSession().prepareStatement("select count(*) from node_checkpoints where status = ? and flow_id = ?")
+                    .apply {
+                        setInt(1, Checkpoint.FlowStatus.HOSPITALIZED.ordinal)
+                        setString(2, id.uuid.toString())
+                    }
+                    .use { ps ->
+                        ps.executeQuery().use { rs ->
+                            rs.next()
+                            rs.getLong(1)
+                        }
+                    }.toInt() == 1
+            }
+        }
+        if (!exists) {
+            throw TimeoutException("Flow was not kept for observation during timeout duration")
+        }
+    }
+
+    internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {
+        companion object {
+            var hook: ((String?) -> Unit)? = null
+            var suspendableHook: FlowLogic<Unit>? = null
+        }
+
+        @Suspendable
+        override fun call(): A {
+            hook?.invoke(stateMachine.clientId)
+            suspendableHook?.let { subFlow(it) }
+            return result
+        }
+    }
+
+    internal class UnSerializableResultFlow: FlowLogic<Any>() {
+        companion object {
+            var firstRun = true
+        }
+
+        @Suspendable
+        override fun call(): Any {
+            stateMachine.suspend(FlowIORequest.ForceCheckpoint, false)
+            return if (firstRun) {
+                firstRun = false
+                Observable.empty<Any>()
+            } else {
+                5 // serializable result
+            }
+        }
+    }
+
+    internal class HospitalizeFlow: FlowLogic<Unit>() {
+
+        @Suspendable
+        override fun call() {
+            throw HospitalizeFlowException("time to go to the doctors")
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -296,7 +296,7 @@ class FlowClientIdTests {
             flowHandle0!!.resultFuture.getOrThrow()
         }
 
-        val flowHandle1: FlowStateMachineHandle<Int> = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        val flowHandle1: FlowStateMachineHandle<Unit> = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
         assertFailsWith<KilledFlowException> {
             flowHandle1.resultFuture.getOrThrow()
         }
@@ -318,7 +318,7 @@ class FlowClientIdTests {
             flowHandle0!!.resultFuture.getOrThrow()
         }
 
-        val flowHandle1: FlowStateMachineHandle<Int> = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
+        val flowHandle1: FlowStateMachineHandle<Unit> = aliceNode.services.startFlowWithClientId(clientId, HospitalizeFlow())
         assertFailsWith<KilledFlowException> {
             flowHandle1.resultFuture.getOrThrow()
         }
@@ -861,6 +861,7 @@ class FlowClientIdTests {
                             rs.getLong(1)
                         }
                     }.toInt() == 1
+                Thread.sleep(1.seconds.toMillis())
             }
         }
         if (!exists) {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -327,7 +328,7 @@ class FlowClientIdTests {
         assertTrue(aliceNode.hasStatus(flowHandle0!!.id, Checkpoint.FlowStatus.KILLED))
         assertTrue(aliceNode.hasException(flowHandle0!!.id))
 
-        aliceNode.internals.smm.killFlow(flowHandle0!!.id)
+        assertFalse(aliceNode.internals.smm.killFlow(flowHandle0!!.id))
         assertTrue(aliceNode.hasStatus(flowHandle0!!.id, Checkpoint.FlowStatus.KILLED))
         assertTrue(aliceNode.hasException(flowHandle0!!.id))
     }


### PR DESCRIPTION
If a flow is started with a client id, do not delete it from the
database. Instead, set the status to `KILLED` and store a
`KilledFlowException` in the database.

Keeping it around allows it to be reattached to using the same
mechanisms as active, completed or failed flows. Furthermore, without
this change it could be possible for a flow to be triggered again if
killed while the reconnecting rpc client is being used.

If there is no client id related to the flow, then kill flow keeps its
original behaviour of deleting all traces of the flow.

Flows cannot be killed if they are `COMPLETED`, `FAILED` or `KILLED`
already.

Logs have been added if requests to kill flows in these statuses are
made.

Do not update the status + persist the exception if the flow was killed
during flow initialisation (before persisting its first checkpoint).

Remove the client id mapping if the flow was killed and did not persist
its original checkpoint.