### PR TITLE
ENT-5754 - RPC startFlow cannot reattach to existing client id flows when flows draining mode is enabled

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
@@ -187,7 +187,7 @@ class FlowWithClientIdTest {
 
             nodeA.rpc.setFlowsDrainingModeEnabled(true)
             assertFailsWith<RejectedCommandException>("Node is draining before shutdown. Cannot start new flows through RPC.") {
-                nodeA.rpc.startFlowWithClientId(clientId, ::ResultFlow, 5).returnValue.getOrThrow(20.seconds)
+                nodeA.rpc.startFlowWithClientId(clientId, ::ResultFlow, 5)
             }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -277,6 +277,10 @@ internal class CordaRPCOpsImpl(
     private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineHandle<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
+            if (context.clientId != null) {
+                return smm.reattachFlowWithClientId(context.clientId!!)
+                    ?: throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
+            }
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
         }
         return flowStarter.invokeFlowAsync(logicType, context, *args).getOrThrow()

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -277,11 +277,9 @@ internal class CordaRPCOpsImpl(
     private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineHandle<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
-            if (context.clientId != null) {
-                return smm.reattachFlowWithClientId(context.clientId!!)
-                    ?: throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
-            }
-            throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
+            return context.clientId?.let {
+                smm.reattachFlowWithClientId<T>(context.clientId!!)
+            } ?: throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
         }
         return flowStarter.invokeFlowAsync(logicType, context, *args).getOrThrow()
     }


### PR DESCRIPTION
Existing client id flows should be re-attachable through RPC `startFlow`, since this is not actually new flow starting, only re-attaching to existing an one.

Modified `CordaRPCOpsImpl.startFlow` to allow existing client id flows to be reattached. If the client id carried by the `startFlow` request does not exist then this is considered an attempt to start a new flow, and therefore we fall back to the existing behavior (i.e. a `RejectedCommandException` is thrown).