### PR TITLE
CORDA-4130: Move checkNotaryWhitelisted call to run under attachmentsClassLoader

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -47,6 +47,8 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
         checkNoNotaryChange()
         checkEncumbrancesValid()
         ltx.checkSupportedHashType()
+        checkTransactionWithTimeWindowIsNotarised()
+        ltx.checkNotaryWhitelisted()
 
         // The following checks ensure the integrity of the current transaction and also of the future chain.
         // See: https://docs.corda.net/head/api-contract-constraints.html
@@ -68,6 +70,10 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
 
         // 5. Final step is to run the contract code. After the first 4 steps we are now sure that we are running the correct code.
         verifyContracts()
+    }
+
+    private fun checkTransactionWithTimeWindowIsNotarised() {
+        if (ltx.timeWindow != null) check(ltx.notary != null) { "Transactions with time-windows must be notarised" }
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -48,7 +48,7 @@ abstract class Verifier(val ltx: LedgerTransaction, protected val transactionCla
         checkEncumbrancesValid()
         ltx.checkSupportedHashType()
         checkTransactionWithTimeWindowIsNotarised()
-        ltx.checkNotaryWhitelisted()
+        checkNotaryWhitelisted(ltx)
 
         // The following checks ensure the integrity of the current transaction and also of the future chain.
         // See: https://docs.corda.net/head/api-contract-constraints.html

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -1,5 +1,6 @@
 package net.corda.core.transactions
 
+import net.corda.core.CordaInternal
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
@@ -51,7 +52,8 @@ abstract class FullTransaction : BaseTransaction() {
     }
 
     /** Make sure the assigned notary is part of the network parameter whitelist. */
-    protected fun checkNotaryWhitelisted() {
+    @CordaInternal
+    internal fun checkNotaryWhitelisted() {
         notary?.let { notaryParty ->
             // Network parameters will never be null if the transaction is resolved from a CoreTransaction rather than constructed directly.
             networkParameters?.let { parameters ->

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -4,7 +4,6 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
-import net.corda.core.internal.checkNotaryWhitelisted
 import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
 

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -1,10 +1,10 @@
 package net.corda.core.transactions
 
-import net.corda.core.CordaInternal
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
+import net.corda.core.internal.checkNotaryWhitelisted
 import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
 
@@ -52,22 +52,7 @@ abstract class FullTransaction : BaseTransaction() {
     }
 
     /** Make sure the assigned notary is part of the network parameter whitelist. */
-    @CordaInternal
-    internal fun checkNotaryWhitelisted() {
-        notary?.let { notaryParty ->
-            // Network parameters will never be null if the transaction is resolved from a CoreTransaction rather than constructed directly.
-            networkParameters?.let { parameters ->
-                val notaryWhitelist = parameters.notaries.map { it.identity }
-                // Transaction can combine different identities of the same notary after key rotation.
-                // Each of these identities should be whitelisted.
-                val notaries = setOf(notaryParty) + (inputs + references).map { it.state.notary }
-                notaries.forEach {
-                    check(it in notaryWhitelist) {
-                        "Notary [${it.description()}] specified by the transaction is not on the network parameter whitelist: " +
-                                " [${notaryWhitelist.joinToString { party -> party.description() }}]"
-                    }
-                }
-            }
-        }
+    protected fun checkNotaryWhitelisted() {
+        checkNotaryWhitelisted(this)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -50,4 +50,9 @@ abstract class FullTransaction : BaseTransaction() {
             "The specified transaction notary must be the one specified by all inputs and input references"
         }
     }
+
+    /** Make sure the assigned notary is part of the network parameter whitelist. */
+    protected fun checkNotaryWhitelisted() {
+        checkNotaryWhitelisted(this)
+    }
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -50,9 +50,4 @@ abstract class FullTransaction : BaseTransaction() {
             "The specified transaction notary must be the one specified by all inputs and input references"
         }
     }
-
-    /** Make sure the assigned notary is part of the network parameter whitelist. */
-    protected fun checkNotaryWhitelisted() {
-        checkNotaryWhitelisted(this)
-    }
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -4,6 +4,7 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
+import net.corda.core.internal.checkNotaryWhitelisted
 import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
 

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -9,6 +9,7 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.identity.Party
 import net.corda.core.internal.AttachmentWithContext
 import net.corda.core.internal.ServiceHubCoreInternal
+import net.corda.core.internal.checkNotaryWhitelisted
 import net.corda.core.internal.combinedHash
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.ServicesForResolution
@@ -329,7 +330,7 @@ private constructor(
     }
 
     init {
-        checkNotaryWhitelisted()
+        checkNotaryWhitelisted(this)
         // TODO: relax this constraint once upgrading encumbered states is supported.
         check(inputs.all { it.state.contract == legacyContractClassName }) {
             "All input states must point to the legacy contract"

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -9,7 +9,6 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.identity.Party
 import net.corda.core.internal.AttachmentWithContext
 import net.corda.core.internal.ServiceHubCoreInternal
-import net.corda.core.internal.checkNotaryWhitelisted
 import net.corda.core.internal.combinedHash
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.ServicesForResolution
@@ -330,7 +329,7 @@ private constructor(
     }
 
     init {
-        checkNotaryWhitelisted(this)
+        checkNotaryWhitelisted()
         // TODO: relax this constraint once upgrading encumbered states is supported.
         check(inputs.all { it.state.contract == legacyContractClassName }) {
             "All input states must point to the legacy contract"

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -120,11 +120,6 @@ private constructor(
             networkParameters, references, componentGroups, serializedInputs, serializedReferences,
             isAttachmentTrusted, verifierFactory, attachmentsClassLoaderCache, DigestService.sha2_256)
 
-    init {
-        if (timeWindow != null) check(notary != null) { "Transactions with time-windows must be notarised" }
-        checkNotaryWhitelisted()
-    }
-
     @KeepForDJVM
     companion object {
         private val logger = contextLogger()


### PR DESCRIPTION
This PR moves the call to checkNotaryWhitelisted to the Verifier.verify method where it will be run using the attachmentsClassLoader. This then allows input states to be deserialised.