### PR TITLE
NOTICK: Do not forcibly publish capsules without classifiers.

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -122,9 +122,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: [
 artifacts {
     archives buildCordaJAR
     runtimeArtifacts buildCordaJAR
-    publish buildCordaJAR {
-        classifier ''
-    }
+    publish buildCordaJAR
 }
 
 publish {

--- a/testing/testserver/testcapsule/build.gradle
+++ b/testing/testserver/testcapsule/build.gradle
@@ -67,9 +67,7 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').tasks.jar) 
 artifacts {
     archives buildWebserverJar
     runtimeArtifacts buildWebserverJar
-    publish buildWebserverJar {
-        classifier ''
-    }
+    publish buildWebserverJar
 }
 
 publish {

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -44,9 +44,7 @@ task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').ta
 artifacts {
     archives buildExplorerJAR
     runtimeArtifacts buildExplorerJAR
-    publish buildExplorerJAR {
-        classifier ""
-    }
+    publish buildExplorerJAR
 }
 
 jar {


### PR DESCRIPTION
It has been observed that three capsule artifacts do have a `-jdk11` classifier when building Corda for Java 11. Fix the common Gradle error that causes this.