### PR TITLE
EG-1561: PicoCLI upgrade and moving initLogging in CordaCliWrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ buildscript {
     ext.snappy_version = '0.4'
     ext.class_graph_version = constants.getProperty('classgraphVersion')
     ext.jcabi_manifests_version = '1.1'
-    ext.picocli_version = '3.9.6'
+    ext.picocli_version = '4.5.1'
     ext.commons_lang_version = '3.9'
     ext.commons_io_version = '2.6'
     ext.controlsfx_version = '8.40.15'

--- a/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt
+++ b/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt
@@ -8,7 +8,7 @@ import kotlin.collections.LinkedHashMap
 fun main(args: Array<String>) {
 
     val parameters = Parameters()
-    CommandLine(parameters).parse(*args)
+    CommandLine(parameters).parseArgs(*args)
     if (parameters.helpRequested) {
         CommandLine.usage(Parameters(), System.out)
         return

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -33,8 +33,6 @@ class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-
         return startup.initialiseAndRun(cmdLineOptions, InitialRegistration(cmdLineOptions.baseDirectory, networkRootTrustStorePath, networkRootTrustStorePassword, skipSchemaCreation, startup))
     }
 
-    override fun initLogging(): Boolean = this.initLogging(cmdLineOptions.baseDirectory)
-
     @Mixin
     val cmdLineOptions = InitialRegistrationCmdLineOptions()
 }

--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/ValidateConfigurationCli.kt
@@ -7,7 +7,6 @@ import net.corda.cliutils.ExitCodes
 import net.corda.common.configuration.parsing.internal.Configuration
 import net.corda.core.utilities.loggerFor
 import net.corda.node.SharedNodeCmdLineOptions
-import net.corda.node.internal.initLogging
 import net.corda.node.services.config.schema.v1.V1NodeConfigurationSpec
 import net.corda.nodeapi.internal.config.toConfigValue
 import picocli.CommandLine.Mixin
@@ -31,8 +30,6 @@ internal class ValidateConfigurationCli : CliWrapperBase("validate-configuration
 
     @Mixin
     private val cmdLineOptions = SharedNodeCmdLineOptions()
-
-    override fun initLogging(): Boolean = initLogging(cmdLineOptions.baseDirectory)
 
     override fun runProgram(): Int {
         val rawConfig = cmdLineOptions.rawConfiguration().doOnErrors(cmdLineOptions::logRawConfigurationErrors).optional ?: return ExitCodes.FAILURE

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -6,6 +6,7 @@ import org.fusesource.jansi.AnsiConsole
 import org.slf4j.event.Level
 import picocli.CommandLine
 import picocli.CommandLine.*
+import java.io.PrintWriter
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -63,45 +64,41 @@ fun CordaCliWrapper.start(args: Array<String>) {
     // This line makes sure ANSI escapes work on Windows, where they aren't supported out of the box.
     AnsiConsole.systemInstall()
 
-        val defaultAnsiMode = if (CordaSystemUtils.isOsWindows()) {
-            Help.Ansi.ON
+    val defaultAnsiMode = if (CordaSystemUtils.isOsWindows()) {
+        Help.Ansi.ON
+    } else {
+        Help.Ansi.AUTO
+    }
+
+    // only print stacktraces if verbose requested by users
+    cmd.executionExceptionHandler = IExecutionExceptionHandler { ex: Exception, _: CommandLine, _: ParseResult ->
+        val throwable = ex.cause ?: ex
+        if (this@start.verbose) {
+            throwable.printStackTrace()
+        }
+        printError(throwable.rootMessage ?: "Use --verbose for more details")
+        ExitCodes.FAILURE
+    }
+
+    // init logging before invoking the business logic
+    cmd.executionStrategy = IExecutionStrategy { parseResult: ParseResult ->
+        initLogging()
+        RunLast().execute(parseResult)
+    }
+
+
+    cmd.err = PrintWriter(System.err)
+    cmd.out = PrintWriter(System.out)
+    cmd.colorScheme = Help.defaultColorScheme(defaultAnsiMode)
+
+    @Suppress("SpreadOperator")
+    cmd.execute(*args).let {
+        if (it == ExitCode.OK) {
+            exitProcess(ExitCodes.SUCCESS)
         } else {
-            Help.Ansi.AUTO
+            exitProcess(ExitCodes.FAILURE)
         }
-
-        val exceptionHandler = object : DefaultExceptionHandler<List<Any>>() {
-
-            override fun handleParseException(ex: ParameterException?, args: Array<out String>?): List<Any> {
-                super.handleParseException(ex, args)
-                return listOf(ExitCodes.FAILURE)
-            }
-            override fun handleExecutionException(ex: ExecutionException, parseResult: ParseResult?): List<Any> {
-
-                val throwable = ex.cause ?: ex
-                if (this@start.verbose || this@start.subCommands.any { it.verbose }) {
-                    throwable.printStackTrace()
-                }
-                printError(throwable.rootMessage ?: "Use --verbose for more details")
-                return listOf(ExitCodes.FAILURE)
-            }
-        }
-        @Suppress("SpreadOperator")
-        val results = cmd.parseWithHandlers(RunLast().useOut(System.out).useAnsi(defaultAnsiMode),
-                exceptionHandler.useErr(System.err).useAnsi(defaultAnsiMode), *args)
-
-
-        // If an error code has been returned, use this and exit
-        results?.firstOrNull()?.let {
-            if (it is Int) {
-                exitProcess(it)
-            } else {
-                exitProcess(ExitCodes.FAILURE)
-            }
-        }
-
-        // If no results returned, picocli ran something without invoking the main program, e.g. --help or --version, so exit successfully
-        exitProcess(ExitCodes.SUCCESS)
-
+    }
 }
 
 @Command(mixinStandardHelpOptions = true,
@@ -122,39 +119,13 @@ abstract class CliWrapperBase(val alias: String, val description: String) : Call
     // needs to be parameterless for autocomplete to work.
     lateinit var args: Array<String>
 
-    @Option(names = ["-v", "--verbose", "--log-to-console"], description = ["If set, prints logging to the console as well as to a file."])
-    var verbose: Boolean = false
-
-    @Option(names = ["--logging-level"],
-            completionCandidates = LoggingLevelConverter.LoggingLevels::class,
-            description = ["Enable logging at this level and higher. Possible values: \${COMPLETION-CANDIDATES}"],
-            converter = [LoggingLevelConverter::class]
-    )
-    var loggingLevel: Level = Level.INFO
-
-    // This needs to be called before loggers (See: NodeStartup.kt:51 logger called by lazy, initLogging happens before).
-    // Node's logging is more rich. In corda configurations two properties, defaultLoggingLevel and consoleLogLevel, are usually used.
-    open fun initLogging(): Boolean {
-        System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
-        if (verbose) {
-            System.setProperty("consoleLogLevel", specifiedLogLevel)
-        }
-        System.setProperty("log-path", Paths.get(".").toString())
-        return true
-    }
-
     // Override this function with the actual method to be run once all the arguments have been parsed. The return number
     // is the exit code to be returned
     abstract fun runProgram(): Int
 
     override fun call(): Int {
-        initLogging()
         logger.info("Application Args: ${args.joinToString(" ")}")
         return runProgram()
-    }
-
-    val specifiedLogLevel: String by lazy {
-        System.getProperty("log4j2.level")?.toLowerCase(Locale.ENGLISH) ?: loggingLevel.name.toLowerCase(Locale.ENGLISH)
     }
 }
 
@@ -169,6 +140,31 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
     }
 
     private val installShellExtensionsParser = InstallShellExtensionsParser(this)
+
+    @Option(names = ["-v", "--verbose", "--log-to-console"], description = ["If set, prints logging to the console as well as to a file."])
+    var verbose: Boolean = false
+
+    @Option(names = ["--logging-level"],
+            completionCandidates = LoggingLevelConverter.LoggingLevels::class,
+            description = ["Enable logging at this level and higher. Possible values: \${COMPLETION-CANDIDATES}"],
+            converter = [LoggingLevelConverter::class]
+    )
+    var loggingLevel: Level = Level.INFO
+
+    val specifiedLogLevel: String by lazy {
+        System.getProperty("log4j2.level")?.toLowerCase(Locale.ENGLISH) ?: loggingLevel.name.toLowerCase(Locale.ENGLISH)
+    }
+
+    // This needs to be called before loggers (See: NodeStartup.kt:51 logger called by lazy, initLogging happens before).
+    // Node's logging is more rich. In corda configurations two properties, defaultLoggingLevel and consoleLogLevel, are usually used.
+    open fun initLogging(): Boolean {
+        System.setProperty("defaultLogLevel", specifiedLogLevel) // These properties are referenced from the XML config file.
+        if (verbose) {
+            System.setProperty("consoleLogLevel", specifiedLogLevel)
+        }
+        System.setProperty("log-path", Paths.get(".").toString())
+        return true
+    }
 
     protected open fun additionalSubCommands(): Set<CliWrapperBase> = emptySet()
 

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -141,10 +141,11 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
 
     private val installShellExtensionsParser = InstallShellExtensionsParser(this)
 
-    @Option(names = ["-v", "--verbose", "--log-to-console"], description = ["If set, prints logging to the console as well as to a file."])
+    @Option(names = ["-v", "--verbose", "--log-to-console"], scope = ScopeType.INHERIT,
+            description = ["If set, prints logging to the console as well as to a file."])
     var verbose: Boolean = false
 
-    @Option(names = ["--logging-level"],
+    @Option(names = ["--logging-level"], scope = ScopeType.INHERIT,
             completionCandidates = LoggingLevelConverter.LoggingLevels::class,
             description = ["Enable logging at this level and higher. Possible values: \${COMPLETION-CANDIDATES}"],
             converter = [LoggingLevelConverter::class]

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Main.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Main.kt
@@ -19,7 +19,7 @@ val baseArgs = CliParser()
 
 fun main(args: Array<String>) {
     SerializationEngine.init()
-    CommandLine(baseArgs).parse(*args)
+    CommandLine(baseArgs).parseArgs(*args)
     testDockerConnectivity()
 
     if (baseArgs.usageHelpRequested) {

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Main.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Main.kt
@@ -35,7 +35,7 @@ fun main(args: Array<String>) {
     val argParser: CliParser = when (baseArgs.backendType) {
         AZURE -> {
             val azureArgs = AzureParser()
-            CommandLine(azureArgs).parse(*args)
+            CommandLine(azureArgs).parseArgs(*args)
             azureArgs
         }
         Backend.BackendType.LOCAL_DOCKER -> baseArgs


### PR DESCRIPTION
This PR updates the version of PicoCLI version and allows for global options `--logging-level` or `--log-to-console` to be placed in any order regardless of where sub-commands (such as initial-registration) are placed. 

The previous implementation used a [subclassing approach](https://picocli.info/#_subclassing) for sharing options when using subcommands. However, this approach had a limitation: while options could be shared between multiple commands, options needed to be placed in a particular order to be considered (i.e., after the last command). This was a limitation of the PicoCLI library and was addressed by introducing [Inherited Options](https://picocli.info/#_inherited_options). 

For instance, the `--log-to-console` and `--logging-level` should be set to the same values after running each of the following command: 

> java -jar corda.jar initial-registration --network-root-truststore-password=trustpass --log-to-console --logging-level=DEBUG 

> java -jar corda.jar --log-to-console --logging-level=DEBUG initial-registration --network-root-truststore-password=trustpass

The propose solution does not affect other tools in the Corda ecosystem, as the logging options have been moved to the `CordaCliWrapper`, and each such tool uses this class to inherit command line parsing functionality, instead of `CliWrapperBase`.
# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
