### PR TITLE
5461: Make RPC testing easier

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -14,9 +14,18 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" withSubpackages="false" static="false" />
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
-          <package name="tornadofx" withSubpackages="false" static="false" />
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="tornadofx" alias="false" withSubpackages="false" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -14,18 +14,9 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="tornadofx" alias="false" withSubpackages="false" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="java.util" withSubpackages="false" static="false" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="tornadofx" withSubpackages="false" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -22,6 +22,7 @@ import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.DriverDSLImpl
+import net.corda.testing.node.internal.InternalDriverDSL
 import net.corda.testing.node.internal.genericDriver
 import net.corda.testing.node.internal.getTimestampAsDirectoryName
 import net.corda.testing.node.internal.newContext
@@ -193,7 +194,7 @@ constructor(
  * @param dsl The dsl itself.
  * @return The value returned in the [dsl] closure.
  */
-fun <A> driver(defaultParameters: DriverParameters = DriverParameters(), dsl: DriverDSL.() -> A): A {
+fun <A> driver(defaultParameters: DriverParameters = DriverParameters(), dsl: InternalDriverDSL.() -> A): A {
     return genericDriver(
             driverDsl = DriverDSLImpl(
                     portAllocation = defaultParameters.portAllocation,
@@ -216,11 +217,11 @@ fun <A> driver(defaultParameters: DriverParameters = DriverParameters(), dsl: Dr
                     djvmCordaSource = defaultParameters.djvmCordaSource,
                     environmentVariables = defaultParameters.environmentVariables,
                     allowHibernateToManageAppSchema = defaultParameters.allowHibernateToManageAppSchema,
-                    premigrateH2Database = defaultParameters.premigrateH2Database
+                    premigrateH2Database = defaultParameters.premigrateH2Database,
+                    autoShutdownNodes = defaultParameters.autoShutdownNodes
             ),
             coerce = { it },
-            dsl = dsl
-    )
+            dsl = dsl)
 }
 
 /**
@@ -281,7 +282,8 @@ data class DriverParameters(
         val djvmCordaSource: List<Path> = emptyList(),
         val environmentVariables: Map<String, String> = emptyMap(),
         val allowHibernateToManageAppSchema: Boolean = true,
-        val premigrateH2Database: Boolean = true
+        val premigrateH2Database: Boolean = true,
+        val autoShutdownNodes: Boolean = true
 ) {
     constructor(cordappsForAllNodes: Collection<TestCordapp>) : this(isDebug = false, cordappsForAllNodes = cordappsForAllNodes)
 
@@ -487,6 +489,7 @@ data class DriverParameters(
     fun withDjvmCordaSource(djvmCordaSource: List<Path>): DriverParameters = copy(djvmCordaSource = djvmCordaSource)
     fun withEnvironmentVariables(variables: Map<String, String>): DriverParameters = copy(environmentVariables = variables)
     fun withAllowHibernateToManageAppSchema(value: Boolean): DriverParameters = copy(allowHibernateToManageAppSchema = value)
+    fun withAutoShutdownNodes(value: Boolean): DriverParameters = copy(autoShutdownNodes = value)
 
     fun copy(
             isDebug: Boolean,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -5,6 +5,7 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.map
+import net.corda.nodeapi.internal.ShutdownHook
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.User
 import java.nio.file.Path
@@ -177,4 +178,6 @@ interface DriverDSL {
      * Returns the next port to use when instantiating test processes that must not conflict on the same machine
      */
     fun nextPort() = PortAllocation.defaultAllocator.nextPort()
+
+    fun handleAutoShutdown(hook: ShutdownHook)
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -54,6 +54,8 @@ interface DriverDSL {
             }
         }
 
+    var autoShutdownNodes: Boolean
+
     /**
      * Start a node using the default values of [NodeParameters].
      *
@@ -179,5 +181,5 @@ interface DriverDSL {
      */
     fun nextPort() = PortAllocation.defaultAllocator.nextPort()
 
-    fun handleAutoShutdown(hook: ShutdownHook)
+    fun handleAutoShutdown(hook: ShutdownHook, closeable: AutoCloseable?)
 }


### PR DESCRIPTION
Since this is my first PR I have to note that it is in accordance with the Developer's Certificate of Origin.

The changes in this PR are done to solve the issue described in ticket 5461 (https://github.com/corda/corda/issues/5461).
There was no possibility to keep the nodes alive while exiting the DSL closure. I added a configuration possibility to start the nodes within the closure without executing an automatic shutdown on exit. An integration test now is able to start nodes, save the dsl, run several different tests consecutively and run the shutdown manually. 
This change is not most elegant, however the interface and default behavior does not change and the same known methods and dsl configuration way is used. 
