### PR TITLE
INFRA-965: Jenkins/NexusIQ integration should target patches

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
                 script {
                     sh "./gradlew --no-daemon properties | grep -E '^(version|group):' >version-properties"
                     /* every build related to Corda X.Y (GA, RC, HC, patch or snapshot) uses the same NexusIQ application */
-                    def version = sh (returnStdout: true, script: "grep ^version: version-properties | sed -e 's/^version: \\([0-9]\\+\\.[0-9]\\+\\).*\$/\\1/'").trim()
+                    def version = sh (returnStdout: true, script: "grep ^version: version-properties | sed -e 's/^version: \\([0-9]\\+\\(\\.[0-9]\\+\\)\\+\\).*\$/\\1/'").trim()
                     def groupId = sh (returnStdout: true, script: "grep ^group: version-properties | sed -e 's/^group: //'").trim()
                     def artifactId = 'corda'
                     nexusAppId = "${groupId}-${artifactId}-${version}"


### PR DESCRIPTION
as well as major/minor releases.

Updated `sed` to extract from `version` all numeric elements, instead of first two.