### PR TITLE
NOTICK Do not use Security.addProvider(BouncyCastleProvider())

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/X509NameConstraintsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/X509NameConstraintsTest.kt
@@ -12,7 +12,6 @@ import org.bouncycastle.asn1.x509.GeneralSubtree
 import org.bouncycastle.asn1.x509.NameConstraints
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Test
-import java.security.Security
 import java.security.UnrecoverableKeyException
 import java.security.cert.CertPathValidator
 import java.security.cert.CertPathValidatorException
@@ -95,7 +94,8 @@ class X509NameConstraintsTest {
 
     @Test
     fun `x500 name with correct cn and extra attribute`() {
-        Security.addProvider(BouncyCastleProvider())
+        // Do not use Security.addProvider(BouncyCastleProvider()) to avoid EdDSA signature disruption in other tests.
+        Crypto.findProvider(BouncyCastleProvider.PROVIDER_NAME)
         val acceptableNames = listOf("CN=Bank A TLS, UID=", "O=Bank A")
                 .map { GeneralSubtree(GeneralName(X500Name(it))) }.toTypedArray()
 

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -54,7 +54,6 @@ import java.math.BigInteger
 import java.net.InetSocketAddress
 import java.security.KeyPair
 import java.security.PrivateKey
-import java.security.Security
 import java.security.cert.X509CRL
 import java.security.cert.X509Certificate
 import java.util.*
@@ -113,7 +112,8 @@ class CertificateRevocationListNodeTests {
 
     @Before
     fun setUp() {
-        Security.addProvider(BouncyCastleProvider())
+        // Do not use Security.addProvider(BouncyCastleProvider()) to avoid EdDSA signature disruption in other tests.
+        Crypto.findProvider(BouncyCastleProvider.PROVIDER_NAME)
         revokedNodeCerts.clear()
         server = CrlServer(NetworkHostAndPort("localhost", 0))
         server.start()


### PR DESCRIPTION
Do not use Security.addProvider(BouncyCastleProvider()) in tests, to avoid disruptions of other tests.