### PR TITLE
backport of bugfix ENT-5752 into OS 4.3

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -142,6 +142,11 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
                 val nextScheduleDelay = try {
                     updateNetworkMapCache()
                 } catch (e: Exception) {
+                    // Check to see if networkmap was reachable before and cached information exists
+                    if (networkMapCache.allNodeHashes.size > 1) {
+                        logger.debug("Networkmap Service unreachable but more than one nodeInfo entries found in the cache. Allowing node start-up to proceed.")
+                        networkMapCache.nodeReady.set(null)
+                    }
                     logger.warn("Error encountered while updating network map, will retry in $defaultRetryInterval", e)
                     defaultRetryInterval
                 }


### PR DESCRIPTION
This is the backport of a bugfix (ENT-5752) for a situation where the absence of NMS connection caused nodes not to start properly. See the original fix here: https://github.com/corda/corda/pull/6716/files

This fix will need to be backported into both OS and ENT 4.3, 4.4 and 4.5