### PR TITLE
NOTICK: Force Gradle to use the most recent SNAPSHOTs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,8 @@ buildscript {
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8"
     }
 
-    configurations.all {
+    configurations.classpath {
+        // FORCE Gradle to use latest SNAPSHOT plugins.
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }
 }
@@ -472,6 +473,9 @@ allprojects {
                     substitute module('org.jetbrains.kotlin:kotlin-stdlib') with module("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
                     substitute module('org.jetbrains.kotlin:kotlin-reflect') with module("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
                 }
+
+                // FORCE Gradle to use latest SNAPSHOT dependencies.
+                cacheChangingModulesFor 0, 'seconds'
             }
         }
     }


### PR DESCRIPTION
The only Gradle configuration that matters inside the `buildscript` is the plugins' `classpath` configuration, so configure its `resolutionStrategy` not to cache SNAPSHOTs. Outside the `buildscript`, only configure the "*Classpath" configurations not to cache SNAPSHOTs. (There's no point setting a `resolutionStrategy` on a configuration that cannot be resolved in the first place.)