### PR TITLE
ENT-6791 New service lifecycle event published just before starting the state machine

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/ServiceLifecycleObserver.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/ServiceLifecycleObserver.kt
@@ -25,6 +25,7 @@ enum class ServiceLifecycleEvent {
      * sense for Corda node to continue its operation. The lifecycle events dispatcher will endeavor to terminate node's JVM as soon
      * as practically possible.
      */
+    BEFORE_STATE_MACHINE_START,
     STATE_MACHINE_STARTED,
 }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/lifecycle/NodeLifecycleObserver.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/lifecycle/NodeLifecycleObserver.kt
@@ -49,6 +49,7 @@ interface NodeLifecycleObserver {
 sealed class NodeLifecycleEvent(val reversedPriority: Boolean = false) {
     class BeforeNodeStart(val nodeInitialContext: NodeInitialContext) : NodeLifecycleEvent()
     class AfterNodeStart<out T : NodeServicesContext>(val nodeServicesContext: T) : NodeLifecycleEvent()
+    class BeforeStateMachineStart<out T : NodeServicesContext>(val nodeServicesContext: T) : NodeLifecycleEvent()
     class StateMachineStarted<out T : NodeServicesContext>(val nodeServicesContext: T) : NodeLifecycleEvent()
     class StateMachineStopped<out T : NodeServicesContext>(val nodeServicesContext: T) : NodeLifecycleEvent(reversedPriority = true)
     class BeforeNodeStop<out T : NodeServicesContext>(val nodeServicesContext: T) : NodeLifecycleEvent(reversedPriority = true)

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
@@ -16,6 +16,7 @@ import net.corda.core.internal.concurrent.transpose
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
+import net.corda.core.node.services.ServiceLifecycleEvent
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -350,7 +351,7 @@ class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
             val alice = startNode(providedName = ALICE_NAME).getOrThrow()
 
             val entities =
-                alice.rpc.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(20.seconds)
+                alice.rpc.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(2000.seconds)
             assertEquals(3, entities.size)
             assertEquals(0, counter)
         }
@@ -854,19 +855,25 @@ class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
         init {
             if (includeRawUpdates) {
                 services.register {
-                    services.vaultService.rawUpdates.subscribe {
-                        if (insertionType == InsertionType.ENTITY_MANAGER) {
-                            services.withEntityManager {
-                                persist(entityWithIdOne)
-                                persist(entityWithIdTwo)
-                                persist(entityWithIdThree)
-                            }
-                        } else {
-                            services.jdbcSession().run {
-                                insert(entityWithIdOne)
-                                insert(entityWithIdTwo)
-                                insert(entityWithIdThree)
-                            }
+                    processEvent(it)
+                }
+            }
+        }
+
+        private fun processEvent(event : ServiceLifecycleEvent) {
+            if (event == ServiceLifecycleEvent.STATE_MACHINE_STARTED) {
+                services.vaultService.rawUpdates.subscribe {
+                    if (insertionType == InsertionType.ENTITY_MANAGER) {
+                        services.withEntityManager {
+                            persist(entityWithIdOne)
+                            persist(entityWithIdTwo)
+                            persist(entityWithIdThree)
+                        }
+                    } else {
+                        services.jdbcSession().run {
+                            insert(entityWithIdOne)
+                            insert(entityWithIdTwo)
+                            insert(entityWithIdThree)
                         }
                     }
                 }

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowEntityManagerTest.kt
@@ -351,7 +351,7 @@ class FlowEntityManagerTest : AbstractFlowEntityManagerTest() {
             val alice = startNode(providedName = ALICE_NAME).getOrThrow()
 
             val entities =
-                alice.rpc.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(2000.seconds)
+                alice.rpc.startFlow(::EntityManagerWithinTheSameDatabaseTransactionFlow).returnValue.getOrThrow(20.seconds)
             assertEquals(3, entities.size)
             assertEquals(0, counter)
         }

--- a/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleFatalTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleFatalTests.kt
@@ -51,12 +51,14 @@ class CordaServiceLifecycleFatalTests {
 
         object FailingObserver : ServiceLifecycleObserver {
             override fun onServiceLifecycleEvent(event: ServiceLifecycleEvent) {
-                val tmpFile = File(System.getProperty(tempFilePropertyName))
-                tmpFile.appendText("\n" + readyToThrowMarker)
-                eventually(duration = 30.seconds) {
-                    assertEquals(goodToThrowMarker, tmpFile.readLines().last())
+                if (event == ServiceLifecycleEvent.STATE_MACHINE_STARTED) {
+                    val tmpFile = File(System.getProperty(tempFilePropertyName))
+                    tmpFile.appendText("\n" + readyToThrowMarker)
+                    eventually(duration = 30.seconds) {
+                        assertEquals(goodToThrowMarker, tmpFile.readLines().last())
+                    }
+                    throw CordaServiceCriticalFailureException("controlled failure")
                 }
-                throw CordaServiceCriticalFailureException("controlled failure")
             }
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
@@ -7,6 +7,7 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.node.services.ServiceLifecycleEvent
+import net.corda.core.node.services.ServiceLifecycleEvent.BEFORE_STATE_MACHINE_START
 import net.corda.core.node.services.ServiceLifecycleEvent.STATE_MACHINE_STARTED
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.getOrThrow
@@ -34,8 +35,8 @@ class CordaServiceLifecycleTests {
             node.rpc.startFlow(::ComputeTextLengthThroughCordaService, TEST_PHRASE).returnValue.getOrThrow()
         }
         assertEquals(TEST_PHRASE.length, result)
-        assertEquals(1, eventsCaptured.size)
-        assertEquals(listOf(STATE_MACHINE_STARTED), eventsCaptured)
+        assertEquals(2, eventsCaptured.size)
+        assertEquals(listOf(BEFORE_STATE_MACHINE_START, STATE_MACHINE_STARTED), eventsCaptured)
     }
 
     @StartableByRPC

--- a/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
@@ -3,6 +3,7 @@ package net.corda.node.services
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.StartableByService
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
@@ -13,9 +14,13 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.InProcess
 import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.enclosedCordapp
+import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.TimeUnit
+
 import kotlin.test.assertEquals
 
 class CordaServiceLifecycleTests {
@@ -23,23 +28,91 @@ class CordaServiceLifecycleTests {
     private companion object {
         const val TEST_PHRASE = "testPhrase"
 
+        // the number of times to register a service callback
+        private var numServiceCallbacks = 0
+        // the set of events a test wants to capture
+        private var eventsToBeCaptured: MutableSet<ServiceLifecycleEvent> = mutableSetOf()
+        // the events that were actually captured in a test
         private val eventsCaptured: MutableList<ServiceLifecycleEvent> = mutableListOf()
+
+    }
+
+    @Before
+    fun setup() {
+        numServiceCallbacks = 1
+        eventsCaptured.clear()
+        eventsToBeCaptured = setOf(BEFORE_STATE_MACHINE_START, STATE_MACHINE_STARTED).toMutableSet()
     }
 
     @Test(timeout=300_000)
 	fun `corda service receives events`() {
-        eventsCaptured.clear()
+        val result = driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = listOf(enclosedCordapp()),
+                notarySpecs = emptyList())) {
+            val node = startNode(providedName = ALICE_NAME).getOrThrow()
+            node.rpc.startFlow(::ComputeTextLengthThroughCordaService, TEST_PHRASE).returnValue.getOrThrow()
+        }
+        val expectedEventsAndTheOrderTheyOccurIn = listOf(BEFORE_STATE_MACHINE_START, STATE_MACHINE_STARTED)
+        assertEquals(TEST_PHRASE.length, result)
+        assertEquals(numServiceCallbacks * 2, eventsCaptured.size)
+        assertEquals(expectedEventsAndTheOrderTheyOccurIn, eventsCaptured)
+    }
+
+    @Test(timeout=300_000)
+    fun `corda service receives BEFORE_STATE_MACHINE_START before the state machine is started`() {
+        testStateMachineManagerStatusWhenServiceEventOccurs(
+                event = BEFORE_STATE_MACHINE_START,
+                expectedResult = TestSmmStateService.STATE_MACHINE_MANAGER_WAS_NOT_STARTED
+        )
+    }
+
+    @Test(timeout=300_000)
+    fun `corda service receives STATE_MACHINE_STARTED after the state machine is started`() {
+        testStateMachineManagerStatusWhenServiceEventOccurs(
+                event = STATE_MACHINE_STARTED,
+                expectedResult = TestSmmStateService.STATE_MACHINE_MANAGER_WAS_STARTED
+        )
+    }
+
+    /**
+     * Commonised
+     */
+    private fun testStateMachineManagerStatusWhenServiceEventOccurs(event: ServiceLifecycleEvent, expectedResult : Int) {
+        val result = driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = listOf(enclosedCordapp()),
+                notarySpecs = emptyList())) {
+            val node = startNode(providedName = ALICE_NAME).getOrThrow()
+            if (node is InProcess) {    // assuming the node-handle is always one of these
+                val svc = node.services.cordaService(TestSmmStateService::class.java)
+                svc.getSmmStartedForEvent(event)
+            } else {
+                TestSmmStateService.STATE_MACHINE_MANAGER_UNKNOWN_STATUS
+            }
+        }
+        assertEquals(expectedResult, result)
+    }
+
+    @Test(timeout=300_000)
+    fun `corda node blocks until all BEFORE_STATE_MACHINE_START events are processed`() {
+        /*
+            Register 200 callbacks for a bit of 'volume' - this is how many times each service event will be delivered.
+            There is a slight delay in each handler for BEFORE_STATE_MACHINE_START.
+
+            When the test completes, there should have been 200 x BEFORE_STATE_MACHINE_STARTs received.
+            If not then the node did not block and
+            */
+        numServiceCallbacks = 200
+        eventsToBeCaptured = setOf(BEFORE_STATE_MACHINE_START).toMutableSet()   // only interested in BEFORE_STATE_MACHINE_START
+
         val result = driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = listOf(enclosedCordapp()),
                 notarySpecs = emptyList())) {
             val node = startNode(providedName = ALICE_NAME).getOrThrow()
             node.rpc.startFlow(::ComputeTextLengthThroughCordaService, TEST_PHRASE).returnValue.getOrThrow()
         }
         assertEquals(TEST_PHRASE.length, result)
-        assertEquals(2, eventsCaptured.size)
-        assertEquals(listOf(BEFORE_STATE_MACHINE_START, STATE_MACHINE_STARTED), eventsCaptured)
+        assertEquals(numServiceCallbacks, eventsCaptured.size)
     }
 
     @StartableByRPC
+    @StartableByService
     class ComputeTextLengthThroughCordaService(private val text: String) : FlowLogic<Int>() {
         @Suspendable
         override fun call(): Int {
@@ -53,17 +126,21 @@ class CordaServiceLifecycleTests {
     class TextLengthComputingService(services: AppServiceHub) : SingletonSerializeAsToken() {
 
         init {
-            services.register { addEvent(it) }
+            for (n in 1..numServiceCallbacks) {
+                services.register { addEvent(it) }
+            }
         }
 
         private fun addEvent(event: ServiceLifecycleEvent) {
             when (event) {
-                STATE_MACHINE_STARTED -> {
-                    eventsCaptured.add(event)
+                BEFORE_STATE_MACHINE_START -> {
+                    TimeUnit.MILLISECONDS.sleep(25) // tiny delay to slow thing down a bit
                 }
                 else -> {
-                    eventsCaptured.add(event)
                 }
+            }
+            if (event in eventsToBeCaptured) {
+                eventsCaptured.add(event)
             }
         }
 
@@ -71,5 +148,43 @@ class CordaServiceLifecycleTests {
             require(text.isNotEmpty()) { "Length must be at least 1." }
             return text.length
         }
+    }
+
+    /**
+     * Service that checks the State Machine Manager state (started, not started) when service events are received.
+     */
+    @CordaService
+    class TestSmmStateService(private val services: AppServiceHub) : SingletonSerializeAsToken() {
+
+        companion object {
+            const val STATE_MACHINE_MANAGER_UNKNOWN_STATUS = -1
+            const val STATE_MACHINE_MANAGER_WAS_NOT_STARTED = 0
+            const val STATE_MACHINE_MANAGER_WAS_STARTED = 1
+        }
+
+        var smmStateAtEvent = mutableMapOf<ServiceLifecycleEvent, Int>()
+
+        init {
+            services.register { addEvent(it) }
+        }
+
+        private fun addEvent(event: ServiceLifecycleEvent) {
+            smmStateAtEvent[event] = checkSmmStarted()
+        }
+
+        private fun checkSmmStarted() : Int {
+            // try to start a flow; success == SMM started
+            try {
+                services.startFlow(ComputeTextLengthThroughCordaService(TEST_PHRASE)).returnValue.getOrThrow()
+                return STATE_MACHINE_MANAGER_WAS_STARTED
+            } catch (ex : UninitializedPropertyAccessException) {
+                return STATE_MACHINE_MANAGER_WAS_NOT_STARTED
+            }
+        }
+
+        /**
+         * Given an event, was the SMM started when the event was received?
+         */
+        fun getSmmStartedForEvent(event: ServiceLifecycleEvent) : Int = smmStateAtEvent.getOrDefault(event, STATE_MACHINE_MANAGER_UNKNOWN_STATUS)
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
@@ -19,7 +19,6 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 import kotlin.test.assertEquals
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -634,7 +634,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             tokenizableServices = null
 
             verifyCheckpointsCompatible(frozenTokenizableServices)
-            nodeLifecycleEventsDistributor.distributeEvent(NodeLifecycleEvent.BeforeStateMachineStart(nodeServicesContext))
+            nodeLifecycleEventsDistributor.distributeEvent(NodeLifecycleEvent.BeforeStateMachineStart(nodeServicesContext)).get()
             val callback = smm.start(frozenTokenizableServices)
             val smmStartedFuture = rootFuture.map { callback() }
             // Shut down the SMM so no Fibers are scheduled.

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -634,6 +634,10 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             tokenizableServices = null
 
             verifyCheckpointsCompatible(frozenTokenizableServices)
+            /* Note the .get() at the end of the distributeEvent call, below.
+               This will block until all Corda Services have returned from processing the event, allowing a service to prevent the
+               state machine manager from starting (just below this) until the service is ready.
+             */
             nodeLifecycleEventsDistributor.distributeEvent(NodeLifecycleEvent.BeforeStateMachineStart(nodeServicesContext)).get()
             val callback = smm.start(frozenTokenizableServices)
             val smmStartedFuture = rootFuture.map { callback() }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -634,6 +634,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             tokenizableServices = null
 
             verifyCheckpointsCompatible(frozenTokenizableServices)
+            nodeLifecycleEventsDistributor.distributeEvent(NodeLifecycleEvent.BeforeStateMachineStart(nodeServicesContext))
             val callback = smm.start(frozenTokenizableServices)
             val smmStartedFuture = rootFuture.map { callback() }
             // Shut down the SMM so no Fibers are scheduled.

--- a/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AppServiceHubImpl.kt
@@ -45,6 +45,10 @@ internal class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: S
                         observer.onServiceLifecycleEvent(ServiceLifecycleEvent.STATE_MACHINE_STARTED)
                         reportSuccess(nodeLifecycleEvent)
                     }
+                    is NodeLifecycleEvent.BeforeStateMachineStart<*> -> Try.on {
+                        observer.onServiceLifecycleEvent(ServiceLifecycleEvent.BEFORE_STATE_MACHINE_START)
+                        reportSuccess(nodeLifecycleEvent)
+                    }
                     else -> super.update(nodeLifecycleEvent)
                 }
             }

--- a/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
@@ -129,16 +129,6 @@ class CordaServiceTest {
                 .hasMessageContaining("com.r3.corda.sdk.tokens.money")
                 .hasMessageEndingWith(" not found on the classpath")
     }
-
-    @Test(timeout=300_000)
-    fun `Corda services receive lifecycle events during node startup`() {
-        val expectedStartupEventsInOrder = listOf(
-                ServiceLifecycleEvent.BEFORE_STATE_MACHINE_START,
-                ServiceLifecycleEvent.STATE_MACHINE_STARTED
-        )
-        val service = nodeA.services.cordaService(TestCordaServiceLifecycleEvents::class.java)
-        assertEquals(expectedStartupEventsInOrder, service.receivedEvents)
-    }
     
     @StartableByService
     class DummyServiceFlow : FlowLogic<InvocationContext>() {
@@ -224,20 +214,6 @@ class CordaServiceTest {
             serviceHub.withEntityManager {
                 createNativeQuery("SELECT * FROM VAULT_STATES").resultList
             }
-        }
-    }
-
-    /** service that subscribes to lifecycle events and captures the events it sees
-     */
-    @CordaService
-    class TestCordaServiceLifecycleEvents(val appServiceHub: AppServiceHub) : SingletonSerializeAsToken() {
-        init {
-            appServiceHub.register { processEvent(it) }
-        }
-        var receivedEvents = mutableListOf<ServiceLifecycleEvent>()
-
-        private fun processEvent(event: ServiceLifecycleEvent) {
-            receivedEvents.add(event)
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
@@ -11,6 +11,7 @@ import net.corda.core.internal.packageName
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.CordaService
+import net.corda.core.node.services.ServiceLifecycleEvent
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.serialization.SingletonSerializeAsToken
@@ -128,6 +129,16 @@ class CordaServiceTest {
                 .hasMessageContaining("com.r3.corda.sdk.tokens.money")
                 .hasMessageEndingWith(" not found on the classpath")
     }
+
+    @Test(timeout=300_000)
+    fun `Corda services receive lifecycle events during node startup`() {
+        val expectedStartupEventsInOrder = listOf(
+                ServiceLifecycleEvent.BEFORE_STATE_MACHINE_START,
+                ServiceLifecycleEvent.STATE_MACHINE_STARTED
+        )
+        val service = nodeA.services.cordaService(TestCordaServiceLifecycleEvents::class.java)
+        assertEquals(expectedStartupEventsInOrder, service.receivedEvents)
+    }
     
     @StartableByService
     class DummyServiceFlow : FlowLogic<InvocationContext>() {
@@ -213,6 +224,20 @@ class CordaServiceTest {
             serviceHub.withEntityManager {
                 createNativeQuery("SELECT * FROM VAULT_STATES").resultList
             }
+        }
+    }
+
+    /** service that subscribes to lifecycle events and captures the events it sees
+     */
+    @CordaService
+    class TestCordaServiceLifecycleEvents(val appServiceHub: AppServiceHub) : SingletonSerializeAsToken() {
+        init {
+            appServiceHub.register { processEvent(it) }
+        }
+        var receivedEvents = mutableListOf<ServiceLifecycleEvent>()
+
+        private fun processEvent(event: ServiceLifecycleEvent) {
+            receivedEvents.add(event)
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
@@ -11,7 +11,6 @@ import net.corda.core.internal.packageName
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.CordaService
-import net.corda.core.node.services.ServiceLifecycleEvent
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.serialization.SingletonSerializeAsToken


### PR DESCRIPTION
At node startup, just prior to starting the state machine, a new service lifecycle event _ServiceLifecycleEvent.BEFORE_STATE_MACHINE_START_ is published.
