### PR TITLE
CORDA-4100 Configurable ComponentGroup hashing function in WireTransaction

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -212,6 +212,7 @@ private interface WireTransactionMixin
 private class WireTransactionSerializer : JsonSerializer<WireTransaction>() {
     override fun serialize(value: WireTransaction, gen: JsonGenerator, serializers: SerializerProvider) {
         gen.writeObject(WireTransactionJson(
+                value.leafDigestService,
                 value.digestService,
                 value.id,
                 value.notary,
@@ -240,11 +241,12 @@ private class WireTransactionDeserializer : JsonDeserializer<WireTransaction>() 
                 wrapper.references,
                 wrapper.networkParametersHash
         )
-        return WireTransaction(componentGroups, wrapper.privacySalt, wrapper.digestService ?: DigestService.sha2_256)
+        return WireTransaction(componentGroups, wrapper.privacySalt, wrapper.digestService ?: DigestService.sha2_256,wrapper.leafDigestService ?: DigestService.sha2_256)
     }
 }
 
 private class WireTransactionJson(@get:JsonInclude(Include.NON_NULL) val digestService: DigestService?,
+                                  @get:JsonInclude(Include.NON_NULL) val leafDigestService: DigestService?,
                                   val id: SecureHash,
                                   val notary: Party?,
                                   val inputs: List<StateRef>,

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -291,7 +291,7 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         println(mapper.writeValueAsString(json))
         val (wtxJson, signaturesJson) = json.assertHasOnlyFields("wire", "signatures")
         assertThat(signaturesJson.childrenAs<TransactionSignature>(mapper)).isEqualTo(stx.sigs)
-        val wtxFields = wtxJson.assertHasOnlyFields("id", "notary", "inputs", "attachments", "outputs", "commands", "timeWindow", "references", "privacySalt", "networkParametersHash", "digestService")
+        val wtxFields = wtxJson.assertHasOnlyFields("id", "notary", "inputs", "attachments", "outputs", "commands", "timeWindow", "references", "privacySalt", "networkParametersHash", "digestService", "leafDigestService")
         assertThat(wtxFields[0].valueAs<SecureHash>(mapper)).isEqualTo(wtx.id)
         assertThat(wtxFields[1].valueAs<Party>(mapper)).isEqualTo(wtx.notary)
         assertThat(wtxFields[2].childrenAs<StateRef>(mapper)).isEqualTo(wtx.inputs)
@@ -302,6 +302,7 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         assertThat(wtxFields[7].childrenAs<StateRef>(mapper)).isEqualTo(wtx.references)
         assertThat(wtxFields[8].valueAs<PrivacySalt>(mapper)).isEqualTo(wtx.privacySalt)
         assertThat(wtxFields[10].valueAs<DigestService>(mapper)).isEqualTo(wtx.digestService)
+        assertThat(wtxFields[10].valueAs<DigestService>(mapper)).isEqualTo(wtx.leafDigestService)
         assertThat(mapper.convertValue<WireTransaction>(wtxJson)).isEqualTo(wtx)
         assertThat(mapper.convertValue<SignedTransaction>(json)).isEqualTo(stx)
     }

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
@@ -496,12 +496,12 @@ class CompatibleTransactionTests {
         // A command with no corresponding signer detected
         // because the pointer of CommandData (3rd leaf) cannot find a corresponding (3rd) signer.
         val updatedFilteredComponentsNoSignersKey1SamePMT = listOf(key1CommandsFtx.filteredComponentGroups[0], noLastSignerGroupSamePartialTree)
-        assertFails { ftxConstructor.call(key1CommandsFtx.id, updatedFilteredComponentsNoSignersKey1SamePMT, key1CommandsFtx.groupHashes, wtx.digestService) }
+        assertFails { ftxConstructor.call(key1CommandsFtx.id, updatedFilteredComponentsNoSignersKey1SamePMT, key1CommandsFtx.groupHashes, wtx.digestService, wtx.leafDigestService) }
 
         // Remove both last signer (KEY1) and related command.
         // Update partial Merkle tree for signers.
         val updatedFilteredComponentsNoLastCommandAndSigners = listOf(noLastCommandDataGroup, noLastSignerGroup)
-        val ftxNoLastCommandAndSigners = ftxConstructor.call(key1CommandsFtx.id, updatedFilteredComponentsNoLastCommandAndSigners, key1CommandsFtx.groupHashes, wtx.digestService)
+        val ftxNoLastCommandAndSigners = ftxConstructor.call(key1CommandsFtx.id, updatedFilteredComponentsNoLastCommandAndSigners, key1CommandsFtx.groupHashes, wtx.digestService, wtx.leafDigestService)
         // verify() will pass as the transaction is well-formed.
         ftxNoLastCommandAndSigners.verify()
         // checkCommandVisibility() will not pass, because checkAllComponentsVisible(ComponentGroupEnum.SIGNERS_GROUP) will fail.
@@ -510,7 +510,7 @@ class CompatibleTransactionTests {
         // Remove last signer for which there is no pointer from a visible commandData. This is the case of Key2.
         // Do not change partial Merkle tree for signers.
         // This time the object can be constructed as there is no pointer mismatch.
-        val ftxNoLastSigner = ftxConstructor.call(key2CommandsFtx.id, updatedFilteredComponentsNoSignersKey2SamePMT, key2CommandsFtx.groupHashes, wtx.digestService)
+        val ftxNoLastSigner = ftxConstructor.call(key2CommandsFtx.id, updatedFilteredComponentsNoSignersKey2SamePMT, key2CommandsFtx.groupHashes, wtx.digestService, wtx.leafDigestService)
         // verify() will fail as we didn't change the partial Merkle tree.
         assertFailsWith<FilteredTransactionVerificationException> { ftxNoLastSigner.verify() }
         // checkCommandVisibility() will not pass.
@@ -518,7 +518,7 @@ class CompatibleTransactionTests {
 
         // Remove last signer for which there is no pointer from a visible commandData. This is the case of Key2.
         // Update partial Merkle tree for signers.
-        val ftxNoLastSignerB = ftxConstructor.call(key2CommandsFtx.id, updatedFilteredComponentsNoSignersKey2, key2CommandsFtx.groupHashes, wtx.digestService)
+        val ftxNoLastSignerB = ftxConstructor.call(key2CommandsFtx.id, updatedFilteredComponentsNoSignersKey2, key2CommandsFtx.groupHashes, wtx.digestService, wtx.leafDigestService)
         // verify() will pass, the transaction is well-formed.
         ftxNoLastSignerB.verify()
         // But, checkAllComponentsVisible() will not pass.
@@ -543,14 +543,14 @@ class CompatibleTransactionTests {
         val alterFilteredComponents = listOf(key1CommandsFtx.filteredComponentGroups[0], alterSignerGroup)
 
         // Do not update groupHashes.
-        val ftxAlterSigner = ftxConstructor.call(key1CommandsFtx.id, alterFilteredComponents, key1CommandsFtx.groupHashes, wtx.digestService)
+        val ftxAlterSigner = ftxConstructor.call(key1CommandsFtx.id, alterFilteredComponents, key1CommandsFtx.groupHashes, wtx.digestService, wtx.leafDigestService)
         // Visible components in signers group cannot be verified against their partial Merkle tree.
         assertFailsWith<FilteredTransactionVerificationException> { ftxAlterSigner.verify() }
         // Also, checkAllComponentsVisible() will not pass (groupHash matching will fail).
         assertFailsWith<ComponentVisibilityException> { ftxAlterSigner.checkCommandVisibility(DUMMY_KEY_1.public) }
 
         // Update groupHashes.
-        val ftxAlterSignerB = ftxConstructor.call(key1CommandsFtx.id, alterFilteredComponents, key1CommandsFtx.groupHashes.subList(0, 6) + alterMTree.hash, wtx.digestService)
+        val ftxAlterSignerB = ftxConstructor.call(key1CommandsFtx.id, alterFilteredComponents, key1CommandsFtx.groupHashes.subList(0, 6) + alterMTree.hash, wtx.digestService, wtx.leafDigestService)
         // Visible components in signers group cannot be verified against their partial Merkle tree.
         assertFailsWith<FilteredTransactionVerificationException> { ftxAlterSignerB.verify() }
         // Also, checkAllComponentsVisible() will not pass (top level Merkle tree cannot be verified against transaction's id).

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
@@ -429,7 +429,7 @@ class CompatibleTransactionTests {
                 timeWindowGroup,
                 ComponentGroup(SIGNERS_GROUP.ordinal, twoCommandsforKey1.map { it.signers.serialize() })
         )
-        val wtx = WireTransaction(componentGroups = componentGroups, privacySalt = PrivacySalt(), digestService = DigestService.default)
+        val wtx = WireTransaction(componentGroups = componentGroups, privacySalt = PrivacySalt(), digestService = DigestService.default, leafDigestService = DigestService.default)
 
         // Filter KEY_1 commands (commands 1 and 3).
         fun filterKEY1Commands(elem: Any): Boolean {

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -206,8 +206,14 @@ class HashAgility {
         internal var digestService = DigestService.sha2_256
             private set
 
-        fun init(txHashAlgoName: String? = null, txHashAlgoClass: String? = null) {
+        @Volatile
+        internal var leafDigestService = DigestService.sha2_256
+            private set
+
+        fun init(txHashAlgoName: String? = null, txHashAlgoClass: String? = null,
+                 leafHashAlgoName: String? = null, leafHashAlgoClass: String? = null) {
             digestService = DigestService.sha2_256
+
             txHashAlgoName?.let {
                 // Verify that algorithm exists.
                 DigestAlgorithmFactory.create(it)
@@ -216,6 +222,18 @@ class HashAgility {
             txHashAlgoClass?.let {
                 val algorithm = DigestAlgorithmFactory.registerClass(it)
                 digestService = DigestService(algorithm)
+            }
+
+            leafDigestService = digestService
+
+            leafHashAlgoName?.let {
+                // Verify that algorithm exists.
+                DigestAlgorithmFactory.create(it)
+                leafDigestService = DigestService(it)
+            }
+            leafHashAlgoClass?.let {
+                val algorithm = DigestAlgorithmFactory.registerClass(it)
+                leafDigestService = DigestService(algorithm)
             }
         }
 
@@ -230,6 +248,7 @@ class HashAgility {
  * and as a parameter to MerkleTree.getMerkleTree(...) method. Default: SHA2_256.
  */
 val ServicesForResolution.digestService get() = HashAgility.digestService
+val ServicesForResolution.leafDigestService get() = HashAgility.leafDigestService
 
 fun ServicesForResolution.requireSupportedHashType(hash: NamedByHash) {
     require(HashAgility.isAlgorithmSupported(hash.id.algorithm)) {

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -178,7 +178,8 @@ open class TransactionBuilder(
                             referenceStates,
                             services.networkParametersService.currentHash),
                     privacySalt,
-                    services.digestService
+                    services.digestService,
+                    services.leafDigestService
             )
         }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
@@ -216,13 +216,15 @@ object WireTransactionSerializer : Serializer<WireTransaction>() {
         kryo.writeClassAndObject(output, obj.componentGroups)
         kryo.writeClassAndObject(output, obj.privacySalt)
         kryo.writeClassAndObject(output, obj.digestService)
+        kryo.writeClassAndObject(output, obj.leafDigestService)
     }
 
     override fun read(kryo: Kryo, input: Input, type: Class<WireTransaction>): WireTransaction {
         val componentGroups: List<ComponentGroup> = uncheckedCast(kryo.readClassAndObject(input))
         val privacySalt = kryo.readClassAndObject(input) as PrivacySalt
-        val digestService = kryo.readClassAndObject(input) as? DigestService
-        return WireTransaction(componentGroups, privacySalt, digestService ?: DigestService.sha2_256)
+        val digestService = kryo.readClassAndObject(input) as? DigestService ?: DigestService.sha2_256
+        val leafDigestService = kryo.readClassAndObject(input) as? DigestService ?: DigestService.sha2_256
+        return WireTransaction(componentGroups, privacySalt, digestService, leafDigestService)
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -178,7 +178,9 @@ open class NodeStartup : NodeStartupLogging {
         // Temp Step. Enable experimental hash agility feature allowing to override default transaction hash algorithm.
         val txHashAlgoName = System.getProperty("experimental.corda.txHashAlgoName")
         val txHashAlgoClass = System.getProperty("experimental.corda.txHashAlgoClass")
-        HashAgility.init(txHashAlgoName, txHashAlgoClass)
+        val leafHashAlgoName = System.getProperty("experimental.corda.leafHashAlgoName")
+        val leafHashAlgoClass = System.getProperty("experimental.corda.leafHashAlgoClass")
+        HashAgility.init(txHashAlgoName, txHashAlgoClass, leafHashAlgoName, leafHashAlgoClass)
 
         // Step 4. Print banner and basic node info.
         val versionInfo = getVersionInfo()

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -156,9 +156,10 @@ fun createWireTransaction(inputs: List<StateRef>,
                           notary: Party?,
                           timeWindow: TimeWindow?,
                           privacySalt: PrivacySalt = PrivacySalt(),
-                          digestService: DigestService = DigestService.default): WireTransaction {
+                          digestService: DigestService = DigestService.default,
+                          leafDigestService: DigestService = DigestService.default): WireTransaction {
     val componentGroups = createComponentGroups(inputs, outputs, commands, attachments, notary, timeWindow, emptyList(), null)
-    return WireTransaction(componentGroups, privacySalt, digestService)
+    return WireTransaction(componentGroups, privacySalt, digestService, leafDigestService)
 }
 
 /**


### PR DESCRIPTION
Updates to WireTransaction to allow separate hashing function for ComponentGroup MerkleTree leaves vs Merkle Tree nodes/roots.