### PR TITLE
ENT-6532: Close AttachmentsClassLoader on eviction to avoid leaking file descriptors.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -173,13 +173,12 @@ import org.jolokia.jvmagent.JolokiaServerConfig
 import org.slf4j.Logger
 import rx.Scheduler
 import java.lang.reflect.InvocationTargetException
-import java.net.URLConnection
 import java.sql.Connection
 import java.sql.Savepoint
 import java.time.Clock
 import java.time.Duration
 import java.time.format.DateTimeParseException
-import java.util.*
+import java.util.Properties
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -238,7 +237,6 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         }
 
         quasarExcludePackages(configuration)
-        disableURLConnectionCache()
 
         if (allowHibernateToManageAppSchema && !configuration.devMode) {
             throw ConfigurationException("Hibernate can only be used to manage app schema in development while using dev mode. " +
@@ -425,13 +423,6 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
 
             stage2Proxy
         }
-    }
-
-    private fun disableURLConnectionCache() {
-        object : URLConnection(null) {
-            override fun connect() {
-            }
-        }.defaultUseCaches = false
     }
 
     private fun quasarExcludePackages(nodeConfiguration: NodeConfiguration) {

--- a/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
@@ -33,7 +33,8 @@ open class DefaultNamedCacheFactory protected constructor(private val metricRegi
     override fun bindWithMetrics(metricRegistry: MetricRegistry): BindableNamedCacheFactory = DefaultNamedCacheFactory(metricRegistry, this.nodeConfiguration)
     override fun bindWithConfig(nodeConfiguration: NodeConfiguration): BindableNamedCacheFactory = DefaultNamedCacheFactory(this.metricRegistry, nodeConfiguration)
 
-    open protected fun <K, V> configuredForNamed(caffeine: Caffeine<K, V>, name: String): Caffeine<K, V> {
+    @Suppress("ComplexMethod")
+    protected open fun <K, V> configuredForNamed(caffeine: Caffeine<K, V>, name: String): Caffeine<K, V> {
         return with(nodeConfiguration!!) {
             when {
                 name.startsWith("RPCSecurityManagerShiroCache_") -> with(security?.authService?.options?.cache!!) { caffeine.maximumSize(maxEntries).expireAfterWrite(expireAfterSecs, TimeUnit.SECONDS) }
@@ -84,7 +85,7 @@ open class DefaultNamedCacheFactory protected constructor(private val metricRegi
         return configuredForNamed(caffeine, name).build<K, V>(loader)
     }
 
-    open protected val defaultCacheSize = 1024L
+    protected open val defaultCacheSize = 1024L
     private val defaultAttachmentsClassLoaderCacheSize = defaultCacheSize / CACHE_SIZE_DENOMINATOR
 }
 private const val CACHE_SIZE_DENOMINATOR = 4L


### PR DESCRIPTION
`URLClassLoader` generates and caches a lot of temporary information, which is all released when its `close()` method is ultimately invoked. The `AttachmentsClassLoader` extends `URLClassLoader`, but assumed that there would be nothing to close because an `attachment://` URL only describes a memory buffer and not a file. Unfortunately, Java writes that buffer to a temporary file in order to unzip its contents :cry:, and file descriptors for these temporary files are then allowed to leak.

Modify the cache so that the `deserializationClassLoader` is closed when its `SerializationContext` is evicted. This should prevent  file descriptors from leaking without disabling caching for URLs.

Note that Quasar does not instrument classes belonging to an `AttachmentsClassLoader` anyway.

I have proved to myself that evicting entries from the `AttachmentsClassLoader_cache` now closes the file descriptors to the deleted `$TMPDIR/jar_cache*.tmp` entries, which _should_ fix the underlying problem and allow us to use `URLConnection.setUseCaches(true)` again.