### PR TITLE
INFRA-1904: Enable Snyk Delta on C4 ENT/OS shared pipeline

### DIFF
--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -11,6 +11,14 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
     }
 
+    /*
+     * List environment variables in alphabetical order
+     */
+    environment {
+        SNYK_API_TOKEN = credentials('c4-os-snyk-api-token-secret')
+        C4_OS_SNYK_ORG_ID = credentials('c4-os-snyk-org-id')
+    }
+
     stages {
         stage('Detekt check') {
             steps {
@@ -21,6 +29,25 @@ pipeline {
         stage('Compilation warnings check') {
             steps {
                 sh "./gradlew --no-daemon -Pcompilation.warningsAsErrors=true compileAll"
+            }
+        }
+
+        stage('Snyk Delta') {
+            agent {
+                docker {
+                    image 'build-zulu-openjdk:8'
+                    reuseNode true
+                    registryUrl 'https://engineering-docker.software.r3.com/'
+                    registryCredentialsId 'artifactory-credentials'
+                    args '-v /tmp:/host_tmp'
+                }
+            }
+            environment {
+                GRADLE_USER_HOME = "/host_tmp/gradle"
+            }
+            steps {
+                sh 'mkdir -p ${GRADLE_USER_HOME}'
+                snykDeltaScan(env.SNYK_API_TOKEN, env.C4_OS_SNYK_ORG_ID)
             }
         }
 


### PR DESCRIPTION
Snyk Delta should be running on any Corda PR’s to check if any build files have been modified and are introducing new security vulnerabilities. If it is a newly added build file it should also do a full Snyk test to similarly check for introduced vulnerabilities.

PR adds stage to run Snyk Delta on the code compatibility checks on Corda 4 Ent to check for any build changes made and for vulnerabilities introduced.