### PR TITLE
ENT-6637 & ENT-6618: Removed jgroups and dbcp from artemis dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,6 +460,8 @@ allprojects {
             // Netty-All is an uber-jar which contains every Netty module.
             // Exclude it to force us to use the individual Netty modules instead.
             exclude group: 'io.netty', module: 'netty-all'
+
+            exclude group: 'org.jgroups', module: 'jgroups'
         }
         runtime {
             // We never want isolated.jar on classPath, since we want to test jar being dynamically loaded as an attachment

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -127,7 +127,9 @@ dependencies {
     // TODO: remove the forced update of commons-collections and beanutils when artemis updates them
     compile "org.apache.commons:commons-collections4:${commons_collections_version}"
     compile "commons-beanutils:commons-beanutils:${beanutils_version}"
-    compile "org.apache.activemq:artemis-server:${artemis_version}"
+    compile("org.apache.activemq:artemis-server:${artemis_version}") {
+        exclude group: 'org.apache.commons', module: 'commons-dbcp2'
+    }
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
     runtime("org.apache.activemq:artemis-amqp-protocol:${artemis_version}") {
         // Gains our proton-j version from core module.


### PR DESCRIPTION
Removed jgroups and dbcp from artemis dependencies. This is due to the fact they are generating CVE's.