### PR TITLE
ENT-6975: Updated docker jdk version to 345 for zulu ubuntu and 8u342…

### DIFF
--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:8u322
+FROM azul/zulu-openjdk:8u345
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \

--- a/docker/src/docker/Dockerfile-debug
+++ b/docker/src/docker/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:8u322
+FROM azul/zulu-openjdk:8u345
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \

--- a/docker/src/docker/DockerfileAL
+++ b/docker/src/docker/DockerfileAL
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8u322-al2
+FROM amazoncorretto:8u342-al2
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN yum -y install bash && \


### PR DESCRIPTION
ENT-6975: Updated docker jdk versions. 345 for ubuntu zulu and 342_al2 for amazon corretto. (342_al2 is latest available).