### PR TITLE
INFRA-683: Use safe navigation operator for correct field

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -248,7 +248,7 @@ pipeline {
                     // Comparing the dates of the previous and current builds achieves this,
                     // i.e. we will only send an email for the first build on a given day.
                     def prevBuildDate = new Date(
-                            currentBuild?.previousBuild.timeInMillis ?: 0).clearTime()
+                            currentBuild.previousBuild?.timeInMillis ?: 0).clearTime()
                     def currentBuildDate = new Date(
                             currentBuild.timeInMillis).clearTime()
 

--- a/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
@@ -215,6 +215,7 @@ class AuthDBTests : NodeBasedTest() {
 
     @After
     fun tearDown() {
+        node.node.stop()
         db.close()
     }
 


### PR DESCRIPTION
when checking the time of previous build.
Handles an edge case when there is the very first build for the branch
