### PR TITLE
ENT-6423: Handle internal_error during SSL handshake gracefully

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
@@ -302,7 +302,7 @@ internal class AMQPChannelHandler(private val serverMode: Boolean,
                                                                            -> logWarnWithMDC("Received close_notify during handshake")
             // io.netty.handler.ssl.SslHandler.setHandshakeFailureTransportFailure()
             cause is SSLException && (cause.message?.contains("writing TLS control frames") == true) -> logWarnWithMDC(cause.message!!)
-
+            cause is SSLException && (cause.message?.contains("internal_error") == true) -> logWarnWithMDC("Received internal_error during handshake")
             else -> badCert = true
         }
         logWarnWithMDC("Handshake failure: ${evt.cause().message}")


### PR DESCRIPTION
Porting patch already merged in previous versions (https://github.com/corda/enterprise/pull/4105)