### PR TITLE
ENT-6508 - Prevent directory traversal from zip file names

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -88,11 +88,11 @@ class NodeAttachmentService @JvmOverloads constructor(
 
             while (true) {
                 val cursor = jar.nextJarEntry ?: break
+                // Security check to stop directory traversal from filename entry
+                require(!(cursor.name.contains("../"))) { "Bad character in ${cursor.name}" }
+                require(!(cursor.name.contains("..\\"))) { "Bad character in ${cursor.name}" }
                 if (manifestHasEntries && !allManifestEntries!!.remove(cursor.name)) extraFilesNotFoundInEntries.add(cursor)
                 val entryPath = Paths.get(cursor.name)
-                // Security check to stop directory traversal from filename entry
-                require(!(cursor.name.contains("../"))) { "Bad character in $entryPath" }
-                require(!(cursor.name.contains("..\\"))) { "Bad character in $entryPath" }
                 // Security check to stop zips trying to escape their rightful place.
                 require(!entryPath.isAbsolute) { "Path $entryPath is absolute" }
                 require(entryPath.normalize() == entryPath) { "Path $entryPath is not normalised" }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -90,6 +90,9 @@ class NodeAttachmentService @JvmOverloads constructor(
                 val cursor = jar.nextJarEntry ?: break
                 if (manifestHasEntries && !allManifestEntries!!.remove(cursor.name)) extraFilesNotFoundInEntries.add(cursor)
                 val entryPath = Paths.get(cursor.name)
+                // Security check to stop directory traversal from filename entry
+                require(!(cursor.name.contains("../"))) { "Bad character in $entryPath" }
+                require(!(cursor.name.contains("..\\"))) { "Bad character in $entryPath" }
                 // Security check to stop zips trying to escape their rightful place.
                 require(!entryPath.isAbsolute) { "Path $entryPath is absolute" }
                 require(entryPath.normalize() == entryPath) { "Path $entryPath is not normalised" }


### PR DESCRIPTION
Validate there are no `../` or `..\` in zip jar entry file names.