### PR TITLE
ENT-6315 Allow dumping of paused flows

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -221,7 +221,10 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
                                     instrumentCheckpointAgent(runId)
 
                                 val (bytes, fileName) = try {
-                                    val checkpoint = serialisedCheckpoint.deserialize(checkpointSerializationContext)
+                                    val checkpoint = serialisedCheckpoint.deserialize(
+                                        checkpointSerializationContext,
+                                        alwaysDeserializeFlowState = true
+                                    )
                                     val json = checkpoint.toJson(runId.uuid, now)
                                     val jsonBytes = writer.writeValueAsBytes(json)
                                     jsonBytes to "${json.topLevelFlowClass.simpleName}-${runId.uuid}.json"
@@ -259,7 +262,12 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
 
                             //Dump checkpoints in "fibers" folder
                             for((runId, serializedCheckpoint) in stream) {
-                                val flowState = serializedCheckpoint.deserialize(checkpointSerializationContext).flowState
+                                val flowState = serializedCheckpoint.deserialize(
+                                    checkpointSerializationContext,
+                                    alwaysDeserializeFlowState = true
+                                ).flowState
+                                // This includes paused flows because we have forced the deserialization of the checkpoint's flow state
+                                // which will show as started.
                                 if(flowState is FlowState.Started) writeFiber2Zip(zip, checkpointSerializationContext, runId, flowState)
                             }
 
@@ -354,6 +362,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
                 topLevelFlowLogic = flowLogic,
                 flowCallStackSummary = flowCallStack.toSummary(),
                 flowCallStack = flowCallStack,
+                status = status,
                 suspendedOn = (flowState as? FlowState.Started)?.flowIORequest?.toSuspendedOn(
                         timestamp,
                         now
@@ -436,6 +445,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
             val topLevelFlowClass: Class<FlowLogic<*>>,
             val topLevelFlowLogic: FlowLogic<*>,
             val flowCallStackSummary: List<FlowCallSummary>,
+            val status: Checkpoint.FlowStatus,
             val suspendedOn: SuspendedOn?,
             val flowCallStack: List<FlowCall>,
             val origin: Origin,


### PR DESCRIPTION
Checkpoint dumping of paused flows was not working because the dumper
expects a flow to have a `FlowState` of `Unstarted` or `Started`,
however due to a memory optimisation paused flows have their `FlowState`
set to `Paused`. This was causing causing an exception as well as a loss
of potentially useful information.

A flag `alwaysDeserializeCheckpoint` has been added to
`Checkpoint.Serialized.deserialize` which skips the memory optimisation
and forces the deserialization of the flow's `FlowState`.

Paused flows are now included in the dumped output along with their real
`FlowState` which is useful to users even if the flow is paused rather
than waiting for something to complete.

The status of the flow has also been added to the JSON output to assist
users in debugging their flows.