### PR TITLE
EG-1561: Make logging arguments global options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ buildscript {
     ext.snappy_version = '0.4'
     ext.class_graph_version = constants.getProperty('classgraphVersion')
     ext.jcabi_manifests_version = '1.1'
-    ext.picocli_version = '3.9.6'
+    ext.picocli_version = '4.5.1'
     ext.commons_lang_version = '3.9'
     ext.commons_io_version = '2.6'
     ext.controlsfx_version = '8.40.15'

--- a/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt
+++ b/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt
@@ -8,7 +8,7 @@ import kotlin.collections.LinkedHashMap
 fun main(args: Array<String>) {
 
     val parameters = Parameters()
-    CommandLine(parameters).parse(*args)
+    CommandLine(parameters).parseArgs(*args)
     if (parameters.helpRequested) {
         CommandLine.usage(Parameters(), System.out)
         return

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -79,7 +79,7 @@ open class NodeStartupCli : CordaCliWrapper("corda", "Runs a Corda Node") {
     private val runMigrationScriptsCli by lazy { RunMigrationScriptsCli(startup) }
     private val synchroniseAppSchemasCli by lazy { SynchroniseSchemasCli(startup) }
 
-    override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
+    //override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     override fun additionalSubCommands() = setOf(networkCacheCli,
             justGenerateNodeInfoCli,
@@ -144,6 +144,38 @@ open class NodeStartupCli : CordaCliWrapper("corda", "Runs a Corda Node") {
                 override fun run(node: Node) = startup.startNode(node, startupTime)
             }, requireCertificates = true)
         }
+    }
+
+    override fun initLogging(): Boolean {
+        val baseDirectory = cmdLineOptions.baseDirectory
+
+        System.setProperty("defaultLogLevel",  specifiedLogLevel) // These properties are referenced from the XML config file.
+        System.setProperty("log-path", (baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
+        if (verbose) {
+            System.setProperty("consoleLoggingEnabled", "true")
+            System.setProperty("consoleLogLevel", specifiedLogLevel)
+            Node.renderBasicInfoToConsole = false
+        }
+
+        //Test for access to the logging path and shutdown if we are unable to reach it.
+        val logPath = baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME
+        try {
+            logPath.safeSymbolicRead().createDirectories()
+        } catch (e: IOException) {
+            printError("Unable to create logging directory ${logPath.toString()}. Node will now shutdown.")
+            return false
+        } catch (e: SecurityException) {
+            printError("Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
+            return false
+        }
+        if (!logPath.isDirectory()) {
+            printError("Unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
+            return false
+        }
+
+        SLF4JBridgeHandler.removeHandlersForRootLogger() // The default j.u.l config adds a ConsoleHandler.
+        SLF4JBridgeHandler.install()
+        return true
     }
 }
 
@@ -510,34 +542,4 @@ interface NodeStartupLogging {
             else -> error.logAsUnexpected("Exception during node startup")
         }
     }
-}
-
-fun initLogging(baseDirectory: Path, specifiedLogLevel: String = "INFO", verbose: Boolean = false): Boolean {
-    System.setProperty("defaultLogLevel",  specifiedLogLevel) // These properties are referenced from the XML config file.
-    System.setProperty("log-path", (baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
-    if (verbose) {
-        System.setProperty("consoleLoggingEnabled", "true")
-        System.setProperty("consoleLogLevel", specifiedLogLevel)
-        Node.renderBasicInfoToConsole = false
-    }
-
-    //Test for access to the logging path and shutdown if we are unable to reach it.
-    val logPath = baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME
-    try {
-        logPath.safeSymbolicRead().createDirectories()
-    } catch (e: IOException) {
-        printError("Unable to create logging directory ${logPath.toString()}. Node will now shutdown.")
-        return false
-    } catch (e: SecurityException) {
-        printError("Current user is unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
-        return false
-    }
-    if (!logPath.isDirectory()) {
-        printError("Unable to access logging directory ${logPath.toString()}. Node will now shutdown.")
-        return false
-    }
-
-    SLF4JBridgeHandler.removeHandlersForRootLogger() // The default j.u.l config adds a ConsoleHandler.
-    SLF4JBridgeHandler.install()
-    return true
 }

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -59,8 +59,6 @@ abstract class NodeCliCommand(alias: String, description: String, val startup: N
         const val LOGS_DIRECTORY_NAME = "logs"
     }
 
-    //override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
-
     @Mixin
     val cmdLineOptions = SharedNodeCmdLineOptions()
 }
@@ -78,8 +76,6 @@ open class NodeStartupCli : CordaCliWrapper("corda", "Runs a Corda Node") {
     private val validateConfigurationCli by lazy { ValidateConfigurationCli() }
     private val runMigrationScriptsCli by lazy { RunMigrationScriptsCli(startup) }
     private val synchroniseAppSchemasCli by lazy { SynchroniseSchemasCli(startup) }
-
-    //override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     override fun additionalSubCommands() = setOf(networkCacheCli,
             justGenerateNodeInfoCli,
@@ -147,10 +143,8 @@ open class NodeStartupCli : CordaCliWrapper("corda", "Runs a Corda Node") {
     }
 
     override fun initLogging(): Boolean {
-        val baseDirectory = cmdLineOptions.baseDirectory
-
         System.setProperty("defaultLogLevel",  specifiedLogLevel) // These properties are referenced from the XML config file.
-        System.setProperty("log-path", (baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
+        System.setProperty("log-path", (cmdLineOptions.baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
         if (verbose) {
             System.setProperty("consoleLoggingEnabled", "true")
             System.setProperty("consoleLogLevel", specifiedLogLevel)
@@ -158,7 +152,7 @@ open class NodeStartupCli : CordaCliWrapper("corda", "Runs a Corda Node") {
         }
 
         //Test for access to the logging path and shutdown if we are unable to reach it.
-        val logPath = baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME
+        val logPath = cmdLineOptions.baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME
         try {
             logPath.safeSymbolicRead().createDirectories()
         } catch (e: IOException) {

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -59,7 +59,7 @@ abstract class NodeCliCommand(alias: String, description: String, val startup: N
         const val LOGS_DIRECTORY_NAME = "logs"
     }
 
-    override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
+    //override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     @Mixin
     val cmdLineOptions = SharedNodeCmdLineOptions()
@@ -512,14 +512,14 @@ interface NodeStartupLogging {
     }
 }
 
-fun CliWrapperBase.initLogging(baseDirectory: Path): Boolean {
-    //System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
+fun initLogging(baseDirectory: Path, specifiedLogLevel: String = "INFO", verbose: Boolean = false): Boolean {
+    System.setProperty("defaultLogLevel",  specifiedLogLevel) // These properties are referenced from the XML config file.
     System.setProperty("log-path", (baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
-//    if (verbose) {
-//        System.setProperty("consoleLoggingEnabled", "true")
-//        System.setProperty("consoleLogLevel", specifiedLogLevel)
-//        Node.renderBasicInfoToConsole = false
-//    }
+    if (verbose) {
+        System.setProperty("consoleLoggingEnabled", "true")
+        System.setProperty("consoleLogLevel", specifiedLogLevel)
+        Node.renderBasicInfoToConsole = false
+    }
 
     //Test for access to the logging path and shutdown if we are unable to reach it.
     val logPath = baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -513,13 +513,13 @@ interface NodeStartupLogging {
 }
 
 fun CliWrapperBase.initLogging(baseDirectory: Path): Boolean {
-    System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
+    //System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
     System.setProperty("log-path", (baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME).toString())
-    if (verbose) {
-        System.setProperty("consoleLoggingEnabled", "true")
-        System.setProperty("consoleLogLevel", specifiedLogLevel)
-        Node.renderBasicInfoToConsole = false
-    }
+//    if (verbose) {
+//        System.setProperty("consoleLoggingEnabled", "true")
+//        System.setProperty("consoleLogLevel", specifiedLogLevel)
+//        Node.renderBasicInfoToConsole = false
+//    }
 
     //Test for access to the logging path and shutdown if we are unable to reach it.
     val logPath = baseDirectory / NodeCliCommand.LOGS_DIRECTORY_NAME

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -29,11 +29,12 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
     var skipSchemaCreation: Boolean = false
 
     override fun runProgram() : Int {
+        initLogging(cmdLineOptions.baseDirectory)
         val networkRootTrustStorePath: Path = networkRootTrustStorePathParameter ?: cmdLineOptions.baseDirectory / "certificates" / "network-root-truststore.jks"
         return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, skipSchemaCreation, startup))
     }
 
-    override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
+    //override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     @Mixin
     val cmdLineOptions = InitialRegistrationCmdLineOptions()

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -29,7 +29,7 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
     var skipSchemaCreation: Boolean = false
 
     override fun runProgram() : Int {
-        initLogging(cmdLineOptions.baseDirectory)
+        //initLogging(cmdLineOptions.baseDirectory)
         val networkRootTrustStorePath: Path = networkRootTrustStorePathParameter ?: cmdLineOptions.baseDirectory / "certificates" / "network-root-truststore.jks"
         return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, skipSchemaCreation, startup))
     }

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -29,12 +29,9 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
     var skipSchemaCreation: Boolean = false
 
     override fun runProgram() : Int {
-        //initLogging(cmdLineOptions.baseDirectory)
         val networkRootTrustStorePath: Path = networkRootTrustStorePathParameter ?: cmdLineOptions.baseDirectory / "certificates" / "network-root-truststore.jks"
         return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, skipSchemaCreation, startup))
     }
-
-    //override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
 
     @Mixin
     val cmdLineOptions = InitialRegistrationCmdLineOptions()

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
@@ -7,7 +7,6 @@ import net.corda.cliutils.ExitCodes
 import net.corda.common.configuration.parsing.internal.Configuration
 import net.corda.core.utilities.loggerFor
 import net.corda.node.SharedNodeCmdLineOptions
-import net.corda.node.internal.initLogging
 import net.corda.node.services.config.schema.v1.V1NodeConfigurationSpec
 import net.corda.nodeapi.internal.config.toConfigValue
 import picocli.CommandLine.Mixin
@@ -31,8 +30,6 @@ internal class ValidateConfigurationCli : CliWrapperBase("validate-configuration
 
     @Mixin
     private val cmdLineOptions = SharedNodeCmdLineOptions()
-
-    //override fun initLogging(): Boolean = initLogging(cmdLineOptions.baseDirectory)
 
     override fun runProgram(): Int {
         val rawConfig = cmdLineOptions.rawConfiguration().doOnErrors(cmdLineOptions::logRawConfigurationErrors).optional ?: return ExitCodes.FAILURE

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
@@ -32,7 +32,7 @@ internal class ValidateConfigurationCli : CliWrapperBase("validate-configuration
     @Mixin
     private val cmdLineOptions = SharedNodeCmdLineOptions()
 
-    override fun initLogging(): Boolean = initLogging(cmdLineOptions.baseDirectory)
+    //override fun initLogging(): Boolean = initLogging(cmdLineOptions.baseDirectory)
 
     override fun runProgram(): Int {
         val rawConfig = cmdLineOptions.rawConfiguration().doOnErrors(cmdLineOptions::logRawConfigurationErrors).optional ?: return ExitCodes.FAILURE

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -33,7 +33,6 @@ class NodeStartupCliTest {
         }
     }
 
-    @Ignore
     @Test(timeout=300_000)
 	fun `no command line arguments`() {
         CommandLine.populateCommand(startup)
@@ -52,7 +51,6 @@ class NodeStartupCliTest {
         Assertions.assertThat(startup.cmdLineOptions.networkRootTrustStorePathParameter).isEqualTo(null)
     }
 
-    @Ignore
     @Test(timeout=300_000)
 	fun `--base-directory`() {
         CommandLine.populateCommand(startup, CommonCliConstants.BASE_DIR, (workingDirectory / "another-base-dir").toString())
@@ -61,14 +59,12 @@ class NodeStartupCliTest {
         Assertions.assertThat(startup.cmdLineOptions.networkRootTrustStorePathParameter).isEqualTo(null)
     }
 
-    @Ignore
     @Test(timeout=300_000)
     fun `--nodeconf using relative path will be changed to absolute path`() {
         CommandLine.populateCommand(startup, CommonCliConstants.CONFIG_FILE, customNodeConf)
         Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo(workingDirectory / customNodeConf)
     }
 
-    @Ignore
     @Test(timeout=300_000)
     fun `--nodeconf using absolute path will not be changed`() {
         CommandLine.populateCommand(startup, CommonCliConstants.CONFIG_FILE, (rootDirectory / customNodeConf).toString())

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -83,7 +83,7 @@ class NodeStartupCliTest {
         node.verbose = true
         // With verbose set, initLogging can accidentally attempt to access a logger before all required system properties are set. This
         // causes the logging config to be parsed too early, resulting in logs being written to the wrong directory
-        node.initLogging(dir)
+        //node.initLogging(dir)
         LoggerFactory.getLogger("").debug("Test message")
         assertTrue(dir.resolve("logs").exists())
         assertFalse(Paths.get("./logs").exists())
@@ -98,11 +98,9 @@ class NodeStartupCliTest {
 
         startup.args = arrayOf()
 
-        startup.cmd.parseArgs(
-                "--logging-level=DEBUG", "--log-to-console",
+        startup.cmd.parseArgs("--logging-level=DEBUG", "--log-to-console",
                 "--base-directory", baseDir.absolutePath,
-                "initial-registration", "--network-root-truststore-password=password"
-                )
+                "initial-registration", "--network-root-truststore-password=password")
 
         Assertions.assertThat(startup.loggingLevel).isEqualTo(Level.DEBUG)
         Assertions.assertThat(startup.verbose).isEqualTo(true)

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -96,10 +96,13 @@ class NodeStartupCliTest {
         temporaryFolder.create()
         val baseDir = temporaryFolder.newFolder("baseDir")
 
-        CommandLine.populateCommand(startup,
-                "--log-to-console", "--logging-level=DEBUG",
+        startup.args = arrayOf()
+
+        startup.cmd.parseArgs(
+                "--logging-level=DEBUG", "--log-to-console",
                 "--base-directory", baseDir.absolutePath,
-                "initial-registration", "--network-root-truststore-password=password")
+                "initial-registration", "--network-root-truststore-password=password"
+                )
 
         Assertions.assertThat(startup.loggingLevel).isEqualTo(Level.DEBUG)
         Assertions.assertThat(startup.verbose).isEqualTo(true)
@@ -113,10 +116,13 @@ class NodeStartupCliTest {
         temporaryFolder.create()
         val baseDir = temporaryFolder.newFolder("baseDir")
 
-        CommandLine.populateCommand(startup,
+        startup.args = arrayOf()
+
+        startup.cmd.parseArgs(
                 "--base-directory", baseDir.absolutePath,
                 "initial-registration", "--network-root-truststore-password=password",
-                "--log-to-console", "--logging-level=DEBUG")
+                "--logging-level=DEBUG", "--log-to-console"
+        )
 
         Assertions.assertThat(startup.loggingLevel).isEqualTo(Level.DEBUG)
         Assertions.assertThat(startup.verbose).isEqualTo(true)

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -79,7 +79,7 @@ class NodeStartupCliTest {
         node.verbose = true
         // With verbose set, initLogging can accidentally attempt to access a logger before all required system properties are set. This
         // causes the logging config to be parsed too early, resulting in logs being written to the wrong directory
-        //node.initLogging(dir)
+        node.initLogging()
         LoggerFactory.getLogger("").debug("Test message")
         assertTrue(dir.resolve("logs").exists())
         assertFalse(Paths.get("./logs").exists())

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -85,8 +85,8 @@ fun CordaCliWrapper.start(args: Array<String>) {
         RunLast().useErr(System.err).useOut(System.out).useAnsi(defaultAnsiMode).execute(parseResult)
     }
 
-    cmd.executionExceptionHandler = executionExceptionHandler // only print stacktraces if verbose requested by users
-    cmd.executionStrategy = executionStrategy // init logging before invoking the business logic
+    cmd.executionExceptionHandler = executionExceptionHandler
+    cmd.executionStrategy = executionStrategy
 
     @Suppress("SpreadOperator")
     exitProcess(cmd.execute(*args))
@@ -115,7 +115,6 @@ abstract class CliWrapperBase(val alias: String, val description: String) : Call
     abstract fun runProgram(): Int
 
     override fun call(): Int {
-        //initLogging()
         logger.info("Application Args: ${args.joinToString(" ")}")
         return runProgram()
     }
@@ -148,19 +147,14 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
         return true
     }
 
-    @Option(
-            names = ["-v", "--verbose", "--log-to-console"],
-            description = ["If set, prints logging to the console as well as to a file."],
-            scope = ScopeType.INHERIT
-    )
+    @Option(names = ["-v", "--verbose", "--log-to-console"], scope = ScopeType.INHERIT,
+            description = ["If set, prints logging to the console as well as to a file."])
     var verbose: Boolean = false
 
-    @Option(names = ["--logging-level"],
+    @Option(names = ["--logging-level"], scope = ScopeType.INHERIT,
             completionCandidates = LoggingLevelConverter.LoggingLevels::class,
             description = ["Enable logging at this level and higher. Possible values: \${COMPLETION-CANDIDATES}"],
-            converter = [LoggingLevelConverter::class],
-            scope = ScopeType.INHERIT
-    )
+            converter = [LoggingLevelConverter::class])
     var loggingLevel: Level = Level.INFO
 
     protected open fun additionalSubCommands(): Set<CliWrapperBase> = emptySet()

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -1,6 +1,5 @@
 package net.corda.cliutils
 
-import net.corda.core.internal.rootMessage
 import net.corda.core.utilities.contextLogger
 import org.fusesource.jansi.AnsiConsole
 import org.slf4j.event.Level

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -121,8 +121,6 @@ abstract class CliWrapperBase(val alias: String, val description: String) : Call
     // needs to be parameterless for autocomplete to work.
     lateinit var args: Array<String>
 
-    abstract fun initLogging(): Boolean
-
     // Override this function with the actual method to be run once all the arguments have been parsed. The return number
     // is the exit code to be returned
     abstract fun runProgram(): Int
@@ -152,7 +150,7 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
 
     // This needs to be called before loggers (See: NodeStartup.kt:51 logger called by lazy, initLogging happens before).
     // Node's logging is more rich. In corda configurations two properties, defaultLoggingLevel and consoleLogLevel, are usually used.
-    override fun initLogging(): Boolean {
+    open fun initLogging(): Boolean {
         System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
         if (verbose) {
             System.setProperty("consoleLogLevel", specifiedLogLevel)

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -85,6 +85,7 @@ fun CordaCliWrapper.start(args: Array<String>) {
         RunLast().useErr(System.err).useOut(System.out).useAnsi(defaultAnsiMode).execute(parseResult)
     }
 
+    @Suppress("SpreadOperator")
     cmd.execute(*args).let {
         if (it == ExitCode.OK) {
             exitProcess(ExitCodes.SUCCESS)

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -6,6 +6,7 @@ import org.fusesource.jansi.AnsiConsole
 import org.slf4j.event.Level
 import picocli.CommandLine
 import picocli.CommandLine.*
+import java.io.PrintWriter
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -82,8 +83,12 @@ fun CordaCliWrapper.start(args: Array<String>) {
     // init logging before invoking the business logic
     cmd.executionStrategy = IExecutionStrategy { parseResult: ParseResult ->
         initLogging()
-        RunLast().useErr(System.err).useOut(System.out).useAnsi(defaultAnsiMode).execute(parseResult)
+        RunLast().execute(parseResult)
     }
+
+    cmd.err = PrintWriter(System.err)
+    cmd.out = PrintWriter(System.out)
+    cmd.colorScheme = Help.defaultColorScheme(defaultAnsiMode)
 
     @Suppress("SpreadOperator")
     cmd.execute(*args).let {

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
@@ -180,7 +180,6 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
 @Command(helpCommand = true)
 class InstallShellExtensionsParser(private val cliWrapper: CordaCliWrapper) : CliWrapperBase("install-shell-extensions", "Install alias and autocompletion for bash and zsh") {
     private val generator = ShellExtensionsGenerator(cliWrapper)
-
     override fun runProgram(): Int {
         return generator.installShellExtensions()
     }

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
@@ -180,6 +180,11 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
 @Command(helpCommand = true)
 class InstallShellExtensionsParser(private val cliWrapper: CordaCliWrapper) : CliWrapperBase("install-shell-extensions", "Install alias and autocompletion for bash and zsh") {
     private val generator = ShellExtensionsGenerator(cliWrapper)
+
+    override fun initLogging(): Boolean {
+        return cliWrapper.initLogging()
+    }
+
     override fun runProgram(): Int {
         return generator.installShellExtensions()
     }

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
@@ -181,10 +181,6 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
 class InstallShellExtensionsParser(private val cliWrapper: CordaCliWrapper) : CliWrapperBase("install-shell-extensions", "Install alias and autocompletion for bash and zsh") {
     private val generator = ShellExtensionsGenerator(cliWrapper)
 
-    override fun initLogging(): Boolean {
-        return cliWrapper.initLogging()
-    }
-
     override fun runProgram(): Int {
         return generator.installShellExtensions()
     }

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Main.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Main.kt
@@ -19,7 +19,7 @@ val baseArgs = CliParser()
 
 fun main(args: Array<String>) {
     SerializationEngine.init()
-    CommandLine(baseArgs).parse(*args)
+    CommandLine(baseArgs).parseArgs(*args)
     testDockerConnectivity()
 
     if (baseArgs.usageHelpRequested) {
@@ -35,7 +35,7 @@ fun main(args: Array<String>) {
     val argParser: CliParser = when (baseArgs.backendType) {
         AZURE -> {
             val azureArgs = AzureParser()
-            CommandLine(azureArgs).parse(*args)
+            CommandLine(azureArgs).parseArgs(*args)
             azureArgs
         }
         Backend.BackendType.LOCAL_DOCKER -> baseArgs


### PR DESCRIPTION
This PR updates the version of PicoCLI version and allows for global options `--logging-level` or `--log-to-console` to be placed in any order regardless of where sub-commands (such as initial-registration) are placed. 

The previous implementation used a [subclassing approach](https://picocli.info/#_subclassing) for sharing options when using subcommands. However, this approach had a limitation: while options could be shared between multiple commands, options needed to be placed in a particular order to be considered (i.e., after the last command). This was a limitation of the PicoCLI library and was addressed by introducing [Inherited Options](https://picocli.info/#_inherited_options). 

For instance, the `--log-to-console` and `--logging-level` should be set to the same values after running each of the following command: 

> java -jar corda.jar initial-registration --network-root-truststore-password=trustpass --log-to-console --logging-level=DEBUG 

> java -jar corda.jar --log-to-console --logging-level=DEBUG initial-registration --network-root-truststore-password=trustpass

The propose solution does not affect other tools in the Corda ecosystem, as the logging options have been moved to the `CordaCliWrapper`, and each such tool uses this class to inherit command line parsing functionality, instead of `CliWrapperBase`.
# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
