### PR TITLE
ENT-6856 - Do not black-list AMQP targets that suffer a handshake failure

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionChange.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionChange.kt
@@ -3,8 +3,8 @@ package net.corda.nodeapi.internal.protonwrapper.netty
 import java.net.InetSocketAddress
 import java.security.cert.X509Certificate
 
-data class ConnectionChange(val remoteAddress: InetSocketAddress, val remoteCert: X509Certificate?, val connected: Boolean, val badCert: Boolean) {
+data class ConnectionChange(val remoteAddress: InetSocketAddress, val remoteCert: X509Certificate?, val connected: Boolean, val connectionResult: ConnectionResult) {
     override fun toString(): String {
-        return "ConnectionChange remoteAddress: $remoteAddress connected state: $connected cert subject: ${remoteCert?.subjectDN} cert ok: ${!badCert}"
+        return "ConnectionChange remoteAddress: $remoteAddress connected state: $connected cert subject: ${remoteCert?.subjectDN} result: ${connectionResult}"
     }
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionResult.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionResult.kt
@@ -1,0 +1,6 @@
+package net.corda.nodeapi.internal.protonwrapper.netty
+
+enum class ConnectionResult {
+    NO_ERROR,
+    HANDSHAKE_FAILURE
+}

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
@@ -14,6 +14,7 @@ import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.configureWithDevSSLCertificate
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPClient
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPConfiguration
+import net.corda.nodeapi.internal.protonwrapper.netty.ConnectionResult
 import net.corda.nodeapi.internal.protonwrapper.netty.init
 import net.corda.nodeapi.internal.protonwrapper.netty.initialiseTrustStoreAndEnableCrlChecking
 import net.corda.nodeapi.internal.protonwrapper.netty.toRevocationConfig
@@ -29,6 +30,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.TrustManagerFactory
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -211,7 +213,7 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
                 val clientConnect = clientConnected.get()
                 assertFalse(clientConnect.connected)
                 // Not a badCert, but a timeout during handshake
-                assertFalse(clientConnect.badCert)
+                assertEquals(ConnectionResult.NO_ERROR, clientConnect.connectionResult)
             }
         }
         assertFalse(serverThread.isActive)


### PR DESCRIPTION
Connection-failures that were previously interpreted as 'bad certificate' that would previously be black-listed (and then never re-attempted) are now added to a list of 'handshake failure retry' targets. These targets are retried in the event that all 'normal' targets are unavailable, but the retries are made with much larger intervals - 5 attempts at 5m intervals, then once a day.

Once a connection is made, the node forgets that any targets might have previously suffered handshake failures and in the event of a subsequent connection issue, all targets are treated as 'good' again.

Back-fitted from Ent-4.10.