### PR TITLE
NOTICK: Removed jcenter dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,6 @@ buildscript {
                 }
             }
             mavenCentral()
-            jcenter()
         }
     }
     dependencies {
@@ -430,7 +429,6 @@ allprojects {
                 }
             }
             mavenCentral()
-            jcenter()
         }
     }
 

--- a/tools/checkpoint-agent/build.gradle
+++ b/tools/checkpoint-agent/build.gradle
@@ -9,7 +9,6 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -20,7 +19,6 @@ buildscript {
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
 }
 
 apply plugin: 'kotlin'


### PR DESCRIPTION
Jcenter dependency is removed for the build to pick the dependencies from either Maven Central or Corda-dependency repo in Artifactory