### PR TITLE
CORDA-4127 Bumped platformVersion from 9 to 10

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -11,7 +11,7 @@ java8MinUpdateVersion=171
 # When incrementing platformVersion make sure to update          #
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #
 # ***************************************************************#
-platformVersion=9
+platformVersion=10
 guavaVersion=28.0-jre
 # Quasar version to use with Java 8:
 quasarVersion=0.7.13_r3

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -28,7 +28,7 @@ import java.util.jar.JarInputStream
 
 // *Internal* Corda-specific utilities.
 
-const val PLATFORM_VERSION = 9
+const val PLATFORM_VERSION = 10
 
 fun ServicesForResolution.ensureMinimumPlatformVersion(requiredMinPlatformVersion: Int, feature: String) {
     checkMinimumPlatformVersion(networkParameters.minimumPlatformVersion, requiredMinPlatformVersion, feature)


### PR DESCRIPTION
Following Hash Agility changes to the core module, a platform Version bump is required.