### PR TITLE
ENT-6386: Revert change of behaviour in rpcOps.wellKnownPartyFromX500Name for revoked identity

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/identity/CertificateRotationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/identity/CertificateRotationTest.kt
@@ -31,6 +31,7 @@ import java.security.PublicKey
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+import kotlin.test.assertNotNull
 
 class CertificateRotationTest {
     private val ref = OpaqueBytes.of(0x01)
@@ -180,7 +181,7 @@ class CertificateRotationTest {
 
         advertiseNodesToNetwork(mockNet.defaultNotaryNode, bob2, charlie)
 
-        assertNull(bob2.services.identityService.wellKnownPartyFromX500Name(ALICE_NAME))
+        assertNotNull(bob2.services.identityService.wellKnownPartyFromX500Name(ALICE_NAME))
         assertNull(charlie.services.identityService.wellKnownPartyFromX500Name(ALICE_NAME))
 
         bob2.services.startFlow(CashPaymentFlow(1000.DOLLARS, charlie.party, false))

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -14,6 +14,7 @@ import net.corda.node.internal.DBNetworkParametersStorage
 import net.corda.node.internal.schemas.NodeInfoSchemaV1
 import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.keys.BasicHSMKeyManagementService
+import net.corda.node.services.network.PersistentNetworkMapCache
 import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.node.services.vault.NodeVaultService
@@ -133,7 +134,8 @@ object VaultMigrationSchemaV1 : MappedSchema(schemaFamily = VaultMigrationSchema
                 PersistentIdentityService.PersistentPublicKeyHashToParty::class.java,
                 BasicHSMKeyManagementService.PersistentKey::class.java,
                 NodeAttachmentService.DBAttachment::class.java,
-                DBNetworkParametersStorage.PersistentNetworkParameters::class.java
+                DBNetworkParametersStorage.PersistentNetworkParameters::class.java,
+                PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java
         )
 )
 

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.identity
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.AbstractParty
@@ -22,6 +23,7 @@ import net.corda.node.internal.schemas.NodeInfoSchemaV1
 import net.corda.node.services.api.IdentityServiceInternal
 import net.corda.node.services.keys.BasicHSMKeyManagementService
 import net.corda.node.services.network.NotaryUpdateListener
+import net.corda.node.services.network.PersistentNetworkMapCache
 import net.corda.node.services.persistence.PublicKeyHashToExternalId
 import net.corda.node.services.persistence.WritablePublicKeyToOwningIdentityCache
 import net.corda.node.utilities.AppendOnlyPersistentMap
@@ -46,6 +48,8 @@ import java.security.cert.CollectionCertStoreParameters
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
 import java.util.*
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.stream.Stream
 import javax.annotation.concurrent.ThreadSafe
 import javax.persistence.Column
@@ -139,6 +143,8 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
 
         private fun mapToKey(party: PartyAndCertificate) = party.owningKey.toStringShort()
     }
+
+    val archiveIdentityExecutor: ExecutorService = Executors.newCachedThreadPool(ThreadFactoryBuilder().setNameFormat("archive-named-identity-thread-%d").build())
 
     @Entity
     @javax.persistence.Table(name = "${NODE_DATABASE_PREFIX}identities")
@@ -312,7 +318,76 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = database.transaction {
-        nameToParty[name]?.orElse(null)
+        if (nameToParty[name]?.isPresent == true) {
+            nameToParty[name]?.get()
+        }
+        else {
+            retrievePartyFromArchive(name)
+        }
+    }
+
+    private fun retrievePartyFromArchive(name: CordaX500Name): Party? {
+        val hashKey = database.transaction {
+            val query = session.criteriaBuilder.createQuery(PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java)
+            val queryRoot = query.from(PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java)
+            query.where(session.criteriaBuilder.equal(queryRoot.get<String>("name"), name.toString()))
+            val resultList = session.createQuery(query).resultList
+            if (resultList.isNotEmpty()) {
+                resultList?.first()?.publicKeyHash
+            }
+            else {
+                retrieveHashKeyAndCacheParty(name)
+            }
+        }
+        return hashKey?.let { keyToPartyAndCert[it]?.party }
+    }
+
+    private fun retrieveHashKeyAndCacheParty(name: CordaX500Name): String? {
+        return database.transaction {
+            val cb = session.criteriaBuilder
+            val query = cb.createQuery(PersistentPublicKeyHashToParty::class.java)
+            val root = query.from(PersistentPublicKeyHashToParty::class.java)
+            val isNotConfidentialIdentity = cb.equal(root.get<String>("publicKeyHash"), root.get<String>("owningKeyHash"))
+            val matchName = cb.equal(root.get<String>("name"), name.toString())
+            query.select(root).where(cb.and(matchName, isNotConfidentialIdentity))
+            val resultList = session.createQuery(query).resultList
+            var hashKey: String? = if (resultList.isNotEmpty()) {
+                if (resultList.size == 1) {
+                    resultList?.single()?.owningKeyHash
+                }
+                else {
+                    selectIdentityHash(session, resultList.mapNotNull { it.publicKeyHash }, name)
+                }
+            } else {
+                null
+            }
+            archiveNamedIdentity(name.toString(), hashKey)
+            hashKey
+        }
+    }
+
+    private fun selectIdentityHash(session: Session, hashList: List<String>, name: CordaX500Name): String? {
+        val cb = session.criteriaBuilder
+        val query = cb.createQuery(PersistentPublicKeyHashToCertificate::class.java)
+        val root = query.from(PersistentPublicKeyHashToCertificate::class.java)
+        query.select(root).where(root.get<String>("publicKeyHash").`in`(hashList))
+        val resultList = session.createQuery(query).resultList
+        resultList.sortWith(compareBy { PartyAndCertificate(X509CertificateFactory().delegate.generateCertPath(it.identity.inputStream())).certificate.notBefore })
+        log.warn("Retrieving identity hash for removed identity '${name}', more that one hash found, returning last one according to notBefore validity of certificate." +
+                 " Hash returned is ${resultList.last().publicKeyHash}")
+        return resultList.last().publicKeyHash
+    }
+
+    private fun archiveNamedIdentity(name:String, publicKeyHash: String?) {
+        archiveIdentityExecutor.submit {
+            database.transaction {
+                val deleteQuery = session.criteriaBuilder.createCriteriaDelete(PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java)
+                val queryRoot = deleteQuery.from(PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java)
+                deleteQuery.where(session.criteriaBuilder.equal(queryRoot.get<String>("name"), name))
+                session.createQuery(deleteQuery).executeUpdate()
+                session.save(PersistentNetworkMapCache.PersistentPartyToPublicKeyHash(name, publicKeyHash))
+            }
+        }.get()
     }
 
     override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -17,6 +17,7 @@ import net.corda.core.node.services.NetworkMapCache.MapChange
 import net.corda.core.node.services.PartyInfo
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.serialization.serialize
+import net.corda.core.utilities.MAX_HASH_HEX_SIZE
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
@@ -34,6 +35,9 @@ import java.security.PublicKey
 import java.security.cert.CertPathValidatorException
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
 import javax.persistence.PersistenceException
 
 /** Database-based network map cache. */
@@ -60,6 +64,18 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
 
     @Volatile
     private lateinit var rotatedNotaries: Set<CordaX500Name>
+
+    @Entity
+    @javax.persistence.Table(name = "node_named_identities")
+    data class PersistentPartyToPublicKeyHash(
+            @Id
+            @Suppress("MagicNumber") // database column width
+            @Column(name = "name", length = 128, nullable = false)
+            var name: String = "",
+
+            @Column(name = "pk_hash", length = MAX_HASH_HEX_SIZE, nullable = true)
+            var publicKeyHash: String? = ""
+    )
 
     // Notary whitelist may contain multiple identities with the same X.500 name after certificate rotation.
     // Exclude duplicated entries, which are not present in the network map.
@@ -294,12 +310,23 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
         synchronized(_changed) {
             database.transaction {
                 removeInfoDB(session, node)
+                archiveNamedIdentity(session, node)
                 changePublisher.onNext(MapChange.Removed(node))
             }
         }
         // Invalidate caches outside database transaction to prevent reloading of uncommitted values.
         invalidateIdentityServiceCaches(node)
         logger.debug { "Done removing node with info: $node" }
+    }
+
+    private fun archiveNamedIdentity(session: Session, nodeInfo: NodeInfo) {
+        nodeInfo.legalIdentities.forEach { party ->
+            val deleteQuery = session.criteriaBuilder.createCriteriaDelete(PersistentPartyToPublicKeyHash::class.java)
+            val queryRoot = deleteQuery.from(PersistentPartyToPublicKeyHash::class.java)
+            deleteQuery.where(session.criteriaBuilder.equal(queryRoot.get<String>("name"), party.name.toString()))
+            session.createQuery(deleteQuery).executeUpdate()
+            session.save(PersistentPartyToPublicKeyHash(party.name.toString(), party.owningKey.toStringShort() ))
+        }
     }
 
     override val allNodes: List<NodeInfo>

--- a/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
@@ -50,7 +50,7 @@ class NodeSchemaService(private val extraSchemas: Set<MappedSchema> = emptySet()
                     PersistentIdentityService.PersistentHashToPublicKey::class.java,
                     ContractUpgradeServiceImpl.DBContractUpgrade::class.java,
                     DBNetworkParametersStorage.PersistentNetworkParameters::class.java,
-                    PublicKeyHashToExternalId::class.java
+                    PublicKeyHashToExternalId::class.java,
                     PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java
             )) {
         override val migrationResource = "node-core.changelog-master"

--- a/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
@@ -14,6 +14,7 @@ import net.corda.node.services.events.NodeSchedulerService
 import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.keys.BasicHSMKeyManagementService
 import net.corda.node.services.messaging.P2PMessageDeduplicator
+import net.corda.node.services.network.PersistentNetworkMapCache
 import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.persistence.NodeAttachmentService
@@ -50,6 +51,7 @@ class NodeSchemaService(private val extraSchemas: Set<MappedSchema> = emptySet()
                     ContractUpgradeServiceImpl.DBContractUpgrade::class.java,
                     DBNetworkParametersStorage.PersistentNetworkParameters::class.java,
                     PublicKeyHashToExternalId::class.java
+                    PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java
             )) {
         override val migrationResource = "node-core.changelog-master"
     }

--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -27,6 +27,7 @@
     <include file="migration/node-core.changelog-v14-data.xml"/>
     <include file="migration/node-core.changelog-v16.xml"/>
     <include file="migration/node-core.changelog-v20.xml"/>
+    <include file="migration/node-core.changelog-v22.xml"/>
 
     <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
     <include file="migration/vault-schema.changelog-v9.xml"/>

--- a/node/src/main/resources/migration/node-core.changelog-v22.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v22.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3.Corda" id="add_node_named_identities_table_back_in">
+        <createTable tableName="node_named_identities">
+            <column name="name" type="NVARCHAR(128)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="pk_hash" type="NVARCHAR(130)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/test/kotlin/net/corda/node/migration/MigrationTestSchema.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/MigrationTestSchema.kt
@@ -50,7 +50,7 @@ object IdentityTestSchemaV1 : MappedSchema(
             @Column(name = "name", length = 128, nullable = false)
             var name: String = "",
 
-            @Column(name = "pk_hash", length = MAX_HASH_HEX_SIZE, nullable = false)
+            @Column(name = "pk_hash", length = MAX_HASH_HEX_SIZE, nullable = true)
             var publicKeyHash: String = ""
     )
 


### PR DESCRIPTION
Reverts the change of behaviour in rpcOps.wellKnownPartyFromX500Name for revoked identity that occurred due to certificate rotation work.