### PR TITLE
INFRA-1299: switch from Azure Jenkins agents to AWS

### DIFF
--- a/.ci/dev/compatibility/JenkinsfileJDK11Compile
+++ b/.ci/dev/compatibility/JenkinsfileJDK11Compile
@@ -1,3 +1,8 @@
+#!groovy
+/**
+ * Jenkins pipeline to build Corda Opensource Pull Requests with JDK11.
+ */
+
 @Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
@@ -6,8 +11,8 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 pipeline {
     agent {
         dockerfile {
-            label 'k8s'
-            additionalBuildArgs "--build-arg USER=stresstester"
+            label 'standard'
+            additionalBuildArgs '--build-arg USER="${USER}"' // DON'T change quotation - USER variable is substituted by SHELL!!!!
             filename '.ci/dev/compatibility/DockerfileJDK11'
         }
     }

--- a/.ci/dev/publish-branch/Jenkinsfile.preview
+++ b/.ci/dev/publish-branch/Jenkinsfile.preview
@@ -1,11 +1,15 @@
 #!groovy
+/**
+ * Jenkins pipeline to build Corda Opensource Preview.
+ */
+
 @Library('corda-shared-build-pipeline-steps')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 
 pipeline {
-    agent { label 'k8s' }
+    agent { label 'standard' }
 
     options {
         timestamps()


### PR DESCRIPTION
* JDK11 compatibility - simply switch to AWS Jenkins agent
* Corda preview - simply switch from Azure agent to AWS agent
* part of retiring `k8s` agent used for parallel builds
