### PR TITLE
ENT-6637: Targeted exclude of the jgroups dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,8 +460,6 @@ allprojects {
             // Netty-All is an uber-jar which contains every Netty module.
             // Exclude it to force us to use the individual Netty modules instead.
             exclude group: 'io.netty', module: 'netty-all'
-
-            exclude group: 'org.jgroups', module: 'jgroups'
         }
         runtime {
             // We never want isolated.jar on classPath, since we want to test jar being dynamically loaded as an attachment

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -55,7 +55,9 @@ dependencies {
     // TODO: remove the forced update of commons-collections and beanutils when artemis updates them
     compile "org.apache.commons:commons-collections4:${commons_collections_version}"
     compile "commons-beanutils:commons-beanutils:${beanutils_version}"
-    compile "org.apache.activemq:artemis-core-client:${artemis_version}"
+    compile("org.apache.activemq:artemis-core-client:${artemis_version}") {
+        exclude group: 'org.jgroups', module: 'jgroups'
+    }
 
     // Unit testing helpers.
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -17,7 +17,9 @@ dependencies {
     // TODO: remove the forced update of commons-collections and beanutils when artemis updates them
     compile "org.apache.commons:commons-collections4:${commons_collections_version}"
     compile "commons-beanutils:commons-beanutils:${beanutils_version}"
-    compile "org.apache.activemq:artemis-core-client:${artemis_version}"
+    compile("org.apache.activemq:artemis-core-client:${artemis_version}") {
+        exclude group: 'org.jgroups', module: 'jgroups'
+    }
     compile "org.apache.activemq:artemis-commons:${artemis_version}"
 
     compile "io.netty:netty-handler-proxy:$netty_version"
@@ -62,6 +64,7 @@ dependencies {
     compile ("org.apache.activemq:artemis-amqp-protocol:${artemis_version}") {
         // Gains our proton-j version from core module.
         exclude group: 'org.apache.qpid', module: 'proton-j'
+        exclude group: 'org.jgroups', module: 'jgroups'
     }
 }
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -129,11 +129,15 @@ dependencies {
     compile "commons-beanutils:commons-beanutils:${beanutils_version}"
     compile("org.apache.activemq:artemis-server:${artemis_version}") {
         exclude group: 'org.apache.commons', module: 'commons-dbcp2'
+        exclude group: 'org.jgroups', module: 'jgroups'
     }
-    compile "org.apache.activemq:artemis-core-client:${artemis_version}"
+    compile("org.apache.activemq:artemis-core-client:${artemis_version}") {
+        exclude group: 'org.jgroups', module: 'jgroups'
+    }
     runtime("org.apache.activemq:artemis-amqp-protocol:${artemis_version}") {
         // Gains our proton-j version from core module.
         exclude group: 'org.apache.qpid', module: 'proton-j'
+        exclude group: 'org.jgroups', module: 'jgroups'
     }
 
     // Manifests: for reading stuff from the manifest file


### PR DESCRIPTION
ENT-6637: Now a more targeted exclude of the jgroups dependency.