### PR TITLE
CORDA-3974: NetworkMapCache should link entries with different public keys by X.500 name

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
@@ -263,7 +263,7 @@ class P2PMessagingClient(val config: NodeConfiguration,
     }
 
     private fun updateBridgesOnNetworkChange(change: NetworkMapCache.MapChange) {
-        log.info("Updating bridges on network map change: ${change.node}")
+        log.info("Updating bridges on network map change: ${change::class.simpleName} ${change.node}")
         fun gatherAddresses(node: NodeInfo): Sequence<BridgeEntry> {
             return state.locked {
                 node.legalIdentitiesAndCerts.map {

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt
@@ -132,7 +132,7 @@ class NetworkMapCacheTest {
         val aliceCertificate2 = aliceInfo2.legalIdentitiesAndCerts.single()
         bobCache.addOrUpdateNode(aliceInfo2)
 
-        // Check that keys and certificates are different
+        // Check that keys are the same and certificates are different
         assertThat(aliceKey).isEqualTo(aliceKey2)
         assertThat(aliceCertificate.certificate).isNotEqualTo(aliceCertificate2.certificate)
 


### PR DESCRIPTION
Replace NodeInfo in NetworkMapCache by X.500 name.
Also, improve logging, including printout of the key hash.