### PR TITLE
ENT-6716 Remove Corda OS image publishing to Docker hub for CE4.8.x patches and below

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -11,6 +11,7 @@ boolean isReleaseBranch = (env.BRANCH_NAME =~ /^release\/os\/.*/)
 boolean isReleaseTag = (env.TAG_NAME =~ /^release-.*(?<!_JDK11)$/)
 boolean isInternalRelease = (env.TAG_NAME =~ /^internal-release-.*$/)
 boolean isReleaseCandidate = (env.TAG_NAME =~ /^(release-.*(RC|HC).*(?<!_JDK11))$/)
+boolean isReleasePatch = (env.TAG_NAME =~ /^release.*([1-9]\d*|0)(\.([1-9]\d*|0)){2}$/)
 
 /*
 ** calculate the stage for NexusIQ evaluation
@@ -307,7 +308,7 @@ pipeline {
 
         stage('Publish Release to Docker Hub') {
             when {
-                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate}
+                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate && !isReleasePatch}
             }
             steps {
                 withCredentials([


### PR DESCRIPTION
Adding in Patch Tag check (boolean regex) so patches are not released to Docker Hub

Mocked and tested on:
https://ci03.dev.r3.com/job/Build-Team-Test-Repo/job/release%252Fos%252F9.99/
https://ci03.dev.r3.com/job/Build-Team-Test-Repo/view/tags/job/release-os-test-9.9.9/
https://ci03.dev.r3.com/job/Build-Team-Test-Repo/view/tags/job/release-os-test-9.99/