### PR TITLE
NAAS-295 Fix notary flow retries after ETA message sent

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/IdempotentFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/IdempotentFlow.kt
@@ -17,7 +17,12 @@ interface IdempotentFlow
  * next available notary cluster member.
  *
  * Note that any sub-flows called by a [TimedFlow] are assumed to be [IdempotentFlow] and will NOT have checkpoints
- * persisted. Otherwise, it wouldn't be possible to correctly reset the [TimedFlow].
+ * persisted. Otherwise, it wouldn't be possible to correctly reset the [TimedFlow]. An implication of this is that
+ * idempotent flows must not only return the same final result of the flow, but if a flow returns multiple messages
+ * the full set of messages must be returned on subsequent attempts in the same order as the first flow.
+ *
+ * An example of this would be if a notary returns an ETA message at any point, then any subsequent retries of the
+ * flow must also send such a message before returning the actual notarisation result.
  */
 // TODO: allow specifying retry settings per flow
 interface TimedFlow : IdempotentFlow {

--- a/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
@@ -63,8 +63,17 @@ abstract class NotaryServiceFlow(
             verifyTransaction(requestPayload)
 
             val eta = service.getEstimatedWaitTime(tx.inputs.size + tx.references.size)
-            if (eta > etaThreshold && counterpartyCanHandleBackPressure()) {
-                otherSideSession.send(WaitTimeUpdate(eta))
+            if (counterpartyCanHandleBackPressure()) {
+                if (eta > etaThreshold) {
+                    otherSideSession.send(WaitTimeUpdate(eta))
+                } else if (stateMachine.ourSenderUUID == null) {
+                    // This implies we are handling a flow retry. As we may have already responded
+                    // with an ETA message on a previous attempt, we must ensure a new unique
+                    // message id is used to prevent the actual response from being de-duplicated
+                    // by the client. This sleep forces an increment of the suspend component of
+                    // the message id. See Jira NAAS-295 for full details.
+                    sleep(Duration.ZERO)
+                }
             }
 
             service.commitInputStates(


### PR DESCRIPTION
## Problem overview

Prior to this change, it was possible for a (client) Corda node that requested notarisation to end up in a state where it had states that appear to be unconsumed from the perspective of the client node, despite the fact that the notary service had successfully notarised the requested transaction and consumed it’s input states. This happened when the following sequence of events occured:

1. A client node made a notarisation request to the notary
2. The notary was under heavy load at the point the notary was ready to perform uniqueness checking for the request, resulting in the notary protocol backpressure mechanism sending an ETA message back to the client
3. The notarisation attempt failed during uniqueness checking with a `NotaryError.General` error. 
4. During a successful subsequent retry, the notary was no longer under heavy load, and therefore did not send an ETA message back to the client

Under these circumstances, because of how the flow framework generates message ids, the notarisation success / failure message was allocated a message id that was identical to that of the ETA message sent on a previous attempt. This lead to the client side de-duplication logic filtering the message out, which meant it never received the notarisation result and instead immediately received the session end message, leading to an unexpected session end message. This can be visualised as follows:

| Message id          | Notary message sent | Client message received          |
|--------------------|-------------------------|----------------------------------|
| 1 (Attempt N)      | ETA update                 | ETA Update                              |
| 1 (Attempt N+1) | Notarisation response | _Ignored - duplicate id_          |
| 2 (Attempt N+1) | Session end                 | Session end **(unexpected)** |

This scenario was most likely to occur when the notary backing database was unavailable. This would lead to notarisation requests backing up in the notary worker internal request queue, and it would keep on attempting to contact the database and timing out, which in turn caused flow retries, which will increase the queue length. Combined with the slow response time to process each batch of requests (due to a 30s DB timeout), the ETA would spike, leading to the backpressure mechanism triggering. When the database came back up, the batch processing times would drop significantly, and the queue size would drop, which would at some point result in the ETA returning to normal, and some of the flows not triggering the backpressure mechanism on retry.

The end result is that the transactions would have been successfully notarised and the input states consumed from the perspective of the notary, but the client node (and any other participants who need to be informed) were unaware of this.

It is worth mentioning that because the error is client side, the issue does not lead to a risk of a double spend; the data stored on the notary is correct and would correctly prevent any subsequent attempts to spend the same states in a different transaction.

## Solution

Because `NotaryServiceFlow` is an idempotent flow, it is expected that not only is the end result of the notarisation the same for any given retry / replay of a flow, but also that the same sequence of messages are returned to the client. The problem here is that we may or may not have sent an ETA message as part of a previous execution of a flow, and we have no context as to what was done in a subsequent retry.

To work around this, we detect whether we are retrying a flow or not, which can be deduced by `stateMachine.ourSenderUUID` being null.  If we are, and we do not need to generate an ETA message, then instead then we force a suspend, which internally results in incrementing our message id. This means that the actual notarisation response will always have a message id which has not been seen by the client before, avoiding the de-duplication issues.

This is not a general solution, and works specifically for the `NotaryServiceFlow` because this always returns exactly 1 or 2 messages to the client; an (optional) ETA message, followed by the notarisation response. This means that:

- If a previous attempt returned an ETA message (id 1), a retry will now always return a response at id 2.
- If a previous attempt did not return an ETA message, then either no response was received at all, so there are no duplication issues to worry about, and the retry will still have id 2 (skipping id 1). Or, a response was received by the client which was the actual notarisation response, and the retry should be irrelevant.

Comments have also been enhanced to clarify expectations around `IdempotentFlow`, and to explain the change, given it is not obvious.

## Test notes

See test notes document attached to Jira ticket NAAS-295 for details.