### PR TITLE
ENT-6609 update docker images to ensure use 8u312

### DIFF
--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM azul/zulu-openjdk:8u312
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \
+    apt-mark hold zulu8-jdk && \
     apt-get -y upgrade && \
     apt-get -y install bash curl unzip && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/src/docker/DockerfileAL
+++ b/docker/src/docker/DockerfileAL
@@ -1,11 +1,10 @@
-FROM amazonlinux:2
+FROM amazoncorretto:8u312-al2
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
-RUN amazon-linux-extras enable corretto8 && \
-    yum -y install java-1.8.0-amazon-corretto-devel  && \
-    yum -y install bash && \
+RUN yum -y install bash && \
     yum -y install curl && \
     yum -y install unzip && \
+    yum -y install shadow-utils.x86_64 && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     mkdir -p /opt/corda/cordapps && \


### PR DESCRIPTION
As per our support matrix java version should be 8u312

Changes:

- Exclude java from apk upgrade of alpine image as this was bumping the java version after base image stage
- Use correct Amazon Corretto Base image for 8u312 , shadow-utils.x86_64 added here as groupadd command was not available in this new base image