### PR TITLE
ENT-6784: Change provisions for Artemis Server logging

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -202,7 +202,11 @@
             <AppenderRef ref="Console-ErrorCode-Selector"/>
             <AppenderRef ref="RollingFile-ErrorCode-Appender"/>
         </Logger>
-        <Logger name="org.apache.activemq.artemis.core.server" level="error" additivity="false">
+        <Logger name="org.apache.activemq.artemis.core.server" level="info" additivity="false">
+            <Filters>
+                <RegexFilter regex=".*AMQ222165.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <RegexFilter regex=".*AMQ222166.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </Filters>
             <AppenderRef ref="Console-ErrorCode-Selector"/>
             <AppenderRef ref="RollingFile-ErrorCode-Appender"/>
         </Logger>

--- a/testing/test-common/src/main/resources/log4j2-test.xml
+++ b/testing/test-common/src/main/resources/log4j2-test.xml
@@ -90,7 +90,11 @@
             <AppenderRef ref="Console-ErrorCode-Appender"/>
             <AppenderRef ref="RollingFile-ErrorCode-Appender"/>
         </Logger>
-        <Logger name="org.apache.activemq.artemis.core.server" level="error" additivity="false">
+        <Logger name="org.apache.activemq.artemis.core.server" level="info" additivity="false">
+            <Filters>
+                <RegexFilter regex=".*AMQ222165.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <RegexFilter regex=".*AMQ222166.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </Filters>
             <AppenderRef ref="Console-ErrorCode-Appender"/>
             <AppenderRef ref="RollingFile-ErrorCode-Appender"/>
         </Logger>


### PR DESCRIPTION
As a side effect of enabling warnings for Artemis was the following messages to be produced in the Node's log:
```
[WARN ] 2022-05-16T14:53:01,203Z [main] core.server. - AMQ222165: No Dead Letter Address configured for queue rpc.server in AddressSettings
[WARN ] 2022-05-16T14:53:01,203Z [main] core.server. - AMQ222166: No Expiry Address configured for queue rpc.server in AddressSettings
...
[WARN ] 2022-05-16T14:53:01,885Z [Thread-1 (ActiveMQ-server-org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl$6@70eb0c59)] core.server. - AMQ222165: No Dead Letter Address configured for queue p2p.inbound.DL5WQBEduTfiTzdLkg7iXcz5vY4oaJNdJr7Y4xaLvYszPj in AddressSettings
[WARN ] 2022-05-16T14:53:01,885Z [Thread-1 (ActiveMQ-server-org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl$6@70eb0c59)] core.server. - AMQ222166: No Expiry Address configured for queue p2p.inbound.DL5WQBEduTfiTzdLkg7iXcz5vY4oaJNdJr7Y4xaLvYszPj in AddressSettings
```

To suppress them a dedicated filter been added.
The change to logging configuration been tested locally using out-of-process integration tests.