### PR TITLE
INFRA-1720: remove docker hub publishing from nightly job for 4.4

### DIFF
--- a/.ci/dev/publish-branch/Jenkinsfile.nightly
+++ b/.ci/dev/publish-branch/Jenkinsfile.nightly
@@ -113,16 +113,6 @@ pipeline {
             }
         }
 
-        stage('Publish Nightly to Docker Hub') {
-            steps {
-                withCredentials([
-                        usernamePassword(credentialsId: 'corda-publisher-docker-hub-credentials',
-                                usernameVariable: 'DOCKER_USERNAME',
-                                passwordVariable: 'DOCKER_PASSWORD')]) {
-                    sh "./gradlew pushOfficialImages"
-                }
-            }
-        }
     }
 
 


### PR DESCRIPTION
remove redundant code 