### PR TITLE
INFRA-1697: remove authentication details from gradlew wrapper download and add helper to add them in when ran on CI

### DIFF
--- a/.ci/dev/compatibility/JenkinsfileJDK11Azul
+++ b/.ci/dev/compatibility/JenkinsfileJDK11Azul
@@ -102,6 +102,7 @@ pipeline {
         stage('Compile') {
             steps {
                 dir(sameAgentFolder) {
+                    authenticateGradleWrapper()
                     sh script: [
                             './gradlew',
                             COMMON_GRADLE_PARAMS,

--- a/.ci/dev/compatibility/JenkinsfileJDK11Compile
+++ b/.ci/dev/compatibility/JenkinsfileJDK11Compile
@@ -25,6 +25,7 @@ pipeline {
     stages {
         stage('JDK 11 Compile') {
             steps {
+                authenticateGradleWrapper()
                 sh "./gradlew --no-daemon -Pcompilation.allWarningsAsErrors=true -Ptests.failFast=false " +
                 "-Ptests.ignoreFailures=true clean compileAll --stacktrace"
             }

--- a/.ci/dev/mswin/Jenkinsfile
+++ b/.ci/dev/mswin/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
                 stage('Unit Tests') {
                     agent { label 'mswin' }
                     steps {
+                        authenticateGradleWrapper()
                         bat "./gradlew --no-daemon " +
                                 "--stacktrace " +
                                 "-Pcompilation.warningsAsErrors=false " +

--- a/.ci/dev/nightly-regression/Jenkinsfile
+++ b/.ci/dev/nightly-regression/Jenkinsfile
@@ -91,6 +91,7 @@ pipeline {
                         }
                         stage('Recompile') {
                             steps {
+                                authenticateGradleWrapper()
                                 sh script: [
                                         './gradlew',
                                         COMMON_GRADLE_PARAMS,

--- a/.ci/dev/nightly-regression/Jenkinsfile
+++ b/.ci/dev/nightly-regression/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
     stages {
         stage('Compile') {
             steps {
-                 authenticateGradleWrapper()
+                authenticateGradleWrapper()
                 sh script: [
                         './gradlew',
                         COMMON_GRADLE_PARAMS,

--- a/.ci/dev/nightly-regression/Jenkinsfile
+++ b/.ci/dev/nightly-regression/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
     stages {
         stage('Compile') {
             steps {
+                 authenticateGradleWrapper()
                 sh script: [
                         './gradlew',
                         COMMON_GRADLE_PARAMS,

--- a/.ci/dev/open-j9/Jenkinsfile
+++ b/.ci/dev/open-j9/Jenkinsfile
@@ -3,6 +3,7 @@
  * Jenkins pipeline to build Corda OS release branches and tags.
  * PLEASE NOTE: we DO want to run a build for each commit!!!
  */
+@Library('corda-shared-build-pipeline-steps')
 
 /**
  * Sense environment

--- a/.ci/dev/open-j9/Jenkinsfile
+++ b/.ci/dev/open-j9/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
     stages {
         stage('Unit Tests') {
             steps {
+                authenticateGradleWrapper()
                 sh "./gradlew clean --continue test --info -Ptests.failFast=true"
             }
         }

--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     stages {
         stage('Detekt check') {
             steps {
+                authenticateGradleWrapper()
                 sh "./gradlew --no-daemon clean detekt"
             }
         }

--- a/.ci/dev/publish-api-docs/Jenkinsfile
+++ b/.ci/dev/publish-api-docs/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
         stage('Publish Archived API Docs to Artifactory') {
             when { tag pattern: /^docs-release-os-V(\d+\.\d+)(\.\d+){0,1}(-GA){0,1}(-\d{4}-\d\d-\d\d-\d{4}){0,1}$/, comparator: 'REGEXP' }
             steps {
+                authenticateGradleWrapper()
                 sh "./gradlew :clean :docs:artifactoryPublish -DpublishApiDocs"
             }
         }

--- a/.ci/dev/publish-branch/Jenkinsfile.nightly
+++ b/.ci/dev/publish-branch/Jenkinsfile.nightly
@@ -63,6 +63,7 @@ pipeline {
     stages {
         stage('Sonatype Check') {
             steps {
+                authenticateGradleWrapper()
                 sh "./gradlew --no-daemon clean jar"
                 script {
                     sh "./gradlew --no-daemon properties | grep -E '^(version|group):' >version-properties"

--- a/.ci/dev/publish-branch/Jenkinsfile.preview
+++ b/.ci/dev/publish-branch/Jenkinsfile.preview
@@ -29,6 +29,7 @@ pipeline {
     stages {
         stage('Publish to Artifactory') {
             steps {
+                authenticateGradleWrapper()
                 rtServer (
                         id: 'R3-Artifactory',
                         url: 'https://software.r3.com/artifactory',

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -3,6 +3,7 @@
  * Jenkins pipeline to build Corda OS release branches and tags.
  * PLEASE NOTE: we DO want to run a build for each commit!!!
  */
+@Library('corda-shared-build-pipeline-steps')
 
 /**
  * Sense environment
@@ -169,6 +170,7 @@ pipeline {
                         }
                         stage('Recompile') {
                             steps {
+                                authenticateGradleWrapper()
                                 sh script: [
                                         './gradlew',
                                         COMMON_GRADLE_PARAMS,

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
     stages {
         stage('Compile') {
             steps {
+                authenticateGradleWrapper()
                 sh script: [
                         './gradlew',
                         COMMON_GRADLE_PARAMS,

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -317,7 +317,7 @@ pipeline {
                             './gradlew',
                             COMMON_GRADLE_PARAMS,
                             'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/community-node',
+                            '-Pdocker.image.repository=corda/corda',
                             '--image OFFICIAL'
                             ].join(' ')
                 }

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -317,7 +317,7 @@ pipeline {
                             './gradlew',
                             COMMON_GRADLE_PARAMS,
                             'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/corda',
+                            '-Pdocker.image.repository=corda/community-node',
                             '--image OFFICIAL'
                             ].join(' ')
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,6 +94,7 @@ pipeline {
                         }
                         stage('Recompile') {
                             steps {
+                                authenticateGradleWrapper()
                                 sh script: [
                                         './gradlew',
                                         COMMON_GRADLE_PARAMS,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
     stages {
         stage('Compile') {
             steps {
+                authenticateGradleWrapper()
                 sh script: [
                         './gradlew',
                         COMMON_GRADLE_PARAMS,

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -42,12 +42,6 @@ enum ImageVariant {
     String dockerFile
     String javaVersion
 
-    String versionString(String baseTag, String version) {
-        return "${baseTag}-${knownAs}" +
-                (knownAs.isEmpty() ? "" : "-") +
-                "java${javaVersion}-" + version
-    }
-
     ImageVariant(ImageVariant other) {
         this.knownAs = other.knownAs
         this.dockerFile = other.dockerFile
@@ -64,16 +58,9 @@ enum ImageVariant {
         return project.properties.getOrDefault("docker.image.repository", "corda/corda")
     }
 
-    static private final String runTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
-
-    def getName(Project project) {
-        return versionString(getRepository(project), project.version.toString().toLowerCase())
-    }
-
     Set<Identifier> buildTags(Project project) {
-        final String suffix = project.version.toString().toLowerCase().contains("snapshot") ? runTime : "RELEASE"
-        return [suffix, "latest"].stream().map {
-            toAppend -> "${getName(project)}:${toAppend}".toString()
+        return ["${project.version.toString().toLowerCase()}-${knownAs}-${javaVersion}"].stream().map {
+            toAppend -> "${getRepository(project)}:${toAppend}".toString()
         }.map(Identifier.&fromCompoundString).collect(Collectors.toSet())
     }
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -33,25 +33,25 @@ shadowJar {
 }
 
 enum ImageVariant {
-    UBUNTU_ZULU("zulu", "Dockerfile", "1.8"),
-    UBUNTU_ZULU_11("zulu", "Dockerfile11", "11"),
-    AL_CORRETTO("corretto", "DockerfileAL", "1.8"),
+    UBUNTU_ZULU("Dockerfile", "1.8", "zulu-openjdk8"),
+    UBUNTU_ZULU_11("Dockerfile11", "11", "zulu-openjdk11"),
+    AL_CORRETTO("DockerfileAL", "1.8", "amazonlinux2"),
     OFFICIAL(UBUNTU_ZULU)
 
-    String knownAs
     String dockerFile
     String javaVersion
+    String baseImgaeFullName
 
     ImageVariant(ImageVariant other) {
-        this.knownAs = other.knownAs
         this.dockerFile = other.dockerFile
         this.javaVersion = other.javaVersion
+        this.baseImgaeFullName = other.baseImgaeFullName
     }
 
-    ImageVariant(String knownAs, String dockerFile, String javaVersion) {
-        this.knownAs = knownAs
+    ImageVariant(String dockerFile, String javaVersion, String baseImgaeFullName) {
         this.dockerFile = dockerFile
         this.javaVersion = javaVersion
+        this.baseImgaeFullName = baseImgaeFullName
     }
 
     static final String getRepository(Project project) {
@@ -59,7 +59,7 @@ enum ImageVariant {
     }
 
     Set<Identifier> buildTags(Project project) {
-        return ["${project.version.toString().toLowerCase()}-${knownAs}-${javaVersion}"].stream().map {
+        return ["${project.version.toString().toLowerCase()}-${baseImgaeFullName}"].stream().map {
             toAppend -> "${getRepository(project)}:${toAppend}".toString()
         }.map(Identifier.&fromCompoundString).collect(Collectors.toSet())
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Auth details removed from gradlew wrapper download - CI runs will use proxy local developers to use gradle servers