### PR TITLE
ENT-6414 `reattachFlowWithClientId` throws `NullPointerException` if user specifies non-existent client ID

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -50,6 +50,7 @@ import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CordaRPCClientReconnectionTest {
@@ -591,6 +592,29 @@ class CordaRPCClientReconnectionTest {
                 val result0 = flowHandle0.returnValue.getOrThrow()
                 assertEquals(5, result0)
                 assertThat(rpcOps.reconnectingRPCConnection.isClosed())
+            }
+        }
+    }
+
+    @Test(timeout=300_000)
+    fun `reconnecting 'reattachFlowWithClientId' rpc works if called with non-existent client id`() {
+        driver(DriverParameters(inMemoryDB = false, cordappsForAllNodes = listOf(this.enclosedCordapp()))) {
+            val address = NetworkHostAndPort("localhost", portAllocator.nextPort())
+            fun startNode(additionalCustomOverrides: Map<String, Any?> = emptyMap()): NodeHandle {
+                return startNode(
+                        providedName = CHARLIE_NAME,
+                        rpcUsers = listOf(CordaRPCClientTest.rpcUser),
+                        customOverrides = mapOf("rpcSettings.address" to address.toString()) + additionalCustomOverrides
+                ).getOrThrow()
+            }
+
+            val node = startNode()
+            val client = CordaRPCClient(node.rpcAddress, config)
+            (client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect)).use {
+                val rpcOps = it.proxy as ReconnectingCordaRPCOps
+                val clientId = UUID.randomUUID().toString()
+                val flowHandle = rpcOps.reattachFlowWithClientId<Any>(clientId)
+                assertNull(flowHandle)
             }
         }
     }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -612,8 +612,8 @@ class CordaRPCClientReconnectionTest {
             val client = CordaRPCClient(node.rpcAddress, config)
             (client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect)).use {
                 val rpcOps = it.proxy as ReconnectingCordaRPCOps
-                val clientId = UUID.randomUUID().toString()
-                val flowHandle = rpcOps.reattachFlowWithClientId<Any>(clientId)
+                val nonExistentClientId = UUID.randomUUID().toString()
+                val flowHandle = rpcOps.reattachFlowWithClientId<Any>(nonExistentClientId)
                 assertNull(flowHandle)
             }
         }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -391,10 +391,11 @@ class ReconnectingCordaRPCOps private constructor(
                     initialFeed.copy(updates = observable)
                 }
                 FlowHandleWithClientId::class.java -> {
-                    val initialHandle: FlowHandleWithClientId<Any?> = uncheckedCast(doInvoke(method, args,
+                    // initialHandle can be null. See @CordaRPCOps.reattachFlowWithClientId.
+                    val initialHandle: FlowHandleWithClientId<Any?>? = uncheckedCast(doInvoke(method, args,
                             reconnectingRPCConnection.gracefulReconnect.maxAttempts))
 
-                    val initialFuture = initialHandle.returnValue
+                    val initialFuture = initialHandle?.returnValue ?: return null
                     // This is the future that is returned to the client. It will get carried until we reconnect to the node.
                     val returnFuture = openFuture<Any?>()
 


### PR DESCRIPTION
Fixes `NullPointerException` thrown in `net.corda.client.rpc.internal.ReconnectingCordaRPCOps$ErrorInterceptingHandler.invoke` for method `reattachFlowWithClientId` when executed for a non-existent client id.