### PR TITLE
ENT-8794 Delay closing of attachment class loaders

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/AttachmentsClassLoaderTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/AttachmentsClassLoaderTests.kt
@@ -75,7 +75,7 @@ class AttachmentsClassLoaderTests {
         val BOB = TestIdentity(BOB_NAME, 80).party
         val dummyNotary = TestIdentity(DUMMY_NOTARY_NAME, 20)
         val DUMMY_NOTARY get() = dummyNotary.party
-        val PROGRAM_ID: String = "net.corda.testing.contracts.MyDummyContract"
+        const val PROGRAM_ID = "net.corda.testing.contracts.MyDummyContract"
     }
 
     @Rule
@@ -576,6 +576,7 @@ class AttachmentsClassLoaderTests {
                         attachmentsClassLoaderCache = attachmentsClassLoaderCache
                 )
                 transactions.add(transaction)
+                System.gc()
                 Thread.sleep(1)
             }
 
@@ -607,7 +608,7 @@ class AttachmentsClassLoaderTests {
                 }
             """.trimIndent()
 
-        System.out.println(output)
+        println(output)
         return output
     }
 
@@ -615,6 +616,7 @@ class AttachmentsClassLoaderTests {
 
         val attachment = object : AbstractAttachment({contractJarPath.inputStream().readBytes()}, uploader = "app") {
             @Suppress("OverridingDeprecatedMember")
+            @Deprecated("Use signerKeys. There is no requirement that attachment signers are Corda parties.")
             override val signers: List<Party> = emptyList()
             override val signerKeys: List<PublicKey> = emptyList()
             override val size: Int = 1234
@@ -625,6 +627,7 @@ class AttachmentsClassLoaderTests {
         return listOf(
                 object : AbstractAttachment({ISOLATED_CONTRACTS_JAR_PATH.openStream().readBytes()}, uploader = "app") {
                     @Suppress("OverridingDeprecatedMember")
+                    @Deprecated("Use signerKeys. There is no requirement that attachment signers are Corda parties.")
                     override val signers: List<Party> = emptyList()
                     override val signerKeys: List<PublicKey> = emptyList()
                     override val size: Int = 1234
@@ -633,6 +636,7 @@ class AttachmentsClassLoaderTests {
                 object : AbstractAttachment({fakeAttachment("importantDoc.pdf", "I am a pdf!").inputStream().readBytes()
                                                                                                                    }, uploader = "app") {
                     @Suppress("OverridingDeprecatedMember")
+                    @Deprecated("Use signerKeys. There is no requirement that attachment signers are Corda parties.")
                     override val signers: List<Party> = emptyList()
                     override val signerKeys: List<PublicKey> = emptyList()
                     override val size: Int = 1234

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -77,7 +77,6 @@ abstract class AbstractVerifier(
      */
     final override fun verify() {
         try {
-            println("Verifying class loader $transactionClassLoader")
             TransactionVerifier(transactionClassLoader).apply(transaction)
         } catch (e: TransactionVerificationException) {
             logger.error("Error validating transaction ${ltx.id}.", e.cause)

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionVerifierServiceInternal.kt
@@ -16,9 +16,9 @@ import net.corda.core.contracts.TransactionState
 import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.contracts.TransactionVerificationException.ConflictingAttachmentsRejection
 import net.corda.core.contracts.TransactionVerificationException.ConstraintPropagationRejection
+import net.corda.core.contracts.TransactionVerificationException.ContractConstraintRejection
 import net.corda.core.contracts.TransactionVerificationException.ContractCreationError
 import net.corda.core.contracts.TransactionVerificationException.ContractRejection
-import net.corda.core.contracts.TransactionVerificationException.ContractConstraintRejection
 import net.corda.core.contracts.TransactionVerificationException.Direction
 import net.corda.core.contracts.TransactionVerificationException.DuplicateAttachmentsRejection
 import net.corda.core.contracts.TransactionVerificationException.InvalidConstraintRejection
@@ -77,6 +77,7 @@ abstract class AbstractVerifier(
      */
     final override fun verify() {
         try {
+            println("Verifying class loader $transactionClassLoader")
             TransactionVerifier(transactionClassLoader).apply(transaction)
         } catch (e: TransactionVerificationException) {
             logger.error("Error validating transaction ${ltx.id}.", e.cause)

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -508,6 +508,7 @@ class AttachmentsClassLoaderCacheImpl(cacheFactory: NamedCacheFactory) : Singlet
                     }
 
                     try {
+                        println("Closing class loader ${head.classLoaderToClose}")
                         head.classLoaderToClose.close()
                     } catch (e: Exception) {
                         loggerFor<AttachmentsClassLoaderCacheImpl>().warn("Error destroying serialization context for ${head.cacheKey}", e)

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -491,7 +491,7 @@ class AttachmentsClassLoaderCacheImpl(cacheFactory: NamedCacheFactory) : Singlet
                 if (autoCloseable != null) {
                     // Queue to be closed once the BasicVerifier, which has a strong reference chain to this SerializationContext
                     // has gone out of scope
-                    toBeClosed += ToBeClosed(WeakReference(context!!), autoCloseable, key!!)
+                    toBeClosed += ToBeClosed(WeakReference(context), autoCloseable, key!!)
                 }
 
                 // Try and close the class loader at the head of the queue if the associated SerializationContext has gone out of scope


### PR DESCRIPTION
Delay closing of attachment class loaders until all SerializationContext that refer to them (from BasicVerifier) have gone out of scope.

We also have had to remove re-use of JAR files across AttachmentsClassLoaders as the JVM does not reference count the JAR files, so closing a class loader (to stop file handle leaks) closes the JAR file sitting under other class loaders if any of the attachments are in-common between the two (or more).

This does not leak temporary files on the file system as each temporary file created from an attachment is automatically deleted.  However, it will be slower than re-using the JAR files for each attachment, as each time one is referenced, a new temporary JAR file is created, and the signatures need to be re-verified.  However, it turns out that we verify the attachments multiple times when creating an AttachmentsClassLoader (lots of openAsJar() followed by nextEntry() - which checks sigs etc) already, so I think we can discount this overhead as one that already exists.

I did attempt reference counting, but some parts of the JDK conspire against it and ultimately I was unsuccessful, and required to a lot of fragile code messing around in `sun.*` packages to get close.

