### PR TITLE
CORDA-4105 Add public API to allow custom serialization schemes

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -5935,6 +5935,20 @@ public @interface net.corda.core.serialization.CordaSerializationTransformRename
 public @interface net.corda.core.serialization.CordaSerializationTransformRenames
   public abstract net.corda.core.serialization.CordaSerializationTransformRename[] value()
 ##
+@DoNotImplement
+public interface net.corda.core.serialization.CustomSerializationContext
+  @NotNull
+  public abstract ClassLoader getDeserializationClassLoader()
+  @NotNull
+  public abstract net.corda.core.serialization.ClassWhitelist getWhitelist()
+##
+public interface net.corda.core.serialization.CustomSerializationScheme
+  @NotNull
+  public abstract T deserialize(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.CustomSerializationContext)
+  public abstract int getSchemeId()
+  @NotNull
+  public abstract net.corda.core.utilities.ByteSequence serialize(T, net.corda.core.serialization.CustomSerializationContext)
+##
 public @interface net.corda.core.serialization.DeprecatedConstructorForDeserialization
   public abstract int version()
 ##

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -5935,19 +5935,12 @@ public @interface net.corda.core.serialization.CordaSerializationTransformRename
 public @interface net.corda.core.serialization.CordaSerializationTransformRenames
   public abstract net.corda.core.serialization.CordaSerializationTransformRename[] value()
 ##
-@DoNotImplement
-public interface net.corda.core.serialization.CustomSerializationContext
-  @NotNull
-  public abstract ClassLoader getDeserializationClassLoader()
-  @NotNull
-  public abstract net.corda.core.serialization.ClassWhitelist getWhitelist()
-##
 public interface net.corda.core.serialization.CustomSerializationScheme
   @NotNull
-  public abstract T deserialize(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.CustomSerializationContext)
+  public abstract T deserialize(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.SerializationSchemeContext)
   public abstract int getSchemeId()
   @NotNull
-  public abstract net.corda.core.utilities.ByteSequence serialize(T, net.corda.core.serialization.CustomSerializationContext)
+  public abstract net.corda.core.utilities.ByteSequence serialize(T, net.corda.core.serialization.SerializationSchemeContext)
 ##
 public @interface net.corda.core.serialization.DeprecatedConstructorForDeserialization
   public abstract int version()
@@ -6089,6 +6082,13 @@ public static final class net.corda.core.serialization.SerializationFactory$Comp
   public final net.corda.core.serialization.SerializationFactory getCurrentFactory()
   @NotNull
   public final net.corda.core.serialization.SerializationFactory getDefaultFactory()
+##
+@DoNotImplement
+public interface net.corda.core.serialization.SerializationSchemeContext
+  @NotNull
+  public abstract ClassLoader getDeserializationClassLoader()
+  @NotNull
+  public abstract net.corda.core.serialization.ClassWhitelist getWhitelist()
 ##
 public interface net.corda.core.serialization.SerializationToken
   @NotNull

--- a/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
@@ -1,37 +1,51 @@
 package net.corda.core.serialization
 
+import net.corda.core.DoNotImplement
 import java.io.NotSerializableException
 
 /***
- * Implement this interface to add your own Serialization Scheme.
- * This is an experimental feature.
+ * Implement this interface to add your own Serialization Scheme. This is an experimental feature. All methods in this class MUST be
+ * thread safe i.e. methods from the same instance of this class can be called in different threads simultaneously.
  */
 interface CustomSerializationScheme {
     /**
-     * This must return a magic number used to uniquely (within a network) identify the Scheme.
+     * This method must return an id used to uniquely identify the Scheme. This should be unique within a network as serialized data might
+     * be sent over the wire.
      */
     fun getSchemeId(): Int
 
     /**
-     * This method must deserialize (any) object from SerializedBytes.
+     * This method must deserialize the data stored [bytes] into an instance of [T].
+     *
+     * @param bytes the serialized data.
+     * @param clazz the class to instantiate.
+     * @param context used to pass information about how the object should be deserialized.
      */
     @Throws(NotSerializableException::class)
     fun <T : Any> deserialize(bytes: SerializedBytes<T>, clazz: Class<T>, context: CustomSerializationContext): T
 
     /**
-     * This method must serialize (any) object into SerializedBytes.
+     * This method must be able to serialize any object [T] into SerializedBytes.
+     *
+     * @param obj the object to be serialized.
+     * @param context used to pass information about how the object should be serialized.
      */
     @Throws(NotSerializableException::class)
     fun <T : Any> serialize(obj: T, context: CustomSerializationContext): SerializedBytes<T>
 }
 
+/**
+ * This is used to pass information about how the object should be serialized and deserialized. This context might change depending on where
+ * [CustomSerializationScheme.deserialize] or [CustomSerializationScheme.serialize] are called internally.
+ */
+@DoNotImplement
 interface CustomSerializationContext {
     /**
      * The class loader to use for deserialization.
      */
     val deserializationClassLoader: ClassLoader
     /**
-     * A whitelist that contains (mostly for security purposes) which classes can be serialized and deserialized.
+     * A whitelist that contains (mostly for security purposes) which classes are authorised to be serialized and deserialized.
      */
     val whitelist: ClassWhitelist
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
@@ -1,6 +1,5 @@
 package net.corda.core.serialization
 
-import net.corda.core.DoNotImplement
 import net.corda.core.utilities.ByteSequence
 import java.io.NotSerializableException
 
@@ -23,7 +22,7 @@ interface CustomSerializationScheme {
      * @param context used to pass information about how the object should be deserialized.
      */
     @Throws(NotSerializableException::class)
-    fun <T : Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: CustomSerializationContext): T
+    fun <T : Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: SerializationSchemeContext): T
 
     /**
      * This method must be able to serialize any object [T] into a ByteSequence.
@@ -32,21 +31,5 @@ interface CustomSerializationScheme {
      * @param context used to pass information about how the object should be serialized.
      */
     @Throws(NotSerializableException::class)
-    fun <T : Any> serialize(obj: T, context: CustomSerializationContext): ByteSequence
-}
-
-/**
- * This is used to pass information about how the object should be serialized and deserialized. This context might change depending on where
- * [CustomSerializationScheme.deserialize] or [CustomSerializationScheme.serialize] are called internally.
- */
-@DoNotImplement
-interface CustomSerializationContext {
-    /**
-     * The class loader to use for deserialization.
-     */
-    val deserializationClassLoader: ClassLoader
-    /**
-     * A whitelist that contains (mostly for security purposes) which classes are authorised to be serialized and deserialized.
-     */
-    val whitelist: ClassWhitelist
+    fun <T : Any> serialize(obj: T, context: SerializationSchemeContext): ByteSequence
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
@@ -10,22 +10,20 @@ interface CustomSerializationScheme {
     /**
      * This must return a magic number used to uniquely (within a network) identify the Scheme.
      */
-    fun getSerializationMagic(): CustomSerializationMagic
+    fun getSchemeId(): Int
 
     /**
      * This method must deserialize (any) object from SerializedBytes.
      */
     @Throws(NotSerializableException::class)
-    fun deserialize(bytes: SerializedBytes<*>, clazz: Class<*>, context: CustomSerializationContext): Any
+    fun <T : Any> deserialize(bytes: SerializedBytes<T>, clazz: Class<T>, context: CustomSerializationContext): T
 
     /**
      * This method must serialize (any) object into SerializedBytes.
      */
     @Throws(NotSerializableException::class)
-    fun serialize(obj: Any, context: CustomSerializationContext): SerializedBytes<*>
+    fun <T : Any> serialize(obj: T, context: CustomSerializationContext): SerializedBytes<T>
 }
-
-class CustomSerializationMagic(val magicNumber: Int)
 
 interface CustomSerializationContext {
     /**

--- a/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
@@ -1,6 +1,7 @@
 package net.corda.core.serialization
 
 import net.corda.core.DoNotImplement
+import net.corda.core.utilities.ByteSequence
 import java.io.NotSerializableException
 
 /***
@@ -22,16 +23,16 @@ interface CustomSerializationScheme {
      * @param context used to pass information about how the object should be deserialized.
      */
     @Throws(NotSerializableException::class)
-    fun <T : Any> deserialize(bytes: SerializedBytes<T>, clazz: Class<T>, context: CustomSerializationContext): T
+    fun <T : Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: CustomSerializationContext): T
 
     /**
-     * This method must be able to serialize any object [T] into SerializedBytes.
+     * This method must be able to serialize any object [T] into a ByteSequence.
      *
      * @param obj the object to be serialized.
      * @param context used to pass information about how the object should be serialized.
      */
     @Throws(NotSerializableException::class)
-    fun <T : Any> serialize(obj: T, context: CustomSerializationContext): SerializedBytes<T>
+    fun <T : Any> serialize(obj: T, context: CustomSerializationContext): ByteSequence
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CustomSerializationScheme.kt
@@ -1,0 +1,39 @@
+package net.corda.core.serialization
+
+import java.io.NotSerializableException
+
+/***
+ * Implement this interface to add your own Serialization Scheme.
+ * This is an experimental feature.
+ */
+interface CustomSerializationScheme {
+    /**
+     * This must return a magic number used to uniquely (within a network) identify the Scheme.
+     */
+    fun getSerializationMagic(): CustomSerializationMagic
+
+    /**
+     * This method must deserialize (any) object from SerializedBytes.
+     */
+    @Throws(NotSerializableException::class)
+    fun deserialize(bytes: SerializedBytes<*>, clazz: Class<*>, context: CustomSerializationContext): Any
+
+    /**
+     * This method must serialize (any) object into SerializedBytes.
+     */
+    @Throws(NotSerializableException::class)
+    fun serialize(obj: Any, context: CustomSerializationContext): SerializedBytes<*>
+}
+
+class CustomSerializationMagic(val magicNumber: Int)
+
+interface CustomSerializationContext {
+    /**
+     * The class loader to use for deserialization.
+     */
+    val deserializationClassLoader: ClassLoader
+    /**
+     * A whitelist that contains (mostly for security purposes) which classes can be serialized and deserialized.
+     */
+    val whitelist: ClassWhitelist
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
@@ -1,0 +1,23 @@
+package net.corda.core.serialization
+
+import net.corda.core.DoNotImplement
+
+/**
+ * This is used to pass information into [CustomSerializationScheme] about how the object should be (de)serialized.
+ * This context can change depending on the specific circumstances in the node when (de)serialization occurs.
+ */
+@DoNotImplement
+interface SerializationSchemeContext {
+    /**
+     * The class loader to use for deserialization. This is guaranteed to be able to load all the required classes passed into
+     * [CustomSerializationScheme.deserialize].
+     */
+    val deserializationClassLoader: ClassLoader
+    /**
+     * A whitelist that contains (mostly for security purposes) which classes are authorised to be deserialized.
+     * A secure implementation will not instantiate any object which is not whitelisted when deserializing.
+     * To catch classes missing from the whitelist as early as possible it is HIGHLY recommended to also check this whitelist when
+     * serializing (as well as deserialising) objects.
+     */
+    val whitelist: ClassWhitelist
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
@@ -14,11 +14,11 @@ import java.nio.ByteBuffer
 class CustomSerializationSchemeAdapter(private val customScheme: CustomSerializationScheme): SerializationScheme {
 
     companion object {
-        const val SERIALIZATION_MAGIC_BUFFER_SIZE = 4
+        const val SERIALIZATION_SCHEME_ID_SIZE = 4
     }
 
     val serializationSchemeMagic = CordaSerializationMagic("CUS".toByteArray()
-            + ByteBuffer.allocate(SERIALIZATION_MAGIC_BUFFER_SIZE).putInt(customScheme.getSchemeId()).array())
+            + ByteBuffer.allocate(SERIALIZATION_SCHEME_ID_SIZE).putInt(customScheme.getSchemeId()).array())
 
     override fun canDeserializeVersion(magic: CordaSerializationMagic, target: SerializationContext.UseCase): Boolean {
         return magic == serializationSchemeMagic
@@ -36,7 +36,7 @@ class CustomSerializationSchemeAdapter(private val customScheme: CustomSerializa
     override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {
         val stream = ByteArrayOutputStream()
         stream.write(serializationSchemeMagic.bytes)
-        stream.write(customScheme.serialize<T>(obj, SerializationContextAdapter(context)).bytes)
+        stream.write(customScheme.serialize(obj, SerializationContextAdapter(context)).bytes)
         return SerializedBytes(stream.toByteArray())
     }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
@@ -29,8 +29,12 @@ class CustomSerializationSchemeAdapter(private val customScheme: CustomSerializa
         if (readMagic != serializationSchemeMagic)
             throw NotSerializableException("Scheme ${customScheme::class.java} is incompatible with blob." +
                     " Magic from blob = $readMagic (Expected = $serializationSchemeMagic)")
-      return customScheme.deserialize(byteSequence.subSequence(serializationSchemeMagic.size, byteSequence.size - serializationSchemeMagic.size), clazz, SerializationContextAdapter(context))
-  }
+        return customScheme.deserialize(
+            byteSequence.subSequence(serializationSchemeMagic.size, byteSequence.size - serializationSchemeMagic.size),
+            clazz,
+            SerializationContextAdapter(context)
+        )
+    }
 
     override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {
         val stream = ByteArrayOutputStream()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
@@ -1,5 +1,6 @@
 package net.corda.nodeapi.internal.serialization
 
+import jdk.nashorn.internal.ir.annotations.Ignore
 import net.corda.core.serialization.CustomSerializationContext
 import net.corda.core.serialization.CustomSerializationScheme
 import net.corda.core.serialization.SerializationContext
@@ -31,8 +32,9 @@ class CustomSerializationSchemeAdapter(private val customScheme: CustomSerializa
             throw NotSerializableException("Scheme ${customScheme::class.java} is incompatible with blob." +
                     " Magic from blob = $readMagic (Expected = $serializationSchemeMagic)")
         val withOutMagic = byteSequence.bytes.slice(serializationSchemeMagic.size .. byteSequence.size - 1).toByteArray()
-        return customScheme.deserialize(SerializedBytes<T>(withOutMagic), clazz, SerializationContextAdapter(context)) as T
-    }
+      @Suppress("UNCHECKED_CAST")
+      return customScheme.deserialize(SerializedBytes<T>(withOutMagic), clazz, SerializationContextAdapter(context)) as T
+  }
 
     override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {
         val stream = ByteArrayOutputStream()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
@@ -1,6 +1,5 @@
 package net.corda.nodeapi.internal.serialization
 
-import jdk.nashorn.internal.ir.annotations.Ignore
 import net.corda.core.serialization.CustomSerializationContext
 import net.corda.core.serialization.CustomSerializationScheme
 import net.corda.core.serialization.SerializationContext

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
@@ -29,8 +29,7 @@ class CustomSerializationSchemeAdapter(private val customScheme: CustomSerializa
         if (readMagic != serializationSchemeMagic)
             throw NotSerializableException("Scheme ${customScheme::class.java} is incompatible with blob." +
                     " Magic from blob = $readMagic (Expected = $serializationSchemeMagic)")
-        val withOutMagic = byteSequence.bytes.slice(serializationSchemeMagic.size until byteSequence.size).toByteArray()
-      return customScheme.deserialize(SerializedBytes(withOutMagic), clazz, SerializationContextAdapter(context))
+      return customScheme.deserialize(byteSequence.subSequence(serializationSchemeMagic.size, byteSequence.size - serializationSchemeMagic.size), clazz, SerializationContextAdapter(context))
   }
 
     override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
@@ -1,0 +1,48 @@
+package net.corda.nodeapi.internal.serialization
+
+import net.corda.core.serialization.CustomSerializationContext
+import net.corda.core.serialization.CustomSerializationScheme
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializedBytes
+import net.corda.core.utilities.ByteSequence
+import net.corda.serialization.internal.CordaSerializationMagic
+import net.corda.serialization.internal.SerializationScheme
+import java.io.ByteArrayOutputStream
+import java.io.NotSerializableException
+import java.nio.ByteBuffer
+
+class CustomSerializationSchemeAdapter(private val customScheme: CustomSerializationScheme): SerializationScheme {
+
+    companion object {
+        //If only this was C
+        const val SIZE_OF_INT = 4
+    }
+
+    val serializationSchemeMagic = CordaSerializationMagic("CUS".toByteArray()
+            + ByteBuffer.allocate(SIZE_OF_INT).putInt(customScheme.getSerializationMagic().magicNumber).array())
+
+    override fun canDeserializeVersion(magic: CordaSerializationMagic, target: SerializationContext.UseCase): Boolean {
+        return magic == serializationSchemeMagic
+    }
+
+    override fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: SerializationContext): T {
+        val readMagic = byteSequence.take(serializationSchemeMagic.size)
+        if (readMagic != serializationSchemeMagic)
+            throw NotSerializableException("Scheme ${customScheme::class.java} is incompatible with blob." +
+                    " Magic from blob = $readMagic (Expected = $serializationSchemeMagic)")
+        val withOutMagic = byteSequence.bytes.slice(serializationSchemeMagic.size .. byteSequence.size - 1).toByteArray()
+        return customScheme.deserialize(SerializedBytes<T>(withOutMagic), clazz, SerializationContextAdapter(context)) as T
+    }
+
+    override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {
+        val stream = ByteArrayOutputStream()
+        stream.write(serializationSchemeMagic.bytes)
+        stream.write(customScheme.serialize(obj, SerializationContextAdapter(context)).bytes)
+        return SerializedBytes(stream.toByteArray())
+    }
+
+    private class SerializationContextAdapter(context: SerializationContext) : CustomSerializationContext {
+        override val deserializationClassLoader = context.deserializationClassLoader
+        override val whitelist = context.whitelist
+    }
+}

--- a/node-api/src/test/java/net/corda/nodeapi/internal/serialization/DummyCustomSerializationSchemeInJava.java
+++ b/node-api/src/test/java/net/corda/nodeapi/internal/serialization/DummyCustomSerializationSchemeInJava.java
@@ -1,0 +1,29 @@
+package net.corda.nodeapi.internal.serialization;
+
+import net.corda.core.serialization.CustomSerializationContext;
+import net.corda.core.serialization.CustomSerializationScheme;
+import net.corda.core.serialization.SerializedBytes;
+
+public class DummyCustomSerializationSchemeInJava implements CustomSerializationScheme {
+
+        public class DummyOutput {}
+
+        static final int testMagic = 7;
+
+        @Override
+        public int getSchemeId() {
+            return testMagic;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(SerializedBytes<T> bytes, Class<T> clazz, CustomSerializationContext context) {
+            return (T)new DummyOutput();
+        }
+
+        @Override
+        public <T> SerializedBytes<T> serialize(T obj, CustomSerializationContext context) {
+            byte[] myBytes = {0xA, 0xA};
+            return new SerializedBytes<>(myBytes);
+        }
+}

--- a/node-api/src/test/java/net/corda/nodeapi/internal/serialization/DummyCustomSerializationSchemeInJava.java
+++ b/node-api/src/test/java/net/corda/nodeapi/internal/serialization/DummyCustomSerializationSchemeInJava.java
@@ -1,6 +1,6 @@
 package net.corda.nodeapi.internal.serialization;
 
-import net.corda.core.serialization.CustomSerializationContext;
+import net.corda.core.serialization.SerializationSchemeContext;
 import net.corda.core.serialization.CustomSerializationScheme;
 import net.corda.core.serialization.SerializedBytes;
 import net.corda.core.utilities.ByteSequence;
@@ -18,12 +18,12 @@ public class DummyCustomSerializationSchemeInJava implements CustomSerialization
 
         @Override
         @SuppressWarnings("unchecked")
-        public <T> T deserialize(ByteSequence bytes, Class<T> clazz, CustomSerializationContext context) {
+        public <T> T deserialize(ByteSequence bytes, Class<T> clazz, SerializationSchemeContext context) {
             return (T)new DummyOutput();
         }
 
         @Override
-        public <T> SerializedBytes<T> serialize(T obj, CustomSerializationContext context) {
+        public <T> SerializedBytes<T> serialize(T obj, SerializationSchemeContext context) {
             byte[] myBytes = {0xA, 0xA};
             return new SerializedBytes<>(myBytes);
         }

--- a/node-api/src/test/java/net/corda/nodeapi/internal/serialization/DummyCustomSerializationSchemeInJava.java
+++ b/node-api/src/test/java/net/corda/nodeapi/internal/serialization/DummyCustomSerializationSchemeInJava.java
@@ -3,6 +3,7 @@ package net.corda.nodeapi.internal.serialization;
 import net.corda.core.serialization.CustomSerializationContext;
 import net.corda.core.serialization.CustomSerializationScheme;
 import net.corda.core.serialization.SerializedBytes;
+import net.corda.core.utilities.ByteSequence;
 
 public class DummyCustomSerializationSchemeInJava implements CustomSerializationScheme {
 
@@ -17,7 +18,7 @@ public class DummyCustomSerializationSchemeInJava implements CustomSerialization
 
         @Override
         @SuppressWarnings("unchecked")
-        public <T> T deserialize(SerializedBytes<T> bytes, Class<T> clazz, CustomSerializationContext context) {
+        public <T> T deserialize(ByteSequence bytes, Class<T> clazz, CustomSerializationContext context) {
             return (T)new DummyOutput();
         }
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
@@ -1,6 +1,6 @@
 package net.corda.nodeapi.internal.serialization
 
-import net.corda.core.serialization.CustomSerializationContext
+import net.corda.core.serialization.SerializationSchemeContext
 import net.corda.core.serialization.CustomSerializationScheme
 import net.corda.core.utilities.ByteSequence
 import net.corda.nodeapi.internal.serialization.testutils.serializationContext
@@ -24,12 +24,12 @@ class CustomSerializationSchemeAdapterTests {
             return schemeId
         }
 
-        override fun <T: Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: CustomSerializationContext): T {
+        override fun <T: Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: SerializationSchemeContext): T {
             @Suppress("UNCHECKED_CAST")
             return DummyOutputClass() as T
         }
 
-        override fun <T: Any> serialize(obj: T, context: CustomSerializationContext): ByteSequence {
+        override fun <T: Any> serialize(obj: T, context: SerializationSchemeContext): ByteSequence {
             assertTrue(obj is DummyInputClass)
             return ByteSequence.of(ByteArray(2) { 0x2 })
         }
@@ -43,7 +43,7 @@ class CustomSerializationSchemeAdapterTests {
             return DEFAULT_SCHEME_ID
         }
 
-        override fun <T: Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: CustomSerializationContext): T {
+        override fun <T: Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: SerializationSchemeContext): T {
             bytes.open().use {
                 val data = ByteArray(expectedBytes.size) { 0 }
                 it.read(data)
@@ -53,7 +53,7 @@ class CustomSerializationSchemeAdapterTests {
             return DummyOutputClass() as T
         }
 
-        override fun <T: Any> serialize(obj: T, context: CustomSerializationContext): ByteSequence {
+        override fun <T: Any> serialize(obj: T, context: SerializationSchemeContext): ByteSequence {
             return ByteSequence.of(expectedBytes)
         }
     }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
@@ -1,0 +1,80 @@
+package net.corda.nodeapi.internal.serialization
+
+import net.corda.core.serialization.CustomSerializationContext
+import net.corda.core.serialization.CustomSerializationMagic
+import net.corda.core.serialization.CustomSerializationScheme
+import net.corda.core.serialization.SerializedBytes
+import net.corda.nodeapi.internal.serialization.testutils.serializationContext
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.io.NotSerializableException
+import kotlin.test.assertFailsWith
+
+class CustomSerializationSchemeAdapterTests {
+
+    companion object {
+        const val DEFAULT_MAGIC = 7
+    }
+
+    class DummyInputClass
+    class DummyOutputClass
+
+    class SingleInputAndOutputScheme(val magic: CustomSerializationMagic = CustomSerializationMagic(DEFAULT_MAGIC)): CustomSerializationScheme {
+
+        override fun getSerializationMagic(): CustomSerializationMagic {
+            return magic
+        }
+
+        override fun deserialize(bytes: SerializedBytes<*>, clazz: Class<*>, context: CustomSerializationContext): Any {
+            return DummyOutputClass()
+        }
+
+        override fun serialize(obj: Any, context: CustomSerializationContext): SerializedBytes<*> {
+            assertTrue(obj is DummyInputClass)
+            return SerializedBytes<Any>(ByteArray(2) { 0x2 })
+        }
+    }
+
+    class SameBytesInputAndOutputsAndScheme(): CustomSerializationScheme {
+
+        private val expectedBytes = "123456789".toByteArray()
+
+        override fun getSerializationMagic(): CustomSerializationMagic {
+            return CustomSerializationMagic(DEFAULT_MAGIC)
+        }
+
+        override fun deserialize(bytes: SerializedBytes<*>, clazz: Class<*>, context: CustomSerializationContext): Any {
+            assertTrue(bytes.bytes.contentEquals(expectedBytes))
+            return DummyOutputClass()
+        }
+
+        override fun serialize(obj: Any, context: CustomSerializationContext): SerializedBytes<*> {
+            return SerializedBytes<Any>(expectedBytes)
+        }
+    }
+
+    @Test
+    fun `CustomSerializationSchemeAdapter calls the correct methods in CustomSerializationScheme`() {
+        val scheme = CustomSerializationSchemeAdapter(SingleInputAndOutputScheme())
+        val serializedData = scheme.serialize(DummyInputClass(), serializationContext)
+        val roundTripped = scheme.deserialize(serializedData, Any::class.java, serializationContext)
+        assertTrue(roundTripped is DummyOutputClass)
+    }
+
+    @Test
+    fun `CustomSerializationSchemeAdapter validates the magic`() {
+        val inScheme = CustomSerializationSchemeAdapter(SingleInputAndOutputScheme())
+        val serializedData = inScheme.serialize(DummyInputClass(), serializationContext)
+        val outScheme = CustomSerializationSchemeAdapter(SingleInputAndOutputScheme(CustomSerializationMagic(8)))
+        assertFailsWith<NotSerializableException> {
+            outScheme.deserialize(serializedData, DummyOutputClass::class.java, serializationContext)
+        }
+    }
+
+    @Test
+    fun `CustomSerializationSchemeAdapter preserves the serialized bytes between deserialize and serialize`() {
+        val scheme = CustomSerializationSchemeAdapter(SameBytesInputAndOutputsAndScheme())
+        val serializedData = scheme.serialize(Any(), serializationContext)
+        scheme.deserialize(serializedData, Any::class.java, serializationContext)
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
@@ -35,7 +35,7 @@ class CustomSerializationSchemeAdapterTests {
         }
     }
 
-    class SameBytesInputAndOutputsAndScheme(): CustomSerializationScheme {
+    class SameBytesInputAndOutputsAndScheme: CustomSerializationScheme {
 
         private val expectedBytes = "123456789".toByteArray()
 
@@ -53,7 +53,7 @@ class CustomSerializationSchemeAdapterTests {
         }
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `CustomSerializationSchemeAdapter calls the correct methods in CustomSerializationScheme`() {
         val scheme = CustomSerializationSchemeAdapter(SingleInputAndOutputScheme())
         val serializedData = scheme.serialize(DummyInputClass(), serializationContext)
@@ -61,7 +61,7 @@ class CustomSerializationSchemeAdapterTests {
         assertTrue(roundTripped is DummyOutputClass)
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `CustomSerializationSchemeAdapter validates the magic`() {
         val inScheme = CustomSerializationSchemeAdapter(SingleInputAndOutputScheme())
         val serializedData = inScheme.serialize(DummyInputClass(), serializationContext)
@@ -71,7 +71,7 @@ class CustomSerializationSchemeAdapterTests {
         }
     }
 
-    @Test
+    @Test(timeout=300_000)
     fun `CustomSerializationSchemeAdapter preserves the serialized bytes between deserialize and serialize`() {
         val scheme = CustomSerializationSchemeAdapter(SameBytesInputAndOutputsAndScheme())
         val serializedData = scheme.serialize(Any(), serializationContext)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapterTests.kt
@@ -2,7 +2,6 @@ package net.corda.nodeapi.internal.serialization
 
 import net.corda.core.serialization.CustomSerializationContext
 import net.corda.core.serialization.CustomSerializationScheme
-import net.corda.core.serialization.SerializedBytes
 import net.corda.core.utilities.ByteSequence
 import net.corda.nodeapi.internal.serialization.testutils.serializationContext
 import org.junit.Test


### PR DESCRIPTION
Added public interface CustomSerializationScheme so custom serialization schemes can be implemented. Added adapter code which takes an implementation of this interface and creates an implementation of SerializationScheme (this is the internal equivalent which existed before this PR). Currently this adapter is only used by tests, the idea is to eventually use this in the node after discovering implementations of CustomSerializationScheme.