### PR TITLE
ENT-6948 flow hospital tests fail if the node shuts down before flows complete

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -39,6 +39,7 @@ import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
+import net.corda.testing.flows.waitForAllFlowsToComplete
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.findCordapp
@@ -231,6 +232,8 @@ class FlowHospitalTest {
                 it.startFlow(::SpendStateAndCatchDoubleSpendFlow, nodeBHandle.nodeInfo.singleIdentity(), ref).returnValue.getOrThrow(20.seconds)
                 it.startFlow(::SpendStateAndCatchDoubleSpendFlow, nodeBHandle.nodeInfo.singleIdentity(), ref).returnValue.getOrThrow(20.seconds)
             }
+
+            waitForAllFlowsToComplete(nodeBHandle)
         }
         // 1 is the notary failing to notarise and propagating the error
         // 2 is the receiving flow failing due to the unexpected session end error
@@ -286,6 +289,8 @@ class FlowHospitalTest {
                 it.startFlow(::SpendStateAndCatchDoubleSpendFlow, nodeBHandle.nodeInfo.singleIdentity(), ref).returnValue.getOrThrow(20.seconds)
                 it.startFlow(::SpendStateAndCatchDoubleSpendFlow, nodeBHandle.nodeInfo.singleIdentity(), ref, true).returnValue.getOrThrow(20.seconds)
             }
+
+            waitForAllFlowsToComplete(nodeBHandle)
         }
         // 1 is the notary failing to notarise and propagating the error
         assertEquals(1, dischargedCounter)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/flows/FlowTestsUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/flows/FlowTestsUtils.kt
@@ -1,6 +1,7 @@
 package net.corda.testing.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import co.paralleluniverse.strands.Strand
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
@@ -8,6 +9,7 @@ import net.corda.core.toFuture
 import net.corda.core.utilities.UntrustworthyData
 import net.corda.core.utilities.unwrap
 import net.corda.node.internal.InitiatedFlowFactory
+import net.corda.testing.driver.NodeHandle
 import net.corda.testing.node.internal.TestStartedNode
 import rx.Observable
 import kotlin.reflect.KClass
@@ -95,4 +97,13 @@ fun <T : FlowLogic<*>> TestStartedNode.registerCoreFlowFactory(initiatingFlowCla
                                                                initiatedFlowClass: Class<T>,
                                                                flowFactory: (FlowSession) -> T, track: Boolean): Observable<T> {
     return this.internals.registerInitiatedFlowFactory(initiatingFlowClass, initiatedFlowClass, InitiatedFlowFactory.Core(flowFactory), track)
+}
+
+fun waitForAllFlowsToComplete(nodeHandle: NodeHandle, maxIterations: Int = 10, iterationDelay: Long = 500) {
+    (0..maxIterations).forEach {
+        if (nodeHandle.rpc.stateMachinesSnapshot().isEmpty()) {
+            return
+        }
+        Strand.sleep(iterationDelay)
+    }
 }


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

The flow hospital tests have assertions that are only applicable if the flows are complete. 

The node driver DSL sends a soft shutdown to the node once the closure completes, if a flow is in suspended state then the shutdown proceeds and the node terminates. This means flows that were suspended awaiting a response, do not complete.

This change checks that there are no active or suspended flows in the flow state machine for a given node. It will wait for this condition based on the specified parameters (defaults to approx. 5 seconds).

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
