### PR TITLE
ENT-6913 - Updated KDoc for quick RPCs

### DIFF
--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -392,7 +392,11 @@ interface CordaRPCOps : RPCOps {
     /** Queries attachments metadata */
     fun queryAttachments(query: AttachmentQueryCriteria, sorting: AttachmentSort?): List<AttachmentId>
 
-    /** Returns the node's current time. */
+    /** Returns the node's current time.
+     *
+     * Is a quick RPC, meaning that it is handled outside the node's standard thread pool in order to provide a
+     * quick response even when the node is dealing with a high volume of RPC calls.
+     */
     fun currentNodeTime(): Instant
 
     /**

--- a/core/src/main/kotlin/net/corda/core/messaging/RPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/RPCOps.kt
@@ -8,6 +8,10 @@ import net.corda.core.DoNotImplement
  */
 @DoNotImplement
 interface RPCOps {
-    /** Returns the RPC protocol version. Exists since version 0 so guaranteed to be present. */
+    /** Returns the RPC protocol version. Exists since version 0 so guaranteed to be present.
+     *
+     * Getting this property is handled as a quick RPC, meaning that it is handled outside the node's standard
+     * thread pool in order to provide a quick response even when the node is dealing with a high volume of RPC calls.
+     */
     val protocolVersion: Int
 }


### PR DESCRIPTION
Updated the KDoc for the following RPCs, to indicate that (as of ENT-6866) they are now 'quick RPCS'.

- _CordaRPCOps::currentNodeTime()_
- _protocolVersion_ for all RPC Ops

This is a docs-only update; no working code/functionality has been changed.
Really, this should have been done as part of ENT-6866 but it was forgotten.