### PR TITLE
INFRA-1309: migrate docker-compose-rule-junit4 from Bintray to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ buildscript {
     ext.liquibase_version = '3.6.3'
     ext.artifactory_contextUrl = 'https://software.r3.com/artifactory'
     ext.snake_yaml_version = constants.getProperty('snakeYamlVersion')
-    ext.docker_compose_rule_version = '0.35.0'
+    ext.docker_compose_rule_version = '1.5.0'
     ext.selenium_version = '3.141.59'
     ext.ghostdriver_version = '2.1.0'
     ext.proguard_version = constants.getProperty('proguardVersion')

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -53,12 +53,6 @@ configurations {
     systemTestCompile.extendsFrom testCompile
 }
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/palantir/releases' // docker-compose-rule is published on bintray
-    }
-}
-
 dependencies {
     compile "commons-io:commons-io:$commons_io_version"
     compile project(":samples:irs-demo:web")

--- a/samples/irs-demo/src/system-test/kotlin/net/corda/irs/IRSDemoDockerTest.kt
+++ b/samples/irs-demo/src/system-test/kotlin/net/corda/irs/IRSDemoDockerTest.kt
@@ -1,7 +1,6 @@
 package net.corda.irs
 
 import com.palantir.docker.compose.DockerComposeRule
-import com.palantir.docker.compose.ImmutableDockerComposeRule
 import com.palantir.docker.compose.configuration.DockerComposeFiles
 import com.palantir.docker.compose.connection.waiting.HealthChecks
 import org.junit.ClassRule
@@ -30,7 +29,7 @@ class IRSDemoDockerTest {
 
         @ClassRule
         @JvmField
-        var docker: ImmutableDockerComposeRule = DockerComposeRule.builder()
+        var docker: DockerComposeRule = DockerComposeRule.builder()
                 .files(DockerComposeFiles.from(
                         System.getProperty("CORDAPP_DOCKER_COMPOSE"),
                         System.getProperty("WEB_DOCKER_COMPOSE")))


### PR DESCRIPTION
docker-compose-rule-junit4 is available from Maven Central, but from
version 1.0.0 onwards

Bumping version number to 1.5.0 introduces following list of
dependencies:

* com.fasterxml.jackson.core:jackson-annotations:2.4.4 (Apache 2.0)
* com.fasterxml.jackson.core:jackson-core:2.9.7 (Apache 2.0)
* com.fasterxml.jackson.core:jackson-databind:2.11.0 (Apache 2.0)
* com.fasterxml.jackson.core:jackson-databind:2.9.7 (Apache 2.0)
* com.fasterxml.jackson.core:jackson-databind:2.9.8 (Apache 2.0)
* com.fasterxml.jackson.core:jackson-databind:2.9.9 (Apache 2.0)
* com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.8 (Apache
  2.0)
* com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.2
  (Apache 2.0)
* com.fasterxml.jackson.datatype:jackson-datatype-guava:2.9.8 (Apache
  2.0)
* com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.8 (Apache
  2.0)
* com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8 (Apache
  2.0)
* com.fasterxml.jackson.module:jackson-module-afterburner:2.9.8 (Apache
  2.0)
* com.github.zafarkhaja:java-semver:0.9.0 (MIT)
* com.google.code.findbugs:jsr305:3.0.2 (Apache 2.0)
* com.google.errorprone:error_prone_annotations:2.3.3 (Apache 2.0)
* com.google.guava:guava:18.0 (Apache 2.0)
* com.google.guava:guava:21.0  (Apache 2.0)
* commons-io:commons-io:2.6  (Apache 2.0)
* com.palantir.conjure.java.api:errors:2.12.0 (Apache 2.0)
* com.palantir.conjure.java:conjure-lib:5.15.0 (Apache 2.0)
* com.palantir.conjure.java.runtime:conjure-java-jackson-serialization:
  4.18.1 (Apache 2.0)
* com.palantir.docker.compose:docker-compose-rule-core:1.5.0 (Apache
  2.0)
* com.palantir.docker.compose:docker-compose-rule-events-api-objects:
  1.5.0 (Apache 2.0)
* com.palantir.docker.compose:docker-compose-rule-junit4:1.5.0 (Apache
  2.0)
* com.palantir.ri:resource-identifier:1.1.0 (Apache 2.0)
* com.palantir.safe-logging:preconditions:1.11.0 (Apache 2.0)
* com.palantir.safe-logging:preconditions:1.13.0 (Apache 2.0)
* com.palantir.safe-logging:preconditions:1.9.0 (Apache 2.0)
* com.palantir.safe-logging:safe-logging:1.11.0 (Apache 2.0)
* com.palantir.safe-logging:safe-logging:1.13.0 (Apache 2.0)
* com.palantir.tokens:auth-tokens:3.6.1  (Apache 2.0)
* jakarta.annotation:jakarta.annotation-api:1.3.5 (EPL 2.0)
* jakarta.ws.rs:jakarta.ws.rs-api:2.1.6 (EPL 2.0)
* joda-time:joda-time:2.10.3 (Apache 2.0)
* junit:junit:4.13 (EPL 1.0)
* one.util:streamex:0.7.2 (Apache 2.0)
* org.apache.commons:commons-lang3:3.7 (Apache 2.0)
* org.awaitility:awaitility:4.0.2 (Apache 2.0)
* org.hamcrest:hamcrest:2.1 (BSD 3-clause)
* org.hamcrest:hamcrest-core:2.1 (BSD 3-clause)
* org.slf4j:slf4j-api:1.7.25 (MIT)
