### PR TITLE
ENT-6426: update docker tagging inline with our dockerhub policies

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -317,7 +317,7 @@ pipeline {
                             './gradlew',
                             COMMON_GRADLE_PARAMS,
                             'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/corda',
+                            '-Pdocker.image.repository=corda/community-node',
                             '--image OFFICIAL'
                             ].join(' ')
                 }

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -42,12 +42,6 @@ enum ImageVariant {
     String dockerFile
     String javaVersion
 
-    String versionString(String baseTag, String version) {
-        return "${baseTag}-${knownAs}" +
-                (knownAs.isEmpty() ? "" : "-") +
-                "java${javaVersion}-" + version
-    }
-
     ImageVariant(ImageVariant other) {
         this.knownAs = other.knownAs
         this.dockerFile = other.dockerFile
@@ -64,16 +58,9 @@ enum ImageVariant {
         return project.properties.getOrDefault("docker.image.repository", "corda/corda")
     }
 
-    static private final String runTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
-
-    def getName(Project project) {
-        return versionString(getRepository(project), project.version.toString().toLowerCase())
-    }
-
     Set<Identifier> buildTags(Project project) {
-        final String suffix = project.version.toString().toLowerCase().contains("snapshot") ? runTime : "RELEASE"
-        return [suffix, "latest"].stream().map {
-            toAppend -> "${getName(project)}:${toAppend}".toString()
+        return ["${project.version.toString().toLowerCase()}-${knownAs}-${javaVersion}"].stream().map {
+            toAppend -> "${getRepository(project)}:${toAppend}".toString()
         }.map(Identifier.&fromCompoundString).collect(Collectors.toSet())
     }
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -33,25 +33,25 @@ shadowJar {
 }
 
 enum ImageVariant {
-    UBUNTU_ZULU("zulu", "Dockerfile", "1.8"),
-    UBUNTU_ZULU_11("zulu", "Dockerfile11", "11"),
-    AL_CORRETTO("corretto", "DockerfileAL", "1.8"),
+    UBUNTU_ZULU("Dockerfile", "1.8", "zulu-openjdk8"),
+    UBUNTU_ZULU_11("Dockerfile11", "11", "zulu-openjdk11"),
+    AL_CORRETTO("DockerfileAL", "1.8", "amazonlinux2"),
     OFFICIAL(UBUNTU_ZULU)
 
-    String knownAs
     String dockerFile
     String javaVersion
+    String baseImgaeFullName
 
     ImageVariant(ImageVariant other) {
-        this.knownAs = other.knownAs
         this.dockerFile = other.dockerFile
         this.javaVersion = other.javaVersion
+        this.baseImgaeFullName = other.baseImgaeFullName
     }
 
-    ImageVariant(String knownAs, String dockerFile, String javaVersion) {
-        this.knownAs = knownAs
+    ImageVariant(String dockerFile, String javaVersion, String baseImgaeFullName) {
         this.dockerFile = dockerFile
         this.javaVersion = javaVersion
+        this.baseImgaeFullName = baseImgaeFullName
     }
 
     static final String getRepository(Project project) {
@@ -59,7 +59,7 @@ enum ImageVariant {
     }
 
     Set<Identifier> buildTags(Project project) {
-        return ["${project.version.toString().toLowerCase()}-${knownAs}-${javaVersion}"].stream().map {
+        return ["${project.version.toString().toLowerCase()}-${baseImgaeFullName}"].stream().map {
             toAppend -> "${getRepository(project)}:${toAppend}".toString()
         }.map(Identifier.&fromCompoundString).collect(Collectors.toSet())
     }


### PR DESCRIPTION
update docker tagging inline with our policies

**old tagging example**
corda/corda-zulu-java1.8-4.8.5:latest

**new tagging for CE**
corda/community-node:4.9-zulu-openjdk8

based on pattern
{repo}:{version}-{base-Image}

Remove some redundant code


