### PR TITLE
CORDA-4111 Change Component Group Lazy Serialization 

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -154,7 +154,8 @@ fun createComponentGroups(inputs: List<StateRef>,
                           timeWindow: TimeWindow?,
                           references: List<StateRef>,
                           networkParametersHash: SecureHash?): List<ComponentGroup> {
-    val serialize = { value: Any, _: Int -> value.serialize() }
+    val serializationContext = SerializationFactory.defaultFactory.defaultContext
+    val serialize = { value: Any, _: Int -> value.serialize(context = serializationContext) }
     val componentGroupMap: MutableList<ComponentGroup> = mutableListOf()
     if (inputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(ComponentGroupEnum.INPUTS_GROUP.ordinal, inputs.lazyMapped(serialize)))
     if (references.isNotEmpty()) componentGroupMap.add(ComponentGroup(ComponentGroupEnum.REFERENCES_GROUP.ordinal, references.lazyMapped(serialize)))


### PR DESCRIPTION
To use the serialization context when the lazy map is constructed instead of checking the thread local (global) context when the lazy map is accessed.

We store the serialization context when the lazy map is constructed and use that when the map is accessed.

We need this change to use a Custom Serialisation Scheme with the components of the component group which are serialized lazily. 

If this is deemed to be the wrong behaviour we can instead turn this on only when using a Custom Serialisation Scheme.