### PR TITLE
ENT-8823: StartEnd events now dont get mangled when parent span is a …

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -9391,7 +9391,8 @@ public class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.
   public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean)
   public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean, boolean)
   public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean, boolean, boolean)
-  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean, boolean, boolean, boolean)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean, boolean, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.time.Duration component1()
   @NotNull
@@ -9419,7 +9420,7 @@ public class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.
   @NotNull
   public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
   @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean, boolean, boolean)
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, boolean, boolean, boolean, boolean)
   public boolean equals(Object)
   public int getCacheConcurrencyLevel()
   @NotNull
@@ -9427,6 +9428,7 @@ public class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.
   @NotNull
   public java.time.Duration getConnectionRetryInterval()
   public double getConnectionRetryIntervalMultiplier()
+  public boolean getCopyBaggageToTags()
   @NotNull
   public java.time.Duration getDeduplicationCacheExpiry()
   public int getMaxFileSize()

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -179,7 +179,9 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
 
         open val simpleLogTelemetryEnabled: Boolean = false,
 
-        open val spanStartEndEventsEnabled: Boolean = true
+        open val spanStartEndEventsEnabled: Boolean = false,
+
+        open val copyBaggageToTags: Boolean = false
 ) {
 
     companion object {
@@ -226,7 +228,8 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
                 deduplicationCacheExpiry,
                 openTelemetryEnabled,
                 simpleLogTelemetryEnabled,
-                spanStartEndEventsEnabled
+                spanStartEndEventsEnabled,
+                copyBaggageToTags
         )
     }
 
@@ -246,7 +249,8 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
             deduplicationCacheExpiry: Duration = this.deduplicationCacheExpiry,
             openTelemetryEnabled: Boolean = this.openTelemetryEnabled,
             simpleLogTelemetryEnabled: Boolean = this.simpleLogTelemetryEnabled,
-            spanStartEndEventsEnabled: Boolean = this.spanStartEndEventsEnabled
+            spanStartEndEventsEnabled: Boolean = this.spanStartEndEventsEnabled,
+            copyBaggageToTags: Boolean = this.copyBaggageToTags
     ): CordaRPCClientConfiguration {
         return CordaRPCClientConfiguration(
                 connectionMaxRetryInterval,
@@ -262,7 +266,8 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
                 deduplicationCacheExpiry,
                 openTelemetryEnabled,
                 simpleLogTelemetryEnabled,
-                spanStartEndEventsEnabled
+                spanStartEndEventsEnabled,
+                copyBaggageToTags
         )
     }
 
@@ -286,6 +291,7 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
         if (openTelemetryEnabled != other.openTelemetryEnabled) return false
         if (simpleLogTelemetryEnabled != other.simpleLogTelemetryEnabled) return false
         if (spanStartEndEventsEnabled != other.spanStartEndEventsEnabled) return false
+        if (copyBaggageToTags != other.copyBaggageToTags) return false
 
         return true
     }
@@ -306,6 +312,7 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
         result = 31 * result + openTelemetryEnabled.hashCode()
         result = 31 * result + simpleLogTelemetryEnabled.hashCode()
         result = 31 * result + spanStartEndEventsEnabled.hashCode()
+        result = 31 * result + copyBaggageToTags.hashCode()
         return result
     }
 
@@ -321,7 +328,8 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
                 "deduplicationCacheExpiry=$deduplicationCacheExpiry, " +
                 "openTelemetryEnabled=$openTelemetryEnabled, " +
                 "simpleLogTelemetryEnabled=$simpleLogTelemetryEnabled, " +
-                "spanStartEndEventsEnabled=$spanStartEndEventsEnabled)"
+                "spanStartEndEventsEnabled=$spanStartEndEventsEnabled, " +
+                "copyBaggageToTags=$copyBaggageToTags )"
     }
 
     // Left in for backwards compatibility with version 3.1

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -102,7 +102,7 @@ class RPCClient<I : RPCOps>(
 
             val targetString = "${transport.params[TransportConstants.HOST_PROP_NAME]}:${transport.params[TransportConstants.PORT_PROP_NAME]}"
             val rpcClientTelemetry = RPCClientTelemetry("rpcClient-$targetString", rpcConfiguration.openTelemetryEnabled,
-                    rpcConfiguration.simpleLogTelemetryEnabled, rpcConfiguration.spanStartEndEventsEnabled)
+                    rpcConfiguration.simpleLogTelemetryEnabled, rpcConfiguration.spanStartEndEventsEnabled, rpcConfiguration.copyBaggageToTags)
             val sessionId = Trace.SessionId.newInstance()
             val distributionMux = DistributionMux(listeners, username)
             val proxyHandler = RPCClientProxyHandler(rpcConfiguration, username, password, serverLocator,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientTelemetry.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientTelemetry.kt
@@ -5,7 +5,9 @@ import net.corda.core.internal.telemetry.SimpleLogTelemetryComponent
 import net.corda.core.internal.telemetry.TelemetryServiceImpl
 import net.corda.core.utilities.contextLogger
 
-class RPCClientTelemetry(val serviceName: String, val openTelemetryEnabled: Boolean, val simpleLogTelemetryEnabled: Boolean, val spanStartEndEventsEnabled: Boolean) {
+class RPCClientTelemetry(val serviceName: String, val openTelemetryEnabled: Boolean,
+                         val simpleLogTelemetryEnabled: Boolean, val spanStartEndEventsEnabled: Boolean,
+                         val copyBaggageToTags: Boolean) {
 
     companion object {
         private val log = contextLogger()
@@ -16,7 +18,7 @@ class RPCClientTelemetry(val serviceName: String, val openTelemetryEnabled: Bool
     init {
         if (openTelemetryEnabled) {
             try {
-                val openTelemetryComponent = OpenTelemetryComponent(serviceName, spanStartEndEventsEnabled)
+                val openTelemetryComponent = OpenTelemetryComponent(serviceName, spanStartEndEventsEnabled, copyBaggageToTags)
                 if (openTelemetryComponent.isEnabled()) {
                     telemetryService.addTelemetryComponent(openTelemetryComponent)
                     log.debug("OpenTelemetry enabled")

--- a/constants.properties
+++ b/constants.properties
@@ -13,8 +13,8 @@ java8MinUpdateVersion=171
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #
 # ***************************************************************#
 platformVersion=12
-openTelemetryVersion=1.17.0
-openTelemetrySemConvVersion=1.17.0-alpha
+openTelemetryVersion=1.20.1
+openTelemetrySemConvVersion=1.20.1-alpha
 guavaVersion=28.0-jre
 # Quasar version to use with Java 8:
 quasarVersion=0.7.15_r3

--- a/core/src/main/kotlin/net/corda/core/internal/telemetry/SimpleLogTelemetryComponent.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/telemetry/SimpleLogTelemetryComponent.kt
@@ -57,13 +57,13 @@ class SimpleLogTelemetryComponent : TelemetryComponent {
         logContexts[traceId] = SimpleLogContext(traceId, baggageAttributes)
         clientId?.let { MDC.put(CLIENT_ID, it) }
         MDC.put(TRACE_ID, traceId.toString())
-        log.debug {"startSpanForFlow: name: $name, traceId: $traceId, flowId: $flowId, clientId: $clientId, attributes: ${attributes+baggageAttributes}"}
+        log.info("startSpanForFlow: name: $name, traceId: $traceId, flowId: $flowId, clientId: $clientId, attributes: ${attributes+baggageAttributes}")
     }
 
     // Check when you start a top level flow the startSpanForFlow appears just once, and so the endSpanForFlow also appears just once
     // So its valid to do the MDC clear here. For remotes nodes as well
     private fun endSpanForFlow(telemetryId: UUID) {
-        log.debug {"endSpanForFlow: traceId: ${traces.get()}"}
+        log.info("endSpanForFlow: traceId: ${traces.get()}")
         logContexts.remove(telemetryId)
         MDC.clear()
     }
@@ -73,12 +73,12 @@ class SimpleLogTelemetryComponent : TelemetryComponent {
         val flowId = flowLogic?.runId
         val clientId = flowLogic?.stateMachine?.clientId
         val traceId = traces.get()
-        log.debug {"startSpan: name: $name, traceId: $traceId, flowId: $flowId, clientId: $clientId, attributes: $attributes"}
+        log.info("startSpan: name: $name, traceId: $traceId, flowId: $flowId, clientId: $clientId, attributes: $attributes")
     }
 
     @Suppress("UNUSED_PARAMETER")
     private fun endSpan(telemetryId: UUID) {
-        log.debug {"endSpan: traceId: ${traces.get()}"}
+        log.info("endSpan: traceId: ${traces.get()}")
     }
 
     override fun getCurrentTelemetryData(): SimpleLogContext {
@@ -119,7 +119,7 @@ class SimpleLogTelemetryComponent : TelemetryComponent {
     private fun setStatus(telemetryId: UUID, telemetryStatusCode: TelemetryStatusCode, message: String) {
         when(telemetryStatusCode) {
             TelemetryStatusCode.ERROR -> log.error("setStatus: traceId: ${traces.get()}, statusCode: ${telemetryStatusCode}, message: message")
-            TelemetryStatusCode.OK, TelemetryStatusCode.UNSET -> log.debug {"setStatus: traceId: ${traces.get()}, statusCode: ${telemetryStatusCode}, message: message" }
+            TelemetryStatusCode.OK, TelemetryStatusCode.UNSET -> log.info("setStatus: traceId: ${traces.get()}, statusCode: ${telemetryStatusCode}, message: message")
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/internal/telemetry/SimpleLogTelemetryComponent.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/telemetry/SimpleLogTelemetryComponent.kt
@@ -2,7 +2,6 @@ package net.corda.core.internal.telemetry
 
 import net.corda.core.flows.FlowLogic
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.utilities.debug
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -256,7 +256,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     }
     val cordappLoader: CordappLoader = makeCordappLoader(configuration, versionInfo).closeOnStop(false)
     val telemetryService: TelemetryServiceImpl = TelemetryServiceImpl().also {
-        val openTelemetryComponent = OpenTelemetryComponent(configuration.myLegalName.toString(), configuration.telemetry.spanStartEndEventsEnabled)
+        val openTelemetryComponent = OpenTelemetryComponent(configuration.myLegalName.toString(), configuration.telemetry.spanStartEndEventsEnabled, configuration.telemetry.copyBaggageToTags)
         if (configuration.telemetry.openTelemetryEnabled && openTelemetryComponent.isEnabled()) {
             it.addTelemetryComponent(openTelemetryComponent)
         }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -224,7 +224,8 @@ data class FlowTimeoutConfiguration(
 data class TelemetryConfiguration(
         val openTelemetryEnabled: Boolean,
         val simpleLogTelemetryEnabled: Boolean,
-        val spanStartEndEventsEnabled: Boolean
+        val spanStartEndEventsEnabled: Boolean,
+        val copyBaggageToTags: Boolean
 )
 
 internal typealias Valid<TARGET> = Validated<TARGET, Configuration.Validation.Error>

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -134,7 +134,7 @@ data class NodeConfigurationImpl(
         fun database(devMode: Boolean) = DatabaseConfig(
                 exportHibernateJMXStatistics = devMode
         )
-        val telemetry = TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = true)
+        val telemetry = TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = false, copyBaggageToTags = false)
     }
 
     companion object {

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/ConfigSections.kt
@@ -229,10 +229,11 @@ internal object TelemetryConfigurationSpec : Configuration.Specification<Telemet
     private val openTelemetryEnabled by boolean()
     private val simpleLogTelemetryEnabled by boolean()
     private val spanStartEndEventsEnabled by boolean()
+    private val copyBaggageToTags by boolean()
 
     override fun parseValid(configuration: Config, options: Configuration.Options): Valid<TelemetryConfiguration> {
         val config = configuration.withOptions(options)
-        return valid(TelemetryConfiguration(config[openTelemetryEnabled], config[simpleLogTelemetryEnabled], config[spanStartEndEventsEnabled]))
+        return valid(TelemetryConfiguration(config[openTelemetryEnabled], config[simpleLogTelemetryEnabled], config[spanStartEndEventsEnabled], config[copyBaggageToTags]))
     }
 }
 

--- a/node/src/main/resources/corda-reference.conf
+++ b/node/src/main/resources/corda-reference.conf
@@ -28,5 +28,6 @@ verifierType = InMemory
 telemetry {
     openTelemetryEnabled = true,
     simpleLogTelemetryEnabled = false,
-    spanStartEndEventsEnabled = true
+    spanStartEndEventsEnabled = false,
+    copyBaggageToTags = false
 }

--- a/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
@@ -196,7 +196,7 @@ class NodeTest {
                 rpcUsers = emptyList(),
                 verifierType = VerifierType.InMemory,
                 flowTimeout = FlowTimeoutConfiguration(timeout = Duration.ZERO, backoffBase = 1.0, maxRestartCount = 1),
-                telemetry = TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = true),
+                telemetry = TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = false, copyBaggageToTags = false),
                 rpcSettings = NodeRpcSettings(address = fakeAddress, adminAddress = null, ssl = null),
                 messagingServerAddress = null,
                 notary = null,

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -397,7 +397,7 @@ class NodeConfigurationImplTest {
                 p2pAddress = NetworkHostAndPort("localhost", 0),
                 messagingServerAddress = null,
                 flowTimeout = FlowTimeoutConfiguration(5.seconds, 3, 1.0),
-                telemetry = TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = true),
+                telemetry = TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = false, copyBaggageToTags = false),
                 notary = null,
                 devMode = true,
                 noLocalShell = false,

--- a/opentelemetry/build.gradle
+++ b/opentelemetry/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'java-library'
     id 'net.corda.plugins.publish-utils'
+    id 'com.jfrog.artifactory'
 }
 
 description 'OpenTelemetry SDK Bundle'

--- a/opentelemetry/build.gradle
+++ b/opentelemetry/build.gradle
@@ -1,11 +1,8 @@
 import static org.gradle.api.JavaVersion.VERSION_1_8
 
 plugins {
-    // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    id 'org.jetbrains.kotlin.jvm' // version '1.6.21'
-    // Apply the java-library plugin for API and implementation separation.
+    id 'org.jetbrains.kotlin.jvm'
     id 'java-library'
-    //id 'com.github.johnrengelman.shadow' // version '7.1.2'
     id 'net.corda.plugins.publish-utils'
 }
 

--- a/opentelemetry/opentelemetry-driver/build.gradle
+++ b/opentelemetry/opentelemetry-driver/build.gradle
@@ -1,11 +1,9 @@
 import static org.gradle.api.JavaVersion.VERSION_1_8
 
 plugins {
-    // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    id 'org.jetbrains.kotlin.jvm' // version '1.6.21'
-    // Apply the java-library plugin for API and implementation separation.
+    id 'org.jetbrains.kotlin.jvm'
     id 'java-library'
-    id 'com.github.johnrengelman.shadow' // version '7.1.2'
+    id 'com.github.johnrengelman.shadow'
     id 'net.corda.plugins.publish-utils'
 }
 

--- a/opentelemetry/opentelemetry-driver/build.gradle
+++ b/opentelemetry/opentelemetry-driver/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'java-library'
     id 'com.github.johnrengelman.shadow'
     id 'net.corda.plugins.publish-utils'
+    id 'com.jfrog.artifactory'
 }
 
 description 'OpenTelemetry Driver'
@@ -36,4 +37,3 @@ publish {
     disableDefaultJar = true
     name  'corda-opentelemetry-driver'
 }
-

--- a/opentelemetry/src/main/kotlin/net/corda/opentelemetrydriver/OpenTelemetryDriver.kt
+++ b/opentelemetry/src/main/kotlin/net/corda/opentelemetrydriver/OpenTelemetryDriver.kt
@@ -1,9 +1,11 @@
 package net.corda.opentelemetrydriver
 
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.context.propagation.TextMapPropagator
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -32,7 +34,8 @@ class OpenTelemetryDriver(serviceName: String) {
         val openTelemetry: OpenTelemetry = OpenTelemetrySdk.builder()
                 .setTracerProvider(sdkTracerProvider)
                 .setMeterProvider(sdkMeterProvider)
-                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .setPropagators(ContextPropagators.create(TextMapPropagator.composite(W3CTraceContextPropagator.getInstance(),
+                                                                                      W3CBaggagePropagator.getInstance())))
                 .build()
 
     fun shutdown() {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -492,7 +492,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
             doReturn(emptyList<SecureHash>()).whenever(it).extraNetworkMapKeys
             doReturn(listOf(baseDirectory / "cordapps")).whenever(it).cordappDirectories
             doReturn(emptyList<String>()).whenever(it).quasarExcludePackages
-            doReturn(TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = true)).whenever(it).telemetry
+            doReturn(TelemetryConfiguration(openTelemetryEnabled = true, simpleLogTelemetryEnabled = false, spanStartEndEventsEnabled = false, copyBaggageToTags = false)).whenever(it).telemetry
             parameters.configOverrides(it)
         }
 


### PR DESCRIPTION
ENT-8823: StartEnd events now don't get mangled when parent span is a user span. 
Changed the default for these startEnd events to be generated to be false. There is potentially a network impact of all these event spans on the network which may not be desirable in production.
Added a configuration option copyBaggageToTags which when true will copy any baggage in the current context to tags. Default is false.
Switched to using the OT propagator when sending context between nodes.


