### PR TITLE
NOTICK: Change repository for `ghostdriver` library

### DIFF
--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -78,15 +78,6 @@ dependencies {
     testCompile "com.github.detro:ghostdriver:$ghostdriver_version"
 }
 
-repositories {
-    maven {
-        url 'https://maven.scijava.org/content/repositories/public/'
-        content {
-            includeGroup 'com.github.detro'
-        }
-    }
-}
-
 bootRepackage {
     enabled = false
 }


### PR DESCRIPTION
* Maven SCI Java repository is not available
* `ghostdriver` moved to `corda-dependencies` repository in R3
  Artifactory
* backporting to Corda OS 4.3 https://github.com/corda/corda/pull/7015