### PR TITLE
ENT-6286: Switch to official version of Artemis library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -405,7 +405,6 @@ allprojects {
                     includeGroup 'org.crashub'
                     includeGroup 'com.github.bft-smart'
                     includeGroup 'com.github.detro'
-                    includeGroup 'org.apache.activemq'
                 }
             }
             maven {


### PR DESCRIPTION
Version number is the same as ours - `2.19.1`, removing `includeGroup 'org.apache.activemq'` from Corda Dependencies repository, will make it fall back to Maven Central where the official version is available.

The change was tested in ENT by: https://github.com/corda/enterprise/pull/4396