### PR TITLE
ENT-6584: Move sending of events to finally block. 

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt
@@ -112,12 +112,11 @@ class DatabaseTransaction(
         } finally {
             clearException()
             contextTransactionOrNull = outerTransaction
-        }
-
-        if (outerTransaction == null) {
-            synchronized(this) {
-                closed = true
-                boundary.onNext(CordaPersistence.Boundary(id, committed))
+            if (outerTransaction == null) {
+                synchronized(this) {
+                    closed = true
+                    boundary.onNext(CordaPersistence.Boundary(id, committed))
+                }
             }
         }
     }


### PR DESCRIPTION
In the DatabaseTransaction close operation move the sending of events to the finally block. This makes sure it gets executed in the event of an exception.
