### PR TITLE
CORDA-4101: Remove attachmentPresence cache

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -60,7 +60,6 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
     val noLocalShell: Boolean get() = false
     val transactionCacheSizeBytes: Long get() = defaultTransactionCacheSize
     val attachmentContentCacheSizeBytes: Long get() = defaultAttachmentContentCacheSize
-    val attachmentCacheBound: Long get() = defaultAttachmentCacheBound
     // do not change this value without syncing it with ScheduledFlowsDrainingModeTest
     val drainingModePollPeriod: Duration get() = Duration.ofSeconds(5)
     val extraNetworkMapKeys: List<UUID>
@@ -110,7 +109,6 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
         }
 
         internal val defaultAttachmentContentCacheSize: Long = 10.MB
-        internal const val defaultAttachmentCacheBound = 1024L
 
         const val cordappDirectoriesKey = "cordappDirectories"
 

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -65,7 +65,6 @@ data class NodeConfigurationImpl(
         override val database: DatabaseConfig = Defaults.database(devMode),
         private val transactionCacheSizeMegaBytes: Int? = Defaults.transactionCacheSizeMegaBytes,
         private val attachmentContentCacheSizeMegaBytes: Int? = Defaults.attachmentContentCacheSizeMegaBytes,
-        override val attachmentCacheBound: Long = Defaults.attachmentCacheBound,
         override val extraNetworkMapKeys: List<UUID> = Defaults.extraNetworkMapKeys,
         // do not use or remove (breaks DemoBench together with rejection of unknown configuration keys during parsing)
         private val h2port: Int? = Defaults.h2port,
@@ -112,7 +111,6 @@ data class NodeConfigurationImpl(
         const val localShellUnsafe: Boolean = false
         val transactionCacheSizeMegaBytes: Int? = null
         val attachmentContentCacheSizeMegaBytes: Int? = null
-        const val attachmentCacheBound: Long = NodeConfiguration.defaultAttachmentCacheBound
         val extraNetworkMapKeys: List<UUID> = emptyList()
         val h2port: Int? = null
         val h2Settings: NodeH2Settings? = null

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -40,7 +40,6 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
     private val localShellUnsafe by boolean().optional().withDefaultValue(Defaults.localShellUnsafe)
     private val database by nested(DatabaseConfigSpec).optional()
     private val noLocalShell by boolean().optional().withDefaultValue(Defaults.noLocalShell)
-    private val attachmentCacheBound by long().optional().withDefaultValue(Defaults.attachmentCacheBound)
     private val extraNetworkMapKeys by string().mapValid(::toUUID).list().optional().withDefaultValue(Defaults.extraNetworkMapKeys)
     private val tlsCertCrlDistPoint by string().mapValid(::toURL).optional()
     private val tlsCertCrlIssuer by string().mapValid(::toPrincipal).optional()
@@ -118,7 +117,6 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     localShellUnsafe = config[localShellUnsafe],
                     database = database,
                     noLocalShell = config[noLocalShell],
-                    attachmentCacheBound = config[attachmentCacheBound],
                     extraNetworkMapKeys = config[extraNetworkMapKeys],
                     tlsCertCrlDistPoint = config[tlsCertCrlDistPoint],
                     tlsCertCrlIssuer = config[tlsCertCrlIssuer],

--- a/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
@@ -43,7 +43,6 @@ open class DefaultNamedCacheFactory protected constructor(private val metricRegi
                 name == "HibernateConfiguration_sessionFactories" -> caffeine.maximumSize(database.mappedSchemaCacheSize)
                 name == "DBTransactionStorage_transactions" -> caffeine.maximumWeight(transactionCacheSizeBytes)
                 name == "NodeAttachmentService_attachmentContent" -> caffeine.maximumWeight(attachmentContentCacheSizeBytes)
-                name == "NodeAttachmentService_attachmentPresence" -> caffeine.maximumSize(attachmentCacheBound)
                 name == "NodeAttachmentService_contractAttachmentVersions" -> caffeine.maximumSize(defaultCacheSize)
                 name == "PersistentIdentityService_keyToPartyAndCert" -> caffeine.maximumSize(defaultCacheSize)
                 name == "PersistentIdentityService_nameToParty" -> caffeine.maximumSize(defaultCacheSize)


### PR DESCRIPTION
The attachmentPresence cache does not seem to serve a useful purpose anymore. It also contains the attachment content which it should not be doing.
This PR removes this cache and so the NodeAttachmentService now uses a single attachmentContent cache.