### PR TITLE
ENT-6495: bump java base version

### DIFF
--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:8u192
+FROM azul/zulu-openjdk:8u312
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \

--- a/docker/src/docker/Dockerfile-debug
+++ b/docker/src/docker/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:8u192
+FROM azul/zulu-openjdk:8u312
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \


### PR DESCRIPTION
bump base image in line with supported versions.

![image](https://user-images.githubusercontent.com/5963044/152676868-924c53ba-ca7a-41a0-9612-2cae5ae0e869.png)
