### PR TITLE
ENT-6609 update docker images so repo for community edition is corda/community

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -319,7 +319,7 @@ pipeline {
                             './gradlew',
                             COMMON_GRADLE_PARAMS,
                             'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/corda',
+                            '-Pdocker.image.repository=corda/community',
                             '--image OFFICIAL'
                             ].join(' ')
                 }


### PR DESCRIPTION
Docker hub repo for Corda community edition should be corda/community rather than corda/corda