### PR TITLE
NOTICK: Change repository for `ghostdriver` library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,6 +404,7 @@ allprojects {
                     includeGroup 'co.paralleluniverse'
                     includeGroup 'org.crashub'
                     includeGroup 'com.github.bft-smart'
+                    includeGroup 'com.github.detro'
                 }
             }
             maven {

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -72,15 +72,6 @@ dependencies {
     testCompile "com.github.detro:ghostdriver:$ghostdriver_version"
 }
 
-repositories {
-    maven {
-        url 'https://maven.scijava.org/content/repositories/public/'
-        content {
-            includeGroup 'com.github.detro'
-        }
-    }
-}
-
 bootRepackage {
     enabled = false
 }


### PR DESCRIPTION
Since SCI Java repository is no longer available, the library has been copied to the internal `corda-dependencies` repository.
