### PR TITLE
NOTICK: add flag to ensure API docs are published as part of release

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -271,7 +271,7 @@ pipeline {
                 rtGradleRun(
                         usesPlugin: true,
                         useWrapper: true,
-                        switches: '-s --info',
+                        switches: '-s --info -DpublishApiDocs',
                         tasks: 'artifactoryPublish',
                         deployerId: 'deployer',
                         buildName: env.ARTIFACTORY_BUILD_NAME


### PR DESCRIPTION
Publish of api-docs expects publishApiDocs flag present to ensure publishing, this should happen as part of release tag builds