### PR TITLE
ENT-6983 - Filter out unwanted Artemis warnings

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -204,12 +204,15 @@
         </Logger>
         <Logger name="org.apache.activemq.artemis.core.server" level="warn" additivity="false">
             <Filters>
-                <RegexFilter regex=".*AMQ222061.*" onMatch="DENY" onMismatch="NEUTRAL"/>
-                <RegexFilter regex=".*AMQ222107.*" onMatch="DENY" onMismatch="NEUTRAL"/>
                 <RegexFilter regex=".*AMQ222165.*" onMatch="DENY" onMismatch="NEUTRAL"/>
                 <RegexFilter regex=".*AMQ222166.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
-            <AppenderRef ref="Console-ErrorCode-Selector"/>
+            <AppenderRef ref="Console-ErrorCode-Selector">
+                <Filters>
+                    <RegexFilter regex=".*AMQ222061.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                    <RegexFilter regex=".*AMQ222107.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                </Filters>
+            </AppenderRef>
             <AppenderRef ref="RollingFile-ErrorCode-Appender"/>
         </Logger>
         <Logger name="org.apache.activemq.audit" level="error" additivity="false">

--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -203,14 +203,12 @@
             <AppenderRef ref="RollingFile-ErrorCode-Appender"/>
         </Logger>
         <Logger name="org.apache.activemq.artemis.core.server" level="warn" additivity="false">
-            <Filters>
-                <RegexFilter regex=".*AMQ222165.*" onMatch="DENY" onMismatch="NEUTRAL"/>
-                <RegexFilter regex=".*AMQ222166.*" onMatch="DENY" onMismatch="NEUTRAL"/>
-            </Filters>
             <AppenderRef ref="Console-ErrorCode-Selector">
                 <Filters>
                     <RegexFilter regex=".*AMQ222061.*" onMatch="DENY" onMismatch="NEUTRAL"/>
                     <RegexFilter regex=".*AMQ222107.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                    <RegexFilter regex=".*AMQ222165.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                    <RegexFilter regex=".*AMQ222166.*" onMatch="DENY" onMismatch="NEUTRAL"/>
                 </Filters>
             </AppenderRef>
             <AppenderRef ref="RollingFile-ErrorCode-Appender"/>

--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -204,6 +204,8 @@
         </Logger>
         <Logger name="org.apache.activemq.artemis.core.server" level="warn" additivity="false">
             <Filters>
+                <RegexFilter regex=".*AMQ222061.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <RegexFilter regex=".*AMQ222107.*" onMatch="DENY" onMismatch="NEUTRAL"/>
                 <RegexFilter regex=".*AMQ222165.*" onMatch="DENY" onMismatch="NEUTRAL"/>
                 <RegexFilter regex=".*AMQ222166.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>


### PR DESCRIPTION
Updated the Artemis logger configuration so that warnings are written to the log but not to the console.

AMQ222061: Client connection failed, clearing up resources for session
AMQ222107: Cleared up resources for session
AMQ222165: No Dead Letter Address
AMQ222166: No Expiry Address

Previously, the latter two were filtered out for both the console and the log file.
