### PR TITLE
CORDA-4257: Do not emit warning when StatePointer.isResolved = false

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -741,9 +741,11 @@ open class TransactionBuilder(
                     addReferenceState(resolvedStateAndRef.referenced())
                 }
             } else {
-                log.warn("WARNING: You must pass in a ServiceHub reference to TransactionBuilder to resolve " +
-                        "state pointers outside of flows. If you are writing a unit test then pass in a " +
-                        "MockServices instance.")
+                if (nextStatePointer.isResolved) {
+                    log.warn("WARNING: You must pass in a ServiceHub reference to TransactionBuilder to resolve " +
+                            "state pointers outside of flows. If you are writing a unit test then pass in a " +
+                            "MockServices instance.")
+                }
                 return
             }
         }


### PR DESCRIPTION
The warning is quite misleading because it is emitted in the case where the `ServiceHub` reference on `TransactionBuilder` is not `null`, but one or more state pointers were configured to not be automatically resolved by the transaction builder. When using the default arguments for the smart constructors on `StatePointer.Companion` this includes all static pointers.

# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- ~[ ] If you added public APIs, did you write the JavaDocs/kdocs?~
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
