### PR TITLE
ENT-8794 Delay closing of attachment class loaders

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -35,6 +35,7 @@ import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import java.io.IOException
 import java.io.InputStream
+import java.lang.ref.Reference
 import java.lang.ref.WeakReference
 import java.net.URL
 import java.net.URLClassLoader
@@ -44,8 +45,10 @@ import java.net.URLStreamHandlerFactory
 import java.security.MessageDigest
 import java.security.Permission
 import java.util.Locale
+import java.util.Queue
 import java.util.ServiceLoader
 import java.util.WeakHashMap
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.function.Function
 
 /**
@@ -333,6 +336,7 @@ class AttachmentsClassLoader(attachments: List<Attachment>,
 @VisibleForTesting
 object AttachmentsClassLoaderBuilder {
     private const val CACHE_SIZE = 16
+    private const val STRONG_REFERENCE_TO_CACHED_SERIALIZATION_CONTEXT = "cachedSerializationContext"
 
     private val fallBackCache: AttachmentsClassLoaderCache = AttachmentsClassLoaderSimpleCacheImpl(CACHE_SIZE)
 
@@ -352,16 +356,15 @@ object AttachmentsClassLoaderBuilder {
         val attachmentIds = attachments.mapTo(LinkedHashSet(), Attachment::id)
 
         val cache = attachmentsClassLoaderCache ?: fallBackCache
-        val serializationContext = cache.computeIfAbsent(AttachmentsClassLoaderKey(attachmentIds, params), Function { key ->
+        val cachedSerializationContext = cache.computeIfAbsent(AttachmentsClassLoaderKey(attachmentIds, params), Function { key ->
             // Create classloader and load serializers, whitelisted classes
             val transactionClassLoader = AttachmentsClassLoader(attachments, key.params, txId, isAttachmentTrusted, parent)
             val serializers = try {
                 createInstancesOfClassesImplementing(transactionClassLoader, SerializationCustomSerializer::class.java,
                         JDK1_2_CLASS_FILE_FORMAT_MAJOR_VERSION..JDK8_CLASS_FILE_FORMAT_MAJOR_VERSION)
-                }
-                catch(ex: UnsupportedClassVersionError) {
-                    throw TransactionVerificationException.UnsupportedClassVersionError(txId, ex.message!!, ex)
-                }
+            } catch (ex: UnsupportedClassVersionError) {
+                throw TransactionVerificationException.UnsupportedClassVersionError(txId, ex.message!!, ex)
+            }
             val whitelistedClasses = ServiceLoader.load(SerializationWhitelist::class.java, transactionClassLoader)
                     .flatMap(SerializationWhitelist::whitelist)
 
@@ -375,11 +378,17 @@ object AttachmentsClassLoaderBuilder {
                     .withWhitelist(whitelistedClasses)
                     .withCustomSerializers(serializers)
                     .withoutCarpenter()
-        }).withProperties(mapOf<Any, Any>(
-            // Duplicate the SerializationContext from the cache and give
-            // it these extra properties, just for this transaction.
-            AMQP_ENVELOPE_CACHE_PROPERTY to HashMap<Any, Any>(AMQP_ENVELOPE_CACHE_INITIAL_CAPACITY),
-            DESERIALIZATION_CACHE_PROPERTY to HashMap<Any, Any>()
+        })
+
+        val serializationContext = cachedSerializationContext.withProperties(mapOf<Any, Any>(
+                // Duplicate the SerializationContext from the cache and give
+                // it these extra properties, just for this transaction.
+                // However, keep a strong reference to the cached SerializationContext so we can
+                // leverage the power of WeakReferences in the AttachmentsClassLoaderCacheImpl to figure
+                // out when all these have gone out of scope by the BasicVerifier going out of scope.
+                AMQP_ENVELOPE_CACHE_PROPERTY to HashMap<Any, Any>(AMQP_ENVELOPE_CACHE_INITIAL_CAPACITY),
+                DESERIALIZATION_CACHE_PROPERTY to HashMap<Any, Any>(),
+                STRONG_REFERENCE_TO_CACHED_SERIALIZATION_CONTEXT to cachedSerializationContext
         ))
 
         // Deserialize all relevant classes in the transaction classloader.
@@ -471,17 +480,33 @@ interface AttachmentsClassLoaderCache {
 @DeleteForDJVM
 class AttachmentsClassLoaderCacheImpl(cacheFactory: NamedCacheFactory) : SingletonSerializeAsToken(), AttachmentsClassLoaderCache {
 
+    private class ToBeClosed(val serializationContextReference: Reference<SerializationContext>, val classLoaderToClose: AutoCloseable, val cacheKey: AttachmentsClassLoaderKey)
+
+    private val toBeClosed: Queue<ToBeClosed> = LinkedBlockingQueue()
+
     private val cache: Cache<AttachmentsClassLoaderKey, SerializationContext> = cacheFactory.buildNamed(
-        // Close deserialization classloaders when we evict them
-        // to release any resources they may be holding.
-        @Suppress("TooGenericExceptionCaught")
-        Caffeine.newBuilder().removalListener { key, context, _ ->
-            try {
-                (context?.deserializationClassLoader as? AutoCloseable)?.close()
-            } catch (e: Exception) {
-                loggerFor<AttachmentsClassLoaderCacheImpl>().warn("Error destroying serialization context for $key", e)
-            }
-        }, "AttachmentsClassLoader_cache"
+            // Close deserialization classloaders when we evict them
+            // to release any resources they may be holding.
+            @Suppress("TooGenericExceptionCaught")
+            Caffeine.newBuilder().removalListener { key, context, _ ->
+                val autoCloseable = context?.deserializationClassLoader as? AutoCloseable
+                if (autoCloseable != null) {
+                    toBeClosed += ToBeClosed(WeakReference(context!!), autoCloseable, key!!)
+                }
+                while (true) {
+                    val peeked: ToBeClosed? = toBeClosed.peek()
+                    if (peeked == null || peeked.serializationContextReference.get() != null) break // Stop processing queue
+
+                    // The reference has been cleared, so context has gone out of all scopes
+                    toBeClosed.poll() // We only peeked previously
+                    try {
+                        peeked.classLoaderToClose.close()
+                    } catch (e: Exception) {
+                        loggerFor<AttachmentsClassLoaderCacheImpl>().warn("Error destroying serialization context for ${peeked.cacheKey}", e)
+                    }
+                }
+
+            }, "AttachmentsClassLoader_cache"
     )
 
     override fun computeIfAbsent(key: AttachmentsClassLoaderKey, mappingFunction: Function<in AttachmentsClassLoaderKey, out SerializationContext>): SerializationContext {


### PR DESCRIPTION
(Yes, I need to fix title etc once I locate a JIRA)

Delay closing of attachment class loaders until all SerializationContext that refer to them (from BasicVerifier) have gone out of scope.