### PR TITLE
CORE-4784: Generate license and wiki reports

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -5,7 +5,6 @@
  */
 @Library('corda-shared-build-pipeline-steps')
 
-
 /**
  * Sense environment
  */
@@ -120,6 +119,73 @@ pipeline {
                         iqScanPatterns: [[scanPattern: 'node/capsule/build/libs/corda*.jar']],
                         iqStage: params.nexusIqStage
                 )
+            }
+        }
+        stage('Generate Wiki Report') {
+            when {
+                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate && !isReleasePatch }
+                beforeAgent true
+            }
+            agent {
+                docker {
+                    image 'nexusiq-sonatype-cli:latest'
+                    reuseNode true
+                    registryUrl 'https://engineering-docker.software.r3.com/'
+                    registryCredentialsId 'artifactory-credentials'
+                }
+            }
+            options {
+                retry(3)
+            }
+            environment {
+                NEXUS_APP_ID="${nexusAppId}"
+                NEXUS_APP_STAGE="${params.nexusIqStage}"
+                NEXUSIQ_CREDENTIALS = credentials('jenkins-nexusiq-credentials')
+            }
+            steps {
+                sh '''
+                    rm -f wiki-report.md
+                    env NEXUSIQ_USERNAME="${NEXUSIQ_CREDENTIALS_USR}" \
+                        NEXUSIQ_PASSWORD="${NEXUSIQ_CREDENTIALS_PSW}" \
+                            /opt/app/wrapper wiki-report \
+                                --app "${NEXUS_APP_ID}" \
+                                --stage "${NEXUS_APP_STAGE}" >wiki-report.md
+                '''.stripIndent()
+                archiveArtifacts 'wiki-report.md'
+            }
+        }
+        stage('Generate Licence Report') {
+            when {
+                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate && !isReleasePatch }
+                beforeAgent true
+            }
+            agent {
+                docker {
+                    image 'nexusiq-licence-report:latest'
+                    reuseNode true
+                    registryUrl 'https://engineering-docker.software.r3.com/'
+                    registryCredentialsId 'artifactory-credentials'
+                }
+            }
+            options {
+                retry(3)
+            }
+            environment {
+                NEXUS_APP_ID="${nexusAppId}"
+                NEXUS_APP_STAGE="${params.nexusIqStage}"
+                NEXUSIQ_CREDENTIALS = credentials('jenkins-nexusiq-credentials')
+            }
+            steps {
+                sh '''\
+                    rm -rf report
+                    env NEXUSIQ_USERNAME="${NEXUSIQ_CREDENTIALS_USR}" \
+                        NEXUSIQ_PASSWORD="${NEXUSIQ_CREDENTIALS_PSW}" \
+                            /opt/app/wrapper --write --outdir report \
+                                --force \
+                                --app "${NEXUS_APP_ID}" \
+                                --stage "${NEXUS_APP_STAGE}"
+                '''.stripIndent()
+                archiveArtifacts 'report/*.md'
             }
         }
 


### PR DESCRIPTION
Two new stages, `Generate Wiki Report` and `Generate Licence Report` started only for GA releases.

Test builds are at https://ci01.dev.r3.com/job/Corda-Open-Source/job/Corda-OS-Release-Branch-Tests/job/corda/job/notick%252Fupdated-release-jenkinsfile-4.4/