### PR TITLE
ENT-6685: Add s3 publish to allow Corda CE downloading binaries from download.corda.net

### DIFF
--- a/.ci/dev/compatibility/DockerfileJDK11
+++ b/.ci/dev/compatibility/DockerfileJDK11
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:11
+FROM azul/zulu-openjdk:11.0.14
 RUN apt-get update && apt-get install -y curl apt-transport-https \
                                               ca-certificates \
                                               curl \

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -375,7 +375,7 @@ pipeline {
             }
             steps {
                     build job: "uploadToS3",
-                    parameters: [password(name: "GPG_KEY_PASS", value: params.GPG_KEY_PASS), string(name: 'UPSTREAM_VERSION_SUFFIX', value: env.VERSION_SUFFIX), string(name: 'UPSTREAM_PROJECT_NAME', value: 'upload-test'), string(name: "RELEASE_TYPE", value:'RC' )]
+                    parameters: [password(name: "GPG_KEY_PASS", value: params.GPG_KEY_PASS), string(name: 'UPSTREAM_VERSION_SUFFIX', value: env.VERSION_SUFFIX), string(name: 'UPSTREAM_PROJECT_NAME', value: env.JOB_NAME), string(name: "RELEASE_TYPE", value: "${isReleaseCandidate ? 'RC' : 'GA'}" )]
 
             }
         }

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -3,6 +3,7 @@
  * Jenkins pipeline to build Corda OS release branches and tags.
  * PLEASE NOTE: we DO want to run a build for each commit!!!
  */
+@Library('corda-shared-build-pipeline-steps')
 
 /**
  * Sense environment
@@ -325,6 +326,61 @@ pipeline {
                 }
             }
         }
+
+		stage('Prepare for S3 upload') {
+
+		    when {
+                expression { isReleaseTag }
+            }
+            steps {
+                script {
+                    sh 'rm -rf build/downloaded-files'
+                    def propsFile = readProperties  file:'constants.properties'
+                    version="${propsFile['cordaVersion']}-${propsFile['versionSuffix']}"
+
+                    withEnv(["CORDA_VERSION=${version}"]) {
+						rtDownload(
+								serverId: 'R3 Artifactory',
+								spec: '''{
+									"files": [
+										{
+										"pattern" : "corda-releases/net/corda/*/${CORDA_VERSION}/*.jar",
+										"target" : "build/downloaded-files/community/",
+										"flat" : true,
+										"sortBy" : ["created"],
+										"sortOrder" : "desc"
+										}
+								   ]
+								}''',
+						)
+					}
+
+                    tar file: 'communityBinaries.tar', archive: false, dir: 'build/downloaded-files/community',overwrite: true
+                    zip zipFile: 'communityBinaries.zip', archive: false, dir: 'build/downloaded-files/community',overwrite: true
+
+                    // create S3 properties file
+                    sh 'mkdir build/downloaded-files/community/communityArchives'
+                    writeFile file: 'build/downloaded-files/community/communityArchives.upload.properties', text: "path=corda-community-edition/${version}"
+
+                    // clean up and final archive
+                    sh 'rm -rf build/downloaded-files/community/*jar && mv communityBinaries* build/downloaded-files/community/communityArchives'
+                    tar file: 'toUpload.tar.gz', archive: true, dir: 'build/downloaded-files/community', overwrite: true
+                }
+            }
+        }
+
+		stage('S3 Upload') {
+		    when {
+                expression { isReleaseTag }
+            }
+            steps {
+                    build job: "uploadToS3",
+                    parameters: [password(name: "GPG_KEY_PASS", value: params.GPG_KEY_PASS), string(name: 'UPSTREAM_VERSION_SUFFIX', value: env.VERSION_SUFFIX), string(name: 'UPSTREAM_PROJECT_NAME', value: 'upload-test'), string(name: "RELEASE_TYPE", value:'RC' )]
+
+            }
+        }
+
+
     }
 
     post {

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -3,7 +3,6 @@
  * Jenkins pipeline to build Corda OS release branches and tags.
  * PLEASE NOTE: we DO want to run a build for each commit!!!
  */
-@Library('corda-shared-build-pipeline-steps')
 
 /**
  * Sense environment

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -317,7 +317,7 @@ pipeline {
                             './gradlew',
                             COMMON_GRADLE_PARAMS,
                             'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/community-node',
+                            '-Pdocker.image.repository=corda/corda',
                             '--image OFFICIAL'
                             ].join(' ')
                 }

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -317,7 +317,7 @@ pipeline {
                             './gradlew',
                             COMMON_GRADLE_PARAMS,
                             'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/corda',
+                            '-Pdocker.image.repository=corda/community-node',
                             '--image OFFICIAL'
                             ].join(' ')
                 }

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -42,12 +42,6 @@ enum ImageVariant {
     String dockerFile
     String javaVersion
 
-    String versionString(String baseTag, String version) {
-        return "${baseTag}-${knownAs}" +
-                (knownAs.isEmpty() ? "" : "-") +
-                "java${javaVersion}-" + version
-    }
-
     ImageVariant(ImageVariant other) {
         this.knownAs = other.knownAs
         this.dockerFile = other.dockerFile
@@ -64,16 +58,9 @@ enum ImageVariant {
         return project.properties.getOrDefault("docker.image.repository", "corda/corda")
     }
 
-    static private final String runTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
-
-    def getName(Project project) {
-        return versionString(getRepository(project), project.version.toString().toLowerCase())
-    }
-
     Set<Identifier> buildTags(Project project) {
-        final String suffix = project.version.toString().toLowerCase().contains("snapshot") ? runTime : "RELEASE"
-        return [suffix, "latest"].stream().map {
-            toAppend -> "${getName(project)}:${toAppend}".toString()
+        return ["${project.version.toString().toLowerCase()}-${knownAs}-${javaVersion}"].stream().map {
+            toAppend -> "${getRepository(project)}:${toAppend}".toString()
         }.map(Identifier.&fromCompoundString).collect(Collectors.toSet())
     }
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -33,25 +33,25 @@ shadowJar {
 }
 
 enum ImageVariant {
-    UBUNTU_ZULU("zulu", "Dockerfile", "1.8"),
-    UBUNTU_ZULU_11("zulu", "Dockerfile11", "11"),
-    AL_CORRETTO("corretto", "DockerfileAL", "1.8"),
+    UBUNTU_ZULU("Dockerfile", "1.8", "zulu-openjdk8"),
+    UBUNTU_ZULU_11("Dockerfile11", "11", "zulu-openjdk11"),
+    AL_CORRETTO("DockerfileAL", "1.8", "amazonlinux2"),
     OFFICIAL(UBUNTU_ZULU)
 
-    String knownAs
     String dockerFile
     String javaVersion
+    String baseImgaeFullName
 
     ImageVariant(ImageVariant other) {
-        this.knownAs = other.knownAs
         this.dockerFile = other.dockerFile
         this.javaVersion = other.javaVersion
+        this.baseImgaeFullName = other.baseImgaeFullName
     }
 
-    ImageVariant(String knownAs, String dockerFile, String javaVersion) {
-        this.knownAs = knownAs
+    ImageVariant(String dockerFile, String javaVersion, String baseImgaeFullName) {
         this.dockerFile = dockerFile
         this.javaVersion = javaVersion
+        this.baseImgaeFullName = baseImgaeFullName
     }
 
     static final String getRepository(Project project) {
@@ -59,7 +59,7 @@ enum ImageVariant {
     }
 
     Set<Identifier> buildTags(Project project) {
-        return ["${project.version.toString().toLowerCase()}-${knownAs}-${javaVersion}"].stream().map {
+        return ["${project.version.toString().toLowerCase()}-${baseImgaeFullName}"].stream().map {
             toAppend -> "${getRepository(project)}:${toAppend}".toString()
         }.map(Identifier.&fromCompoundString).collect(Collectors.toSet())
     }


### PR DESCRIPTION
Update Jenkins logic to 

- pull all Jars associated with previous publish stage if it is a release tag
- ZIp and Tar these
- Build up s3 properties file
- Archive all of this
- Call downstream s3 publishing job.

Note to reviewer this logic has been tested here: https://ci02.dev.r3.com/job/Corda5/job/upload-test/ 

Also update JDK 11 base image needed for Compatibility PR gate