### PR TITLE
ENT-6494 log4j upgrade 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ buildscript {
     ext.servlet_version = '4.0.1'
     ext.assertj_version = '3.12.2'
     ext.slf4j_version = '1.7.30'
-    ext.log4j_version = '2.12.1'
+    ext.log4j_version = '2.15.0'
     ext.bouncycastle_version = constants.getProperty("bouncycastleVersion")
     ext.guava_version = constants.getProperty("guavaVersion")
     ext.caffeine_version = constants.getProperty("caffeineVersion")


### PR DESCRIPTION
Upgrade log4j version to 2.15.0 due to the zero day exploit. Smoke tests all passed locally.

