### PR TITLE
ENT-6858: In our Corda BC provider add support for Signature.Ed25519

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
@@ -33,6 +33,7 @@ val cordaBouncyCastleProvider = BouncyCastleProvider().apply {
     putAll(EdDSASecurityProvider())
     // Override the normal EdDSA engine with one which can handle X509 keys.
     put("Signature.${EdDSAEngine.SIGNATURE_ALGORITHM}", X509EdDSAEngine::class.java.name)
+    put("Signature.Ed25519", X509EdDSAEngine::class.java.name)
     addKeyInfoConverter(`id-Curve25519ph`, object : AsymmetricKeyInfoConverter {
         override fun generatePublic(keyInfo: SubjectPublicKeyInfo) = decodePublicKey(EDDSA_ED25519_SHA512, keyInfo.encoded)
         override fun generatePrivate(keyInfo: PrivateKeyInfo) = decodePrivateKey(EDDSA_ED25519_SHA512, keyInfo.encoded)


### PR DESCRIPTION
In our Corda BC provider add support for Signature.Ed25519 using our own X509EdDSAEngine. Needed so that we can upgrade BC in ENT. A later BC was being pulled in when trying to upgrade netty in ENT.

This change is already in OS 4.5 and above.
Also for ref see https://github.com/corda/corda/pull/6873