### PR TITLE
ENT-6511, ENT-6811: graceful shutdown backport from 4.6

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ReconnectingCordaRPCOps.kt
@@ -292,6 +292,7 @@ class ReconnectingCordaRPCOps private constructor(
     }
     private class ErrorInterceptingHandler(val reconnectingRPCConnection: ReconnectingRPCConnection) : InvocationHandler {
         private fun Method.isStartFlow() = name.startsWith("startFlow") || name.startsWith("startTrackedFlow")
+        private fun Method.isShutdown() = name == "shutdown" || name == "gracefulShutdown" || name == "terminate"
 
         private fun checkIfIsStartFlow(method: Method, e: InvocationTargetException) {
             if (method.isStartFlow()) {
@@ -306,7 +307,7 @@ class ReconnectingCordaRPCOps private constructor(
          *
          * A negative number for [maxNumberOfAttempts] means an unlimited number of retries will be performed.
          */
-        @Suppress("ThrowsCount", "ComplexMethod")
+        @Suppress("ThrowsCount", "ComplexMethod", "NestedBlockDepth")
         private fun doInvoke(method: Method, args: Array<out Any>?, maxNumberOfAttempts: Int): Any? {
             checkIfClosed()
             var remainingAttempts = maxNumberOfAttempts
@@ -318,20 +319,20 @@ class ReconnectingCordaRPCOps private constructor(
                         log.debug { "RPC $method invoked successfully." }
                     }
                 } catch (e: InvocationTargetException) {
-                    if (method.name.equals("shutdown", true)) {
-                        log.debug("Shutdown invoked, stop reconnecting.", e)
-                        reconnectingRPCConnection.notifyServerAndClose()
-                        break
-                    }
                     when (e.targetException) {
                         is RejectedCommandException -> {
                             log.warn("Node is being shutdown. Operation ${method.name} rejected. Retrying when node is up...", e)
                             reconnectingRPCConnection.reconnectOnError(e)
                         }
                         is ConnectionFailureException -> {
-                            log.warn("Failed to perform operation ${method.name}. Connection dropped. Retrying....", e)
-                            reconnectingRPCConnection.reconnectOnError(e)
-                            checkIfIsStartFlow(method, e)
+                            if (method.isShutdown()) {
+                                log.debug("Shutdown invoked, stop reconnecting.", e)
+                                reconnectingRPCConnection.notifyServerAndClose()
+                            } else {
+                                log.warn("Failed to perform operation ${method.name}. Connection dropped. Retrying....", e)
+                                reconnectingRPCConnection.reconnectOnError(e)
+                                checkIfIsStartFlow(method, e)
+                            }
                         }
                         is RPCException -> {
                             rethrowIfUnrecoverable(e.targetException as RPCException)

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -111,6 +111,8 @@ object InteractiveShell {
         YAML
     }
 
+    private fun isShutdownCmd(cmd: String) = cmd == "shutdown" || cmd == "gracefulShutdown" || cmd == "terminate"
+
     fun startShell(configuration: ShellConfiguration, classLoader: ClassLoader? = null, standalone: Boolean = false) {
         makeRPCConnection = { username: String, password: String ->
             val connection = if (standalone) {
@@ -623,6 +625,10 @@ object InteractiveShell {
                     throw e.rootCause
                 }
             }
+            if (isShutdownCmd(cmd)) {
+                out.println("Called 'shutdown' on the node.\nQuitting the shell now.").also { out.flush() }
+                onExit.invoke()
+            }
         } catch (e: StringToMethodCallParser.UnparseableCallException) {
             out.println(e.message, Decoration.bold, Color.red)
             if (e !is StringToMethodCallParser.UnparseableCallException.NoSuchFile) {
@@ -633,10 +639,6 @@ object InteractiveShell {
         } finally {
             InputStreamSerializer.invokeContext = null
             InputStreamDeserializer.closeAll()
-        }
-        if (cmd == "shutdown") {
-            out.println("Called 'shutdown' on the node.\nQuitting the shell now.").also { out.flush() }
-            onExit.invoke()
         }
         return result
     }


### PR DESCRIPTION
Two commits backported.  IIRC the second was to cover a bug picked up by QA.  Or maybe it was because the original was incomplete.