### PR TITLE
INFRA-2021: Revert - Temp fix for Snyk Delta

### DIFF
--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
             }
             steps {
                 sh 'mkdir -p ${GRADLE_USER_HOME}'
-				authenticateGradleWrapper()
+                authenticateGradleWrapper()
                 snykDeltaScan(env.SNYK_API_TOKEN, env.C4_OS_SNYK_ORG_ID)
             }
         }

--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -20,6 +20,19 @@ pipeline {
     }
 
     stages {
+        stage('Detekt check') {
+            steps {
+                authenticateGradleWrapper()
+                sh "./gradlew --no-daemon clean detekt"
+            }
+        }
+
+        stage('Compilation warnings check') {
+            steps {
+                sh "./gradlew --no-daemon -Pcompilation.warningsAsErrors=true compileAll"
+            }
+        }
+
         stage('Snyk Delta') {
             agent {
                 docker {
@@ -36,19 +49,6 @@ pipeline {
             steps {
                 sh 'mkdir -p ${GRADLE_USER_HOME}'
                 snykDeltaScan(env.SNYK_API_TOKEN, env.C4_OS_SNYK_ORG_ID)
-            }
-        }
-        
-        stage('Detekt check') {
-            steps {
-                authenticateGradleWrapper()
-                sh "./gradlew --no-daemon clean detekt"
-            }
-        }
-
-        stage('Compilation warnings check') {
-            steps {
-                sh "./gradlew --no-daemon -Pcompilation.warningsAsErrors=true compileAll"
             }
         }
 

--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -48,6 +48,7 @@ pipeline {
             }
             steps {
                 sh 'mkdir -p ${GRADLE_USER_HOME}'
+				authenticateGradleWrapper()
                 snykDeltaScan(env.SNYK_API_TOKEN, env.C4_OS_SNYK_ORG_ID)
             }
         }


### PR DESCRIPTION
This reverts commit 2ce0409bd25000621e4d7e7a555dd11952af40a9.

The previous commit was to unblock PR's hitting Snyk Delta stage. 
**New fix** to add in the `authenticateGradleWrapper()` to th Snyk Delta stage when the pipeline switches to a new `build-zulu-openjdk:8` agent. 
