### PR TITLE
NOTICK Integrate Splunk logging, tracing and metrics export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,9 @@ buildscript {
     ext.controlsfx_version = '8.40.15'
     ext.detekt_version = constants.getProperty('detektVersion')
     ext.docker_java_version = constants.getProperty("dockerJavaVersion")
+    ext.splunklibraryVersion = constants.getProperty('splunklibraryVersion')
+    ext.jmxPrometheusAgentVersion = constants.getProperty('jmxPrometheusAgentVersion')
+    ext.openTelemetryAgentVersion = constants.getProperty('openTelemetryAgentVersion')
     if (JavaVersion.current().isJava8()) {
         ext.fontawesomefx_commons_version = '8.15'
         ext.fontawesomefx_fontawesome_version = '4.7.0-5'
@@ -238,7 +241,7 @@ apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.r3.testing.distributed-testing'
 
 
-// If the command line project option -PversionFromGit is added to the gradle invocation, we'll resolve 
+// If the command line project option -PversionFromGit is added to the gradle invocation, we'll resolve
 // the latest git commit hash and timestamp and create a version postfix from that
 if (project.hasProperty("versionFromGit")){
     ext.versionSuffix = "${grgit.head().dateTime.format("yyyyMMdd_HHmmss")}-${grgit.head().abbreviatedId}"
@@ -428,6 +431,17 @@ allprojects {
             }
             mavenCentral()
             jcenter()
+            maven { url "https://repo.spring.io/libs-milestone"
+                content {
+                    includeGroup 'com.splunk.logging'
+                }
+            }
+            maven { url "https://dl.bintray.com/open-telemetry/maven"
+                content {
+                    includeGroup 'io.opentelemetry'
+                    includeGroup 'io.opentelemetry.instrumentation.auto'
+                }
+            }
         }
     }
 

--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -2,6 +2,17 @@
 <Configuration status="info" shutdownHook="disable">
 
     <Properties>
+        <Property name="splunkEnabled">${env:SPLUNK_ENABLED:-false}</Property>
+        <Property name="host">${env:HOST:-${docker:containerId:-localhost}}</Property>
+        <Property name="splunk.url">${env:SPLUNK_URL}</Property>
+        <Property name="splunk.token">${env:SPLUNK_TOKEN}</Property>
+        <Property name="splunk.index">${env:SPLUNK_INDEX}</Property>
+        <Property name="splunk.source">${env:SPLUNK_SOURCE:-corda}</Property>
+        <Property name="splunk.sourcetype">${env:SPLUNK_SOURCETYPE:-corda:logs}</Property>
+        <Property name="splunk.batch_size_bytes">${env:SPLUNK_BATCH_SIZE_BYTES:-65536}</Property>
+        <Property name="splunk.batch_size_count">${env:SPLUNK_BATCH_SIZE_COUNT:-1000}</Property>
+        <Property name="splunk.batch_interval">${env:SPLUNK_BATCH_INTERVAL:-500}</Property>
+        <Property name="splunk.disableCertificateValidation">${env:SPLUNK_SKIPTLSVERIFY:-false}</Property>
         <Property name="log-path">${sys:log-path:-logs}</Property>
         <Property name="log-name">node-${hostName}</Property>
         <Property name="diagnostic-log-name">diagnostic-${hostName}</Property>
@@ -15,8 +26,13 @@
             <Script language="nashorn"><![CDATA[
                 var System = Java.type('java.lang.System');
                 var level = System.getProperty("consoleLogLevel");
-                var enabled = System.getProperty("consoleLoggingEnabled");
-                enabled == "true" && (level == "debug" || level == "trace") ? "Console-Debug-Appender" : "Console-Appender";
+                var splunkEnabled = System.getProperty("splunkEnabled");
+                if (splunkEnabled == "true") {
+                  "Splunk";
+                } else {
+                  var enabled = System.getProperty("consoleLoggingEnabled");
+                  enabled == "true" && (level == "debug" || level == "trace") ? "Console-Debug-Appender" : "Console-Appender";
+                }
             ]]></Script>
             <AppenderSet>
 
@@ -58,6 +74,21 @@
                         </ScriptPatternSelector>
                     </PatternLayout>
                 </Console>
+
+                <SplunkHttp name="Splunk"
+                            url="${sys:splunk.url}"
+                            token="${sys:splunk.token}"
+                            host="${sys:host}"
+                            index="${sys:splunk.index}"
+                            source="${sys:splunk.source}"
+                            sourcetype="${sys:splunk.sourcetype}"
+                            messageFormat="text"
+                            batch_size_bytes="${sys:splunk.batch_size_bytes}"
+                            batch_size_count="${sys:splunk.batch_size_count}"
+                            batch_interval="${sys:splunk.batch_interval}"
+                            disableCertificateValidation="${sys:splunk.disableCertificateValidation}">
+                    <PatternLayout pattern="%msg" />
+                </SplunkHttp>
             </AppenderSet>
         </ScriptAppenderSelector>
 

--- a/constants.properties
+++ b/constants.properties
@@ -36,3 +36,6 @@ openSourceBranch=https://github.com/corda/corda/blob/release/os/4.4
 openSourceSamplesBranch=https://github.com/corda/samples/blob/release-V4
 jolokiaAgentVersion=1.6.1
 detektVersion=1.0.1
+splunklibraryVersion=1.8.0
+jmxPrometheusAgentVersion=0.14.0
+openTelemetryAgentVersion=0.8.0

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
     compile "org.apache.logging.log4j:log4j-web:${log4j_version}"
     compile "org.slf4j:jul-to-slf4j:$slf4j_version"
+    compile "com.splunk.logging:splunk-library-javalogging:$splunklibraryVersion"
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     runtimeOnly "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
@@ -139,6 +140,8 @@ dependencies {
 
     // Coda Hale's Metrics: for monitoring of key statistics
     compile "io.dropwizard.metrics:metrics-jmx:$metrics_version"
+    // Open Telemetry SDK
+    compile "io.opentelemetry:opentelemetry-sdk:0.9.1"
 
     // TypeSafe Config: for simple and human friendly config files.
     compile "com.typesafe:config:$typesafe_config_version"
@@ -285,11 +288,13 @@ quasar {
             "com.github.benmanes.caffeine.**",
             "com.google.**",
             "com.lmax.**",
+            "com.splunk.**",
             "com.zaxxer.**",
             "djvm**",
             "net.bytebuddy**",
             "io.github.classgraph**",
             "io.netty*",
+            "io.opentelemetry**",
             "liquibase**",
             "net.corda.djvm**",
             "net.i2p.crypto.**",

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -13,6 +13,7 @@ evaluationDependsOn(':node')
 configurations {
     runtimeArtifacts.extendsFrom runtimeClasspath
     capsuleRuntime
+    javaAgent
 }
 
 dependencies {
@@ -28,6 +29,11 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"
+
+    // agents added to the capsule jar
+    javaAgent group: 'io.opentelemetry.instrumentation.auto', name: 'opentelemetry-javaagent', version: openTelemetryAgentVersion, classifier: 'all'
+    javaAgent group: 'io.prometheus.jmx', name: 'jmx_prometheus_javaagent', version: jmxPrometheusAgentVersion
+
 }
 
 jar.enabled = false
@@ -50,9 +56,11 @@ task buildCordaJAR(type: FatCapsule, dependsOn: [
     archiveName = archiveFileName.get()
     applicationSource = files(
         nodeProject.configurations.runtimeClasspath,
+        project.configurations.javaAgent.files,
         nodeProject.tasks.jar,
         nodeProject.buildDir.toString() + '/resources/main/corda-reference.conf',
         "$rootDir/config/dev/log4j2.xml",
+        'prometheus-config.yaml',
         'NOTICE' // Copy CDDL notice
     )
     from configurations.capsuleRuntime.files.collect { zipTree(it) }
@@ -96,9 +104,11 @@ task buildCordaJAR(type: FatCapsule, dependsOn: [
         applicationVersion = corda_release_version
         applicationId = "net.corda.node.Corda"
         // See experimental/quasar-hook/README.md for how to generate.
-        def quasarExcludeExpression = "x(antlr**;bftsmart**;co.paralleluniverse**;com.codahale**;com.esotericsoftware**;com.fasterxml**;com.google**;com.ibm**;com.intellij**;com.jcabi**;com.nhaarman**;com.opengamma**;com.typesafe**;com.zaxxer**;de.javakaffee**;groovy**;groovyjarjarantlr**;groovyjarjarasm**;io.atomix**;io.github**;io.netty**;jdk**;kotlin**;net.corda.djvm**;djvm**;net.bytebuddy**;net.i2p**;org.apache**;org.bouncycastle**;org.codehaus**;org.crsh**;org.dom4j**;org.fusesource**;org.h2**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.objectweb**;org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**;org.jolokia**;com.lmax**;picocli**;liquibase**;com.github.benmanes**;org.json**;org.postgresql**;nonapi.io.github.classgraph**)"
+        def quasarExcludeExpression = "x(antlr**;bftsmart**;co.paralleluniverse**;com.codahale**;com.esotericsoftware**;com.fasterxml**;com.google**;com.ibm**;com.intellij**;com.jcabi**;com.nhaarman**;com.opengamma**;com.splunk**;com.typesafe**;com.zaxxer**;de.javakaffee**;groovy**;groovyjarjarantlr**;groovyjarjarasm**;io.atomix**;io.github**;io.netty**;io.opentelemetry**;jdk**;kotlin**;net.corda.djvm**;djvm**;net.bytebuddy**;net.i2p**;org.apache**;org.bouncycastle**;org.codehaus**;org.crsh**;org.dom4j**;org.fusesource**;org.h2**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.objectweb**;org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**;org.jolokia**;com.lmax**;picocli**;liquibase**;com.github.benmanes**;org.json**;org.postgresql**;nonapi.io.github.classgraph**)"
         def quasarClassLoaderExclusion = "l(net.corda.djvm.**;net.corda.core.serialization.internal.**)"
         javaAgents = quasar_classifier ? ["quasar-core-${quasar_version}-${quasar_classifier}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"] : ["quasar-core-${quasar_version}.jar=${quasarExcludeExpression}${quasarClassLoaderExclusion}"]
+        javaAgents << "jmx_prometheus_javaagent-${jmxPrometheusAgentVersion}.jar=\$PROMETHEUS_HOST:\$PROMETHEUS_PORT:\$CAPSULE_DIR/prometheus-config.yaml"
+        javaAgents << "opentelemetry-javaagent-${openTelemetryAgentVersion}-all.jar"
         systemProperties['visualvm.display.name'] = 'Corda'
         if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
             minJavaVersion = '1.8.0'

--- a/node/capsule/prometheus-config.yaml
+++ b/node/capsule/prometheus-config.yaml
@@ -1,0 +1,22 @@
+---
+rules:
+  # net.corda<type=Caches, component=NodeVaultService_producedStates, name=hits><>Count
+  - pattern: 'net.corda<type=(\w+), component=(\w+), name=(\w+)><>(\w+)(\d+)'
+    name: corda.$1.$3
+    value: $5
+    type: GAUGE
+    attrNameSnakeCase: true
+    labels:
+      type: $1
+      source: "corda"
+      component: $2
+      bucket: $4
+  - pattern: 'net.corda<type=(\w+), name=(\w+)><>(.*): (\d+)'
+    name: corda.$1.$2
+    value: $4
+    type: GAUGE
+    attrNameSnakeCase: true
+    labels:
+      type: $1
+      source: "corda"
+      bucket: $3


### PR DESCRIPTION
* Adds native Splunk logging to Corda nodes. With this change, logs can flow directly to a Splunk instance. Configuration is set via environment variables that can be overridden with system properties.
* Adds OpenTelemetry agent offering all traces to a remote backend, using environment variables as defined per OpenTelemetry specification here: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md
* Adds Prometheus JMX exporter mapping all corda metrics using a configuration file.

Since Corda uses Capsule, I changed the build to embed those agents as part of the executable jar and be used at runtime.


# PR Checklist:

- [X] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [X] If you added public APIs, did you write the JavaDocs?
- [X] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [X] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).
