### PR TITLE
CORE-4784: remove obsolete check when generating NexusIQ reports

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
         }
         stage('Generate Wiki Report') {
             when {
-                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate && !isReleasePatch }
+                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate }
                 beforeAgent true
             }
             agent {
@@ -156,7 +156,7 @@ pipeline {
         }
         stage('Generate Licence Report') {
             when {
-                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate && !isReleasePatch }
+                expression { isReleaseTag && !isInternalRelease && !isReleaseCandidate }
                 beforeAgent true
             }
             agent {


### PR DESCRIPTION
* do not use `isReleasePatch` when deciding if NexusIQ reports should be
  created. That is not available after 4.8 branch and reports should be
  generated for the patched releases in the first place.