### PR TITLE
EG-3714 Fixes based on JAVA HSM sample testing

### DIFF
--- a/node-api/src/main/java/net/corda/nodeapi/internal/config/CustomConfigParser.java
+++ b/node-api/src/main/java/net/corda/nodeapi/internal/config/CustomConfigParser.java
@@ -1,0 +1,16 @@
+package net.corda.nodeapi.internal.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to provide ConfigParser for the class,
+ * the [parseAs] method will use the provided parser instead of data class constructs to parse the object.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomConfigParser {
+    Class parser();
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt
@@ -28,20 +28,12 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.full.createInstance
-import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.jvmErasure
 
 @Target(AnnotationTarget.PROPERTY)
 annotation class OldConfig(val value: String)
-
-/**
- * This annotation can be used to provide ConfigParser for the class,
- * the [parseAs] method will use the provided parser instead of data class constructs to parse the object.
- */
-@Target(AnnotationTarget.CLASS)
-annotation class CustomConfigParser(val parser:  KClass<out ConfigParser<*>>)
 
 interface ConfigParser<T> {
     fun parse(config: Config): T
@@ -77,7 +69,9 @@ fun <T : Any> Config.parseAs(
         baseDirectory: Path? = null
 ): T {
     // Use custom parser if provided, instead of treating the object as data class.
-    clazz.findAnnotation<CustomConfigParser>()?.let { return uncheckedCast(it.parser.createInstance().parse(this)) }
+    @Suppress("UNCHECKED_CAST")
+    clazz.java.getAnnotation(CustomConfigParser::class.java)?.let {
+        return ((it.parser.createInstance() as ConfigParser<T>).parse(this)) }
 
     require(clazz.isData) {
         "Only Kotlin data classes or class annotated with CustomConfigParser can be parsed. Offending: ${clazz.qualifiedName}"

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/RevocationConfig.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/RevocationConfig.kt
@@ -7,7 +7,7 @@ import net.corda.nodeapi.internal.config.CustomConfigParser
 /**
  * Data structure for controlling the way how Certificate Revocation Lists are handled.
  */
-@CustomConfigParser(RevocationConfigParser::class)
+@CustomConfigParser(parser = RevocationConfigParser::class)
 interface RevocationConfig {
 
     enum class Mode {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/config/ConfigParsingTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/config/ConfigParsingTest.kt
@@ -266,7 +266,7 @@ class ConfigParsingTest {
 
     data class TestObjects(val values: List<TestObject>)
 
-    @CustomConfigParser(TestParser::class)
+    @CustomConfigParser(parser = TestParser::class)
     sealed class TestObject {
         data class Type1(val value: String) : TestObject()
         data class Type2(val value: String) : TestObject()


### PR DESCRIPTION
Various fixes based on the experience testing the AWS CloudHSM sample in JAVA:

- Added @Throws annotation to the crypto artifacts so Java can implement and extend them
- Changed CustomConfigParser annotation (as Java classes are data classes) to be JAVA as Kotlin annotations don't allow have 