### PR TITLE
CORDA-4100: Updates to DigestAlgorithm interface

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1851,14 +1851,14 @@ public final class net.corda.core.crypto.CryptoUtils extends java.lang.Object
 ##
 public interface net.corda.core.crypto.DigestAlgorithm
   @NotNull
-  public abstract byte[] componentDigest(byte[])
-  @NotNull
   public abstract byte[] digest(byte[])
   @NotNull
   public abstract String getAlgorithm()
   public abstract int getDigestLength()
   @NotNull
   public abstract byte[] nonceDigest(byte[])
+  @NotNull
+  public abstract byte[] preImageResistantDigest(byte[])
 ##
 @CordaSerializable
 public class net.corda.core.crypto.DigitalSignature extends net.corda.core.utilities.OpaqueBytes

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1851,12 +1851,14 @@ public final class net.corda.core.crypto.CryptoUtils extends java.lang.Object
 ##
 public interface net.corda.core.crypto.DigestAlgorithm
   @NotNull
+  public abstract byte[] componentDigest(byte[])
+  @NotNull
   public abstract byte[] digest(byte[])
   @NotNull
   public abstract String getAlgorithm()
   public abstract int getDigestLength()
   @NotNull
-  public abstract byte[] preImageResistantDigest(byte[])
+  public abstract byte[] nonceDigest(byte[])
 ##
 @CordaSerializable
 public class net.corda.core.crypto.DigitalSignature extends net.corda.core.utilities.OpaqueBytes

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1851,14 +1851,14 @@ public final class net.corda.core.crypto.CryptoUtils extends java.lang.Object
 ##
 public interface net.corda.core.crypto.DigestAlgorithm
   @NotNull
+  public abstract byte[] componentDigest(byte[])
+  @NotNull
   public abstract byte[] digest(byte[])
   @NotNull
   public abstract String getAlgorithm()
   public abstract int getDigestLength()
   @NotNull
   public abstract byte[] nonceDigest(byte[])
-  @NotNull
-  public abstract byte[] preImageResistantDigest(byte[])
 ##
 @CordaSerializable
 public class net.corda.core.crypto.DigitalSignature extends net.corda.core.utilities.OpaqueBytes

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
@@ -28,11 +28,11 @@ interface DigestAlgorithm {
      * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
-    fun nonceDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
+    fun preImageResistantDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
 
     /**
      * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
-    fun componentDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
+    fun nonceDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
 }

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
@@ -28,7 +28,7 @@ interface DigestAlgorithm {
      * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
-    fun componentDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
+    fun preImageResistantDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
 
     /**
      * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
@@ -28,7 +28,7 @@ interface DigestAlgorithm {
      * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
-    fun preImageResistantDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
+    fun componentDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
 
     /**
      * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
@@ -29,4 +29,16 @@ interface DigestAlgorithm {
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
     fun preImageResistantDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
+
+    /**
+     * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
+     * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
+     */
+    fun nonceDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
+
+    /**
+     * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
+     * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
+     */
+    fun componentDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
 }

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
@@ -25,13 +25,15 @@ interface DigestAlgorithm {
     fun digest(bytes: ByteArray): ByteArray
 
     /**
-     * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
+     * Computes the digest of the [ByteArray] which is resistant to pre-image attacks. Only used to calculate the hash of the leaves of the
+     * ComponentGroup Merkle tree, starting from its serialized components.
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
-    fun preImageResistantDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
+    fun componentDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
 
     /**
-     * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
+     * Computes the digest of the [ByteArray] which is resistant to pre-image attacks. Only used to calculate the nonces for the leaves of
+     * the ComponentGroup Merkle tree.
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
     fun nonceDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestAlgorithm.kt
@@ -28,12 +28,6 @@ interface DigestAlgorithm {
      * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
      * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
      */
-    fun preImageResistantDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
-
-    /**
-     * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
-     * Default implementation provides double hashing, but can it be changed to single hashing or something else for better performance.
-     */
     fun nonceDigest(bytes: ByteArray): ByteArray = digest(digest(bytes))
 
     /**

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
@@ -91,7 +91,7 @@ data class DigestService(val hashAlgorithm: String) {
      *  otherwise it's defined by DigestAlgorithm.preImageResistantDigest(nonce || serializedComponent). */
     fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash {
         val data = nonce.bytes + opaqueBytes.bytes
-        return SecureHash.componentHashAs(hashAlgorithm, data)
+        return SecureHash.preImageResistantDigestHashAs(hashAlgorithm, data)
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
@@ -91,7 +91,7 @@ data class DigestService(val hashAlgorithm: String) {
      *  otherwise it's defined by DigestAlgorithm.preImageResistantDigest(nonce || serializedComponent). */
     fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash {
         val data = nonce.bytes + opaqueBytes.bytes
-        return SecureHash.preImageResistantHashAs(hashAlgorithm, data)
+        return SecureHash.componentHashAs(hashAlgorithm, data)
     }
 
     /**
@@ -113,7 +113,7 @@ data class DigestService(val hashAlgorithm: String) {
      */
     fun computeNonce(privacySalt: PrivacySalt, groupIndex: Int, internalIndex: Int) : SecureHash {
         val data = (privacySalt.bytes + ByteBuffer.allocate(NONCE_SIZE).putInt(groupIndex).putInt(internalIndex).array())
-        return SecureHash.preImageResistantHashAs(hashAlgorithm, data)
+        return SecureHash.nonceHashAs(hashAlgorithm, data)
     }
 }
 

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
@@ -91,7 +91,7 @@ data class DigestService(val hashAlgorithm: String) {
      *  otherwise it's defined by DigestAlgorithm.preImageResistantDigest(nonce || serializedComponent). */
     fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash {
         val data = nonce.bytes + opaqueBytes.bytes
-        return SecureHash.preImageResistantDigestHashAs(hashAlgorithm, data)
+        return SecureHash.preImageResistantHashAs(hashAlgorithm, data)
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
@@ -91,7 +91,7 @@ data class DigestService(val hashAlgorithm: String) {
      *  otherwise it's defined by DigestAlgorithm.preImageResistantDigest(nonce || serializedComponent). */
     fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash {
         val data = nonce.bytes + opaqueBytes.bytes
-        return SecureHash.preImageResistantHashAs(hashAlgorithm, data)
+        return SecureHash.componentHashAs(hashAlgorithm, data)
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigestService.kt
@@ -91,7 +91,7 @@ data class DigestService(val hashAlgorithm: String) {
      *  otherwise it's defined by DigestAlgorithm.preImageResistantDigest(nonce || serializedComponent). */
     fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash {
         val data = nonce.bytes + opaqueBytes.bytes
-        return SecureHash.componentHashAs(hashAlgorithm, data)
+        return SecureHash.preImageResistantHashAs(hashAlgorithm, data)
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -216,7 +216,25 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
-        fun preImageResistantHashAs(algorithm: String, bytes: ByteArray): SecureHash {
+        fun componentHashAs(algorithm: String, bytes: ByteArray): SecureHash {
+            return if (algorithm == SHA2_256) {
+                sha256Twice(bytes)
+            } else {
+                val digest = digestFor(algorithm).get()
+                val firstHash = digest.preImageResistantDigest(bytes)
+                HASH(algorithm, digest.digest(firstHash))
+            }
+        }
+
+        /**
+         * Computes the digest of the [ByteArray] which is resistant to pre-image attacks.
+         * It computes the hash of the hash for SHA2-256 and other algorithms loaded via JCA [MessageDigest].
+         * For custom algorithms the strategy can be modified via [DigestAlgorithm].
+         * @param algorithm The [MessageDigest] algorithm to use.
+         * @param bytes The [ByteArray] to hash.
+         */
+        @JvmStatic
+        fun nonceHashAs(algorithm: String, bytes: ByteArray): SecureHash {
             return if (algorithm == SHA2_256) {
                 sha256Twice(bytes)
             } else {

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -216,7 +216,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
-        fun preImageResistantDigestHashAs(algorithm: String, bytes: ByteArray): SecureHash {
+        fun preImageResistantHashAs(algorithm: String, bytes: ByteArray): SecureHash {
             return if (algorithm == SHA2_256) {
                 sha256Twice(bytes)
             } else {

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -216,12 +216,12 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
-        fun preImageResistantHashAs(algorithm: String, bytes: ByteArray): SecureHash {
+        fun componentHashAs(algorithm: String, bytes: ByteArray): SecureHash {
             return if (algorithm == SHA2_256) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val hash = digest.preImageResistantDigest(bytes)
+                val hash = digest.componentDigest(bytes)
                 HASH(algorithm, hash)
             }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -221,8 +221,8 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val firstHash = digest.preImageResistantDigest(bytes)
-                HASH(algorithm, digest.digest(firstHash))
+                val hash = digest.preImageResistantDigest(bytes)
+                HASH(algorithm, hash)
             }
         }
 
@@ -239,8 +239,8 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val firstHash = digest.nonceDigest(bytes)
-                HASH(algorithm, digest.digest(firstHash))
+                val hash = digest.nonceDigest(bytes)
+                HASH(algorithm, hash)
             }
         }
 

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -216,12 +216,12 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
-        fun componentHashAs(algorithm: String, bytes: ByteArray): SecureHash {
+        fun preImageResistantHashAs(algorithm: String, bytes: ByteArray): SecureHash {
             return if (algorithm == SHA2_256) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val hash = digest.componentDigest(bytes)
+                val hash = digest.preImageResistantDigest(bytes)
                 HASH(algorithm, hash)
             }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -221,7 +221,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val firstHash = digest.preImageResistantDigest(bytes)
+                val firstHash = digest.componentDigest(bytes)
                 HASH(algorithm, digest.digest(firstHash))
             }
         }
@@ -239,7 +239,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val firstHash = digest.preImageResistantDigest(bytes)
+                val firstHash = digest.nonceDigest(bytes)
                 HASH(algorithm, digest.digest(firstHash))
             }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -216,12 +216,12 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
-        fun componentHashAs(algorithm: String, bytes: ByteArray): SecureHash {
+        fun preImageResistantDigestHashAs(algorithm: String, bytes: ByteArray): SecureHash {
             return if (algorithm == SHA2_256) {
                 sha256Twice(bytes)
             } else {
                 val digest = digestFor(algorithm).get()
-                val firstHash = digest.componentDigest(bytes)
+                val firstHash = digest.preImageResistantDigest(bytes)
                 HASH(algorithm, digest.digest(firstHash))
             }
         }

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -320,8 +320,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
     internal val availableComponentNonces: Map<Int, List<SecureHash>> by lazy {
         if(digestService.hashAlgorithm == SecureHash.SHA2_256) {
             componentGroups.associate { it.groupIndex to it.components.mapIndexed { internalIndex, internalIt -> digestService.componentHash(internalIt, privacySalt, it.groupIndex, internalIndex) } }
-        }
-        else {
+        } else {
             componentGroups.associate { it.groupIndex to it.components.mapIndexed { internalIndex, _ -> digestService.computeNonce(privacySalt, it.groupIndex, internalIndex) } }
         }
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -318,7 +318,12 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
      * nothing about the rest.
      */
     internal val availableComponentNonces: Map<Int, List<SecureHash>> by lazy {
-        componentGroups.associate { it.groupIndex to it.components.mapIndexed { internalIndex, internalIt -> digestService.componentHash(internalIt, privacySalt, it.groupIndex, internalIndex) } }
+        if(digestService.hashAlgorithm == SecureHash.SHA2_256) {
+            componentGroups.associate { it.groupIndex to it.components.mapIndexed { internalIndex, internalIt -> digestService.componentHash(internalIt, privacySalt, it.groupIndex, internalIndex) } }
+        }
+        else {
+            componentGroups.associate { it.groupIndex to it.components.mapIndexed { internalIndex, _ -> digestService.computeNonce(privacySalt, it.groupIndex, internalIndex) } }
+        }
     }
 
     /**


### PR DESCRIPTION
Updated DigestAlgorithm interface to separate componentHash and computeNonce hashing functions.

This allows to: 
- individually override the default behavior of double hashing in both functions and therefore optimize the ComponentGroup components hashing
- select different hash algorithms for the digest() function vs the computeNonce()/componentHash() functions, where the first is used to hash nodes/roots, the latters to hash ComponentGroup tree leaves.

In the case of multiple hash algorithm exposed by a single DigestAlgorithm implementation, the digest length of the should be the same.