### PR TITLE
ENT-6460 Empty flow arguments on error transition

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt
@@ -63,7 +63,12 @@ class ErrorFlowTransition(
                     status = Checkpoint.FlowStatus.FAILED,
                     flowState = FlowState.Finished,
                     checkpointState = startingState.checkpoint.checkpointState.copy(
-                        numberOfCommits = startingState.checkpoint.checkpointState.numberOfCommits + 1
+                        numberOfCommits = startingState.checkpoint.checkpointState.numberOfCommits + 1,
+                        invocationContext = if (startingState.checkpoint.checkpointState.invocationContext.arguments!!.isNotEmpty()) {
+                            startingState.checkpoint.checkpointState.invocationContext.copy(arguments = emptyList())
+                        } else {
+                            startingState.checkpoint.checkpointState.invocationContext
+                        }
                     )
                 )
                 currentState = currentState.copy(


### PR DESCRIPTION
A user passed in a `FlowLogic` as an argument into another `FlowLogic`
called `subFlow` on it and had it throw an exception.

This all occurred before the first checkpoint, causing the state machine
to try and persist a FAILED checkpoint containing the flow's arguments.
Because the arguments contained a `FlowLogic` that had been started via
`subFlow` it held a reference to `FlowLogic._stateMachine` which cannot
be serialized.

This caused the flow to fail when trying to persist the fact that it
failed.

The flow arguments are now emptied during `ErrorFlowTransition` to
resolve this issue which mimics the behaviour of the first suspend.
Note, this only takes the arguments out of the serialized checkpoint, it
does not affect the flow metadata and therefore a flow's arguments can
still be viewed.