### PR TITLE
NOTICK Remove Slack tagging on successful/unstable builds

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -388,12 +388,12 @@ pipeline {
         }
         success {
             script {
-                sendSlackNotifications("good", "BUILD PASSED", true, "#corda-corda4-open-source-build-notifications")
+                sendSlackNotifications("good", "BUILD PASSED", false, "#corda-corda4-open-source-build-notifications")
             }
         }
         unstable {
             script {                 
-                sendSlackNotifications("warning", "BUILD UNSTABLE - Unstable Builds are likely a result of Nexus Sonar Scanner violations", true, "#corda-corda4-open-source-build-notifications")                      
+                sendSlackNotifications("warning", "BUILD UNSTABLE - Unstable Builds are likely a result of Nexus Sonar Scanner violations", false, "#corda-corda4-open-source-build-notifications")                      
             }
         }
         failure {


### PR DESCRIPTION
Updating pipeline to utilize the shared pipeline logic for e-mail and slack notifications. Also modified the e-mail recipient to use a secret text in Jenkins credentials store rather than the hard coded e-mail string.