### PR TITLE
ENT-5768 startFlowWithClientId permissions

### DIFF
--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt
@@ -54,6 +54,9 @@ class RPCPermissionsTests : AbstractRPCTest() {
             assertNotAllowed {
                 proxy.validatePermission("startFlowDynamic", "net.corda.flows.DummyFlow")
             }
+            assertNotAllowed {
+                proxy.validatePermission("startFlow", "net.corda.flows.DummyFlow")
+            }
         }
     }
 
@@ -64,6 +67,10 @@ class RPCPermissionsTests : AbstractRPCTest() {
             val proxy = testProxyFor(adminUser)
             proxy.validatePermission("startFlowDynamic", "net.corda.flows.DummyFlow")
             proxy.validatePermission("startTrackedFlowDynamic", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startFlowDynamicWithClientId", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startFlow", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startTrackedFlow", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startFlowWithClientId", "net.corda.flows.DummyFlow")
         }
     }
 
@@ -74,6 +81,10 @@ class RPCPermissionsTests : AbstractRPCTest() {
             val proxy = testProxyFor(joeUser)
             proxy.validatePermission("startFlowDynamic", "net.corda.flows.DummyFlow")
             proxy.validatePermission("startTrackedFlowDynamic", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startFlowDynamicWithClientId", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startFlow", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startTrackedFlow", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startFlowWithClientId", "net.corda.flows.DummyFlow")
         }
     }
 
@@ -87,6 +98,18 @@ class RPCPermissionsTests : AbstractRPCTest() {
             }
             assertNotAllowed {
                 proxy.validatePermission("startTrackedFlowDynamic", "net.corda.flows.OtherFlow")
+            }
+            assertNotAllowed {
+                proxy.validatePermission("startFlowDynamicWithClientId", "net.corda.flows.OtherFlow")
+            }
+            assertNotAllowed {
+                proxy.validatePermission("startFlow", "net.corda.flows.OtherFlow")
+            }
+            assertNotAllowed {
+                proxy.validatePermission("startTrackedFlow", "net.corda.flows.OtherFlow")
+            }
+            assertNotAllowed {
+                proxy.validatePermission("startFlowWithClientId", "net.corda.flows.OtherFlow")
             }
         }
     }
@@ -118,6 +141,16 @@ class RPCPermissionsTests : AbstractRPCTest() {
             proxy.validatePermission("startFlowDynamic", "net.corda.flows.DummyFlow")
             proxy.validatePermission("startTrackedFlowDynamic", "net.corda.flows.DummyFlow")
             proxy.validatePermission("startTrackedFlowDynamic", "net.corda.flows.OtherFlow")
+            proxy.validatePermission("startFlowDynamicWithClientId", "net.corda.flows.OtherFlow")
+            proxy.validatePermission("startFlowDynamicWithClientId", "net.corda.flows.DummyFlow")
+
+            proxy.validatePermission("startFlow", "net.corda.flows.OtherFlow")
+            proxy.validatePermission("startFlow", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startTrackedFlow", "net.corda.flows.DummyFlow")
+            proxy.validatePermission("startTrackedFlow", "net.corda.flows.OtherFlow")
+            proxy.validatePermission("startFlowWithClientId", "net.corda.flows.OtherFlow")
+            proxy.validatePermission("startFlowWithClientId", "net.corda.flows.DummyFlow")
+
             assertNotAllowed {
                 proxy.validatePermission("startTrackedFlowDynamic", "net.banned.flows.OtherFlow")
             }

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -314,6 +314,7 @@ interface CordaRPCOps : RPCOps {
 
     /**
      * Removes a flow's [clientId] to result/ exception mapping. If the mapping is of a running flow, then the mapping will not get removed.
+     * This version will only remove flow's that were started by the same user currently calling [removeClientId].
      *
      * See [startFlowDynamicWithClientId] for more information.
      *
@@ -322,12 +323,32 @@ interface CordaRPCOps : RPCOps {
     fun removeClientId(clientId: String): Boolean
 
     /**
-     * Returns all finished flows that were started with a client id.
+     * Removes a flow's [clientId] to result/ exception mapping. If the mapping is of a running flow, then the mapping will not get removed.
+     * This version can be called for all client ids, ignoring which user originally started a flow using the input [clientId].
      *
-     * @return A [Map] containing client ids for finished flows, mapped to [true] if finished successfully,
-     * [false] if completed exceptionally.
+     * See [startFlowDynamicWithClientId] for more information.
+     *
+     * @return whether the mapping was removed.
+     */
+    fun removeClientIdAsAdmin(clientId: String): Boolean
+
+    /**
+     * Returns all finished flows that were started with a client id. This version only returns the client ids for flows started by the same
+     * user currently calling [finishedFlowsWithClientIds].
+     *
+     * @return A [Map] containing client ids for finished flows started by the user calling [finishedFlowsWithClientIds], mapped to [true]
+     * if finished successfully, [false] if completed exceptionally.
      */
     fun finishedFlowsWithClientIds(): Map<String, Boolean>
+
+    /**
+     * Returns all finished flows that were started with a client id. This version does not filter the returned values by the user that
+     * started the finished flows.
+     *
+     * @return A [Map] containing all client ids for finished flows, mapped to [true] if finished successfully,
+     * [false] if completed exceptionally.
+     */
+    fun finishedFlowsWithClientIdsAsAdmin(): Map<String, Boolean>
 
     /** Returns Node's NodeInfo, assuming this will not change while the node is running. */
     fun nodeInfo(): NodeInfo

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -324,7 +324,7 @@ interface CordaRPCOps : RPCOps {
 
     /**
      * Removes a flow's [clientId] to result/ exception mapping. If the mapping is of a running flow, then the mapping will not get removed.
-     * This version can be called for all client ids, ignoring which user originally started a flow using the input [clientId].
+     * This version can be called for all client ids, ignoring which user originally started a flow with [clientId].
      *
      * See [startFlowDynamicWithClientId] for more information.
      *
@@ -333,8 +333,8 @@ interface CordaRPCOps : RPCOps {
     fun removeClientIdAsAdmin(clientId: String): Boolean
 
     /**
-     * Returns all finished flows that were started with a client id. This version only returns the client ids for flows started by the same
-     * user currently calling [finishedFlowsWithClientIds].
+     * Returns all finished flows that were started with a client ID for which the client ID mapping has not been removed. This version only
+     * returns the client ids for flows started by the same user currently calling [finishedFlowsWithClientIds].
      *
      * @return A [Map] containing client ids for finished flows started by the user calling [finishedFlowsWithClientIds], mapped to [true]
      * if finished successfully, [false] if completed exceptionally.
@@ -342,8 +342,7 @@ interface CordaRPCOps : RPCOps {
     fun finishedFlowsWithClientIds(): Map<String, Boolean>
 
     /**
-     * Returns all finished flows that were started with a client id. This version does not filter the returned values by the user that
-     * started the finished flows.
+     * Returns all finished flows that were started with a client id by all RPC users for which the client ID mapping has not been removed.
      *
      * @return A [Map] containing all client ids for finished flows, mapped to [true] if finished successfully,
      * [false] if completed exceptionally.

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -173,14 +173,14 @@ internal class CordaRPCOpsImpl(
     override fun killFlow(id: StateMachineRunId): Boolean = smm.killFlow(id)
 
     override fun <T> reattachFlowWithClientId(clientId: String): FlowHandleWithClientId<T>? {
-        return smm.reattachFlowWithClientId<T>(clientId)?.run {
+        return smm.reattachFlowWithClientId<T>(clientId, context().principal())?.run {
             FlowHandleWithClientIdImpl(id = id, returnValue = resultFuture, clientId = clientId)
         }
     }
 
-    override fun removeClientId(clientId: String): Boolean = smm.removeClientId(clientId)
+    override fun removeClientId(clientId: String): Boolean = smm.removeClientId(clientId, context().principal())
 
-    override fun finishedFlowsWithClientIds(): Map<String, Boolean> = smm.finishedFlowsWithClientIds()
+    override fun finishedFlowsWithClientIds(): Map<String, Boolean> = smm.finishedFlowsWithClientIds(context().principal())
 
     override fun stateMachinesFeed(): DataFeed<List<StateMachineInfo>, StateMachineUpdate> {
 

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -281,9 +281,8 @@ internal class CordaRPCOpsImpl(
     private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, context: InvocationContext, args: Array<out Any?>): FlowStateMachineHandle<T> {
         if (!logicType.isAnnotationPresent(StartableByRPC::class.java)) throw NonRpcFlowException(logicType)
         if (isFlowsDrainingModeEnabled()) {
-            return context.clientId?.let {
-                smm.reattachFlowWithClientId<T>(context.clientId!!)
-            } ?: throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
+            return context.clientId?.let { smm.reattachFlowWithClientId<T>(it, context.principal()) }
+                ?: throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
         }
         return flowStarter.invokeFlowAsync(logicType, context, *args).getOrThrow()
     }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -178,9 +178,13 @@ internal class CordaRPCOpsImpl(
         }
     }
 
-    override fun removeClientId(clientId: String): Boolean = smm.removeClientId(clientId, context().principal())
+    override fun removeClientId(clientId: String): Boolean = smm.removeClientId(clientId, context().principal(), false)
 
-    override fun finishedFlowsWithClientIds(): Map<String, Boolean> = smm.finishedFlowsWithClientIds(context().principal())
+    override fun removeClientIdAsAdmin(clientId: String): Boolean = smm.removeClientId(clientId, context().principal(), true)
+
+    override fun finishedFlowsWithClientIds(): Map<String, Boolean> = smm.finishedFlowsWithClientIds(context().principal(), false)
+
+    override fun finishedFlowsWithClientIdsAsAdmin(): Map<String, Boolean> = smm.finishedFlowsWithClientIds(context().principal(), true)
 
     override fun stateMachinesFeed(): DataFeed<List<StateMachineInfo>, StateMachineUpdate> {
 

--- a/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt
@@ -144,31 +144,35 @@ private object RPCPermissionResolver : PermissionResolver {
     private const val ACTION_INVOKE_RPC = "invokerpc"
     private const val ACTION_ALL = "all"
     private val FLOW_RPC_CALLS = setOf(
-            "startFlowDynamic",
-            "startTrackedFlowDynamic",
-            "startFlow",
-            "startTrackedFlow")
+        "startFlowDynamic",
+        "startTrackedFlowDynamic",
+        "startFlowDynamicWithClientId",
+        "startFlow",
+        "startTrackedFlow",
+        "startFlowWithClientId"
+    )
+
+    private val FLOW_RPC_PERMITTED_START_FLOW_CALLS = setOf("startFlow", "startFlowDynamic")
+    private val FLOW_RPC_PERMITTED_TRACKED_START_FLOW_CALLS = setOf("startTrackedFlow", "startTrackedFlowDynamic")
+    private val FLOW_RPC_PERMITTED_START_FLOW_WITH_CLIENT_ID_CALLS = setOf("startFlowWithClientId", "startFlowDynamicWithClientId")
 
     override fun resolvePermission(representation: String): Permission {
-    	val action = representation.substringBefore(SEPARATOR).toLowerCase()
+        val action = representation.substringBefore(SEPARATOR).toLowerCase()
         when (action) {
             ACTION_INVOKE_RPC -> {
                 val rpcCall = representation.substringAfter(SEPARATOR, "")
-                require(representation.count { it == SEPARATOR } == 1 && !rpcCall.isEmpty()) {
-                    "Malformed permission string"
-                }
-                val permitted = when(rpcCall) {
-                    "startFlow" -> setOf("startFlowDynamic", rpcCall)
-                    "startTrackedFlow" -> setOf("startTrackedFlowDynamic", rpcCall)
+                require(representation.count { it == SEPARATOR } == 1 && rpcCall.isNotEmpty()) { "Malformed permission string" }
+                val permitted = when (rpcCall) {
+                    "startFlow" -> FLOW_RPC_PERMITTED_START_FLOW_CALLS
+                    "startTrackedFlow" -> FLOW_RPC_PERMITTED_TRACKED_START_FLOW_CALLS
+                    "startFlowWithClientId" -> FLOW_RPC_PERMITTED_START_FLOW_WITH_CLIENT_ID_CALLS
                     else -> setOf(rpcCall)
                 }
                 return RPCPermission(permitted)
             }
             ACTION_START_FLOW -> {
                 val targetFlow = representation.substringAfter(SEPARATOR, "")
-                require(targetFlow.isNotEmpty()) {
-                    "Missing target flow after StartFlow"
-                }
+                require(targetFlow.isNotEmpty()) { "Missing target flow after StartFlow" }
                 return RPCPermission(FLOW_RPC_CALLS, targetFlow)
             }
             ACTION_ALL -> {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -586,7 +586,8 @@ class DBCheckpointStorage(
                 or checkpoint.status = ${FlowStatus.KILLED.ordinal}""".trimIndent()
         val query = session.createQuery(jpqlQuery, DBFlowResultMetadataFields::class.java)
         return query.resultList.stream().map {
-            StateMachineRunId(UUID.fromString(it.id)) to FlowResultMetadata(it.status, it.clientId, Principal { it.startedBy })
+            val startedBy = it.startedBy
+            StateMachineRunId(UUID.fromString(it.id)) to FlowResultMetadata(it.status, it.clientId, Principal { startedBy })
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -295,7 +295,7 @@ internal class SingleThreadedStateMachineManager(
         }
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "NestedBlockDepth")
     private fun <A> startFlow(
             flowId: StateMachineRunId,
             flowLogic: FlowLogic<A>,
@@ -331,7 +331,7 @@ internal class SingleThreadedStateMachineManager(
                     // return an exception as they are not permitted to see the result of the flow
                     if (!it.isPermitted(context.principal())) {
                         return@startFlow openFuture<FlowStateMachineHandle<A>>().apply {
-                            setException(PermissionException("User not authorized to start flow with client id [$clientId]"))
+                            setException(PermissionException("A flow using this client id [$clientId] has already been started by another user"))
                         }
                     }
                     val existingFuture = activeOrRemovedClientIdFuture(it, clientId)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -12,6 +12,7 @@ import net.corda.core.utilities.Try
 import net.corda.node.services.messaging.DeduplicationHandler
 import net.corda.node.services.messaging.ReceivedMessage
 import rx.Observable
+import java.security.Principal
 
 /**
  * A StateMachineManager is responsible for coordination and persistence of multiple [FlowStateMachine] objects.
@@ -112,14 +113,14 @@ interface StateMachineManager {
      *
      * @param clientId The client id relating to an existing flow
      */
-    fun <T> reattachFlowWithClientId(clientId: String): FlowStateMachineHandle<T>?
+    fun <T> reattachFlowWithClientId(clientId: String, user: Principal): FlowStateMachineHandle<T>?
 
     /**
      * Removes a flow's [clientId] to result/ exception mapping.
      *
      * @return whether the mapping was removed.
      */
-    fun removeClientId(clientId: String): Boolean
+    fun removeClientId(clientId: String, user: Principal): Boolean
 
     /**
      * Returns all finished flows that were started with a client id.
@@ -127,7 +128,7 @@ interface StateMachineManager {
      * @return A [Map] containing client ids for finished flows, mapped to [true] if finished successfully,
      * [false] if completed exceptionally.
      */
-    fun finishedFlowsWithClientIds(): Map<String, Boolean>
+    fun finishedFlowsWithClientIds(user: Principal): Map<String, Boolean>
 }
 
 // These must be idempotent! A later failure in the state transition may error the flow state, and a replay may call

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -120,7 +120,7 @@ interface StateMachineManager {
      *
      * @return whether the mapping was removed.
      */
-    fun removeClientId(clientId: String, user: Principal): Boolean
+    fun removeClientId(clientId: String, user: Principal, isAdmin: Boolean): Boolean
 
     /**
      * Returns all finished flows that were started with a client id.
@@ -128,7 +128,7 @@ interface StateMachineManager {
      * @return A [Map] containing client ids for finished flows, mapped to [true] if finished successfully,
      * [false] if completed exceptionally.
      */
-    fun finishedFlowsWithClientIds(user: Principal): Map<String, Boolean>
+    fun finishedFlowsWithClientIds(user: Principal, isAdmin: Boolean): Map<String, Boolean>
 }
 
 // These must be idempotent! A later failure in the state transition may error the flow state, and a replay may call

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -21,6 +21,7 @@ import net.corda.testing.node.internal.FINANCE_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.TestStartedNode
+import net.corda.testing.node.internal.newContext
 import net.corda.testing.node.internal.startFlow
 import net.corda.testing.node.internal.startFlowWithClientId
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -340,7 +341,7 @@ class FlowClientIdTests {
         ResultFlow.hook = { counter++ }
         val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         flowHandle0.resultFuture.getOrThrow(20.seconds)
-        val removed = aliceNode.smm.removeClientId(clientId)
+        val removed = aliceNode.smm.removeClientId(clientId, aliceNode.user)
         // On new request with clientId, after the same clientId was removed, a brand new flow will start with that clientId
         val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         flowHandle1.resultFuture.getOrThrow(20.seconds)
@@ -363,7 +364,7 @@ class FlowClientIdTests {
             assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
         }
 
-        aliceNode.smm.removeClientId(clientId)
+        aliceNode.smm.removeClientId(clientId, aliceNode.user)
 
         // assert database status after remove
         aliceNode.services.database.transaction {
@@ -374,7 +375,7 @@ class FlowClientIdTests {
         }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `removing a client id exception clears resources properly`() {
         val clientId = UUID.randomUUID().toString()
         ResultFlow.hook = { throw IllegalStateException() }
@@ -389,7 +390,7 @@ class FlowClientIdTests {
             assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
         }
 
-        aliceNode.smm.removeClientId(clientId)
+        aliceNode.smm.removeClientId(clientId, aliceNode.user)
 
         // assert database status after remove
         aliceNode.services.database.transaction {
@@ -400,7 +401,7 @@ class FlowClientIdTests {
         }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `flow's client id mapping can only get removed once the flow gets removed`() {
         val clientId = UUID.randomUUID().toString()
         var tries = 0
@@ -417,7 +418,7 @@ class FlowClientIdTests {
 
         var removed = false
         while (!removed) {
-            removed = aliceNode.smm.removeClientId(clientId)
+            removed = aliceNode.smm.removeClientId(clientId, aliceNode.user)
             if (!removed) ++failedRemovals
             ++tries
             if (tries >= maxTries) {
@@ -636,7 +637,7 @@ class FlowClientIdTests {
         assertEquals("Flow's ${flowHandle0!!.id} exception was not found in the database. Something is very wrong.", e.message)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `completed flow started with a client id nulls its flow state in database after its lifetime`() {
         val clientId = UUID.randomUUID().toString()
         val flowHandle = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
@@ -648,7 +649,7 @@ class FlowClientIdTests {
         }
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `failed flow started with a client id nulls its flow state in database after its lifetime`() {
         val clientId = UUID.randomUUID().toString()
         ResultFlow.hook = { throw IllegalStateException() }
@@ -664,11 +665,12 @@ class FlowClientIdTests {
             assertNull(dbFlowCheckpoint!!.blob!!.flowStack)
         }
     }
+
     @Test(timeout = 300_000)
     fun `reattachFlowWithClientId can retrieve existing flow future`() {
         val clientId = UUID.randomUUID().toString()
         val flowHandle = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(10))
-        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId)
+        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId, aliceNode.user)
 
         assertEquals(10, flowHandle.resultFuture.getOrThrow(20.seconds))
         assertEquals(clientId, flowHandle.clientId)
@@ -680,7 +682,7 @@ class FlowClientIdTests {
     fun `reattachFlowWithClientId can retrieve a null result from a flow future`() {
         val clientId = UUID.randomUUID().toString()
         val flowHandle = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(null))
-        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId)
+        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId, aliceNode.user)
 
         assertEquals(null, flowHandle.resultFuture.getOrThrow(20.seconds))
         assertEquals(clientId, flowHandle.clientId)
@@ -696,7 +698,7 @@ class FlowClientIdTests {
         assertEquals(10, flowHandle.resultFuture.getOrThrow(20.seconds))
         assertEquals(clientId, flowHandle.clientId)
 
-        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId)
+        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId, aliceNode.user)
 
         assertEquals(flowHandle.id, reattachedFlowHandle?.id)
         assertEquals(flowHandle.resultFuture.get(), reattachedFlowHandle?.resultFuture?.get())
@@ -704,7 +706,7 @@ class FlowClientIdTests {
 
     @Test(timeout = 300_000)
     fun `reattachFlowWithClientId returns null if no flow matches the client id`() {
-        assertEquals(null, aliceNode.smm.reattachFlowWithClientId<Int>(UUID.randomUUID().toString()))
+        assertEquals(null, aliceNode.smm.reattachFlowWithClientId<Int>(UUID.randomUUID().toString(), aliceNode.user))
     }
 
     @Test(timeout = 300_000)
@@ -712,7 +714,7 @@ class FlowClientIdTests {
         ResultFlow.hook = { throw IllegalStateException("Bla bla bla") }
         val clientId = UUID.randomUUID().toString()
         val flowHandle = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(10))
-        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId)
+        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId, aliceNode.user)
 
         assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy {
             flowHandle.resultFuture.getOrThrow(20.seconds)
@@ -733,7 +735,7 @@ class FlowClientIdTests {
             flowHandle.resultFuture.getOrThrow(20.seconds)
         }.withMessage("Bla bla bla")
 
-        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId)
+        val reattachedFlowHandle = aliceNode.smm.reattachFlowWithClientId<Int>(clientId, aliceNode.user)
 
         // [CordaRunTimeException] returned because [IllegalStateException] is not serializable
         assertThatExceptionOfType(CordaRuntimeException::class.java).isThrownBy {
@@ -753,7 +755,7 @@ class FlowClientIdTests {
         }
 
         assertFailsWith<KilledFlowException> {
-            aliceNode.smm.reattachFlowWithClientId<Int>(clientId)?.resultFuture?.getOrThrow()
+            aliceNode.smm.reattachFlowWithClientId<Int>(clientId, aliceNode.user)?.resultFuture?.getOrThrow()
         }
     }
 
@@ -779,7 +781,7 @@ class FlowClientIdTests {
         flows.map { it.resultFuture }.transpose().getOrThrow(30.seconds)
         assertFailsWith<java.lang.IllegalStateException> { failedFlow.resultFuture.getOrThrow(20.seconds) }
 
-        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds()
+        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds(aliceNode.user)
 
         lock.countDown()
 
@@ -791,11 +793,13 @@ class FlowClientIdTests {
 
         assertEquals(
             listOf(10, 10, 10),
-            finishedFlows.filterValues { it }.map { aliceNode.smm.reattachFlowWithClientId<Int>(it.key)?.resultFuture?.get() }
+            finishedFlows.filterValues { it }
+                .map { aliceNode.smm.reattachFlowWithClientId<Int>(it.key, aliceNode.user)?.resultFuture?.get() }
         )
         // [CordaRunTimeException] returned because [IllegalStateException] is not serializable
         assertFailsWith<CordaRuntimeException> {
-            finishedFlows.filterValues { !it }.map { aliceNode.smm.reattachFlowWithClientId<Int>(it.key)?.resultFuture?.getOrThrow() }
+            finishedFlows.filterValues { !it }
+                .map { aliceNode.smm.reattachFlowWithClientId<Int>(it.key, aliceNode.user)?.resultFuture?.getOrThrow() }
         }
     }
 
@@ -810,12 +814,14 @@ class FlowClientIdTests {
             flowHandle0.resultFuture.getOrThrow()
         }
 
-        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds()
+        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds(aliceNode.user)
 
         assertFailsWith<KilledFlowException> {
-            finishedFlows.keys.single().let { aliceNode.smm.reattachFlowWithClientId<Int>(it)?.resultFuture?.getOrThrow() }
+            finishedFlows.keys.single().let { aliceNode.smm.reattachFlowWithClientId<Int>(it, aliceNode.user)?.resultFuture?.getOrThrow() }
         }
     }
+
+    private val TestStartedNode.user get() = services.newContext().principal()
 
     private fun TestStartedNode.hasStatus(id: StateMachineRunId, status: Checkpoint.FlowStatus): Boolean {
         return services.database.transaction {
@@ -870,7 +876,7 @@ class FlowClientIdTests {
         }
     }
 
-    internal class ResultFlow<A>(private val result: A): FlowLogic<A>() {
+    internal class ResultFlow<A>(private val result: A) : FlowLogic<A>() {
         companion object {
             var hook: ((String?) -> Unit)? = null
             var suspendableHook: FlowLogic<Unit>? = null
@@ -884,7 +890,7 @@ class FlowClientIdTests {
         }
     }
 
-    internal class UnSerializableResultFlow: FlowLogic<Any>() {
+    internal class UnSerializableResultFlow : FlowLogic<Any>() {
         companion object {
             var firstRun = true
         }
@@ -901,7 +907,7 @@ class FlowClientIdTests {
         }
     }
 
-    internal class HospitalizeFlow: FlowLogic<Unit>() {
+    internal class HospitalizeFlow : FlowLogic<Unit>() {
 
         @Suspendable
         override fun call() {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -341,7 +341,7 @@ class FlowClientIdTests {
         ResultFlow.hook = { counter++ }
         val flowHandle0 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         flowHandle0.resultFuture.getOrThrow(20.seconds)
-        val removed = aliceNode.smm.removeClientId(clientId, aliceNode.user)
+        val removed = aliceNode.smm.removeClientId(clientId, aliceNode.user, false)
         // On new request with clientId, after the same clientId was removed, a brand new flow will start with that clientId
         val flowHandle1 = aliceNode.services.startFlowWithClientId(clientId, ResultFlow(5))
         flowHandle1.resultFuture.getOrThrow(20.seconds)
@@ -364,7 +364,7 @@ class FlowClientIdTests {
             assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
         }
 
-        aliceNode.smm.removeClientId(clientId, aliceNode.user)
+        aliceNode.smm.removeClientId(clientId, aliceNode.user, false)
 
         // assert database status after remove
         aliceNode.services.database.transaction {
@@ -390,7 +390,7 @@ class FlowClientIdTests {
             assertEquals(1, findRecordsFromDatabase<DBCheckpointStorage.DBFlowMetadata>().size)
         }
 
-        aliceNode.smm.removeClientId(clientId, aliceNode.user)
+        aliceNode.smm.removeClientId(clientId, aliceNode.user, false)
 
         // assert database status after remove
         aliceNode.services.database.transaction {
@@ -418,7 +418,7 @@ class FlowClientIdTests {
 
         var removed = false
         while (!removed) {
-            removed = aliceNode.smm.removeClientId(clientId, aliceNode.user)
+            removed = aliceNode.smm.removeClientId(clientId, aliceNode.user, false)
             if (!removed) ++failedRemovals
             ++tries
             if (tries >= maxTries) {
@@ -781,7 +781,7 @@ class FlowClientIdTests {
         flows.map { it.resultFuture }.transpose().getOrThrow(30.seconds)
         assertFailsWith<java.lang.IllegalStateException> { failedFlow.resultFuture.getOrThrow(20.seconds) }
 
-        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds(aliceNode.user)
+        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds(aliceNode.user, false)
 
         lock.countDown()
 
@@ -814,10 +814,11 @@ class FlowClientIdTests {
             flowHandle0.resultFuture.getOrThrow()
         }
 
-        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds(aliceNode.user)
+        val finishedFlows = aliceNode.smm.finishedFlowsWithClientIds(aliceNode.user, false)
 
         assertFailsWith<KilledFlowException> {
-            finishedFlows.keys.single().let { aliceNode.smm.reattachFlowWithClientId<Int>(it, aliceNode.user)?.resultFuture?.getOrThrow() }
+            finishedFlows.keys.single()
+                .let { aliceNode.smm.reattachFlowWithClientId<Int>(it, aliceNode.user)?.resultFuture?.getOrThrow() }
         }
     }
 


### PR DESCRIPTION
Do not let a user reattach to a flow started by another user.

Reattaching to a flow using `startFlowWithClientId` for a flow not
started by the current user throws a `PermissionException`

Reattaching to a flow using `reattachFlowWithClientId` for a flow not
started by the current user returns null.

`finishedFlowsWithClientIds` does not return flows started by other
users.

Normal rpc permissions around `startFlowWithClientId` and
`startFlowDynamicWithClientId` has also been added.

To allow admins to remove client ids as well as be able to see all the
client ids on the node, admin versions have been added that bypass the
user restrictions. These can be permitted via rpc to only provide
their usage to admins.