### PR TITLE
CORDA-4096: fix for triple hashing with pre image resistant digests

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -221,8 +221,8 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val firstHash = digest.preImageResistantDigest(bytes)
-                HASH(algorithm, digest.digest(firstHash))
+                val hash = digest.preImageResistantDigest(bytes)
+                HASH(algorithm, hash)
             }
         }
 


### PR DESCRIPTION
Fix for triple hashing due to incorrect use of preImageResistantDigest as explained in https://r3-cev.atlassian.net/browse/CORDA-4096