### PR TITLE
NOTICK: Add CORDA_USE_CACHE environment variable

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
         DOCKER_URL = "https://index.docker.io/v1/"
         EMAIL_RECIPIENTS = credentials('corda4-email-recipient')
         SNYK_API_KEY = "c4-os-snyk"
+        CORDA_USE_CACHE = "corda-remotes"
     }
 
     stages {


### PR DESCRIPTION
As per the build file here:  https://github.com/corda/corda/blob/b6f6ca3fe125180c3bf61d955f773dddf8f1a77d/build.gradle#L157 the CORDA_USE_CACHE environment variable can be defined so that the 'corda-remotes' remote repository in Artifactory can be used to resolve dependencies rather then from external repos. 
