### PR TITLE
NOTICK: remove obsolete parameter

### DIFF
--- a/.github/workflows/jira_close_issue.yml
+++ b/.github/workflows/jira_close_issue.yml
@@ -11,7 +11,6 @@ jobs:
       - name: Close
         uses: corda/jira-sync-closed-action@master
         with:
-          project: CORDA
           jiraBaseUrl: https://r3-cev.atlassian.net
           jiraEmail: ${{ secrets.JIRA_USER_EMAIL }}
           jiraToken: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
* removed `project` parameter from `jira-sync-closed-action` as it was never used