### PR TITLE
ENT-6677: NetworkMapCache cleared via command line now also updates node_named_identities table

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -455,7 +455,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         }
     }
 
-    fun clearNetworkMapCache() {
+    open fun clearNetworkMapCache() {
         Node.printBasicNodeInfo("Clearing network map cache entries")
         log.info("Starting clearing of network map cache entries...")
         startDatabase()

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -564,6 +564,11 @@ open class Node(configuration: NodeConfiguration,
         return super.generateAndSaveNodeInfo()
     }
 
+    override fun clearNetworkMapCache() {
+        initialiseSerialization()
+        super.clearNetworkMapCache()
+    }
+
     override fun runDatabaseMigrationScripts(
             updateCoreSchemas: Boolean,
             updateAppSchemas: Boolean,

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -455,7 +455,10 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
         database.transaction {
             val result = getAllNodeInfos(session)
             logger.debug { "Number of node infos to be cleared: ${result.size}" }
-            for (nodeInfo in result) session.remove(nodeInfo)
+            for (nodeInfo in result) {
+                session.remove(nodeInfo)
+                archiveNamedIdentity(session, nodeInfo.toNodeInfo())
+            }
         }
     }
 


### PR DESCRIPTION
When you clear the network map cache via the command line it now also updates node_named_identities table, which is used to store revoked identities.


