### PR TITLE
ENT-6374 - Fix slf4j warning in trader-demo

### DIFF
--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -20,6 +20,9 @@ sourceSets {
             runtimeClasspath += main.output + test.output
             srcDir file('src/integration-test/kotlin')
         }
+        resources {
+            srcDir file('src/integration-test/resources')
+        }
     }
 }
 
@@ -50,7 +53,12 @@ dependencies {
     // Corda integration dependencies
     cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')
 
-    testCompile(project(':node-driver'))
+    testCompile "org.slf4j:slf4j-simple:$slf4j_version"
+    testCompile(project(':node-driver')) {
+        // We already have a SLF4J implementation on our runtime classpath,
+        // and we don't need another one.
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+    }
     
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"

--- a/samples/trader-demo/src/integration-test/resources/simplelogger.properties
+++ b/samples/trader-demo/src/integration-test/resources/simplelogger.properties
@@ -1,0 +1,4 @@
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.logFile=System.out


### PR DESCRIPTION
Reverting the change that added back `log4j-slf4j-impl` to the runtime classpath, since that leads to an slf4j warning when running the trader-demo because there are multiple bindings available.

However, this makes the `TraderDemoTest` to fail with `java.lang.NoClassDefFoundError: Could not initialize class io.netty.util.internal.logging.Slf4JLoggerFactory`. My understanding is this is because the old version of Netty contained slf4j bindings that ended up being used by the test that runs in-process nodes and these were removed in the new version (e.g. see [here](https://mvnrepository.com/artifact/io.netty/netty-common/4.1.46.Final) and [here](https://mvnrepository.com/artifact/io.netty/netty-common/4.1.67.Final)). In order to fix this, I am adding `slf4j-simple` as a test dependency.

I tested by running the trader-demo and confirming the slf4j warnings don't appear anymore.