### PR TITLE
INFRA-749 decreased disk usage of DriverDSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -369,6 +369,7 @@ allprojects {
     tasks.withType(Test).configureEach {
         if (name.contains("integrationTest")) {
             maxParallelForks = (System.env.CORDA_INT_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_INT_TESTING_FORKS".toInteger()
+            systemProperty "net.corda.testing.driver.DriverDSL.wipeArtemisJournal", project.property("integrationTest.wipeArtemisJournal")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ owasp.failOnError=false
 owasp.failBuildOnCVSS=11.0
 compilation.allWarningsAsErrors=false
 test.parallel=false
+#Wipe the `artemis` and `brokers` folders from each node's directory after shutdown in DriverDSL based tests
+integrationTest.wipeArtemisJournal=true


### PR DESCRIPTION
previously a DriverDSL node was meant to delete its H2 database file after shutdown, but since this functionality
was baked in `DriverDSL.startNode` (which is only invoked for ordinary network nodes, not for notary nodes) it didn't work for notary nodes.

I also noticed that, for the same reason, database snapshot was not taken for notary nodes in case of `premigrateH2Database` set to `true` which I assumed it's a bug (I'm not sure about this).
I fixed both of this behavior moving the code inside `net.corda.testing.node.internal.DriverDSLImpl#startNodeInternal` which gets called upon startup of any kind of node.

Also, to decrease disk space usage of running DriverDSL tests, I registered in the same method a shutdown hook to wipe the `artemis` and `broker` folders, this behavior can be overidden for debugging purposes
setting the system property `net.corda.testing.driver.DriverDSL.wipeArtemisJournal` to `false`