### PR TITLE
ENT-6388: Update `Crash` shell to version 1.7.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ buildscript {
     ext.dependency_checker_version = '5.2.0'
     ext.commons_collections_version = '4.3'
     ext.beanutils_version = '1.9.4'
-    ext.crash_version = '1.7.4'
+    ext.crash_version = '1.7.5'
     ext.jsr305_version = constants.getProperty("jsr305Version")
     ext.shiro_version = '1.4.1'
     ext.artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')


### PR DESCRIPTION
This is a newly built internal version of the library which in particular upgrades `org.apache.mina:mina-core` to version `2.0.22` eliminating NexusIQ vulnerability.