### PR TITLE
ENT-8817 OS port of compute deadlock changes

### DIFF
--- a/node/src/test/kotlin/net/corda/node/utilities/InfrequentlyMutatedCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/InfrequentlyMutatedCacheTest.kt
@@ -25,6 +25,11 @@ class InfrequentlyMutatedCacheTest {
         database.close()
     }
 
+    @Test(timeout = 300_000)
+    fun `invalidate outside transaction should not hang`() {
+        cache.invalidate("Fred")
+    }
+
     @Test(timeout=300_000)
 	fun `get from empty cache returns result of loader`() {
         database.transaction {


### PR DESCRIPTION
OS port of https://github.com/corda/enterprise/pull/4629

test timed out after 300000 milliseconds
org.junit.runners.model.TestTimedOutException: test timed out after 300000 milliseconds
at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1934)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.remap(BoundedLocalCache.java:2562)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.compute(BoundedLocalCache.java:2514)
at com.github.benmanes.caffeine.cache.LocalCache.compute(LocalCache.java:95)
at net.corda.node.utilities.InfrequentlyMutatedCache.decrementInvalidators(InfrequentlyMutatedCache.kt:92)
at net.corda.node.utilities.InfrequentlyMutatedCache.invalidate(InfrequentlyMutatedCache.kt:84)
at net.corda.node.utilities.InfrequentlyMutatedCache.access$invalidate(InfrequentlyMutatedCache.kt:18)
at net.corda.node.utilities.InfrequentlyMutatedCache$invalidate$1.apply(InfrequentlyMutatedCache.kt:65)
at net.corda.node.utilities.InfrequentlyMutatedCache$invalidate$1.apply(InfrequentlyMutatedCache.kt:18)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$remap$16(BoundedLocalCache.java:2567)
at com.github.benmanes.caffeine.cache.BoundedLocalCache$$Lambda$103/323142272.apply(Unknown Source)
at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1853)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.remap(BoundedLocalCache.java:2562)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.compute(BoundedLocalCache.java:2514)
at com.github.benmanes.caffeine.cache.LocalCache.compute(LocalCache.java:95)
at net.corda.node.utilities.InfrequentlyMutatedCache.invalidate(InfrequentlyMutatedCache.kt:59)
at net.corda.node.utilities.InfrequentlyMutatedCacheTest.invalidate outside transaction should not hang(InfrequentlyMutatedCacheTest.kt:30)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.lang.Thread.run(Thread.java:748)