### PR TITLE
ENT-5759 Move the test CorDapp

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/persistence/DbSchemaInitialisationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/DbSchemaInitialisationTest.kt
@@ -32,7 +32,7 @@ class DbSchemaInitialisationTest {
             // in dev mode, it fails because the schema of our test CorDapp is missing
             assertThatExceptionOfType(HibernateSchemaChangeException::class.java)
                     .isThrownBy {
-                        startNode(NodeParameters(additionalCordapps = listOf(TestCordapp.findCordapp("net.corda.testing.missingmigrationcordapp")))).getOrThrow()
+                        startNode(NodeParameters(additionalCordapps = listOf(TestCordapp.findCordapp("net.corda.failtesting.missingmigrationcordapp")))).getOrThrow()
                     }
                     .withMessage("Incompatible schema change detected. Please run schema migration scripts (node with sub-command run-migration-scripts). Reason: Schema-validation: missing table [test_table]")
 
@@ -42,9 +42,9 @@ class DbSchemaInitialisationTest {
                         startNode(
                                 ALICE_NAME,
                                 false,
-                                NodeParameters(additionalCordapps = listOf(TestCordapp.findCordapp("net.corda.testing.missingmigrationcordapp")))).getOrThrow()
+                                NodeParameters(additionalCordapps = listOf(TestCordapp.findCordapp("net.corda.failtesting.missingmigrationcordapp")))).getOrThrow()
                     }
-                    .withMessage("Could not create the DataSource: No migration defined for schema: net.corda.testing.missingmigrationcordapp.MissingMigrationSchema v1")
+                    .withMessage("Could not create the DataSource: No migration defined for schema: net.corda.failtesting.missingmigrationcordapp.MissingMigrationSchema v1")
         }
     }
 }

--- a/testing/cordapps/missingmigration/src/main/kotlin/net/corda/failtesting/missingmigrationcordapp/MissingMigrationSchema.kt
+++ b/testing/cordapps/missingmigration/src/main/kotlin/net/corda/failtesting/missingmigrationcordapp/MissingMigrationSchema.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.missingmigrationcordapp
+package net.corda.failtesting.missingmigrationcordapp
 
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState

--- a/testing/cordapps/missingmigration/src/main/kotlin/net/corda/failtesting/missingmigrationcordapp/SimpleFlow.kt
+++ b/testing/cordapps/missingmigration/src/main/kotlin/net/corda/failtesting/missingmigrationcordapp/SimpleFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.missingmigrationcordapp
+package net.corda.failtesting.missingmigrationcordapp
 
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow

--- a/testing/cordapps/missingmigration/src/main/kotlin/net/corda/failtesting/missingmigrationcordapp/TestEntity.kt
+++ b/testing/cordapps/missingmigration/src/main/kotlin/net/corda/failtesting/missingmigrationcordapp/TestEntity.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.missingmigrationcordapp
+package net.corda.failtesting.missingmigrationcordapp
 
 import net.corda.core.identity.AbstractParty
 import net.corda.core.schemas.MappedSchema


### PR DESCRIPTION
Give the (deliberately broken) test CorDapp a different package name so it does not get automatically to all tests looking at CorDapps under `net.corda.testing`.
