### PR TITLE
ENT-5941 - Upgrade Jackson databind while keeping Jackson kotlin version the same

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,8 @@ buildscript {
     ext.asm_version = '7.1'
     ext.artemis_version = '2.6.2'
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.9.7'
+    ext.jackson_version = '2.11.1'
+    ext.jackson_kotlin_version = '2.9.7'
     ext.jetty_version = '9.4.19.v20190610'
     ext.jersey_version = '2.25'
     ext.servlet_version = '4.0.1'

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -9,7 +9,9 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     // Jackson and its plugins: parsing to/from JSON and other textual formats.
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version"
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version") {
+        exclude module: "jackson-databind"
+    }
     // Yaml is useful for parsing strings to method calls.
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version"
     // This adds support for java.time types.

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     // Jackson and its plugins: parsing to/from JSON and other textual formats.
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version"
     // Yaml is useful for parsing strings to method calls.
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version"
     // This adds support for java.time types.

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     cordaCompile project(':core')
     
 
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version")
     
     // only included to control the `DemoClock` as part of the demo application
     // normally `:node` should not be depended on in any CorDapps

--- a/samples/irs-demo/cordapp/workflows-irs/build.gradle
+++ b/samples/irs-demo/cordapp/workflows-irs/build.gradle
@@ -14,9 +14,11 @@ dependencies {
 
     // Corda integration dependencies
     cordaCompile project(':core')
-    
 
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version")
+
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version") {
+        exclude module: "jackson-databind"
+    }
     
     // only included to control the `DemoClock` as part of the demo application
     // normally `:node` should not be depended on in any CorDapps

--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     }
     compile('org.springframework.boot:spring-boot-starter-log4j2')
     runtimeOnly("org.apache.logging.log4j:log4j-web:$log4j_version")
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version")
     compile project(":client:rpc")
     compile project(":client:jackson")
     compile project(":finance:workflows")

--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -70,7 +70,9 @@ dependencies {
     }
     compile('org.springframework.boot:spring-boot-starter-log4j2')
     runtimeOnly("org.apache.logging.log4j:log4j-web:$log4j_version")
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version")
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version") {
+        exclude module: "jackson-databind"
+    }
     compile project(":client:rpc")
     compile project(":client:jackson")
     compile project(":finance:workflows")

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version"
     
     compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     compile "junit:junit:${junit_version}"

--- a/testing/test-cli/build.gradle
+++ b/testing/test-cli/build.gradle
@@ -6,7 +6,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version"
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version") {
+        exclude module: "jackson-databind"
+    }
     
     compile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     compile "junit:junit:${junit_version}"

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile "com.typesafe:config:$typesafe_config_version"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version"
     compile "info.picocli:picocli:$picocli_version"
 
     // TornadoFX: A lightweight Kotlin framework for working with JavaFX UI's.

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -52,7 +52,9 @@ dependencies {
     compile "com.typesafe:config:$typesafe_config_version"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version"
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version") {
+        exclude module: "jackson-databind"
+    }
     compile "info.picocli:picocli:$picocli_version"
 
     // TornadoFX: A lightweight Kotlin framework for working with JavaFX UI's.


### PR DESCRIPTION
Since Kotlin v1.2 limits us on upgrading the version of jackson kotlin module, let's upgrading the version of all other jackson dependencies and keep jackson-module-kotlin the same, and exclude from pulling in the old version of databind.
