### PR TITLE
ENT-6498 Fix API docs dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ buildscript {
     ext.hibernate_version = '5.4.3.Final'
     ext.h2_version = '1.4.199' // Update docs if renamed or removed.
     ext.rxjava_version = '1.3.8'
-    ext.dokka_version = '0.9.17'
+    ext.dokka_version = '0.10.1'
     ext.eddsa_version = '0.3.0'
     ext.dependency_checker_version = '5.2.0'
     ext.commons_collections_version = '4.3'

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -5,6 +5,10 @@ apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 
+dependencies {
+    compile rootProject
+}
+
 def internalPackagePrefixes(sourceDirs) {
     def prefixes = []
     // Kotlin allows packages to deviate from the directory structure, but let's assume they don't:
@@ -36,10 +40,13 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
 }
 
 [dokka, dokkaJavadoc].collect {
-    it.configure {
+    it.configuration {
         moduleName = 'corda'
-        processConfigurations = ['compile']
-        sourceDirs = dokkaSourceDirs
+        dokkaSourceDirs.collect { sourceDir ->
+            sourceRoot {
+                path = sourceDir.path
+            }
+        }
         includes = ['packages.md']
         jdkVersion = 8
         externalDocumentationLink {
@@ -52,7 +59,7 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
             url = new URL("https://www.bouncycastle.org/docs/docs1.5on/")
         }
         internalPackagePrefixes.collect { packagePrefix ->
-            packageOptions {
+            perPackageOption {
                 prefix = packagePrefix
                 suppress = true
             }


### PR DESCRIPTION
As per fixes to enterprise https://github.com/corda/enterprise/pull/4382 but without the addition of missing RPC APIs.