### PR TITLE
ENT-6636: Removing commons-codec - not used.

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -206,7 +206,6 @@ dependencies {
 
     // BFT-Smart dependencies
     compile 'com.github.bft-smart:library:master-v1.1-beta-g6215ec8-87'
-    compile 'commons-codec:commons-codec:1.13'
 
     // Java Atomix: RAFT library
     compile 'io.atomix.copycat:copycat-client:1.2.3'


### PR DESCRIPTION
Removed commons-codec, not used as a compile time dependency. Removed as causing a vulnerability to be reported.

@relyafi Can you review please. This has been removed before (ENT-3542) and reintroduced. There is no compile time dependency requirement I can see.