### PR TITLE
ENT-6711 - Fix for upgrade to Jackson 2.12 and beyond (actual upgrade to 2.13.1)

### DIFF
--- a/.ci/dev/compatibility/DockerfileJDK11
+++ b/.ci/dev/compatibility/DockerfileJDK11
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:11
+FROM azul/zulu-openjdk:11.0.14
 RUN apt-get update && apt-get install -y curl apt-transport-https \
                                               ca-certificates \
                                               curl \

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ buildscript {
     ext.asm_version = '7.1'
     ext.artemis_version = '2.19.1'
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.11.1'
+    ext.jackson_version = '2.12.6'
     ext.jackson_kotlin_version = '2.9.7'
     ext.jetty_version = '9.4.19.v20190610'
     ext.jersey_version = '2.25'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ buildscript {
     ext.asm_version = '7.1'
     ext.artemis_version = '2.19.1'
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.12.6'
+    ext.jackson_version = '2.13.1'
     ext.jackson_kotlin_version = '2.9.7'
     ext.jetty_version = '9.4.19.v20190610'
     ext.jersey_version = '2.25'

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -2,10 +2,24 @@ package net.corda.client.jackson
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.*
-import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.Module
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
 import com.fasterxml.jackson.databind.deser.std.NumberDeserializers
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -21,9 +35,21 @@ import net.corda.core.DoNotImplement
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.*
-import net.corda.core.identity.*
-import net.corda.core.internal.*
+import net.corda.core.crypto.Base58
+import net.corda.core.crypto.MerkleTree
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.toStringShort
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.internal.CertRole
+import net.corda.core.internal.VisibleForTesting
+import net.corda.core.internal.isStatic
+import net.corda.core.internal.kotlinObjectInstance
+import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.IdentityService
@@ -179,6 +205,8 @@ object JacksonSupport {
             addMixIn(X500Principal::class.java, X500PrincipalMixin::class.java)
             addMixIn(X509Certificate::class.java, X509CertificateMixin::class.java)
             addMixIn(CertPath::class.java, CertPathMixin::class.java)
+
+            setConstructorDetector(ConstructorDetector.DEFAULT.withAllowJDKTypeConstructors(true))
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -584,7 +584,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
 
     private object MapSerializer : JsonSerializer<Map<Any, Any>>() {
         override fun serialize(map: Map<Any, Any>, gen: JsonGenerator, serializers: SerializerProvider) {
-            gen.writeStartArray(map, map.size)
+            gen.writeStartArray()
             map.forEach { (key, value) ->
                 gen.jsonObject {
                     writeObjectField("key", key)

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -584,7 +584,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
 
     private object MapSerializer : JsonSerializer<Map<Any, Any>>() {
         override fun serialize(map: Map<Any, Any>, gen: JsonGenerator, serializers: SerializerProvider) {
-            gen.writeStartArray(map.size)
+            gen.writeStartArray(map, map.size)
             map.forEach { (key, value) ->
                 gen.jsonObject {
                     writeObjectField("key", key)

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -9,7 +9,7 @@ plugins {
 ext['artemis.version'] = "$artemis_version"
 ext['hibernate.version'] = "$hibernate_version"
 ext['selenium.version'] = "$selenium_version"
-ext['jackson.version'] = "$jackson_version"
+ext['jackson.version'] = "$jackson_kotlin_version"
 ext['dropwizard-metrics.version'] = "$metrics_version"
 ext['mockito.version'] = "$mockito_version"
 

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -9,6 +9,7 @@ plugins {
 ext['artemis.version'] = "$artemis_version"
 ext['hibernate.version'] = "$hibernate_version"
 ext['selenium.version'] = "$selenium_version"
+// Using jackson_kotlin_version here for JDK11 compatibility with kotlin 1.2.71
 ext['jackson.version'] = "$jackson_kotlin_version"
 ext['dropwizard-metrics.version'] = "$metrics_version"
 ext['mockito.version'] = "$mockito_version"


### PR DESCRIPTION
1. Had to re-enable JDK classes as we rely on them for X500Principal, and disabled by default in 2.12 onwards.
2. Our CordaSerializableClassIntrospector was overriding a method that was deprecated in 2.12 in favour of one with a different signature, so we needed to override that too otherwise it was not called by Jackson.