### PR TITLE
CORDA-4119 Minor changes to serialisation injection for transaction building

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -21,7 +21,6 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.transactions.WireTransaction
 import org.slf4j.MDC
 import java.security.PublicKey
 import java.util.jar.JarInputStream
@@ -60,12 +59,6 @@ enum class JavaVersion(val versionString: String) {
         private val currentVersion: String = System.getProperty("java.specification.version") ?:
                                                throw IllegalStateException("Unable to retrieve system property java.specification.version")
     }
-}
-
-/** Provide access to internal method for AttachmentClassLoaderTests. */
-@DeleteForDJVM
-fun TransactionBuilder.toWireTransaction(services: ServicesForResolution, serializationContext: SerializationContext): WireTransaction {
-    return toWireTransactionWithContext(services, serializationContext)
 }
 
 /** Provide access to internal method for AttachmentClassLoaderTests. */

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -21,6 +21,7 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.transactions.WireTransaction
 import org.slf4j.MDC
 import java.security.PublicKey
 import java.util.jar.JarInputStream
@@ -59,6 +60,12 @@ enum class JavaVersion(val versionString: String) {
         private val currentVersion: String = System.getProperty("java.specification.version") ?:
                                                throw IllegalStateException("Unable to retrieve system property java.specification.version")
     }
+}
+
+/** Provide access to internal method for AttachmentClassLoaderTests. */
+@DeleteForDJVM
+fun TransactionBuilder.toWireTransaction(services: ServicesForResolution, serializationContext: SerializationContext): WireTransaction {
+    return toWireTransactionWithContext(services, serializationContext)
 }
 
 /** Provide access to internal method for AttachmentClassLoaderTests. */

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -134,7 +134,7 @@ interface SerializationContext {
      */
     val encodingWhitelist: EncodingWhitelist
     /**
-     * A map of any addition properties specific to the particular use case.
+     * A map of any additional properties specific to the particular use case.
      */
     val properties: Map<Any, Any>
     /**

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -179,6 +179,11 @@ interface SerializationContext {
     fun withProperty(property: Any, value: Any): SerializationContext
 
     /**
+     * Helper method to return a new context based on this context with the extra properties added.
+     */
+    fun withProperties(extraProperties: Map<Any, Any>): SerializationContext
+
+    /**
      * Helper method to return a new context based on this context with object references disabled.
      */
     fun withoutReferences(): SerializationContext

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
@@ -17,11 +17,14 @@ interface SerializationSchemeContext {
      * A whitelist that contains (mostly for security purposes) which classes are authorised to be deserialized.
      * A secure implementation will not instantiate any object which is not either whitelisted or annotated with [CordaSerializable] when
      * deserializing. To catch classes missing from the whitelist as early as possible it is HIGHLY recommended to also check this
-     * whitelist when serializing (as well as deserialising) objects.
+     * whitelist when serializing (as well as deserializing) objects.
      */
     val whitelist: ClassWhitelist
     /**
-     * A map of any additional properties specific to the particular use case.
+     * A map of any additional properties specific to the particular use case. If these properties are set via
+     * [toWireTransaction][net.corda.core.transactions.TransactionBuilder.toWireTransaction] then they might not be available when
+     * deserializing. If the properties are required when deserializing, they can be added into the blob when serializing and read back
+     * when deserializing.
      */
     val properties: Map<Any, Any>
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
@@ -21,7 +21,7 @@ interface SerializationSchemeContext {
      */
     val whitelist: ClassWhitelist
     /**
-     * A map of any addition properties specific to the particular use case.
+     * A map of any additional properties specific to the particular use case.
      */
     val properties: Map<Any, Any>
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationSchemeContext.kt
@@ -20,4 +20,8 @@ interface SerializationSchemeContext {
      * whitelist when serializing (as well as deserialising) objects.
      */
     val whitelist: ClassWhitelist
+    /**
+     * A map of any addition properties specific to the particular use case.
+     */
+    val properties: Map<Any, Any>
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -160,6 +160,20 @@ open class TransactionBuilder(
         return toWireTransactionWithContext(services, serializationContext).apply { checkSupportedHashType() }
     }
 
+    /**
+     * Generates a [WireTransaction] from this builder, resolves any [AutomaticPlaceholderConstraint], and selects the attachments to use for this transaction.
+     *
+     * @param [serializationContext] the [SerializationContext] used for serialization.
+     *
+     * @returns A new [WireTransaction] that will be unaffected by further changes to this [TransactionBuilder].
+     *
+     * @throws [ZoneVersionTooLowException] if there are reference states and the zone minimum platform version is less than 4.
+     */
+    @Throws(MissingContractAttachments::class)
+    fun toWireTransaction(services: ServicesForResolution, serializationContext: SerializationContext): WireTransaction {
+        return toWireTransactionWithContext(services, serializationContext).apply { checkSupportedHashType() }
+    }
+
     @CordaInternal
     internal fun toWireTransactionWithContext(
         services: ServicesForResolution,

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -165,7 +165,8 @@ open class TransactionBuilder(
      * @param [schemeId] is used to specify the [CustomSerializationScheme] used to serialize each component of the componentGroups of the [WireTransaction].
      * This is an experimental feature.
      *
-     * @param [properties] a list of properties to add to the [SerializationSchemeContext].
+     * @param [properties] a list of properties to add to the [SerializationSchemeContext] these properties can be accessed in [CustomSerializationScheme.serialize]
+     * when serializing the componentGroups of the wire transaction but might not be available when deserializing.
      *
      * @returns A new [WireTransaction] that will be unaffected by further changes to this [TransactionBuilder].
      *

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -21,6 +21,7 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializationFactory
 import net.corda.core.serialization.SerializationMagic
+import net.corda.core.serialization.SerializationSchemeContext
 import net.corda.core.serialization.internal.CustomSerializationSchemeUtils.Companion.getCustomSerializationMagicFromSchemeId
 import net.corda.core.utilities.contextLogger
 import java.security.PublicKey
@@ -155,22 +156,25 @@ open class TransactionBuilder(
      */
     @Throws(MissingContractAttachments::class)
     fun toWireTransaction(services: ServicesForResolution, schemeId: Int): WireTransaction {
-        val magic: SerializationMagic = getCustomSerializationMagicFromSchemeId(schemeId)
-        val serializationContext = SerializationDefaults.P2P_CONTEXT.withPreferredSerializationVersion(magic)
-        return toWireTransactionWithContext(services, serializationContext).apply { checkSupportedHashType() }
+        return toWireTransaction(services, schemeId, emptyMap()).apply { checkSupportedHashType() }
     }
 
     /**
      * Generates a [WireTransaction] from this builder, resolves any [AutomaticPlaceholderConstraint], and selects the attachments to use for this transaction.
      *
-     * @param [serializationContext] the [SerializationContext] used for serialization.
+     * @param [schemeId] is used to specify the [CustomSerializationScheme] used to serialize each component of the componentGroups of the [WireTransaction].
+     * This is an experimental feature.
+     *
+     * @param [properties] a list of properties to add to the [SerializationSchemeContext].
      *
      * @returns A new [WireTransaction] that will be unaffected by further changes to this [TransactionBuilder].
      *
      * @throws [ZoneVersionTooLowException] if there are reference states and the zone minimum platform version is less than 4.
      */
     @Throws(MissingContractAttachments::class)
-    fun toWireTransaction(services: ServicesForResolution, serializationContext: SerializationContext): WireTransaction {
+    fun toWireTransaction(services: ServicesForResolution, schemeId: Int, properties: Map<Any, Any>): WireTransaction {
+        val magic: SerializationMagic = getCustomSerializationMagicFromSchemeId(schemeId)
+        val serializationContext = SerializationDefaults.P2P_CONTEXT.withPreferredSerializationVersion(magic).withProperties(properties)
         return toWireTransactionWithContext(services, serializationContext).apply { checkSupportedHashType() }
     }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/CustomSerializationSchemeAdapter.kt
@@ -42,5 +42,6 @@ class CustomSerializationSchemeAdapter(private val customScheme: CustomSerializa
     private class SerializationSchemeContextAdapter(context: SerializationContext) : SerializationSchemeContext {
         override val deserializationClassLoader = context.deserializationClassLoader
         override val whitelist = context.whitelist
+        override val properties = context.properties
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/CustomSerializationSchemeDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CustomSerializationSchemeDriverTest.kt
@@ -30,10 +30,7 @@ import net.corda.core.internal.concurrent.transpose
 import net.corda.core.internal.copyBytes
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.CustomSerializationScheme
-import net.corda.core.serialization.SerializationDefaults
-import net.corda.core.serialization.SerializationMagic
 import net.corda.core.serialization.SerializationSchemeContext
-import net.corda.core.serialization.internal.CustomSerializationSchemeUtils
 import net.corda.core.serialization.internal.CustomSerializationSchemeUtils.Companion.getSchemeIdIfCustomSerializationMagic
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
@@ -214,11 +211,8 @@ class CustomSerializationSchemeDriverTest {
             val builder = TransactionBuilder()
                     .addOutputState(outputState)
                     .addCommand(DummyCommandData, notary.owningKey)
-            val kryoSchemeWithMapMagic: SerializationMagic =
-                    CustomSerializationSchemeUtils.getCustomSerializationMagicFromSchemeId(KryoSchemeWithMap.SCHEME_ID)
-            val context = SerializationDefaults.P2P_CONTEXT.withPreferredSerializationVersion(kryoSchemeWithMapMagic).
-                withProperty(KryoSchemeWithMap.KEY, KryoSchemeWithMap.VALUE)
-            val wtx = builder.toWireTransaction(serviceHub, context)
+            val mapToCheckWhenSerializing = mapOf<Any, Any>(Pair(KryoSchemeWithMap.KEY, KryoSchemeWithMap.VALUE))
+            val wtx = builder.toWireTransaction(serviceHub, KryoSchemeWithMap.SCHEME_ID, mapToCheckWhenSerializing)
             var success = true
             for (group in wtx.componentGroups) {
                 //Component groups are lazily serialized as we iterate through.

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -649,7 +649,7 @@ open class Node(configuration: NodeConfiguration,
         if (!initialiseSerialization) return
         val classloader = cordappLoader.appClassLoader
         val customScheme = System.getProperty("experimental.corda.customSerializationScheme")?.let {
-            scanForCustomSerializationScheme(it, javaClass.classLoader)
+            scanForCustomSerializationScheme(it, classloader)
         }
         nodeSerializationEnv = SerializationEnvironment.with(
                 SerializationFactoryImpl().apply {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt
@@ -48,6 +48,10 @@ data class SerializationContextImpl @JvmOverloads constructor(override val prefe
         return copy(properties = properties + (property to value))
     }
 
+    override fun withProperties(extraProperties: Map<Any, Any>): SerializationContext {
+        return copy(properties = properties + extraProperties)
+    }
+
     override fun withoutReferences(): SerializationContext {
         return copy(objectReferencesEnabled = false)
     }


### PR DESCRIPTION
Scan the CorDapp classloader instead of the drivers classloader.
Add properties map to CustomSerialiaztionContext (copied from SerializationContext).
Change the API to let a user pass in the serialization context in TransactionBuilder.toLedgerTransaction.
