### PR TITLE
ENT-5737 Update to Hibernate 5.4.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ buildscript {
     ext.hamkrest_version = '1.7.0.0'
     ext.jopt_simple_version = '5.0.2'
     ext.jansi_version = '1.18'
-    ext.hibernate_version = '5.4.3.Final'
+    ext.hibernate_version = '5.4.5.Final'
     ext.h2_version = '1.4.199' // Update docs if renamed or removed.
     ext.postgresql_version = '42.2.5'
     ext.rxjava_version = '1.3.8'


### PR DESCRIPTION
Update to Hibernate 5.4.5 as part of a multi-step update towards 5.4.18.
