### PR TITLE
ENT-6728: Archiving of a legal identity now done in its own txn

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
@@ -15,4 +15,6 @@ interface IdentityServiceInternal : IdentityService {
     fun verifyAndRegisterNewRandomIdentity(identity: PartyAndCertificate)
 
     fun invalidateCaches(name: CordaX500Name) {}
+
+    fun archiveNamedIdentity(name:String, publicKeyHash: String?) {}
 }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -378,7 +378,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
         return resultList.last().publicKeyHash
     }
 
-    private fun archiveNamedIdentity(name:String, publicKeyHash: String?) {
+    override fun archiveNamedIdentity(name:String, publicKeyHash: String?) {
         archiveIdentityExecutor.submit {
             database.transaction {
                 val deleteQuery = session.criteriaBuilder.createCriteriaDelete(PersistentNetworkMapCache.PersistentPartyToPublicKeyHash::class.java)


### PR DESCRIPTION
Archiving of a legal identity now done in its own txn, to cope with clustered notary nodes that have common legal identities between nodes (the service name one is common)

