### PR TITLE
ENT-6421 Expose `dumpCheckpoints` on `CordaRPCOps`

### DIFF
--- a/core/src/main/kotlin/net/corda/core/messaging/flows/FlowManagerRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/flows/FlowManagerRPCOps.kt
@@ -1,14 +1,10 @@
-package net.corda.core.internal.messaging
+package net.corda.core.messaging.flows
 
 import net.corda.core.messaging.RPCOps
 
 /**
  * RPC operations to perform operations related to flows including management of associated persistent states like checkpoints.
  */
-@Deprecated(
-    "A public version of this interface has been exposed that should be interacted with using the MultiRPCClient",
-    ReplaceWith("net.corda.core.messaging.flows.FlowManagerRPCOps")
-)
 interface FlowManagerRPCOps : RPCOps {
 
     /**

--- a/node/src/integration-test/kotlin/net/corda/node/services/messaging/FlowManagerRPCOpsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/messaging/FlowManagerRPCOpsTest.kt
@@ -1,0 +1,67 @@
+@file:Suppress("DEPRECATION")
+package net.corda.node.services.messaging
+
+import net.corda.client.rpc.ext.MultiRPCClient
+import net.corda.core.internal.createDirectories
+import net.corda.core.internal.div
+import net.corda.core.internal.isRegularFile
+import net.corda.core.internal.list
+import net.corda.core.messaging.flows.FlowManagerRPCOps
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.node.internal.NodeStartup
+import net.corda.node.services.Permissions
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.User
+import org.junit.Test
+import kotlin.test.assertNotNull
+import net.corda.core.internal.messaging.FlowManagerRPCOps as InternalFlowManagerRPCOps
+
+class FlowManagerRPCOpsTest {
+
+    @Test(timeout = 300_000)
+    fun `net_corda_core_internal_messaging_FlowManagerRPCOps can be accessed using the MultiRPCClient`() {
+        val user = User("user", "password", setOf(Permissions.all()))
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            val client = MultiRPCClient(nodeAHandle.rpcAddress, InternalFlowManagerRPCOps::class.java, user.username, user.password)
+
+            val logDirPath = nodeAHandle.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
+            logDirPath.createDirectories()
+
+            client.use {
+                val rpcOps = it.start().getOrThrow(20.seconds).proxy
+                rpcOps.dumpCheckpoints()
+                it.stop()
+            }
+
+            assertNotNull(logDirPath.list().singleOrNull { it.isRegularFile() })
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `net_corda_core_messaging_flows_FlowManagerRPCOps can be accessed using the MultiRPCClient`() {
+        val user = User("user", "password", setOf(Permissions.all()))
+        driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = true)) {
+
+            val nodeAHandle = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            val client = MultiRPCClient(nodeAHandle.rpcAddress, FlowManagerRPCOps::class.java, user.username, user.password)
+
+            val logDirPath = nodeAHandle.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
+            logDirPath.createDirectories()
+
+            client.use {
+                val rpcOps = it.start().getOrThrow(20.seconds).proxy
+                rpcOps.dumpCheckpoints()
+                it.stop()
+            }
+
+            assertNotNull(logDirPath.list().singleOrNull { it.isRegularFile() })
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/internal/checkpoints/FlowManagerRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/checkpoints/FlowManagerRPCOpsImpl.kt
@@ -1,13 +1,15 @@
+@file:Suppress("DEPRECATION")
 package net.corda.node.internal.checkpoints
 
 import net.corda.core.internal.PLATFORM_VERSION
-import net.corda.core.internal.messaging.FlowManagerRPCOps
+import net.corda.core.messaging.flows.FlowManagerRPCOps
 import net.corda.node.services.rpc.CheckpointDumperImpl
+import net.corda.core.internal.messaging.FlowManagerRPCOps as InternalFlowManagerRPCOps
 
 /**
  * Implementation of [FlowManagerRPCOps]
  */
-internal class FlowManagerRPCOpsImpl(private val checkpointDumper: CheckpointDumperImpl) : FlowManagerRPCOps {
+internal class FlowManagerRPCOpsImpl(private val checkpointDumper: CheckpointDumperImpl) : FlowManagerRPCOps, InternalFlowManagerRPCOps {
 
     override val protocolVersion: Int = PLATFORM_VERSION
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/checkpoint/CheckpointRpcHelper.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/checkpoint/CheckpointRpcHelper.kt
@@ -1,6 +1,6 @@
 package net.corda.testing.driver.internal.checkpoint
 
-import net.corda.core.internal.messaging.FlowManagerRPCOps
+import net.corda.core.messaging.flows.FlowManagerRPCOps
 import net.corda.testing.driver.NodeHandle
 
 object CheckpointRpcHelper {

--- a/tools/shell/src/main/java/net/corda/tools/shell/CheckpointShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/CheckpointShellCommand.java
@@ -1,6 +1,6 @@
 package net.corda.tools.shell;
 
-import net.corda.core.internal.messaging.FlowManagerRPCOps;
+import net.corda.core.messaging.flows.FlowManagerRPCOps;
 import org.crsh.cli.Command;
 import org.crsh.cli.Man;
 import org.crsh.cli.Named;

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -25,7 +25,6 @@ import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.internal.messaging.AttachmentTrustInfoRPCOps
-import net.corda.core.internal.messaging.FlowManagerRPCOps
 import net.corda.core.internal.packageName_
 import net.corda.core.internal.rootCause
 import net.corda.core.internal.uncheckedCast
@@ -33,6 +32,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.FlowProgressHandle
 import net.corda.core.messaging.StateMachineUpdate
+import net.corda.core.messaging.flows.FlowManagerRPCOps
 import net.corda.core.messaging.pendingFlowsCount
 import net.corda.tools.shell.utlities.ANSIProgressRenderer
 import net.corda.tools.shell.utlities.StdoutANSIProgressRenderer


### PR DESCRIPTION
Put `dumpCheckpoints` and `debugCheckpoints` on the public API by adding
it to `CordaRPCOps`.

Remove `FlowManagerRPCOps` as its internal functions now live in
`CordaRPCOps`.