### PR TITLE
ENT-6743: SuspensionMeta in FlowInfo is null when a runnable flow has previously been hospitalized

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -103,17 +103,6 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
      * Flows should be removed from [flowsInHospital] when they have completed a successful transition.
      */
     private val flowsInHospital = ConcurrentHashMap<StateMachineRunId, FlowFiber>()
-
-    /**
-     * Returns true if the flow is currently being treated in the hospital.
-     * The differs to flows with a medical history (which can accessed via [StaffedFlowHospital.contains]).
-     */
-    @VisibleForTesting
-    internal fun flowInHospital(runId: StateMachineRunId): Boolean {
-        // The .keys avoids https://youtrack.jetbrains.com/issue/KT-18053
-        return runId in flowsInHospital.keys
-    }
-
     private val mutex = ThreadBox(object {
         /**
          * Contains medical history of every flow (a patient) that has entered the hospital. A flow can leave the hospital,
@@ -347,7 +336,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
         }
     }
 
-    operator fun contains(flowId: StateMachineRunId) = mutex.locked { flowId in flowPatients }
+    operator fun contains(flowId: StateMachineRunId) = flowId in flowsInHospital.keys
 
     override fun close() {
         hospitalJobTimer.cancel()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -6,7 +6,6 @@ import net.corda.core.flows.Destination
 import net.corda.core.flows.FlowInfo
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
-import net.corda.core.flows.HospitalizeFlowException
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.KilledFlowException
@@ -30,7 +29,6 @@ import net.corda.testing.node.internal.MessagingServiceSpy
 import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.newContext
-import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.h2.util.Utils
@@ -49,7 +47,6 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -324,25 +321,6 @@ class RetryFlowMockTest {
             val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES,
                     DBTransactionStorage.TransactionStatus.VERIFIED, Instant.now())
             contextTransaction.session.save(tx)
-        }
-    }
-
-    class HospitalizeThenSucceedFlow : FlowLogic<Boolean>() {
-        companion object {
-            var runs = 0
-            var flowRetried = Semaphore(0)
-            var flowWillReturn = Semaphore(0)
-        }
-
-        @Suspendable
-        override fun call(): Boolean {
-            if (runs == 0) {
-                runs++
-                throw HospitalizeFlowException("Hospitalize on first run")
-            }
-            flowRetried.release()
-            flowWillReturn.acquire()
-            return true
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt
@@ -6,6 +6,7 @@ import net.corda.core.flows.Destination
 import net.corda.core.flows.FlowInfo
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
+import net.corda.core.flows.HospitalizeFlowException
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.KilledFlowException
@@ -29,6 +30,7 @@ import net.corda.testing.node.internal.MessagingServiceSpy
 import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.newContext
+import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.h2.util.Utils
@@ -47,6 +49,7 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -321,6 +324,25 @@ class RetryFlowMockTest {
             val tx = DBTransactionStorage.DBTransaction("Foo", null, Utils.EMPTY_BYTES,
                     DBTransactionStorage.TransactionStatus.VERIFIED, Instant.now())
             contextTransaction.session.save(tx)
+        }
+    }
+
+    class HospitalizeThenSucceedFlow : FlowLogic<Boolean>() {
+        companion object {
+            var runs = 0
+            var flowRetried = Semaphore(0)
+            var flowWillReturn = Semaphore(0)
+        }
+
+        @Suspendable
+        override fun call(): Boolean {
+            if (runs == 0) {
+                runs++
+                throw HospitalizeFlowException("Hospitalize on first run")
+            }
+            flowRetried.release()
+            flowWillReturn.acquire()
+            return true
         }
     }
 


### PR DESCRIPTION
Cherry pick of ENT-6743, which is the following:
Previously the 'contains' of StaffedFlowHospital method would check the flowPatients variable to determine if the flow was in the hospital. Problem is the flowPatients stores the medical history, this is kept until the flow is completed. Which meant the method would return true until the flow completed.
'contains' method now checks the flowsInHospital map to determine if flow is in hospital, so when it leaves hospital but not yet completes the flow it returns correct value.