### PR TITLE
ENT-6687: Updated build.gradle so corda-shell is copied into drivers directory

### DIFF
--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -31,6 +31,7 @@ configurations {
 }
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
     compile "javax.servlet:javax.servlet-api:${servlet_version}"

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'net.corda.plugins.cordformation'
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // The bank of corda CorDapp depends upon Cash CorDapp features

--- a/samples/cordapp-configuration/build.gradle
+++ b/samples/cordapp-configuration/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'idea'
 apply plugin: 'net.corda.plugins.cordformation'
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     runtimeOnly project(':node-api')
     // Cordformation needs a SLF4J implementation when executing the Network
     // Bootstrapper, but Log4J doesn't shutdown completely from within Gradle.

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -27,6 +27,7 @@ cordapp {
 }
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     cordapp project(':finance:contracts')
     cordapp project(':finance:workflows')
 

--- a/samples/network-verifier/build.gradle
+++ b/samples/network-verifier/build.gradle
@@ -12,6 +12,7 @@ cordapp {
 }
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     // Cordformation needs this for the Network Bootstrapper.
     runtimeOnly project(':node-api')
 

--- a/samples/notary-demo/build.gradle
+++ b/samples/notary-demo/build.gradle
@@ -15,6 +15,7 @@ cordapp {
 }
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     cordaCompile project(':client:rpc')
     // Corda integration dependencies

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -26,6 +26,7 @@ configurations {
 }
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     cordaCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // The SIMM demo CorDapp depends upon Cash CorDapp features

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -32,6 +32,7 @@ configurations {
 }
 
 dependencies {
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
     cordaCompile project(':client:rpc')


### PR DESCRIPTION
Updated build.gradle so corda-shell is copied into drivers directory. This is just for the sample code in samples directory.