### PR TITLE
ENT-6370 Save just signed transaction as unverified one into node_transactions.

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -7,7 +7,7 @@ jobs:
   check-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: morrisoncole/pr-lint-action@v1.4.1
+      - uses: morrisoncole/pr-lint-action@v1.5.1
         with:
           title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS)-\d+|NOTICK)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -64,18 +64,18 @@ open class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSid
             // We should only send a transaction to the vault for processing if we did in fact fully verify it, and
             // there are no missing signatures. We don't want partly signed stuff in the vault.
             checkBeforeRecording(stx)
-            logger.info("Successfully received fully signed tx. Sending it to the vault for processing.")
+            logger.info("Successfully received fully signed transaction. Sending it to the vault for processing.")
             serviceHub.recordTransactions(statesToRecord, setOf(stx))
             logger.info("Successfully recorded received transaction locally.")
         } else {
-            logger.info("Successfully received non final tx. Recording it as unverified to let us recover from denial of state scenarios.")
-            serviceHub.recordUnverifiedTransaction(stx)
+            logger.info("Successfully received partially signed transaction. Recording it as unverified to let us recover from denial of state scenarios.")
+            serviceHub.recordUnverifiedTransactions(stx)
 
             // Force checkpoint to ensure that all data is flushed to the database.
             val fiber = (Strand.currentStrand() as? FlowStateMachine<*>)
             fiber!!.suspend(FlowIORequest.ForceCheckpoint, false)
 
-            logger.info("Successfully recorded non final tx as unverified.")
+            logger.info("Successfully recorded partially signed transaction as unverified.")
         }
         return stx
     }

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -233,6 +233,12 @@ interface ServiceHub : ServicesForResolution {
     }
 
     /**
+     * Stores the given [SignedTransaction] in the local transaction storage as unverified without sending it to the vault.
+     * This way we can recover that transaction if finality flow gets aborted.
+     */
+    fun recordUnverifiedTransaction(tx: SignedTransaction)
+
+    /**
      * Converts the given [StateRef] into a [StateAndRef] object.
      *
      * @throws TransactionResolutionException if [stateRef] points to a non-existent transaction.

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -236,7 +236,16 @@ interface ServiceHub : ServicesForResolution {
      * Stores the given [SignedTransaction] in the local transaction storage as unverified without sending it to the vault.
      * This way we can recover that transaction if finality flow gets aborted.
      */
-    fun recordUnverifiedTransaction(tx: SignedTransaction)
+    fun recordUnverifiedTransactions(txs: Iterable<SignedTransaction>)
+
+    /**
+     * Stores the given [SignedTransaction] in the local transaction storage as unverified without sending it to the vault.
+     * This way we can recover that transaction if finality flow gets aborted.
+     */
+    fun recordUnverifiedTransactions(vararg txs: SignedTransaction) {
+        @Suppress("SpreadOperator")
+        recordUnverifiedTransactions(listOf(*txs))
+    }
 
     /**
      * Converts the given [StateRef] into a [StateAndRef] object.

--- a/node/src/integration-test/kotlin/net/corda/node/flows/NonFinalisedTransferFlowIntegrationTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/NonFinalisedTransferFlowIntegrationTests.kt
@@ -1,0 +1,132 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.CollectSignaturesFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.NotaryFlow
+import net.corda.core.flows.SignTransactionFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.internal.concurrent.transpose
+import net.corda.core.messaging.startFlow
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.nodeapi.internal.persistence.currentDBSession
+import net.corda.testing.contracts.DummyState
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.DummyCommandData
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeHandle
+import net.corda.testing.driver.driver
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.cordappForClasses
+import org.junit.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+
+/*
+   In this test Alice creates a transaction then Bob sign it and Alice does not run the normal FinalityFlow.
+   So Bob's knowledge about the transaction is that it got left in partially signed/unverified state.
+ */
+
+class NonFinalisedTransferFlowIntegrationTests {
+    @StartableByRPC
+    @InitiatingFlow
+    class NonFinalisedTransferFlow(val party: Party) : FlowLogic<SecureHash>() {
+        @Suspendable
+        override fun call(): SecureHash {
+            val session = initiateFlow(party)
+            val tx = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
+                addOutputState(DummyState(participants = listOf(ourIdentity, party)))
+                addCommand(DummyCommandData, ourIdentity.owningKey, party.owningKey)
+            }
+            val stx = serviceHub.signInitialTransaction(tx)
+            val ftx = subFlow(CollectSignaturesFlow(stx, listOf(session)))
+            return subFlow(OnlyNotarizingFinalityFlow(ftx)).id
+        }
+    }
+
+    class OnlyNotarizingFinalityFlow constructor(val transaction: SignedTransaction) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val notarySignatures = subFlow(NotaryFlow.Client(transaction, skipVerification = true))
+            val notarised = transaction + notarySignatures
+            serviceHub.recordTransactions(StatesToRecord.ONLY_RELEVANT, listOf(notarised))
+            return notarised
+        }
+    }
+
+    @InitiatedBy(NonFinalisedTransferFlow::class)
+    class NonFinalisedTransferResponderFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            subFlow(object : SignTransactionFlow(otherSide) {
+                override fun checkTransaction(stx: SignedTransaction) {
+                }
+            })
+        }
+    }
+
+    @StartableByRPC
+    @InitiatingFlow
+    class QueryUnverifiedTransactionIdsFlow constructor(private val youngerThanTimestamp: Instant,
+                                                        private val olderThanTimestamp: Instant) : FlowLogic<List<String>>() {
+        @Suspendable
+        override fun call() : List<String>{
+            var txIds : List<String> = listOf()
+            serviceHub.withEntityManager {
+                txIds = currentDBSession()
+                        .createNamedQuery("DBTransaction.findUnverifiedTransactions")
+                        .setParameter("youngerThanTimestamp", youngerThanTimestamp)
+                        .setParameter("olderThanTimestamp", olderThanTimestamp)
+                        .resultList
+                        .map { it as String }
+            }
+            return txIds
+        }
+    }
+
+    @Test(timeout = 300_000)
+	fun `test that when finalisation is missing the receiving parties save the partially signed transaction as unverified`() {
+        val cordappClasses = setOf(NonFinalisedTransferFlow::class.java,
+                NonFinalisedTransferResponderFlow::class.java,
+                OnlyNotarizingFinalityFlow::class.java,
+                QueryUnverifiedTransactionIdsFlow::class.java
+        )
+        @Suppress("SpreadOperator")
+        driver(DriverParameters(
+                startNodesInProcess = true,
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, cordappForClasses(*cordappClasses.toTypedArray()))
+        )) {
+
+            fun queryUnverifiedTxIds(node: NodeHandle,
+                                     youngerThanTimestamp: Instant,
+                                     olderThanTimestamp: Instant): List<String> {
+                return node.rpc.startFlow(::QueryUnverifiedTransactionIdsFlow, youngerThanTimestamp, olderThanTimestamp).returnValue.getOrThrow()
+            }
+            val (alice, bob) = listOf(ALICE_NAME, BOB_NAME).map { startNode(providedName = it) }.transpose().getOrThrow()
+
+            val startTime = Instant.now()
+            val txId = alice.rpc.startFlow(::NonFinalisedTransferFlow, bob.nodeInfo.singleIdentity()).returnValue.getOrThrow()
+            val endTime = Instant.now() + 2.seconds
+
+            val aliceUnverifiedTxnIds = queryUnverifiedTxIds(alice, startTime, endTime)
+            val bobUnverifiedTxnIds = queryUnverifiedTxIds(bob, startTime, endTime)
+
+            assertEquals(0, aliceUnverifiedTxnIds.size)
+            assertEquals(1, bobUnverifiedTxnIds.size)
+
+            assertEquals(txId.toString(), bobUnverifiedTxnIds[0])
+
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -166,6 +166,9 @@ interface ServiceHubInternal : ServiceHubCoreInternal {
                 database
         )
     }
+    override fun recordUnverifiedTransaction(tx: SignedTransaction) {
+        validatedTransactions.addUnverifiedTransaction(tx)
+    }
 
     override fun createTransactionsResolver(flow: ResolveTransactionsFlow): TransactionsResolver = DbTransactionsResolver(flow)
 

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -166,8 +166,10 @@ interface ServiceHubInternal : ServiceHubCoreInternal {
                 database
         )
     }
-    override fun recordUnverifiedTransaction(tx: SignedTransaction) {
-        validatedTransactions.addUnverifiedTransaction(tx)
+    override fun recordUnverifiedTransactions(txs: Iterable<SignedTransaction>) {
+        txs.forEach {
+            validatedTransactions.addUnverifiedTransaction(it)
+        }
     }
 
     override fun createTransactionsResolver(flow: ResolveTransactionsFlow): TransactionsResolver = DbTransactionsResolver(flow)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -430,6 +430,9 @@ open class MockServices private constructor(
             (validatedTransactions as WritableTransactionStorage).addTransaction(it)
         }
     }
+    override fun recordUnverifiedTransaction(tx: SignedTransaction) {
+        (validatedTransactions as WritableTransactionStorage).addUnverifiedTransaction(tx)
+    }
 
     override val networkParameters: NetworkParameters
         get() = networkParametersService.run { lookup(currentHash)!! }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -430,8 +430,10 @@ open class MockServices private constructor(
             (validatedTransactions as WritableTransactionStorage).addTransaction(it)
         }
     }
-    override fun recordUnverifiedTransaction(tx: SignedTransaction) {
-        (validatedTransactions as WritableTransactionStorage).addUnverifiedTransaction(tx)
+    override fun recordUnverifiedTransactions(txs: Iterable<SignedTransaction>) {
+        txs.forEach {
+            (validatedTransactions as WritableTransactionStorage).addUnverifiedTransaction(it)
+        }
     }
 
     override val networkParameters: NetworkParameters


### PR DESCRIPTION
LEDG-67 Change record transaction logic to update the transaction itself as well (since it could have got some new signatures).
LEDG-56 Named query for Query unverified Transactions
Also related to ENT-6370. (parts of point 2)