### PR TITLE
CORDA-4104 Improve test coverage of custom serialization scheme discovery

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -73,7 +73,7 @@ import net.corda.node.utilities.DemoClock
 import net.corda.node.utilities.errorAndTerminate
 import net.corda.nodeapi.internal.ArtemisMessagingClient
 import net.corda.common.logging.errorReporting.NodeDatabaseErrors
-import net.corda.core.serialization.CustomSerializationScheme
+import net.corda.node.internal.classloading.scanForCustomSerializationScheme
 import net.corda.nodeapi.internal.ShutdownHook
 import net.corda.nodeapi.internal.addShutdownHook
 import net.corda.nodeapi.internal.bridging.BridgeControlListener
@@ -81,13 +81,11 @@ import net.corda.nodeapi.internal.config.User
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.persistence.CouldNotCreateDataSourceException
 import net.corda.nodeapi.internal.protonwrapper.netty.toRevocationConfig
-import net.corda.nodeapi.internal.serialization.CustomSerializationSchemeAdapter
 import net.corda.serialization.internal.AMQP_P2P_CONTEXT
 import net.corda.serialization.internal.AMQP_RPC_CLIENT_CONTEXT
 import net.corda.serialization.internal.AMQP_RPC_SERVER_CONTEXT
 import net.corda.serialization.internal.AMQP_STORAGE_CONTEXT
 import net.corda.serialization.internal.SerializationFactoryImpl
-import net.corda.serialization.internal.SerializationScheme
 import net.corda.serialization.internal.amqp.SerializationFactoryCacheKey
 import net.corda.serialization.internal.amqp.SerializerFactory
 import org.apache.commons.lang3.SystemUtils
@@ -98,7 +96,6 @@ import rx.Scheduler
 import rx.schedulers.Schedulers
 import java.lang.Long.max
 import java.lang.Long.min
-import java.lang.reflect.Constructor
 import java.net.BindException
 import java.net.InetAddress
 import java.nio.file.Files
@@ -668,25 +665,6 @@ open class Node(configuration: NodeConfiguration,
                 checkpointSerializer = KryoCheckpointSerializer,
                 checkpointContext = KRYO_CHECKPOINT_CONTEXT.withClassLoader(classloader).withCheckpointCustomSerializers(cordappLoader.cordapps.flatMap { it.checkpointCustomSerializers })
         )
-    }
-
-    fun scanForCustomSerializationScheme(className: String, classLoader: ClassLoader) : SerializationScheme {
-        val schemaClass = try {
-            classLoader.loadClass(className)
-        } catch (exception: ClassNotFoundException) {
-            throw ConfigurationException("$className was declared as a custom serialization scheme but could not be found.")
-        }
-        val constructor = validateScheme(schemaClass, className)
-        return CustomSerializationSchemeAdapter(constructor.newInstance() as CustomSerializationScheme)
-    }
-
-    private fun validateScheme(clazz: Class<*>, className: String): Constructor<*> {
-        if (!clazz.interfaces.contains(CustomSerializationScheme::class.java)) {
-            throw ConfigurationException("$className was declared as a custom serialization scheme but does not implement" +
-                    " ${CustomSerializationScheme::class.java.canonicalName}")
-        }
-        return clazz.constructors.singleOrNull { it.parameters.isEmpty() } ?: throw ConfigurationException("$className was declared as a " +
-                "custom serialization scheme but does not have a no argument constructor.")
     }
 
     /** Starts a blocking event loop for message dispatch. */

--- a/node/src/main/kotlin/net/corda/node/internal/classloading/Utils.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/classloading/Utils.kt
@@ -2,6 +2,31 @@
 
 package net.corda.node.internal.classloading
 
+import net.corda.core.serialization.CustomSerializationScheme
+import net.corda.node.internal.ConfigurationException
+import net.corda.nodeapi.internal.serialization.CustomSerializationSchemeAdapter
+import net.corda.serialization.internal.SerializationScheme
+import java.lang.reflect.Constructor
+
 inline fun <reified A : Annotation> Class<*>.requireAnnotation(): A {
     return requireNotNull(getDeclaredAnnotation(A::class.java)) { "$name needs to be annotated with ${A::class.java.name}" }
+}
+
+fun scanForCustomSerializationScheme(className: String, classLoader: ClassLoader) : SerializationScheme {
+    val schemaClass = try {
+        classLoader.loadClass(className)
+    } catch (exception: ClassNotFoundException) {
+        throw ConfigurationException("$className was declared as a custom serialization scheme but could not be found.")
+    }
+    val constructor = validateScheme(schemaClass, className)
+    return CustomSerializationSchemeAdapter(constructor.newInstance() as CustomSerializationScheme)
+}
+
+private fun validateScheme(clazz: Class<*>, className: String): Constructor<*> {
+    if (!clazz.interfaces.contains(CustomSerializationScheme::class.java)) {
+        throw ConfigurationException("$className was declared as a custom serialization scheme but does not implement" +
+                " ${CustomSerializationScheme::class.java.canonicalName}")
+    }
+    return clazz.constructors.singleOrNull { it.parameters.isEmpty() } ?: throw ConfigurationException("$className was declared as a " +
+            "custom serialization scheme but does not have a no argument constructor.")
 }

--- a/node/src/test/kotlin/net/corda/node/internal/CustomSerializationSchemeScanningTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CustomSerializationSchemeScanningTest.kt
@@ -1,0 +1,76 @@
+package net.corda.node.internal
+
+import com.nhaarman.mockito_kotlin.whenever
+import net.corda.core.serialization.CustomSerializationScheme
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationSchemeContext
+import net.corda.core.utilities.ByteSequence
+import net.corda.node.internal.classloading.scanForCustomSerializationScheme
+import org.junit.Test
+import org.mockito.Mockito
+import kotlin.test.assertFailsWith
+
+class CustomSerializationSchemeScanningTest {
+
+    class NonSerializationScheme
+
+    open class DummySerializationScheme : CustomSerializationScheme {
+        override fun getSchemeId(): Int {
+            return 7;
+        }
+
+        override fun <T : Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: SerializationSchemeContext): T {
+            throw RuntimeException("We should never get here.")
+        }
+
+        override fun <T : Any> serialize(obj: T, context: SerializationSchemeContext): ByteSequence {
+            throw RuntimeException("Tried to serialize with DummySerializationScheme")
+        }
+    }
+
+    class DummySerializationSchemeWithoutNoArgConstructor(val myArgument: String) : DummySerializationScheme()
+
+    @Test(timeout = 300_000)
+    fun `Can scan for custom serialization scheme and build a serialization scheme`() {
+        val classLoader = Mockito.mock(ClassLoader::class.java)
+        whenever(classLoader.loadClass(DummySerializationScheme::class.java.canonicalName)).thenAnswer { DummySerializationScheme::class.java }
+        val scheme = scanForCustomSerializationScheme(DummySerializationScheme::class.java.canonicalName, classLoader)
+        val mockContext = Mockito.mock(SerializationContext::class.java)
+        assertFailsWith<RuntimeException>("Tried to serialize with DummySerializationScheme")  {
+            scheme.serialize(Any::class.java, mockContext)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `verification fails with a helpful error if the class is not found in the classloader`() {
+        val classLoader = Mockito.mock(ClassLoader::class.java)
+        val missingClassName = DummySerializationScheme::class.java.canonicalName
+        whenever(classLoader.loadClass(missingClassName)).thenAnswer { throw ClassNotFoundException()}
+        assertFailsWith<ConfigurationException>("$missingClassName was declared as a custom serialization scheme but could not " +
+                "be found.") {
+            scanForCustomSerializationScheme(missingClassName, classLoader)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `verification fails with a helpful error if the class is not a custom serialization scheme`() {
+        val canonicalName = NonSerializationScheme::class.java.canonicalName
+        val classLoader = Mockito.mock(ClassLoader::class.java)
+        whenever(classLoader.loadClass(canonicalName)).thenAnswer { NonSerializationScheme::class.java }
+        assertFailsWith<ConfigurationException>("$canonicalName was declared as a custom serialization scheme but does not " +
+                "implement CustomSerializationScheme.") {
+            scanForCustomSerializationScheme(canonicalName, classLoader)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `verification fails with a helpful error if the class does not have a no arg constructor`() {
+        val classLoader = Mockito.mock(ClassLoader::class.java)
+        val canonicalName = DummySerializationSchemeWithoutNoArgConstructor::class.java.canonicalName
+        whenever(classLoader.loadClass(canonicalName)).thenAnswer { DummySerializationSchemeWithoutNoArgConstructor::class.java }
+        assertFailsWith<ConfigurationException>("$canonicalName was declared as a custom serialization scheme but does not " +
+                "have a no argument constructor.") {
+            scanForCustomSerializationScheme(canonicalName, classLoader)
+        }
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/internal/CustomSerializationSchemeScanningTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CustomSerializationSchemeScanningTest.kt
@@ -20,13 +20,15 @@ class CustomSerializationSchemeScanningTest {
         }
 
         override fun <T : Any> deserialize(bytes: ByteSequence, clazz: Class<T>, context: SerializationSchemeContext): T {
-            throw RuntimeException("We should never get here.")
+            throw DummySerializationSchemeException("We should never get here.")
         }
 
         override fun <T : Any> serialize(obj: T, context: SerializationSchemeContext): ByteSequence {
-            throw RuntimeException("Tried to serialize with DummySerializationScheme")
+            throw DummySerializationSchemeException("Tried to serialize with DummySerializationScheme")
         }
     }
+
+    class DummySerializationSchemeException(override val message: String) : RuntimeException(message)
 
     class DummySerializationSchemeWithoutNoArgConstructor(val myArgument: String) : DummySerializationScheme()
 
@@ -36,7 +38,7 @@ class CustomSerializationSchemeScanningTest {
         whenever(classLoader.loadClass(DummySerializationScheme::class.java.canonicalName)).thenAnswer { DummySerializationScheme::class.java }
         val scheme = scanForCustomSerializationScheme(DummySerializationScheme::class.java.canonicalName, classLoader)
         val mockContext = Mockito.mock(SerializationContext::class.java)
-        assertFailsWith<RuntimeException>("Tried to serialize with DummySerializationScheme")  {
+        assertFailsWith<DummySerializationSchemeException>("Tried to serialize with DummySerializationScheme")  {
             scheme.serialize(Any::class.java, mockContext)
         }
     }


### PR DESCRIPTION
This simple PR improves test coverage of the code which scans for CustomSerializationScheme's. This is not covered by the driver tests as the driver tests scan for CustomSerializationScheme's in a different way. So I have added a separate unit test which tests this.