### PR TITLE
CORDA-4043: Generate 16-octets certificate serial numbers

### DIFF
--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -573,7 +573,8 @@ class X509UtilitiesTest {
         val keyPair = generateKeyPair()
         val subject = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
         val cert = X509Utilities.createSelfSignedCACertificate(subject, keyPair)
-        assertTrue(cert.serialNumber.bitLength() > 64)
+        assertTrue(cert.serialNumber.signum() > 0)
+        assertEquals(127, cert.serialNumber.bitLength())
         val serialized = X509Utilities.buildCertPath(cert).encoded
         val deserialized = X509CertificateFactory().delegate.generateCertPath(serialized.inputStream()).x509Certificates.first()
         assertEquals(cert.serialNumber, deserialized.serialNumber)

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -568,9 +568,9 @@ class X509UtilitiesTest {
 
     @Test(timeout=300_000)
     fun `check certificate serial number length`() {
-        // This test does sanity check that we don't generate 64 bit certificate serial numbers anymore, otherwise it will be timed out.
+        // This test does sanity check that we don't generate 63 bit certificate serial numbers anymore, otherwise it will be timed out.
         // Since serial number assignment is random, there is no deterministic way to check its length.
-        // So there is still theoretical chance for timeout with currently used 128 bit numbers but with extremely low probability (~2^-80).
+        // So there is still theoretical chance for timeout with currently used 127 bit numbers but with extremely low probability (~2^-80).
         val keyPair = generateKeyPair()
         val subject = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
         while (true) {

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -565,4 +565,19 @@ class X509UtilitiesTest {
             cert.checkValidity({ "Error text" }, { }, Date.from(today.toInstant() + 51.days))
         }
     }
+
+    @Test(timeout=300_000)
+    fun `check certificate serial number length`() {
+        // This test does sanity check that we don't generate 64 bit certificate serial numbers anymore, otherwise it will be timed out.
+        // Since serial number assignment is random, there is no deterministic way to check its length.
+        // So there is still theoretical chance for timeout with currently used 128 bit numbers but with extremely low probability (~2^-80).
+        val keyPair = generateKeyPair()
+        val subject = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
+        while (true) {
+            val cert = X509Utilities.createSelfSignedCACertificate(subject, keyPair)
+            if (cert.serialNumber.bitLength() > 64) {
+                return
+            }
+        }
+    }
 }

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -569,10 +569,7 @@ class X509UtilitiesTest {
     }
 
     @Test(timeout = 300_000)
-    fun `check certificate serial number length`() {
-        // Sanity check that we don't generate 63 bit certificate serial numbers anymore.
-        // There is no deterministic way to check certificate serial number length, however the probability of failure on 20-bytes
-        // numbers is rather theoretical (~2^-96).
+    fun `check certificate serial number`() {
         val keyPair = generateKeyPair()
         val subject = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
         val cert = X509Utilities.createSelfSignedCACertificate(subject, keyPair)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -2,7 +2,7 @@ package net.corda.nodeapi.internal.crypto
 
 import net.corda.core.CordaOID
 import net.corda.core.crypto.Crypto
-import net.corda.core.crypto.random63BitValue
+import net.corda.core.crypto.newSecureRandom
 import net.corda.core.internal.*
 import net.corda.core.utilities.days
 import net.corda.core.utilities.millis
@@ -58,6 +58,7 @@ object X509Utilities {
     const val TLS_CERTIFICATE_DAYS_TO_EXPIRY_WARNING_THRESHOLD = 30
     private const val KEY_ALIAS_REGEX = "[a-z0-9-]+"
     private const val KEY_ALIAS_MAX_LENGTH = 100
+    private const val SERIAL_NUMBER_BYTES_LENGTH = 16
 
     /**
      * Checks if the provided key alias does not exceed maximum length and
@@ -184,7 +185,7 @@ object X509Utilities {
                                  nameConstraints: NameConstraints? = null,
                                  crlDistPoint: String? = null,
                                  crlIssuer: X500Name? = null): X509v3CertificateBuilder {
-        val serial = BigInteger.valueOf(random63BitValue())
+        val serial = randomBigInteger(SERIAL_NUMBER_BYTES_LENGTH)
         val keyPurposes = DERSequence(ASN1EncodableVector().apply { certificateType.purposes.forEach { add(it) } })
         val subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(subjectPublicKey.encoded))
         val role = certificateType.role
@@ -363,6 +364,12 @@ object X509Utilities {
             val distPoint = DistributionPoint(distPointName, null, crlIssuerGeneralNames)
             builder.addExtension(Extension.cRLDistributionPoints, false, CRLDistPoint(arrayOf(distPoint)))
         }
+    }
+
+    fun randomBigInteger(sizeInBytes : Int): BigInteger {
+        val bytes = ByteArray(sizeInBytes)
+        newSecureRandom().nextBytes(bytes)
+        return BigInteger(bytes).abs()
     }
 }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -58,7 +58,7 @@ object X509Utilities {
     const val TLS_CERTIFICATE_DAYS_TO_EXPIRY_WARNING_THRESHOLD = 30
     private const val KEY_ALIAS_REGEX = "[a-z0-9-]+"
     private const val KEY_ALIAS_MAX_LENGTH = 100
-    private const val SERIAL_NUMBER_BYTES_LENGTH = 16
+    private const val SERIAL_NUMBER_BYTES_LENGTH = 20
 
     /**
      * Checks if the provided key alias does not exceed maximum length and


### PR DESCRIPTION
Increase the maximum length of generated NODE_IDENTITY and TLS certificate serial numbers from 8 to 16 octets.
Numbers will be generated from 126-bit entropy, while the highest byte will be set to 01xxxxxx to ensure positive sign and constant 127-bit length.