### PR TITLE
INFRA-1720: remove docker hub snapshot publishing from nightly 4.7

### DIFF
--- a/.ci/dev/publish-branch/Jenkinsfile.nightly
+++ b/.ci/dev/publish-branch/Jenkinsfile.nightly
@@ -112,22 +112,6 @@ pipeline {
                 )
             }
         }
-
-        stage('Publish Nightly to Docker Hub') {
-            steps {
-                withCredentials([
-                        usernamePassword(credentialsId: 'corda-publisher-docker-hub-credentials',
-                                usernameVariable: 'DOCKER_USERNAME',
-                                passwordVariable: 'DOCKER_PASSWORD')]) {
-                    sh script: [
-                            './gradlew',
-                            'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/corda',
-                            '--image OFFICIAL'
-                            ].join(' ')
-                }
-            }
-        }
     }
 
 


### PR DESCRIPTION
remove redundant publishing step