### PR TITLE
ENT-6572: Validate LedgerTransaction deserialised from transaction's classloader.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/ConstraintsUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ConstraintsUtils.kt
@@ -16,6 +16,7 @@ typealias Version = Int
  * Attention: this value affects consensus, so it requires a minimum platform version bump in order to be changed.
  */
 const val MAX_NUMBER_OF_KEYS_IN_SIGNATURE_CONSTRAINT = 20
+private const val DJVM_SANDBOX_PREFIX = "sandbox."
 
 private val log = loggerFor<AttachmentConstraint>()
 
@@ -29,10 +30,14 @@ val Attachment.contractVersion: Version get() = if (this is ContractAttachment) 
 val ContractState.requiredContractClassName: String? get() {
     val annotation = javaClass.getAnnotation(BelongsToContract::class.java)
     if (annotation != null) {
-        return annotation.value.java.typeName
+        return annotation.value.java.typeName.removePrefix(DJVM_SANDBOX_PREFIX)
     }
     val enclosingClass = javaClass.enclosingClass ?: return null
-    return if (Contract::class.java.isAssignableFrom(enclosingClass)) enclosingClass.typeName else null
+    return if (Contract::class.java.isAssignableFrom(enclosingClass)) {
+        enclosingClass.typeName.removePrefix(DJVM_SANDBOX_PREFIX)
+    } else {
+        null
+    }
 }
 
 /**

--- a/core/src/test/kotlin/net/corda/core/internal/internalAccessTestHelpers.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/internalAccessTestHelpers.kt
@@ -5,10 +5,12 @@ import net.corda.core.crypto.DigestService
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.Party
 import net.corda.core.node.NetworkParameters
+import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.internal.AttachmentsClassLoaderCache
 import net.corda.core.transactions.ComponentGroup
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.WireTransaction
+import java.util.function.Supplier
 
 /**
  * A set of functions in core:test that allows testing of core internal classes in the core-tests project.
@@ -38,7 +40,17 @@ fun createLedgerTransaction(
         isAttachmentTrusted: (Attachment) -> Boolean,
         attachmentsClassLoaderCache: AttachmentsClassLoaderCache,
         digestService: DigestService = DigestService.default
-): LedgerTransaction = LedgerTransaction.create(inputs, outputs, commands, attachments, id, notary, timeWindow, privacySalt, networkParameters, references, componentGroups, serializedInputs, serializedReferences, isAttachmentTrusted, attachmentsClassLoaderCache, digestService)
+): LedgerTransaction = LedgerTransaction.create(
+    inputs, outputs, commands, attachments, id, notary, timeWindow, privacySalt, networkParameters, references, componentGroups, serializedInputs, serializedReferences, isAttachmentTrusted, attachmentsClassLoaderCache, digestService
+).specialise(::PassthroughVerifier)
 
 fun createContractCreationError(txId: SecureHash, contractClass: String, cause: Throwable) = TransactionVerificationException.ContractCreationError(txId, contractClass, cause)
 fun createContractRejection(txId: SecureHash, contract: Contract, cause: Throwable) = TransactionVerificationException.ContractRejection(txId, contract, cause)
+
+/**
+ * Verify the [LedgerTransaction] we already have.
+ */
+private class PassthroughVerifier(ltx: LedgerTransaction, context: SerializationContext) : AbstractVerifier(ltx, context.deserializationClassLoader) {
+    override val transaction: Supplier<LedgerTransaction>
+        get() = Supplier { ltx }
+}

--- a/node/src/integration-test/kotlin/net/corda/contracts/mutator/MutatorContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/mutator/MutatorContract.kt
@@ -95,9 +95,11 @@ class MutatorContract : Contract {
         }
     }
 
-    private class ExtraSpecialise(ltx: LedgerTransaction, ctx: SerializationContext)
-        : Verifier(ltx, ctx.deserializationClassLoader) {
-        override fun verifyContracts() {}
+    private class ExtraSpecialise(private val ltx: LedgerTransaction, private val ctx: SerializationContext) : Verifier {
+        override fun verify() {
+            ltx.inputStates.forEach(::println)
+            println(ctx.deserializationClassLoader)
+        }
     }
 
     class MutateState(val owner: AbstractParty) : ContractState {

--- a/node/src/integration-test/kotlin/net/corda/node/CashIssueAndPaymentTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CashIssueAndPaymentTest.kt
@@ -30,12 +30,12 @@ class CashIssueAndPaymentTest {
         private val configOverrides = mapOf(NodeConfiguration::reloadCheckpointAfterSuspend.name to true)
         private val CASH_AMOUNT = 500.DOLLARS
 
-        fun parametersFor(): DriverParameters {
+        fun parametersFor(runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 systemProperties = mapOf("co.paralleluniverse.fibers.verifyInstrumentation" to "false"),
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = false, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 notaryCustomOverrides = configOverrides,
                 cordappsForAllNodes = listOf(
                     findCordapp("net.corda.finance.contracts"),

--- a/node/src/integration-test/kotlin/net/corda/node/ContractCannotMutateTransactionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractCannotMutateTransactionTest.kt
@@ -23,7 +23,7 @@ class ContractCannotMutateTransactionTest {
         private val mutatorFlowCorDapp = cordappWithPackages("net.corda.flows.mutator").signed()
         private val mutatorContractCorDapp = cordappWithPackages("net.corda.contracts.mutator").signed()
 
-        fun driverParameters(runInProcess: Boolean): DriverParameters {
+        fun driverParameters(runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
                 startNodesInProcess = runInProcess,
@@ -35,7 +35,7 @@ class ContractCannotMutateTransactionTest {
 
     @Test(timeout = 300_000)
     fun testContractCannotModifyTransaction() {
-        driver(driverParameters(runInProcess = false)) {
+        driver(driverParameters()) {
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
             val txID = CordaRPCClient(hostAndPort = alice.rpcAddress)
                 .start(user.username, user.password)

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithCordappFixupTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithCordappFixupTest.kt
@@ -35,11 +35,11 @@ class ContractWithCordappFixupTest {
         val dependentContractCorDapp = cordappWithPackages("net.corda.contracts.fixup.dependent").signed()
         val standaloneContractCorDapp = cordappWithPackages("net.corda.contracts.fixup.standalone").signed()
 
-        fun driverParameters(cordapps: List<TestCordapp>): DriverParameters {
+        fun driverParameters(cordapps: List<TestCordapp>, runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = cordapps,
                 systemProperties = mapOf("net.corda.transactionbuilder.missingclass.disabled" to true.toString())
             )

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithCustomSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithCustomSerializerTest.kt
@@ -46,7 +46,7 @@ class ContractWithCustomSerializerTest(private val runInProcess: Boolean) {
         driver(DriverParameters(
             portAllocation = incrementalPortAllocation(),
             startNodesInProcess = runInProcess,
-            notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+            notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
             cordappsForAllNodes = listOf(
                 cordappWithPackages("net.corda.flows.serialization.custom").signed(),
                 cordappWithPackages("net.corda.contracts.serialization.custom").signed()

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithGenericTypeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithGenericTypeTest.kt
@@ -31,11 +31,11 @@ class ContractWithGenericTypeTest {
         @JvmField
         val user = User("u", "p", setOf(Permissions.all()))
 
-        fun parameters(): DriverParameters {
+        fun parameters(runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = listOf(
                     cordappWithPackages("net.corda.flows.serialization.generics").signed(),
                     cordappWithPackages("net.corda.contracts.serialization.generics").signed()

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithMissingCustomSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithMissingCustomSerializerTest.kt
@@ -45,7 +45,7 @@ class ContractWithMissingCustomSerializerTest(private val runInProcess: Boolean)
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
                 startNodesInProcess = runInProcess,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = cordapps
             )
         }

--- a/node/src/integration-test/kotlin/net/corda/node/ContractWithSerializationWhitelistTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/ContractWithSerializationWhitelistTest.kt
@@ -43,7 +43,7 @@ class ContractWithSerializationWhitelistTest(private val runInProcess: Boolean) 
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
                 startNodesInProcess = runInProcess,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = listOf(contractCordapp, workflowCordapp)
             )
         }

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicCashIssueAndPaymentTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicCashIssueAndPaymentTest.kt
@@ -32,11 +32,11 @@ class DeterministicCashIssueAndPaymentTest {
         @JvmField
         val djvmSources = DeterministicSourcesRule()
 
-        fun parametersFor(djvmSources: DeterministicSourcesRule): DriverParameters {
+        fun parametersFor(djvmSources: DeterministicSourcesRule, runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 notaryCustomOverrides = configOverrides,
                 cordappsForAllNodes = listOf(
                     findCordapp("net.corda.finance.contracts"),

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractCannotMutateTransactionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractCannotMutateTransactionTest.kt
@@ -28,7 +28,7 @@ class DeterministicContractCannotMutateTransactionTest {
         @JvmField
         val djvmSources = DeterministicSourcesRule()
 
-        fun driverParameters(runInProcess: Boolean): DriverParameters {
+        fun driverParameters(runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
                 startNodesInProcess = runInProcess,
@@ -42,7 +42,7 @@ class DeterministicContractCannotMutateTransactionTest {
 
     @Test(timeout = 300_000)
     fun testContractCannotModifyTransaction() {
-        driver(driverParameters(runInProcess = false)) {
+        driver(driverParameters()) {
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
             val txID = CordaRPCClient(hostAndPort = alice.rpcAddress)
                 .start(user.username, user.password)

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractCryptoTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractCryptoTest.kt
@@ -32,11 +32,11 @@ class DeterministicContractCryptoTest {
         @JvmField
         val djvmSources = DeterministicSourcesRule()
 
-        fun parametersFor(djvmSources: DeterministicSourcesRule): DriverParameters {
+        fun parametersFor(djvmSources: DeterministicSourcesRule, runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = listOf(
                     cordappWithPackages("net.corda.flows.djvm.crypto"),
                     CustomCordapp(

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithCustomSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithCustomSerializerTest.kt
@@ -41,11 +41,11 @@ class DeterministicContractWithCustomSerializerTest {
         @JvmField
         val contractCordapp = cordappWithPackages("net.corda.contracts.serialization.custom").signed()
 
-        fun parametersFor(djvmSources: DeterministicSourcesRule, vararg cordapps: TestCordapp): DriverParameters {
+        fun parametersFor(djvmSources: DeterministicSourcesRule, cordapps: List<TestCordapp>, runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = cordapps.toList(),
                 djvmBootstrapSource = djvmSources.bootstrap,
                 djvmCordaSource = djvmSources.corda
@@ -61,7 +61,7 @@ class DeterministicContractWithCustomSerializerTest {
 
     @Test(timeout=300_000)
 	fun `test DJVM can verify using custom serializer`() {
-        driver(parametersFor(djvmSources, flowCordapp, contractCordapp)) {
+        driver(parametersFor(djvmSources, listOf(flowCordapp, contractCordapp))) {
             val alice = startNode(providedName = ALICE_NAME).getOrThrow()
             val txId = assertDoesNotThrow {
                 alice.rpc.startFlow(::CustomSerializerFlow, Currantsy(GOOD_CURRANTS))
@@ -73,7 +73,7 @@ class DeterministicContractWithCustomSerializerTest {
 
     @Test(timeout=300_000)
 	fun `test DJVM can fail verify using custom serializer`() {
-        driver(parametersFor(djvmSources, flowCordapp, contractCordapp)) {
+        driver(parametersFor(djvmSources, listOf(flowCordapp, contractCordapp))) {
             val alice = startNode(providedName = ALICE_NAME).getOrThrow()
             val currantsy = Currantsy(BAD_CURRANTS)
             val ex = assertThrows<DeterministicVerificationException> {

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithGenericTypeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithGenericTypeTest.kt
@@ -36,11 +36,11 @@ class DeterministicContractWithGenericTypeTest {
         @JvmField
         val djvmSources = DeterministicSourcesRule()
 
-        fun parameters(): DriverParameters {
+        fun parameters(runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = listOf(
                     cordappWithPackages("net.corda.flows.serialization.generics").signed(),
                     cordappWithPackages("net.corda.contracts.serialization.generics").signed()

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithSerializationWhitelistTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithSerializationWhitelistTest.kt
@@ -41,11 +41,11 @@ class DeterministicContractWithSerializationWhitelistTest {
         @JvmField
         val contractCordapp = cordappWithPackages("net.corda.contracts.djvm.whitelist").signed()
 
-        fun parametersFor(djvmSources: DeterministicSourcesRule, vararg cordapps: TestCordapp): DriverParameters {
+        fun parametersFor(djvmSources: DeterministicSourcesRule, cordapps: List<TestCordapp>, runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = cordapps.toList(),
                 djvmBootstrapSource = djvmSources.bootstrap,
                 djvmCordaSource = djvmSources.corda
@@ -61,7 +61,7 @@ class DeterministicContractWithSerializationWhitelistTest {
 
     @Test(timeout=300_000)
 	fun `test DJVM can verify using whitelist`() {
-        driver(parametersFor(djvmSources, flowCordapp, contractCordapp)) {
+        driver(parametersFor(djvmSources, listOf(flowCordapp, contractCordapp))) {
             val alice = startNode(providedName = ALICE_NAME).getOrThrow()
             val txId = assertDoesNotThrow {
                 alice.rpc.startFlow(::DeterministicWhitelistFlow, WhitelistData(GOOD_VALUE))
@@ -73,7 +73,7 @@ class DeterministicContractWithSerializationWhitelistTest {
 
     @Test(timeout=300_000)
 	fun `test DJVM can fail verify using whitelist`() {
-        driver(parametersFor(djvmSources, flowCordapp, contractCordapp)) {
+        driver(parametersFor(djvmSources, listOf(flowCordapp, contractCordapp))) {
             val alice = startNode(providedName = ALICE_NAME).getOrThrow()
             val badData = WhitelistData(BAD_VALUE)
             val ex = assertThrows<DeterministicVerificationException> {

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicEvilContractCannotModifyStatesTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicEvilContractCannotModifyStatesTest.kt
@@ -34,7 +34,7 @@ class DeterministicEvilContractCannotModifyStatesTest {
         @JvmField
         val djvmSources = DeterministicSourcesRule()
 
-        fun driverParameters(runInProcess: Boolean): DriverParameters {
+        fun driverParameters(runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
                 startNodesInProcess = runInProcess,
@@ -53,7 +53,7 @@ class DeterministicEvilContractCannotModifyStatesTest {
     @Test(timeout = 300_000)
     fun testContractThatTriesToModifyStates() {
         val evilData = MutableDataObject(5000)
-        driver(driverParameters(runInProcess = false)) {
+        driver(driverParameters()) {
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
             val ex = assertFailsWith<DeterministicVerificationException> {
                 CordaRPCClient(hostAndPort = alice.rpcAddress)

--- a/node/src/integration-test/kotlin/net/corda/node/services/NonDeterministicContractVerifyTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/NonDeterministicContractVerifyTest.kt
@@ -35,11 +35,11 @@ class NonDeterministicContractVerifyTest {
         @JvmField
         val djvmSources = DeterministicSourcesRule()
 
-        fun parametersFor(djvmSources: DeterministicSourcesRule): DriverParameters {
+        fun parametersFor(djvmSources: DeterministicSourcesRule, runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = listOf(
                     cordappWithPackages("net.corda.flows.djvm.broken"),
                     CustomCordapp(

--- a/node/src/integration-test/kotlin/net/corda/node/services/SandboxAttachmentsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/SandboxAttachmentsTest.kt
@@ -31,11 +31,11 @@ class SandboxAttachmentsTest {
         @JvmField
         val djvmSources = DeterministicSourcesRule()
 
-        fun parametersFor(djvmSources: DeterministicSourcesRule): DriverParameters {
+        fun parametersFor(djvmSources: DeterministicSourcesRule, runInProcess: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
-                startNodesInProcess = false,
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = true)),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, startInProcess = runInProcess, validating = true)),
                 cordappsForAllNodes = listOf(
                     cordappWithPackages("net.corda.flows.djvm.attachment"),
                     CustomCordapp(

--- a/node/src/main/kotlin/net/corda/node/internal/djvm/DeterministicVerifier.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/djvm/DeterministicVerifier.kt
@@ -7,13 +7,14 @@ import net.corda.core.contracts.ComponentGroupEnum.SIGNERS_GROUP
 import net.corda.core.contracts.TransactionState
 import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.crypto.SecureHash
-import net.corda.core.internal.ContractVerifier
+import net.corda.core.internal.TransactionVerifier
 import net.corda.core.internal.Verifier
 import net.corda.core.internal.getNamesOfClassesImplementing
 import net.corda.core.serialization.SerializationCustomSerializer
 import net.corda.core.serialization.SerializationWhitelist
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.utilities.contextLogger
 import net.corda.djvm.SandboxConfiguration
 import net.corda.djvm.execution.ExecutionSummary
 import net.corda.djvm.execution.IsolatedTask
@@ -26,10 +27,14 @@ import java.util.function.Function
 import kotlin.collections.LinkedHashSet
 
 class DeterministicVerifier(
-    ltx: LedgerTransaction,
-    transactionClassLoader: ClassLoader,
+    private val ltx: LedgerTransaction,
+    private val transactionClassLoader: ClassLoader,
     private val sandboxConfiguration: SandboxConfiguration
-) : Verifier(ltx, transactionClassLoader) {
+) : Verifier {
+    private companion object {
+        private val logger = contextLogger()
+    }
+
     /**
      * Read the whitelisted classes without using the [java.util.ServiceLoader] mechanism
      * because the whitelists themselves are untrusted.
@@ -47,7 +52,7 @@ class DeterministicVerifier(
             }
     }
 
-    override fun verifyContracts() {
+    override fun verify() {
         val customSerializerNames = getNamesOfClassesImplementing(transactionClassLoader, SerializationCustomSerializer::class.java)
         val serializationWhitelistNames = getSerializationWhitelistNames(transactionClassLoader)
         val result = IsolatedTask(ltx.id.toString(), sandboxConfiguration).run<Any>(Function { classLoader ->
@@ -113,7 +118,7 @@ class DeterministicVerifier(
                 ))
             }
 
-            val verifier = taskFactory.apply(ContractVerifier::class.java)
+            val verifier = taskFactory.apply(TransactionVerifier::class.java)
 
             // Now execute the contract verifier task within the sandbox...
             verifier.apply(sandboxTx)
@@ -128,7 +133,7 @@ class DeterministicVerifier(
             val sandboxEx = SandboxException(
                 Message.getMessageFromException(this),
                 result.identifier,
-                ClassSource.fromClassName(ContractVerifier::class.java.name),
+                ClassSource.fromClassName(TransactionVerifier::class.java.name),
                 ExecutionSummary(result.costs),
                 this
             )


### PR DESCRIPTION
Rename `ContractVerifier` to `TransactionVerifier` and run the "transaction consistency" checks from there. This means that they will use the copy of `LedgerTransaction` that was (correctly) deserialised using the deserialisation classloader.

Update the DJVM code-path so that it can run the "transaction consistency" checks successfully too. This requires it to recognise `ContractAttachment` types.

And tweak some of the node's "driver" integration tests so that the Notary node is also switched between running in and out of process along with the Alice node.