### PR TITLE
ENT-6914 Added support for javaHome and classPath to node driver

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -99,6 +99,8 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
 
     val javaHome: String?
 
+    val classPath: List<String>?
+
     companion object {
         // default to at least 8MB and a bit extra for larger heap sizes
         val defaultTransactionCacheSize: Long = 8.MB + getAdditionalCacheMemory()

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -97,6 +97,8 @@ interface NodeConfiguration : ConfigurationWithOptionsContainer {
 
     val reloadCheckpointAfterSuspend: Boolean
 
+    val javaHome: String?
+
     companion object {
         // default to at least 8MB and a bit extra for larger heap sizes
         val defaultTransactionCacheSize: Long = 8.MB + getAdditionalCacheMemory()

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -85,8 +85,8 @@ data class NodeConfigurationImpl(
         override val flowExternalOperationThreadPoolSize: Int = Defaults.flowExternalOperationThreadPoolSize,
         override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages,
         override val reloadCheckpointAfterSuspend: Boolean = Defaults.reloadCheckpointAfterSuspend,
-        override val networkParametersPath: Path = baseDirectory
-
+        override val networkParametersPath: Path = baseDirectory,
+        override val javaHome: String? = null
 ) : NodeConfiguration {
     internal object Defaults {
         val jmxMonitoringHttpPort: Int? = null

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -86,7 +86,8 @@ data class NodeConfigurationImpl(
         override val quasarExcludePackages: List<String> = Defaults.quasarExcludePackages,
         override val reloadCheckpointAfterSuspend: Boolean = Defaults.reloadCheckpointAfterSuspend,
         override val networkParametersPath: Path = baseDirectory,
-        override val javaHome: String? = null
+        override val javaHome: String? = null,
+        override val classPath: List<String>? = null
 ) : NodeConfiguration {
     internal object Defaults {
         val jmxMonitoringHttpPort: Int? = null

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -8,7 +8,6 @@ import net.corda.common.validation.internal.Validated.Companion.invalid
 import net.corda.common.validation.internal.Validated.Companion.valid
 import net.corda.node.services.config.*
 import net.corda.node.services.config.NodeConfigurationImpl.Defaults
-import net.corda.node.services.config.NodeConfigurationImpl.Defaults.reloadCheckpointAfterSuspend
 import net.corda.node.services.config.schema.parsers.*
 
 internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfiguration>("NodeConfiguration") {
@@ -73,6 +72,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
     @Suppress("unused")
     private val systemProperties by nestedObject().optional()
     private val javaHome by string().optional()
+    private val classPath by string().list().optional()
 
     override fun parseValid(configuration: Config, options: Configuration.Options): Validated<NodeConfiguration, Configuration.Validation.Error> {
         val config = configuration.withOptions(options)
@@ -139,7 +139,8 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     quasarExcludePackages = config[quasarExcludePackages],
                     reloadCheckpointAfterSuspend = config[reloadCheckpointAfterSuspend],
                     networkParametersPath = networkParametersPath,
-                    javaHome = config[javaHome]
+                    javaHome = config[javaHome],
+                    classPath = config[classPath]
             ))
         } catch (e: Exception) {
             return when (e) {

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -72,6 +72,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
     private val custom by nestedObject().optional()
     @Suppress("unused")
     private val systemProperties by nestedObject().optional()
+    private val javaHome by string().optional()
 
     override fun parseValid(configuration: Config, options: Configuration.Options): Validated<NodeConfiguration, Configuration.Validation.Error> {
         val config = configuration.withOptions(options)
@@ -137,7 +138,8 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     flowExternalOperationThreadPoolSize = config[flowExternalOperationThreadPoolSize],
                     quasarExcludePackages = config[quasarExcludePackages],
                     reloadCheckpointAfterSuspend = config[reloadCheckpointAfterSuspend],
-                    networkParametersPath = networkParametersPath
+                    networkParametersPath = networkParametersPath,
+                    javaHome = config[javaHome]
             ))
         } catch (e: Exception) {
             return when (e) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -90,7 +90,8 @@ interface DriverDSL {
      *     as being in bytes. Append the letter 'k' or 'K' to the value to indicate Kilobytes, 'm' or 'M' to indicate
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
      * @param logLevelOverride log4j log level used to override the default value of info.
-     * @param javaHome the Java home directory
+     * @param javaHome (optional) the Java home directory
+     * @param classPath (optional) the java class path
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      *     it sees all previously started nodes, including the notaries.
      */
@@ -103,7 +104,8 @@ interface DriverDSL {
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
             logLevelOverride: String? = defaultParameters.logLevelOverride,
-            javaHome: String? = null
+            javaHome: String? = null,
+            classPath: List<String>? = null
     ): CordaFuture<NodeHandle> {
         return startNode(defaultParameters.copy(
                 providedName = providedName,
@@ -113,7 +115,8 @@ interface DriverDSL {
                 startInSameProcess = startInSameProcess,
                 maximumHeapSize = maximumHeapSize,
                 logLevelOverride = logLevelOverride,
-                javaHome = javaHome
+                javaHome = javaHome,
+                classPath = classPath
         ))
     }
 
@@ -135,7 +138,8 @@ interface DriverDSL {
      * @param maximumHeapSize The maximum JVM heap size to use for the node as a [String]. By default a number is interpreted
      *     as being in bytes. Append the letter 'k' or 'K' to the value to indicate Kilobytes, 'm' or 'M' to indicate
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
-     * @param javaHome the Java home directory
+     * @param javaHome (optional) the Java home directory
+     * @param classPath (optional) the java classpath
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      *     it sees all previously started nodes, including the notaries.
      */
@@ -147,7 +151,8 @@ interface DriverDSL {
             customOverrides: Map<String, Any?> = defaultParameters.customOverrides,
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
-            javaHome: String? = null
+            javaHome: String? = null,
+            classPath: List<String>? = null
     ): CordaFuture<NodeHandle> {
         return startNode(defaultParameters.copy(
                 providedName = providedName,
@@ -156,7 +161,8 @@ interface DriverDSL {
                 customOverrides = customOverrides,
                 startInSameProcess = startInSameProcess,
                 maximumHeapSize = maximumHeapSize,
-                javaHome = javaHome
+                javaHome = javaHome,
+                classPath = classPath
         ))
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -90,6 +90,7 @@ interface DriverDSL {
      *     as being in bytes. Append the letter 'k' or 'K' to the value to indicate Kilobytes, 'm' or 'M' to indicate
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
      * @param logLevelOverride log4j log level used to override the default value of info.
+     * @param javaHome the Java home directory
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      *     it sees all previously started nodes, including the notaries.
      */
@@ -101,7 +102,8 @@ interface DriverDSL {
             customOverrides: Map<String, Any?> = defaultParameters.customOverrides,
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
-            logLevelOverride: String? = defaultParameters.logLevelOverride
+            logLevelOverride: String? = defaultParameters.logLevelOverride,
+            javaHome: String? = null
     ): CordaFuture<NodeHandle> {
         return startNode(defaultParameters.copy(
                 providedName = providedName,
@@ -110,7 +112,8 @@ interface DriverDSL {
                 customOverrides = customOverrides,
                 startInSameProcess = startInSameProcess,
                 maximumHeapSize = maximumHeapSize,
-                logLevelOverride = logLevelOverride
+                logLevelOverride = logLevelOverride,
+                javaHome = javaHome
         ))
     }
 
@@ -132,6 +135,7 @@ interface DriverDSL {
      * @param maximumHeapSize The maximum JVM heap size to use for the node as a [String]. By default a number is interpreted
      *     as being in bytes. Append the letter 'k' or 'K' to the value to indicate Kilobytes, 'm' or 'M' to indicate
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
+     * @param javaHome the Java home directory
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      *     it sees all previously started nodes, including the notaries.
      */
@@ -142,7 +146,8 @@ interface DriverDSL {
             verifierType: VerifierType = defaultParameters.verifierType,
             customOverrides: Map<String, Any?> = defaultParameters.customOverrides,
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
-            maximumHeapSize: String = defaultParameters.maximumHeapSize
+            maximumHeapSize: String = defaultParameters.maximumHeapSize,
+            javaHome: String? = null
     ): CordaFuture<NodeHandle> {
         return startNode(defaultParameters.copy(
                 providedName = providedName,
@@ -150,7 +155,8 @@ interface DriverDSL {
                 verifierType = verifierType,
                 customOverrides = customOverrides,
                 startInSameProcess = startInSameProcess,
-                maximumHeapSize = maximumHeapSize
+                maximumHeapSize = maximumHeapSize,
+                javaHome = javaHome
         ))
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -95,6 +95,7 @@ interface DriverDSL {
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      *     it sees all previously started nodes, including the notaries.
      */
+    @Suppress("LongParameterList")
     fun startNode(
             defaultParameters: NodeParameters = NodeParameters(),
             providedName: CordaX500Name? = defaultParameters.providedName,
@@ -104,8 +105,8 @@ interface DriverDSL {
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
             logLevelOverride: String? = defaultParameters.logLevelOverride,
-            javaHome: String? = null,
-            classPath: List<String>? = null
+            javaHome: String? = defaultParameters.javaHome,
+            classPath: List<String>? = defaultParameters.classPath
     ): CordaFuture<NodeHandle> {
         return startNode(defaultParameters.copy(
                 providedName = providedName,
@@ -143,6 +144,7 @@ interface DriverDSL {
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      *     it sees all previously started nodes, including the notaries.
      */
+    @Suppress("LongParameterList")
     fun startNode(
             defaultParameters: NodeParameters = NodeParameters(),
             providedName: CordaX500Name? = defaultParameters.providedName,
@@ -151,8 +153,8 @@ interface DriverDSL {
             customOverrides: Map<String, Any?> = defaultParameters.customOverrides,
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
-            javaHome: String? = null,
-            classPath: List<String>? = null
+            javaHome: String? = defaultParameters.javaHome,
+            classPath: List<String>? = defaultParameters.classPath
     ): CordaFuture<NodeHandle> {
         return startNode(defaultParameters.copy(
                 providedName = providedName,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
@@ -36,7 +36,8 @@ data class NodeParameters(
         val additionalCordapps: Collection<TestCordapp> = emptySet(),
         val flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap(),
         val logLevelOverride: String? = null,
-        val rpcAddress: NetworkHostAndPort? = null
+        val rpcAddress: NetworkHostAndPort? = null,
+        val javaHome: String? = null
 ) {
     /**
      * Create a new node parameters object with default values. Each parameter can be specified with its wither method which returns a copy
@@ -53,6 +54,7 @@ data class NodeParameters(
     fun withAdditionalCordapps(additionalCordapps: Set<TestCordapp>): NodeParameters = copy(additionalCordapps = additionalCordapps)
     fun withFlowOverrides(flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>): NodeParameters = copy(flowOverrides = flowOverrides)
     fun withLogLevelOverride(logLevelOverride: String?): NodeParameters = copy(logLevelOverride = logLevelOverride)
+    fun withJavaHome(javaHome: String) = copy(javaHome = javaHome)
 
     constructor(
             providedName: CordaX500Name?,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
@@ -24,6 +24,8 @@ import net.corda.testing.node.User
  * @property logLevelOverride log level to be passed as parameter to an out of process node. ERROR, WARN, INFO, DEBUG, TRACE. This overrides debug port
  * log level argument.
  * @property rpcAddress optional override for RPC address on which node will be accepting RPC connections from the clients. Port provided must be vacant.
+ * @property javaHome optional override the java home directory
+ * @property classPath optional override the classpath
  */
 @Suppress("unused")
 data class NodeParameters(
@@ -37,7 +39,8 @@ data class NodeParameters(
         val flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap(),
         val logLevelOverride: String? = null,
         val rpcAddress: NetworkHostAndPort? = null,
-        val javaHome: String? = null
+        val javaHome: String? = null,
+        val classPath: List<String>? = null
 ) {
     /**
      * Create a new node parameters object with default values. Each parameter can be specified with its wither method which returns a copy
@@ -55,6 +58,7 @@ data class NodeParameters(
     fun withFlowOverrides(flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>): NodeParameters = copy(flowOverrides = flowOverrides)
     fun withLogLevelOverride(logLevelOverride: String?): NodeParameters = copy(logLevelOverride = logLevelOverride)
     fun withJavaHome(javaHome: String) = copy(javaHome = javaHome)
+    fun withClassPath(classPath: List<String>) = copy(classPath = classPath)
 
     constructor(
             providedName: CordaX500Name?,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -345,7 +345,8 @@ class DriverDSLImpl(
                 },
                 NodeConfiguration::verifierType.name to parameters.verifierType.name,
                 NodeConfiguration::flowOverrides.name to flowOverrideConfig.toConfig().root().unwrapped(),
-                NodeConfiguration::additionalNodeInfoPollingFrequencyMsec.name to 1000
+                NodeConfiguration::additionalNodeInfoPollingFrequencyMsec.name to 1000,
+                NodeConfiguration::javaHome.name to parameters.javaHome
         ) + czUrlConfig + jmxConfig + parameters.customOverrides
         return NodeConfig(
                 ConfigHelper.loadConfig(
@@ -1044,7 +1045,8 @@ class DriverDSLImpl(
                     maximumHeapSize = maximumHeapSize,
                     classPath = cp,
                     identifier = identifier,
-                    environmentVariables = environmentVariables
+                    environmentVariables = environmentVariables,
+                    javaHome = config.corda.javaHome
             )
         }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -849,6 +849,11 @@ class DriverDSLImpl(
         return NodeConfig(this.typesafe.plus(mapOf("notary" to mapOf("validating" to validating))))
     }
 
+    private fun getQuasarJarPath(config: NodeConfig): String {
+        val classPath = config.corda.classPath ?: listOf(quasarJarPath)
+        return classPath.first { it.contains("quasar-core") }
+    }
+
     companion object {
         private val RPC_CONNECT_POLL_INTERVAL: Duration = 100.millis
         internal val log = contextLogger()
@@ -910,11 +915,6 @@ class DriverDSLImpl(
             } else {
                 this
             }
-        }
-
-        private fun getQuasarJarPath(config: NodeConfig): String {
-            val classPath = config.corda.classPath ?: listOf(quasarJarPath)
-            return classPath.first { it.contains("quasar-core") }
         }
 
         private inline fun <T> Config.withOptionalValue(key: String, obj: T?, body: (T) -> ConfigValue): Config {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -346,7 +346,8 @@ class DriverDSLImpl(
                 NodeConfiguration::verifierType.name to parameters.verifierType.name,
                 NodeConfiguration::flowOverrides.name to flowOverrideConfig.toConfig().root().unwrapped(),
                 NodeConfiguration::additionalNodeInfoPollingFrequencyMsec.name to 1000,
-                NodeConfiguration::javaHome.name to parameters.javaHome
+                NodeConfiguration::javaHome.name to parameters.javaHome,
+                NodeConfiguration::classPath.name to parameters.classPath
         ) + czUrlConfig + jmxConfig + parameters.customOverrides
         return NodeConfig(
                 ConfigHelper.loadConfig(
@@ -1029,7 +1030,7 @@ class DriverDSLImpl(
 
             // The following dependencies are excluded from the classpath of the created JVM,
             // so that the environment resembles a real one as close as possible.
-            val cp = ProcessUtilities.defaultClassPath.filter { cpEntry ->
+            val cp = config.corda.classPath ?: ProcessUtilities.defaultClassPath.filter { cpEntry ->
                 val cpPathEntry = Paths.get(cpEntry)
                 cpPathEntry.isRegularFile()
                         && !isTestArtifact(cpPathEntry.fileName.toString())

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -754,7 +754,7 @@ class DriverDSLImpl(
             log.info("StartNodeInternal for ${config.corda.myLegalName.organisation} - create schema done")
             val process = startOutOfProcessNode(
                     config,
-                    quasarJarPath,
+                    getQuasarJarPath(config),
                     debugPort,
                     bytemanJarPath,
                     bytemanPort,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -679,7 +679,7 @@ class DriverDSLImpl(
         val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
         val process = startOutOfProcessNode(
                 config,
-                quasarJarPath,
+                getQuasarJarPath(config),
                 debugPort,
                 bytemanJarPath,
                 null,
@@ -694,6 +694,11 @@ class DriverDSLImpl(
         return poll(executorService, "$extraCmdLineFlag (${config.corda.myLegalName})") {
             if (process.isAlive) null else Unit
         }
+    }
+
+    private fun getQuasarJarPath(config: NodeConfig): String {
+        val classPath = config.corda.classPath ?: listOf(quasarJarPath)
+        return classPath.first { it.contains("quasar-core") }
     }
 
     @Suppress("ComplexMethod")

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -696,11 +696,6 @@ class DriverDSLImpl(
         }
     }
 
-    private fun getQuasarJarPath(config: NodeConfig): String {
-        val classPath = config.corda.classPath ?: listOf(quasarJarPath)
-        return classPath.first { it.contains("quasar-core") }
-    }
-
     @Suppress("ComplexMethod")
     private fun startNodeInternal(config: NodeConfig,
                                   webAddress: NetworkHostAndPort,
@@ -915,6 +910,11 @@ class DriverDSLImpl(
             } else {
                 this
             }
+        }
+
+        private fun getQuasarJarPath(config: NodeConfig): String {
+            val classPath = config.corda.classPath ?: listOf(quasarJarPath)
+            return classPath.first { it.contains("quasar-core") }
         }
 
         private inline fun <T> Config.withOptionalValue(key: String, obj: T?, body: (T) -> ConfigValue): Config {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
@@ -13,7 +13,8 @@ object ProcessUtilities {
             jdwpPort: Int? = null,
             extraJvmArguments: List<String> = emptyList(),
             maximumHeapSize: String? = null,
-            environmentVariables: Map<String, String> = emptyMap()
+            environmentVariables: Map<String, String> = emptyMap(),
+            javaHome: String? = null
     ): Process {
         return startJavaProcess(
                 C::class.java.name,
@@ -23,7 +24,8 @@ object ProcessUtilities {
                 jdwpPort,
                 extraJvmArguments,
                 maximumHeapSize,
-                environmentVariables = environmentVariables
+                environmentVariables = environmentVariables,
+                javaHome = javaHome
         )
     }
 
@@ -38,10 +40,11 @@ object ProcessUtilities {
             maximumHeapSize: String? = null,
             identifier: String = "",
             environmentVariables: Map<String,String> = emptyMap(),
-            inheritIO: Boolean = true
+            inheritIO: Boolean = true,
+            javaHome: String? = null
     ): Process {
         val command = mutableListOf<String>().apply {
-            add(javaPath)
+            add("${javaHome ?: DEFAULT_JAVA_HOME}/bin/java")
             (jdwpPort != null) && add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$jdwpPort")
             if (maximumHeapSize != null) add("-Xmx$maximumHeapSize")
             add("-XX:+UseG1GC")
@@ -63,7 +66,7 @@ object ProcessUtilities {
         }.start()
     }
 
-    private val javaPath = (System.getProperty("java.home") / "bin" / "java").toString()
+    val DEFAULT_JAVA_HOME: String = System.getProperty("java.home")
 
     val defaultClassPath: List<String> = System.getProperty("java.class.path").split(File.pathSeparator)
 }


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

As part of the JDK11 compatibility work it has become necessary to be able to write tests which start nodes with a specific JDK and classpath. 

These changes add these two additional parameters to NodeParameters and configuration.

** THIS PR NOT TO BE MERGED UNtiL 4.11 BRANCH HAS BEEN CREATED **

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
