### PR TITLE
NOTICK - forward merge from 4.4 (2021-04-21)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -24,5 +24,6 @@ interface TransactionsResolver {
     @Suspendable
     fun downloadDependencies(batchMode: Boolean)
 
+    @Suspendable
     fun recordDependencies(usedStatesToRecord: StatesToRecord)
 }

--- a/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/DbTransactionsResolver.kt
@@ -94,6 +94,7 @@ class DbTransactionsResolver(private val flow: ResolveTransactionsFlow) : Transa
         logger.debug { "Downloaded ${sortedDependencies?.size} dependencies from remote peer for transactions ${flow.txHashes}" }
     }
 
+    @Suspendable
     override fun recordDependencies(usedStatesToRecord: StatesToRecord) {
         val sortedDependencies = checkNotNull(this.sortedDependencies)
         logger.trace { "Recording ${sortedDependencies.size} dependencies for ${flow.txHashes.size} transactions" }


### PR DESCRIPTION
It's a fast forward merge. @Suspendable annotation was added to recordDependencies function in ServiceHubCoreInternal interface to make it possible for implementations of recordDependencies to suspend.
