### PR TITLE
ENT-6714: Bugfix - Corda logs database password which controls RPC access

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
@@ -47,6 +47,7 @@ import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.nodeapi.internal.persistence.TransactionIsolationLevel
 import net.corda.notary.experimental.bftsmart.BFTSmartConfig
 import net.corda.notary.experimental.raft.RaftConfig
+import java.util.Properties
 
 internal object UserSpec : Configuration.Specification<User>("User") {
     private val username by string().optional()
@@ -67,9 +68,32 @@ internal object UserSpec : Configuration.Specification<User>("User") {
 internal object SecurityConfigurationSpec : Configuration.Specification<SecurityConfiguration>("SecurityConfiguration") {
     private object AuthServiceSpec : Configuration.Specification<SecurityConfiguration.AuthService>("AuthService") {
         private object DataSourceSpec : Configuration.Specification<SecurityConfiguration.AuthService.DataSource>("DataSource") {
+            fun Properties.enablePasswordMasking(): Properties {
+                class PwMasking : Properties() {
+                    fun maskPassword(): Properties {
+                        if (!containsKey("password")) return this
+                        val propsNoPassword = Properties()
+                        // if the properties are passed in to the constructor as defaults
+                        // they don't get printed so adding all keys explicitly
+                        propsNoPassword.putAll(this)
+                        propsNoPassword.setProperty("password", "***")
+                        return propsNoPassword
+                    }
+
+                    override fun toString(): String {
+                        val props = maskPassword()
+                        return props.toString()
+                    }
+                }
+
+                val masker = PwMasking()
+                masker.putAll(this)
+                return masker
+            }
+
             private val type by enum(AuthDataSourceType::class)
             private val passwordEncryption by enum(PasswordEncryption::class).optional().withDefaultValue(SecurityConfiguration.AuthService.DataSource.Defaults.passwordEncryption)
-            private val connection by nestedObject(sensitive = true).map(::toProperties).optional()
+            private val connection by nestedObject(sensitive = true).map{ toProperties(it).enablePasswordMasking() }.optional()
             private val users by nested(UserSpec).list().optional()
 
             override fun parseValid(configuration: Config, options: Configuration.Options): Valid<SecurityConfiguration.AuthService.DataSource> {


### PR DESCRIPTION
### Overview

**Porting the bug fix from Corda ENT ([ENT-3985](https://r3-cev.atlassian.net/browse/ENT-3985)**)

Port the bug fix for [ENT-6714](https://r3-cev.atlassian.net/browse/ENT-6714) which Corda logs database password in logs. Since the fix commit (hash: `1af08cd4558745795dc9e67e2583483bce70fb3e` in `corda/enterprise`) contains unrelated changes and causes merge conflicts, only the fix implementation was manually copied rather then `git cherry-pick`ed. It's unfortunate but there is no unit test to cover the fix, and writing it seems to require refactoring which should be handled in a separate step/PR.

### Test
Verified in deployment that the DB password field is now masked.
```[INFO ] 2022-06-22T16:11:58,043Z [main] security.RPCSecurityManagerImpl. - Constructing DB-backed security data source: {schema=shiro, password=***, jdbcUrl=jdbc:postgresql://localhost:5557/postgres, driverClassName=org.postgresql.Driver, username=my_user}```
