### PR TITLE
NOTICK - fast forward merge from OS 4.4 - make recordDependencies suspendable

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -24,5 +24,6 @@ interface TransactionsResolver {
     @Suspendable
     fun downloadDependencies(batchMode: Boolean)
 
+    @Suspendable
     fun recordDependencies(usedStatesToRecord: StatesToRecord)
 }

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -94,6 +94,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
         logger.debug { "Downloaded ${sortedDependencies?.size} dependencies from remote peer for transactions ${flow.txHashes}" }
     }
 
+    @Suspendable
     override fun recordDependencies(usedStatesToRecord: StatesToRecord) {
         val sortedDependencies = checkNotNull(this.sortedDependencies)
         logger.trace { "Recording ${sortedDependencies.size} dependencies for ${flow.txHashes.size} transactions" }


### PR DESCRIPTION
Add @Suspendable annotation to recordDependencies function in ServiceHubCoreInternal