### PR TITLE
CORDA-4053 - Upgrade artemis from 2.6. to the latest stable (2.15.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ buildscript {
     ext.capsule_version = '1.0.3'
 
     ext.asm_version = '7.1'
-    ext.artemis_version = '2.6.2'
+    ext.artemis_version = '2.15.0'
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
     ext.jackson_version = '2.9.7'
     ext.jetty_version = '9.4.19.v20190610'

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/MessageSizeChecksInterceptor.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/MessageSizeChecksInterceptor.kt
@@ -8,6 +8,7 @@ import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.MessagePac
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage
 import org.apache.activemq.artemis.protocol.amqp.broker.AmqpInterceptor
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
+import org.apache.qpid.proton.amqp.messaging.Data
 
 class ArtemisMessageSizeChecksInterceptor(maxMessageSize: Int) : MessageSizeChecksInterceptor<Packet>(maxMessageSize), Interceptor {
     override fun getMessageSize(packet: Packet?): Int? {
@@ -22,7 +23,7 @@ class ArtemisMessageSizeChecksInterceptor(maxMessageSize: Int) : MessageSizeChec
 }
 
 class AmqpMessageSizeChecksInterceptor(maxMessageSize: Int) : MessageSizeChecksInterceptor<AMQPMessage>(maxMessageSize), AmqpInterceptor {
-    override fun getMessageSize(packet: AMQPMessage?): Int? = packet?.encodeSize
+    override fun getMessageSize(packet: AMQPMessage?): Int? = (packet?.protonMessage?.body as? Data)?.value?.length
 }
 
 /**

--- a/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.internal.div
+import net.corda.core.internal.errors.AddressBindingException
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.seconds
 import net.corda.node.services.config.FlowTimeoutConfiguration
@@ -108,6 +109,7 @@ class ArtemisMessagingTest {
         ServerSocket(serverPort).use {
             val messagingServer = createMessagingServer()
             assertThatThrownBy { messagingServer.start() }
+                    .isInstanceOf(AddressBindingException::class.java)
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/artemis/ArtemisBroker.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/artemis/ArtemisBroker.kt
@@ -19,6 +19,9 @@ data class BrokerAddresses(val primary: NetworkHostAndPort, private val adminArg
     val admin = adminArg ?: primary
 }
 
-fun Throwable.isBindingError() = this is BindException ||
-        this is Errors.NativeIoException && message?.contains("Address already in use") == true ||
-        this is IllegalStateException && this.cause is Errors.NativeIoException && this.cause!!.message?.contains("Address already in use") == true
+fun Throwable.isBindingError(): Boolean {
+    val addressAlreadyUsedMsg = "Address already in use"
+    return this is BindException ||
+            this is Errors.NativeIoException && message?.contains(addressAlreadyUsedMsg) == true ||
+            this is IllegalStateException && this.cause is Errors.NativeIoException && this.cause!!.message?.contains(addressAlreadyUsedMsg) == true
+}

--- a/node/src/main/kotlin/net/corda/node/internal/artemis/ArtemisBroker.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/artemis/ArtemisBroker.kt
@@ -4,6 +4,7 @@ import io.netty.channel.unix.Errors
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.internal.LifecycleSupport
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
+import java.lang.IllegalStateException
 import java.net.BindException
 
 interface ArtemisBroker : LifecycleSupport, AutoCloseable {
@@ -18,4 +19,6 @@ data class BrokerAddresses(val primary: NetworkHostAndPort, private val adminArg
     val admin = adminArg ?: primary
 }
 
-fun java.io.IOException.isBindingError() = this is BindException || this is Errors.NativeIoException && message?.contains("Address already in use") == true
+fun Throwable.isBindingError() = this is BindException ||
+        this is Errors.NativeIoException && message?.contains("Address already in use") == true ||
+        this is IllegalStateException && this.cause is Errors.NativeIoException && this.cause!!.message?.contains("Address already in use") == true

--- a/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt
@@ -8,6 +8,7 @@ import net.corda.node.internal.artemis.*
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.NODE_SECURITY_CONFIG
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.RPC_SECURITY_CONFIG
 import net.corda.node.internal.security.RPCSecurityManager
+import net.corda.node.utilities.artemis.startSynchronously
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.nodeapi.internal.config.MutualSslConfiguration
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
@@ -54,8 +55,8 @@ class ArtemisRpcBroker internal constructor(
     override fun start() {
         logger.debug { "Artemis RPC broker is starting for: $addresses" }
         try {
-            server.start()
-        } catch (e: IOException) {
+            server.startSynchronously()
+        } catch (e: Throwable) {
             logger.error("Unable to start message broker", e)
             if (e.isBindingError()) {
                 throw AddressBindingException(adminAddressOptional?.let { setOf(it, addresses.primary) } ?: setOf(addresses.primary))
@@ -90,7 +91,6 @@ class ArtemisRpcBroker internal constructor(
         val serverSecurityManager = createArtemisSecurityManager(serverConfiguration.loginListener)
 
         return ActiveMQServerImpl(serverConfiguration, serverSecurityManager).apply {
-            registerActivationFailureListener { exception -> throw exception }
             registerPostQueueDeletionCallback { address, qName -> logger.debug("Queue deleted: $qName for $address") }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
@@ -44,7 +44,7 @@ internal class RpcBrokerConfiguration(baseDirectory: Path, maxMessageSize: Int, 
                 "${RPCApi.RPC_CLIENT_QUEUE_NAME_PREFIX}.#" to AddressSettings().apply {
                     maxSizeBytes = 5L * maxMessageSize
                     addressFullMessagePolicy = AddressFullMessagePolicy.PAGE
-                    pageSizeBytes = 1L * maxMessageSize
+                    pageSizeBytes = maxMessageSize
                 }
         )
 

--- a/node/src/main/kotlin/net/corda/node/utilities/artemis/ArtemisStartupUtil.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/artemis/ArtemisStartupUtil.kt
@@ -7,16 +7,16 @@ import java.util.concurrent.CompletableFuture
 
 fun ActiveMQServer.startSynchronously() {
     val startupFuture = CompletableFuture<Unit>()
-    this.registerActivateCallback(object: ActivateCallback {
+    registerActivateCallback(object: ActivateCallback {
         override fun activationComplete() {
             startupFuture.complete(Unit)
         }
     })
-    this.registerActivationFailureListener {
+    registerActivationFailureListener {
         startupFuture.completeExceptionally(it)
     }
 
-    this.start()
+    start()
 
     startupFuture.getOrThrow()
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/artemis/ArtemisStartupUtil.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/artemis/ArtemisStartupUtil.kt
@@ -1,0 +1,22 @@
+package net.corda.node.utilities.artemis
+
+import net.corda.core.utilities.getOrThrow
+import org.apache.activemq.artemis.core.server.ActivateCallback
+import org.apache.activemq.artemis.core.server.ActiveMQServer
+import java.util.concurrent.CompletableFuture
+
+fun ActiveMQServer.startSynchronously() {
+    val startupFuture = CompletableFuture<Unit>()
+    this.registerActivateCallback(object: ActivateCallback {
+        override fun activationComplete() {
+            startupFuture.complete(Unit)
+        }
+    })
+    this.registerActivationFailureListener {
+        startupFuture.completeExceptionally(it)
+    }
+
+    this.start()
+
+    startupFuture.getOrThrow()
+}

--- a/node/src/test/kotlin/net/corda/node/internal/artemis/UserValidationPluginTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/artemis/UserValidationPluginTest.kt
@@ -29,19 +29,19 @@ class UserValidationPluginTest {
 
     @Test(timeout = 300_000)
     fun `accept AMQP message without user`() {
-        plugin.beforeSend(session, rigorousMock(), toAMQPMessage(coreMessage), direct = false, noAutoCreateQueue = false)
+        plugin.beforeSend(session, rigorousMock(), coreMessage.toAMQPMessage(), direct = false, noAutoCreateQueue = false)
     }
 
     @Test(timeout = 300_000)
     fun `accept AMQP message with user`() {
-        val amqpMsg = toAMQPMessage(coreMessage)
+        val amqpMsg = coreMessage.toAMQPMessage()
         amqpMsg.putStringProperty("_AMQ_VALIDATED_USER", ALICE_NAME.toString())
         plugin.beforeSend(session, rigorousMock(), amqpMsg, direct = false, noAutoCreateQueue = false)
     }
 
     @Test(timeout = 300_000)
     fun `reject AMQP message with different user`() {
-        val amqpMsg = toAMQPMessage(coreMessage)
+        val amqpMsg = coreMessage.toAMQPMessage()
         amqpMsg.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
         Assertions.assertThatExceptionOfType(ActiveMQSecurityException::class.java).isThrownBy {
             plugin.beforeSend(session, rigorousMock(), amqpMsg, direct = false, noAutoCreateQueue = false)
@@ -54,7 +54,7 @@ class UserValidationPluginTest {
             doReturn(ArtemisMessagingComponent.NODE_P2P_USER).whenever(it).username
             doReturn(ALICE_NAME.toString()).whenever(it).validatedUser
         }
-        val msg = toAMQPMessage(coreMessage)
+        val msg = coreMessage.toAMQPMessage()
         msg.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
         plugin.beforeSend(internalSession, rigorousMock(), msg, direct = false, noAutoCreateQueue = false)
     }
@@ -76,5 +76,5 @@ class UserValidationPluginTest {
         }.withMessageContaining("Message validation failed")
     }
 
-    private fun toAMQPMessage(message: ClientMessageImpl): AMQPMessage = AMQPConverter.getInstance().fromCore(message, NullStorageManager())
+    private fun ClientMessageImpl.toAMQPMessage(): AMQPMessage = AMQPConverter.getInstance().fromCore(this, NullStorageManager())
 }

--- a/node/src/test/kotlin/net/corda/node/internal/artemis/UserValidationPluginTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/artemis/UserValidationPluginTest.kt
@@ -1,6 +1,8 @@
 package net.corda.node.internal.artemis
 
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.nodeapi.internal.ArtemisMessagingComponent
@@ -9,16 +11,17 @@ import net.corda.testing.core.BOB_NAME
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.core.client.impl.ClientMessageImpl
+import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager
 import org.apache.activemq.artemis.core.server.ServerSession
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage
 import org.apache.activemq.artemis.protocol.amqp.converter.AMQPConverter
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import java.lang.IllegalStateException
 
 class UserValidationPluginTest {
     private val plugin = UserValidationPlugin()
     private val coreMessage = ClientMessageImpl(0, false, 0, System.currentTimeMillis(), 4.toByte(), 1024)
-    private val amqpMessage get() = AMQPConverter.getInstance().fromCore(coreMessage)
     private val session = rigorousMock<ServerSession>().also {
         doReturn(ArtemisMessagingComponent.PEER_USER).whenever(it).username
         doReturn(ALICE_NAME.toString()).whenever(it).validatedUser
@@ -26,20 +29,22 @@ class UserValidationPluginTest {
 
     @Test(timeout = 300_000)
     fun `accept AMQP message without user`() {
-        plugin.beforeSend(session, rigorousMock(), amqpMessage, direct = false, noAutoCreateQueue = false)
+        plugin.beforeSend(session, rigorousMock(), toAMQPMessage(coreMessage), direct = false, noAutoCreateQueue = false)
     }
 
     @Test(timeout = 300_000)
     fun `accept AMQP message with user`() {
-        coreMessage.putStringProperty("_AMQ_VALIDATED_USER", ALICE_NAME.toString())
-        plugin.beforeSend(session, rigorousMock(), amqpMessage, direct = false, noAutoCreateQueue = false)
+        val amqpMsg = toAMQPMessage(coreMessage)
+        amqpMsg.putStringProperty("_AMQ_VALIDATED_USER", ALICE_NAME.toString())
+        plugin.beforeSend(session, rigorousMock(), amqpMsg, direct = false, noAutoCreateQueue = false)
     }
 
     @Test(timeout = 300_000)
     fun `reject AMQP message with different user`() {
-        coreMessage.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
+        val amqpMsg = toAMQPMessage(coreMessage)
+        amqpMsg.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
         Assertions.assertThatExceptionOfType(ActiveMQSecurityException::class.java).isThrownBy {
-            plugin.beforeSend(session, rigorousMock(), amqpMessage, direct = false, noAutoCreateQueue = false)
+            plugin.beforeSend(session, rigorousMock(), amqpMsg, direct = false, noAutoCreateQueue = false)
         }.withMessageContaining("_AMQ_VALIDATED_USER")
     }
 
@@ -49,8 +54,9 @@ class UserValidationPluginTest {
             doReturn(ArtemisMessagingComponent.NODE_P2P_USER).whenever(it).username
             doReturn(ALICE_NAME.toString()).whenever(it).validatedUser
         }
-        coreMessage.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
-        plugin.beforeSend(internalSession, rigorousMock(), amqpMessage, direct = false, noAutoCreateQueue = false)
+        val msg = toAMQPMessage(coreMessage)
+        msg.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
+        plugin.beforeSend(internalSession, rigorousMock(), msg, direct = false, noAutoCreateQueue = false)
     }
 
     @Test(timeout = 300_000)
@@ -62,28 +68,13 @@ class UserValidationPluginTest {
 
     @Test(timeout = 300_000)
     fun `reject message with exception`() {
-        coreMessage.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
-        val messageWithException = object : AMQPMessage(0, amqpMessage.buffer.array(), null) {
-            override fun getStringProperty(key: SimpleString?): String {
-                throw IllegalStateException("My exception")
-            }
-        }
+        val messageWithException = mock<AMQPMessage>()
+        whenever(messageWithException.getStringProperty(any<SimpleString>())).thenThrow(IllegalStateException("My exception"))
         // Artemis swallows all exceptions except ActiveMQException, so making sure that proper exception is thrown
         Assertions.assertThatExceptionOfType(ActiveMQSecurityException::class.java).isThrownBy {
             plugin.beforeSend(session, rigorousMock(), messageWithException, direct = false, noAutoCreateQueue = false)
         }.withMessageContaining("Message validation failed")
     }
 
-    @Test(timeout = 300_000)
-    fun `reject message with security exception`() {
-        coreMessage.putStringProperty("_AMQ_VALIDATED_USER", BOB_NAME.toString())
-        val messageWithException = object : AMQPMessage(0, amqpMessage.buffer.array(), null) {
-            override fun getStringProperty(key: SimpleString?): String {
-                throw ActiveMQSecurityException("My security exception")
-            }
-        }
-        Assertions.assertThatExceptionOfType(ActiveMQSecurityException::class.java).isThrownBy {
-            plugin.beforeSend(session, rigorousMock(), messageWithException, direct = false, noAutoCreateQueue = false)
-        }.withMessageContaining("My security exception")
-    }
+    private fun toAMQPMessage(message: ClientMessageImpl): AMQPMessage = AMQPConverter.getInstance().fromCore(message, NullStorageManager())
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -194,7 +194,7 @@ data class RPCDriverDSL(
     private companion object {
         const val notificationAddress = "notifications"
 
-        private fun ConfigurationImpl.configureCommonSettings(maxFileSize: Int, maxBufferedBytesPerClient: Long) {
+        private fun ConfigurationImpl.configureCommonSettings(maxFileSize: Int, maxBufferedBytesPerClient: Int) {
             name = "RPCDriver"
             managementNotificationAddress = SimpleString(notificationAddress)
             isPopulateValidatedUser = true
@@ -222,14 +222,14 @@ data class RPCDriverDSL(
             )
             addressesSettings = mapOf(
                     "${RPCApi.RPC_CLIENT_QUEUE_NAME_PREFIX}.#" to AddressSettings().apply {
-                        maxSizeBytes = maxBufferedBytesPerClient
+                        maxSizeBytes = maxBufferedBytesPerClient.toLong()
                         addressFullMessagePolicy = AddressFullMessagePolicy.PAGE
-                        pageSizeBytes = maxSizeBytes / 10
+                        pageSizeBytes = maxBufferedBytesPerClient / 10
                     }
             )
         }
 
-        fun createInVmRpcServerArtemisConfig(maxFileSize: Int, maxBufferedBytesPerClient: Long): Configuration {
+        fun createInVmRpcServerArtemisConfig(maxFileSize: Int, maxBufferedBytesPerClient: Int): Configuration {
             return ConfigurationImpl().apply {
                 acceptorConfigurations = setOf(TransportConfiguration(InVMAcceptorFactory::class.java.name))
                 isPersistenceEnabled = false
@@ -237,7 +237,7 @@ data class RPCDriverDSL(
             }
         }
 
-        fun createRpcServerArtemisConfig(maxFileSize: Int, maxBufferedBytesPerClient: Long, baseDirectory: Path, hostAndPort: NetworkHostAndPort): Configuration {
+        fun createRpcServerArtemisConfig(maxFileSize: Int, maxBufferedBytesPerClient: Int, baseDirectory: Path, hostAndPort: NetworkHostAndPort): Configuration {
             return ConfigurationImpl().apply {
                 val artemisDir = "$baseDirectory/artemis"
                 bindingsDirectory = "$artemisDir/bindings"
@@ -267,7 +267,7 @@ data class RPCDriverDSL(
             rpcUser: User = rpcTestUser,
             nodeLegalName: CordaX500Name = fakeNodeLegalName,
             maxFileSize: Int = MAX_MESSAGE_SIZE,
-            maxBufferedBytesPerClient: Long = 10L * MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Int = 10 * MAX_MESSAGE_SIZE,
             configuration: RPCServerConfiguration = RPCServerConfiguration.DEFAULT,
             ops: I,
             queueDrainTimeout: Duration = 5.seconds
@@ -327,7 +327,7 @@ data class RPCDriverDSL(
             rpcUser: User = rpcTestUser,
             nodeLegalName: CordaX500Name = fakeNodeLegalName,
             maxFileSize: Int = MAX_MESSAGE_SIZE,
-            maxBufferedBytesPerClient: Long = 5L * MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Int = 5 * MAX_MESSAGE_SIZE,
             configuration: RPCServerConfiguration = RPCServerConfiguration.DEFAULT,
             customPort: NetworkHostAndPort? = null,
             ops: I
@@ -347,7 +347,7 @@ data class RPCDriverDSL(
             rpcUser: User = rpcTestUser,
             nodeLegalName: CordaX500Name = fakeNodeLegalName,
             maxFileSize: Int = MAX_MESSAGE_SIZE,
-            maxBufferedBytesPerClient: Long = 5L * MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Int = 5 * MAX_MESSAGE_SIZE,
             configuration: RPCServerConfiguration = RPCServerConfiguration.DEFAULT,
             customPort: NetworkHostAndPort? = null,
             listOps: List<I>
@@ -504,7 +504,7 @@ data class RPCDriverDSL(
             serverName: String = "driver-rpc-server-${random63BitValue()}",
             rpcUser: User = rpcTestUser,
             maxFileSize: Int = MAX_MESSAGE_SIZE,
-            maxBufferedBytesPerClient: Long = 10L * MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Int = 10 * MAX_MESSAGE_SIZE,
             customPort: NetworkHostAndPort? = null
     ): CordaFuture<RpcBrokerHandle> {
         val hostAndPort = customPort ?: driverDSL.portAllocation.nextHostAndPort()
@@ -529,7 +529,7 @@ data class RPCDriverDSL(
     private fun startInVmRpcBroker(
             rpcUser: User = rpcTestUser,
             maxFileSize: Int = MAX_MESSAGE_SIZE,
-            maxBufferedBytesPerClient: Long = 10L * MAX_MESSAGE_SIZE
+            maxBufferedBytesPerClient: Int = 10 * MAX_MESSAGE_SIZE
     ): CordaFuture<RpcBrokerHandle> {
         return driverDSL.executorService.fork {
             val artemisConfig = createInVmRpcServerArtemisConfig(maxFileSize, maxBufferedBytesPerClient)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -23,6 +23,7 @@ import net.corda.core.utilities.seconds
 import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.rpc.RPCServer
 import net.corda.node.services.rpc.RPCServerConfiguration
+import net.corda.node.utilities.artemis.startSynchronously
 import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.internal.ArtemisTcpTransport
 import net.corda.serialization.internal.AMQP_RPC_CLIENT_CONTEXT
@@ -512,7 +513,7 @@ data class RPCDriverDSL(
         return driverDSL.executorService.fork {
             val artemisConfig = createRpcServerArtemisConfig(maxFileSize, maxBufferedBytesPerClient, driverDSL.driverDirectory / serverName, hostAndPort)
             val server = ActiveMQServerImpl(artemisConfig, UserSetSecurityManager(setOf(rpcUser, rpcServerUser)))
-            server.start()
+            server.startSynchronously()
             driverDSL.shutdownManager.registerShutdown {
                 server.stop()
                 addressMustNotBeBound(driverDSL.executorService, hostAndPort)


### PR DESCRIPTION
Not to be merged in 4.7 - opening an early PR to get some coverage from the full suite and flush out any hidden issues.

Notes:
* I had to perform some minor changes on the test `UserValidationPluginTest`, because the converter has been changed and it now translates some `_AMQ_` headers into `JMS` properties (see `MessageUtil.getPropertyNames()`). I also removed a test that appeared to test a scenario where `AMQPMessage.getStringProperty` throws an `ActiveMQSecurityException`, which is not really possible since it's a checked exception and this method does not throw any checked exceptions.
* The version of Artemis we were using had a bug, where the results from interceptors were not advised properly. This meant that some checks on message size were not taking effect in some cases. I've tracked down the bug fix and it's [this one](https://issues.apache.org/jira/browse/ARTEMIS-2607). Some tests that were supposed to fail were actually passing (see changes in `ProtonWrapperTest`), because of this reason. So, I adjusted the `AmqpMessageSizeChecksInterceptor`, so that it checks against the encapsulated proton payload and not the encoded size of the amqp message, since that contains extra data that amount to 84 bytes. I also adjusted slightly the tests to increase their coverage.
* The newer versions of Artemis do not propagate errors synchronously during broker restart, they only send them asynchronously through the registered callbacks. As a result, I adjusted the places where we start a broker to register callbacks appropriately and wait on them to ensure startup was successful or propagate errors otherwise. For some more context, see: https://issues.apache.org/jira/browse/ARTEMIS-2950