### PR TITLE
INFRA-1728 set correct java version for JDK 11 base image

### DIFF
--- a/.ci/dev/compatibility/DockerfileJDK11
+++ b/.ci/dev/compatibility/DockerfileJDK11
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:11
+FROM azul/zulu-openjdk:11.0.14
 RUN apt-get update && apt-get install -y curl apt-transport-https \
                                               ca-certificates \
                                               curl \


### PR DESCRIPTION
Use Specific JDK version not the latest Java 11 base image
