### PR TITLE
NOTICK Fix kill flow standalone rpc client test

### DIFF
--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -65,6 +65,9 @@ processSmokeTestResources {
     from(project(':finance:contracts').tasks['jar']) {
         rename '.*finance-contracts-.*', 'cordapp-finance-contracts.jar'
     }
+    from(project(':testing:cordapps:sleeping').tasks['jar']) {
+        rename 'testing-sleeping-cordapp-*', 'cordapp-sleeping.jar'
+    }
 }
 
 // To find potential version conflicts, run "gradle htmlDependencyReport" and then look in
@@ -94,6 +97,7 @@ dependencies {
     smokeTestCompile project(':smoke-test-utils')
     smokeTestCompile project(':finance:contracts')
     smokeTestCompile project(':finance:workflows')
+    smokeTestCompile project(':testing:cordapps:sleeping')
     smokeTestCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     smokeTestCompile "org.apache.logging.log4j:log4j-core:$log4j_version"
     smokeTestCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -8,33 +8,48 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.InputStreamAndHash
-import net.corda.core.messaging.*
+import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.messaging.StateMachineUpdate
+import net.corda.core.messaging.startFlow
+import net.corda.core.messaging.startTrackedFlow
+import net.corda.core.messaging.vaultQueryBy
+import net.corda.core.messaging.vaultTrackBy
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.Vault
-import net.corda.core.node.services.vault.*
+import net.corda.core.node.services.vault.DEFAULT_PAGE_NUM
+import net.corda.core.node.services.vault.PageSpecification
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.node.services.vault.Sort
+import net.corda.core.node.services.vault.SortAttribute
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.minutes
 import net.corda.core.utilities.seconds
 import net.corda.finance.DOLLARS
 import net.corda.finance.POUNDS
 import net.corda.finance.SWISS_FRANCS
 import net.corda.finance.USD
 import net.corda.finance.contracts.asset.Cash
-import net.corda.finance.workflows.getCashBalance
-import net.corda.finance.workflows.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
+import net.corda.finance.workflows.getCashBalance
+import net.corda.finance.workflows.getCashBalances
 import net.corda.java.rpc.StandaloneCordaRPCJavaClientTest
 import net.corda.nodeapi.internal.config.User
+import net.corda.sleeping.SleepingFlow
 import net.corda.smoketesting.NodeConfig
 import net.corda.smoketesting.NodeProcess
 import org.apache.commons.io.output.NullOutputStream
-import org.junit.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
 import org.junit.rules.ExpectedException
 import java.io.FilterInputStream
 import java.io.InputStream
-import java.util.*
+import java.util.Currency
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -240,7 +255,7 @@ class StandaloneCordaRPClientTest {
         exception.expect(PermissionException::class.java)
         exception.expectMessage("User not authorized to perform RPC call killFlow")
 
-        val flowHandle = rpcProxy.startFlow(::CashIssueFlow, 10.DOLLARS, OpaqueBytes.of(0), notaryNodeIdentity)
+        val flowHandle = rpcProxy.startFlow(::SleepingFlow, 1.minutes)
         notary.connect(nonUser).use { connection ->
             val rpcProxy = connection.proxy
             rpcProxy.killFlow(flowHandle.id)
@@ -249,7 +264,7 @@ class StandaloneCordaRPClientTest {
 
     @Test(timeout=300_000)
 	fun `test kill flow with killFlow permission`() {
-        val flowHandle = rpcProxy.startFlow(::CashIssueFlow, 83.DOLLARS, OpaqueBytes.of(0), notaryNodeIdentity)
+        val flowHandle = rpcProxy.startFlow(::SleepingFlow, 1.minutes)
         notary.connect(rpcUser).use { connection ->
             val rpcProxy = connection.proxy
             assertTrue(rpcProxy.killFlow(flowHandle.id))

--- a/settings.gradle
+++ b/settings.gradle
@@ -102,6 +102,7 @@ include 'serialization-tests'
 include 'testing:cordapps:dbfailure:dbfcontracts'
 include 'testing:cordapps:dbfailure:dbfworkflows'
 include 'testing:cordapps:missingmigration'
+include 'testing:cordapps:sleeping'
 
 // Common libraries - start
 include 'common-validation'

--- a/testing/cordapps/sleeping/build.gradle
+++ b/testing/cordapps/sleeping/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'kotlin'
+
+dependencies {
+    compile project(":core")
+}
+
+jar {
+    baseName "testing-sleeping-cordapp"
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
+}

--- a/testing/cordapps/sleeping/src/main/kotlin/net/corda/sleeping/SleepingFlow.kt
+++ b/testing/cordapps/sleeping/src/main/kotlin/net/corda/sleeping/SleepingFlow.kt
@@ -1,0 +1,15 @@
+package net.corda.sleeping
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import java.time.Duration
+
+@StartableByRPC
+class SleepingFlow(private val duration: Duration) : FlowLogic<Unit>() {
+
+    @Suspendable
+    override fun call() {
+        sleep(duration)
+    }
+}


### PR DESCRIPTION
Test was flaky because the flow can finish below it can be killed,
therefore failing the test. Sleep for 1 minute instead to give plenty of
time for the test.