### PR TITLE
NAAS-49 Flag notary/extraConfig block as sensitive

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.4.1
         with:
-          title-regex: '^((CORDA|AG|EG|ENT|INFRA)-\d+|NOTICK)(.*)'
+          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS)-\d+|NOTICK)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
@@ -205,7 +205,7 @@ internal object NotaryConfigSpec : Configuration.Specification<NotaryConfig>("No
     private val serviceLegalName by string().mapValid(::toCordaX500Name).optional()
     private val className by string().optional()
     private val etaMessageThresholdSeconds by int().optional().withDefaultValue(NotaryServiceFlow.defaultEstimatedWaitTime.seconds.toInt())
-    private val extraConfig by nestedObject().map(ConfigObject::toConfig).optional()
+    private val extraConfig by nestedObject(sensitive = true).map(ConfigObject::toConfig).optional()
     private val raft by nested(RaftConfigSpec).optional()
     private val bftSMaRt by nested(BFTSmartConfigSpec).optional()
     private val enableOverridableFlows by boolean().optional()


### PR DESCRIPTION
The `notary/extraConfig` block is intended for use by custom notaries to define configuration specific to the implementation. Some of this configuration may be sensitive, e.g. a JDBC connection string.

Our built in notary configuration blocks, such as `jpa` account for this, and mark the appropriate configuration items as sensitive, preventing them from being displayed in log files. It is not possible to do this for the `extraConfig` block, since the node does not have any context as to its contents.

To handle this, we now mark the entire `extraConfig` block as sensitive, ensuring none of its contents are displayed by the standard node configuration output in logs. Instead, if this is desired, Notary CorDapps can themselves print out relevant information, as they will have the context as to what information is and is not sensitive.

Tested running the Enterprise HA Notary CorDapp, reproducing the scenario documented in [NAAS-49](https://r3-cev.atlassian.net/browse/NAAS-49). Ensured that the entire `extraConfig` block is now shown with asterisks.