### PR TITLE
INFRA-1955: Shared lib implicit import syntax

### DIFF
--- a/.ci/dev/nightly-regression/JenkinsfileSnykScan
+++ b/.ci/dev/nightly-regression/JenkinsfileSnykScan
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps')
+@Library('corda-shared-build-pipeline-steps') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'c4-os-snyk-api-token-secret',


### PR DESCRIPTION
The trailing character added after referencing the shared library is required to successfully import.