### PR TITLE
CORDA-4076: Fix SecureHash compatibility with previous versions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -4,6 +4,7 @@ import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.*
 import net.corda.core.crypto.DigestService
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.algorithm
 import net.corda.core.crypto.hashAs
 import net.corda.core.crypto.internal.DigestAlgorithmFactory
 import net.corda.core.flows.FlowLogic

--- a/core/src/test/kotlin/net/corda/core/crypto/Blake2s256DigestServiceTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/Blake2s256DigestServiceTest.kt
@@ -33,20 +33,23 @@ class Blake2s256DigestServiceTest {
     @Test(timeout = 300_000)
     fun testBlankHash() {
         assertEquals(
-                "C59F682376D137F3F255E671E207D1F2374EBE504E9314208A52D9F88D69E8C8",
-                service.hash(byteArrayOf()).toHexString()
+                "BLAKE_TEST:C59F682376D137F3F255E671E207D1F2374EBE504E9314208A52D9F88D69E8C8",
+                service.hash(byteArrayOf()).toString()
         )
+        assertEquals("C59F682376D137F3F255E671E207D1F2374EBE504E9314208A52D9F88D69E8C8", service.hash(byteArrayOf()).toHexString())
     }
 
     @Test(timeout = 300_000)
     fun testHashBytes() {
         val hash = service.hash(byteArrayOf(0x64, -0x13, 0x42, 0x3a))
+        assertEquals("BLAKE_TEST:9EEA14092257E759ADAA56539A7A88DA1F68F03ABE3D9552A21D4731F4E6ECA0", hash.toString())
         assertEquals("9EEA14092257E759ADAA56539A7A88DA1F68F03ABE3D9552A21D4731F4E6ECA0", hash.toHexString())
     }
 
     @Test(timeout = 300_000)
     fun testHashString() {
         val hash = service.hash("test")
+        assertEquals("BLAKE_TEST:AB76E8F7EEA1968C183D343B756EC812E47D4BC7A3F061F4DDE8948B3E05DAF2", hash.toString())
         assertEquals("AB76E8F7EEA1968C183D343B756EC812E47D4BC7A3F061F4DDE8948B3E05DAF2", hash.toHexString())
     }
 

--- a/node/src/main/kotlin/net/corda/notary/common/BatchSigning.kt
+++ b/node/src/main/kotlin/net/corda/notary/common/BatchSigning.kt
@@ -7,6 +7,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignableData
 import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.algorithm
 import net.corda.core.flows.NotaryError
 import net.corda.core.internal.digestService
 import net.corda.core.node.ServiceHub

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/SecureHashSerializationTest.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/SecureHashSerializationTest.kt
@@ -1,0 +1,45 @@
+package net.corda.serialization.internal
+
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SecureHash.Companion.SHA2_256
+import net.corda.core.crypto.SecureHash.Companion.SHA2_512
+import net.corda.core.crypto.algorithm
+import net.corda.core.serialization.SerializationDefaults
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
+import net.corda.testing.core.SerializationEnvironmentRule
+import org.junit.Assert.assertArrayEquals
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SecureHashSerializationTest {
+    @Rule
+    @JvmField
+    val testSerialization = SerializationEnvironmentRule()
+
+    @Test(timeout = 300_000)
+    fun `serialize and deserialize SHA-256`() {
+        val before = SecureHash.randomSHA256()
+        val bytes = before.serialize(context = SerializationDefaults.P2P_CONTEXT.withoutReferences()).bytes
+        val after = bytes.deserialize<SecureHash>()
+        assertEquals(before, after)
+        assertArrayEquals(before.bytes, after.bytes)
+        assertEquals(before.algorithm, after.algorithm)
+        assertEquals(after.algorithm, SHA2_256)
+        assertTrue(after is SecureHash.SHA256)
+    }
+
+    @Test(timeout = 300_000)
+    fun `serialize and deserialize SHA-512`() {
+        val before = SecureHash.random(SHA2_512)
+        val bytes = before.serialize(context = SerializationDefaults.P2P_CONTEXT.withoutReferences()).bytes
+        val after = bytes.deserialize<SecureHash>()
+        assertEquals(before, after)
+        assertArrayEquals(before.bytes, after.bytes)
+        assertEquals(before.algorithm, after.algorithm)
+        assertEquals(after.algorithm, SHA2_512)
+        assertTrue(after is SecureHash.HASH)
+    }
+}

--- a/tools/shell/src/main/java/net/corda/tools/shell/HashLookupShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/HashLookupShellCommand.java
@@ -1,6 +1,7 @@
 package net.corda.tools.shell;
 
 import net.corda.core.crypto.SecureHash;
+import net.corda.core.crypto.SecureHashKt;
 import net.corda.core.internal.VisibleForTesting;
 import net.corda.core.messaging.CordaRPCOps;
 import net.corda.core.messaging.StateMachineTransactionMapping;
@@ -60,7 +61,7 @@ public class HashLookupShellCommand extends CordaRpcOpsShellCommand {
         Optional<SecureHash> match = mapping.stream()
                 .map(StateMachineTransactionMapping::getTransactionId)
                 .filter(
-                        txId -> txId.equals(txIdHashParsed) || SecureHash.hashAs(txIdHashParsed.getAlgorithm(), txId.getBytes()).equals(txIdHashParsed)
+                        txId -> txId.equals(txIdHashParsed) || SecureHash.hashAs(SecureHashKt.getAlgorithm(txIdHashParsed), txId.getBytes()).equals(txIdHashParsed)
                 )
                 .findFirst();
 


### PR DESCRIPTION
`SecureHash.SHA256` serialized form must be compatible with Corda 4.6.