### PR TITLE
ENT-6533 Update validating notary flow to be non-idempotent (Backport)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
@@ -7,7 +7,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.internal.IdempotentFlow
 import net.corda.core.internal.MIN_PLATFORM_VERSION_FOR_BACKPRESSURE_MESSAGE
 import net.corda.core.internal.checkParameterHash
 import net.corda.core.utilities.seconds
@@ -28,7 +27,7 @@ import java.time.Duration
  * @param etaThreshold If the ETA for processing the request, according to the service, is greater than this, notify the client.
  */
 // See AbstractStateReplacementFlow.Acceptor for why it's Void?
-abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service: SinglePartyNotaryService, private val etaThreshold: Duration) : FlowLogic<Void?>(), IdempotentFlow {
+abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service: SinglePartyNotaryService, private val etaThreshold: Duration) : FlowLogic<Void?>() {
     companion object {
         // TODO: Determine an appropriate limit and also enforce in the network parameters and the transaction builder.
         private const val maxAllowedInputsAndReferences = 10_000

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -6,6 +6,7 @@ import net.corda.core.flows.FlowSession
 import net.corda.core.flows.NotarisationPayload
 import net.corda.core.flows.NotaryError
 import net.corda.core.identity.Party
+import net.corda.core.internal.IdempotentFlow
 import net.corda.core.internal.notary.NotaryInternalException
 import net.corda.core.internal.notary.NotaryServiceFlow
 import net.corda.core.internal.notary.SinglePartyNotaryService
@@ -24,7 +25,10 @@ import java.time.Duration
  * the caller, it is possible to raise a dispute and verify the validity of the transaction and subsequently
  * undo the commit of the input states (the exact mechanism still needs to be worked out).
  */
-class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePartyNotaryService, etaThreshold: Duration) : NotaryServiceFlow(otherSideSession, service, etaThreshold) {
+class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePartyNotaryService, etaThreshold: Duration) :
+        NotaryServiceFlow(otherSideSession, service, etaThreshold),
+        IdempotentFlow
+{
     private val minPlatformVersion get() = serviceHub.networkParameters.minimumPlatformVersion
 
     override fun extractParts(requestPayload: NotarisationPayload): TransactionParts {


### PR DESCRIPTION
Backport from 4.8 to 4.4 - see #7030 for original change.
