### PR TITLE
CORDA-4028 Forcibly register security providers

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/indentity/PartyAndCertificateTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/indentity/PartyAndCertificateTest.kt
@@ -15,25 +15,23 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.getTestPartyAndCertificate
 import net.corda.testing.internal.DEV_ROOT_CA
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.BeforeClass
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.math.BigInteger
 import kotlin.test.assertFailsWith
 
 class PartyAndCertificateTest {
-    companion object {
-        @BeforeClass
-        fun setUpOnce() {
-            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-            Crypto.registerProviders()
-        }
-    }
-
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
+
+    @Before
+    fun setUp() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+    }
 
     @Test
     fun `reject a path with no roles`() {

--- a/core-tests/src/test/kotlin/net/corda/coretests/indentity/PartyAndCertificateTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/indentity/PartyAndCertificateTest.kt
@@ -2,6 +2,7 @@ package net.corda.coretests.indentity
 
 import com.google.common.jimfs.Configuration.unix
 import com.google.common.jimfs.Jimfs
+import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
@@ -14,6 +15,7 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.getTestPartyAndCertificate
 import net.corda.testing.internal.DEV_ROOT_CA
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.math.BigInteger
@@ -23,6 +25,13 @@ class PartyAndCertificateTest {
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
+
+    @Before
+    fun setUp() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+    }
 
     @Test
     fun `reject a path with no roles`() {

--- a/core-tests/src/test/kotlin/net/corda/coretests/indentity/PartyAndCertificateTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/indentity/PartyAndCertificateTest.kt
@@ -15,23 +15,25 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.getTestPartyAndCertificate
 import net.corda.testing.internal.DEV_ROOT_CA
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import java.math.BigInteger
 import kotlin.test.assertFailsWith
 
 class PartyAndCertificateTest {
+    companion object {
+        @BeforeClass
+        fun setUpOnce() {
+            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+            Crypto.registerProviders()
+        }
+    }
+
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
-
-    @Before
-    fun setUp() {
-        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-        Crypto.registerProviders()
-    }
 
     @Test
     fun `reject a path with no roles`() {

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -76,6 +76,10 @@ class NetworkMapUpdaterTest {
 
     @Before
     fun setUp() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+
         ourKeyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         ourNodeInfo = createNodeInfoAndSigned("Our info", ourKeyPair).signed
         server = NetworkMapServer(cacheExpiryMs.millis)

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -33,6 +33,7 @@ import net.corda.testing.internal.DEV_ROOT_CA
 import net.corda.testing.internal.TestNodeInfoBuilder
 import net.corda.testing.internal.createNodeInfoAndSigned
 import net.corda.testing.node.internal.MockKeyManagementService
+import net.corda.testing.node.internal.MockPublicKeyToOwningIdentityCache
 import net.corda.testing.node.internal.network.NetworkMapServer
 import net.corda.testing.node.makeTestIdentityService
 import org.assertj.core.api.Assertions.assertThat
@@ -53,15 +54,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NetworkMapUpdaterTest {
-    companion object {
-        @BeforeClass
-        fun setUpOnce() {
-            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-            Crypto.registerProviders()
-        }
-    }
-
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule(true)
@@ -84,6 +76,10 @@ class NetworkMapUpdaterTest {
 
     @Before
     fun setUp() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+
         ourKeyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         ourNodeInfo = createNodeInfoAndSigned("Our info", ourKeyPair).signed
         server = NetworkMapServer(cacheExpiryMs.millis)

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
@@ -17,6 +17,7 @@ import net.corda.testing.node.internal.network.NetworkMapServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import java.net.URL
@@ -27,6 +28,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
 class NetworkParametersReaderTest {
+    companion object {
+        @BeforeClass
+        fun setUpOnce() {
+            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+            Crypto.registerProviders()
+        }
+    }
+
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule(true)
@@ -39,9 +49,6 @@ class NetworkParametersReaderTest {
 
     @Before
     fun setUp() {
-        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-        Crypto.registerProviders()
 
         fs = Jimfs.newFileSystem(Configuration.unix())
         server = NetworkMapServer(cacheTimeout)

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
@@ -17,7 +17,6 @@ import net.corda.testing.node.internal.network.NetworkMapServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import java.net.URL
@@ -28,15 +27,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
 class NetworkParametersReaderTest {
-    companion object {
-        @BeforeClass
-        fun setUpOnce() {
-            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-            Crypto.registerProviders()
-        }
-    }
-
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule(true)
@@ -49,6 +39,9 @@ class NetworkParametersReaderTest {
 
     @Before
     fun setUp() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
 
         fs = Jimfs.newFileSystem(Configuration.unix())
         server = NetworkMapServer(cacheTimeout)

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.network
 
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
+import net.corda.core.crypto.Crypto
 import net.corda.core.internal.NODE_INFO_DIRECTORY
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
@@ -17,6 +18,7 @@ import net.corda.testing.node.internal.MockPublicKeyToOwningIdentityCache
 import net.corda.testing.node.makeTestIdentityService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -28,6 +30,15 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class NodeInfoWatcherTest {
+    companion object {
+        @BeforeClass
+        fun setUpOnce() {
+            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+            Crypto.registerProviders()
+        }
+    }
+
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -18,7 +18,6 @@ import net.corda.testing.node.internal.MockPublicKeyToOwningIdentityCache
 import net.corda.testing.node.makeTestIdentityService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -30,15 +29,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class NodeInfoWatcherTest {
-    companion object {
-        @BeforeClass
-        fun setUpOnce() {
-            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-            Crypto.registerProviders()
-        }
-    }
-
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
@@ -59,6 +49,10 @@ class NodeInfoWatcherTest {
 
     @Before
     fun start() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+
         nodeInfoAndSigned = createNodeInfoAndSigned(ALICE_NAME)
         val identityService = makeTestIdentityService()
         keyManagementService = MockKeyManagementService(identityService)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -25,6 +25,7 @@ import net.corda.nodeapi.exceptions.DuplicateAttachmentException
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.core.internal.ContractJarTestUtils
 import net.corda.testing.core.internal.ContractJarTestUtils.makeTestContractJar
 import net.corda.testing.core.internal.ContractJarTestUtils.makeTestJar
 import net.corda.testing.core.internal.ContractJarTestUtils.makeTestSignedContractJar
@@ -42,7 +43,6 @@ import org.assertj.core.api.Assertions.*
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Ignore
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -57,14 +57,6 @@ import kotlin.streams.toList
 import kotlin.test.*
 
 class NodeAttachmentServiceTest {
-    companion object {
-        @BeforeClass
-        fun setUpOnce() {
-            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-            Crypto.registerProviders()
-        }
-    }
 
     // Use an in memory file system for testing attachment storage.
     private lateinit var fs: FileSystem
@@ -77,6 +69,10 @@ class NodeAttachmentServiceTest {
 
     @Before
     fun setUp() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+
         LogHelper.setLevel(PersistentUniquenessProvider::class)
 
         val dataSourceProperties = makeTestDataSourceProperties()

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -25,7 +25,6 @@ import net.corda.nodeapi.exceptions.DuplicateAttachmentException
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.core.internal.ContractJarTestUtils
 import net.corda.testing.core.internal.ContractJarTestUtils.makeTestContractJar
 import net.corda.testing.core.internal.ContractJarTestUtils.makeTestJar
 import net.corda.testing.core.internal.ContractJarTestUtils.makeTestSignedContractJar
@@ -43,6 +42,7 @@ import org.assertj.core.api.Assertions.*
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Ignore
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -57,6 +57,14 @@ import kotlin.streams.toList
 import kotlin.test.*
 
 class NodeAttachmentServiceTest {
+    companion object {
+        @BeforeClass
+        fun setUpOnce() {
+            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+            Crypto.registerProviders()
+        }
+    }
 
     // Use an in memory file system for testing attachment storage.
     private lateinit var fs: FileSystem
@@ -69,10 +77,6 @@ class NodeAttachmentServiceTest {
 
     @Before
     fun setUp() {
-        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-        Crypto.registerProviders()
-
         LogHelper.setLevel(PersistentUniquenessProvider::class)
 
         val dataSourceProperties = makeTestDataSourceProperties()

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -7,6 +7,7 @@ import com.google.common.jimfs.Jimfs
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.contracts.ContractAttachment
+import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowLogic
@@ -68,6 +69,10 @@ class NodeAttachmentServiceTest {
 
     @Before
     fun setUp() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+
         LogHelper.setLevel(PersistentUniquenessProvider::class)
 
         val dataSourceProperties = makeTestDataSourceProperties()

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -35,6 +35,7 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest
 import org.junit.After
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 import java.nio.file.FileSystem
 import java.security.PublicKey
@@ -46,6 +47,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NetworkRegistrationHelperTest {
+    companion object {
+        @BeforeClass
+        fun setUpOnce() {
+            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+            Crypto.registerProviders()
+        }
+    }
+
     private lateinit var fs: FileSystem
     private val nodeLegalName = ALICE_NAME
 
@@ -55,10 +65,6 @@ class NetworkRegistrationHelperTest {
 
     @Before
     fun init() {
-        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-        Crypto.registerProviders()
-
         fs = Jimfs.newFileSystem(unix())
         val baseDirectory = fs.getPath("/baseDir").createDirectories()
 

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -36,6 +36,7 @@ import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.nio.file.FileSystem
 import java.security.PublicKey
 import java.security.cert.CertPathValidatorException
 import java.security.cert.X509Certificate
@@ -45,7 +46,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NetworkRegistrationHelperTest {
-    private val fs = Jimfs.newFileSystem(unix())
+    private lateinit var fs: FileSystem
     private val nodeLegalName = ALICE_NAME
 
     private lateinit var config: NodeConfiguration
@@ -54,6 +55,11 @@ class NetworkRegistrationHelperTest {
 
     @Before
     fun init() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+
+        fs = Jimfs.newFileSystem(unix())
         val baseDirectory = fs.getPath("/baseDir").createDirectories()
 
         abstract class AbstractNodeConfiguration : NodeConfiguration

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -35,7 +35,6 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest
 import org.junit.After
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
 import java.nio.file.FileSystem
 import java.security.PublicKey
@@ -47,15 +46,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NetworkRegistrationHelperTest {
-    companion object {
-        @BeforeClass
-        fun setUpOnce() {
-            // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
-            // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
-            Crypto.registerProviders()
-        }
-    }
-
     private lateinit var fs: FileSystem
     private val nodeLegalName = ALICE_NAME
 
@@ -65,6 +55,10 @@ class NetworkRegistrationHelperTest {
 
     @Before
     fun init() {
+        // Register providers before creating Jimfs filesystem. JimFs creates an SSHD instance which
+        // register BouncyCastle and EdDSA provider separately, which wrecks havoc.
+        Crypto.registerProviders()
+
         fs = Jimfs.newFileSystem(unix())
         val baseDirectory = fs.getPath("/baseDir").createDirectories()
 


### PR DESCRIPTION
Forcibly register security providers before starting Jimfs, to resolve a sequencing problem where Jimfs triggers loading of the SFTP filesystem provider, which in turn registers the standard BouncyCastle provider rather than the patched version Corda needs.
