### PR TITLE
Extract notaryHandleTimeout as parameter

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -154,7 +154,8 @@ class DriverDSLImpl(
         val djvmCordaSource: List<Path>,
         val environmentVariables: Map<String, String>,
         val allowHibernateToManageAppSchema: Boolean = true,
-        val premigrateH2Database: Boolean = true
+        val premigrateH2Database: Boolean = true,
+        val notaryHandleTimeout: Duration = Duration.ofMinutes(1)
 ) : InternalDriverDSL {
 
     private var _executorService: ScheduledExecutorService? = null
@@ -854,7 +855,6 @@ class DriverDSLImpl(
         // While starting with inProcess mode, we need to have different names to avoid clashes
         private val inMemoryCounter = AtomicInteger()
 
-        private val notaryHandleTimeout = Duration.ofMinutes(1)
         private val defaultRpcUserList = listOf(InternalUser("default", "default", setOf("ALL")).toConfig().root().unwrapped())
         private val names = arrayOf(ALICE_NAME, BOB_NAME, DUMMY_BANK_A_NAME)
 


### PR DESCRIPTION
Integration workflows tests fail due to hardcoded value for notaryHandleTimeout

I hereby certify that my contribution is in accordance with the [Developer Certificate of Origin](https://developercertificate.org/)