### PR TITLE
ENT-6748: Make sure correct artemis is picked up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -380,6 +380,12 @@ allprojects {
 
     repositories {
         mavenLocal()
+        // Prevents cache giving use the wrong artemis
+        mavenCentral {
+            content {
+                includeGroup 'org.apache.activemq'
+            }
+        }
         // Use system environment to activate caching with Artifactory,
         // because it is actually easier to pass that during parallel build.
         // NOTE: it has to be a name of a virtual repository with all


### PR DESCRIPTION
This makes sure that artemis from maven central is picked up, rather than the one in our cache.