### PR TITLE
ENT-5886 Parameterised queries in `DBCheckpointStorage`

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -691,9 +691,9 @@ class DBCheckpointStorage(
 
     private fun setDBFlowMetadataFinishTime(flowId: String, now: Instant) {
         currentDBSession()
-            .createNativeQuery("Update ${NODE_DATABASE_PREFIX}flow_metadata set finish_time = :finish_time where flow_id = :id")
+            .createNativeQuery("Update ${NODE_DATABASE_PREFIX}flow_metadata set finish_time = :finish_time where flow_id = :flow_id")
             .setParameter("finish_time", now)
-            .setParameter("id", flowId)
+            .setParameter("flow_id", flowId)
             .executeUpdate()
     }
 


### PR DESCRIPTION
Direct SQL was causing issues with the saving of instants not
maintaining their timezones properly.

Changing to parameterised queries fixed this issue.

Also changed other queries to do the same, since it is good practice to
query in this way.
