### PR TITLE
INFRA-1549: added SCIJAVA repo

### DIFF
--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -78,6 +78,15 @@ dependencies {
     testCompile "com.github.detro:ghostdriver:$ghostdriver_version"
 }
 
+repositories {
+    maven {
+        url 'https://maven.scijava.org/content/repositories/public/'
+        content {
+            includeGroup 'com.github.detro'
+        }
+    }
+}
+
 bootRepackage {
     enabled = false
 }


### PR DESCRIPTION
* `com.github.detro:ghostdriver` is gone from repositories configured
  already
* SCI Java public repo has it, and it is configured to resolve
  `com.github.detro` group only
