### PR TITLE
ENT-8898: Replaced JDK cert revocation with custom plugable implementation

### DIFF
--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     // SQL connection pooling library
     compile "com.zaxxer:HikariCP:$hikari_version"
-    
+
     // ClassGraph: classpath scanning
     compile "io.github.classgraph:classgraph:$class_graph_version"
 
@@ -54,6 +54,9 @@ dependencies {
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
+
+    testCompile project(':node-driver')
+
     // Unit testing helpers.
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -438,6 +438,8 @@ class X509CertificateFactory {
     fun generateCertPath(vararg certificates: X509Certificate): CertPath = generateCertPath(certificates.asList())
 
     fun generateCertPath(certificates: List<X509Certificate>): CertPath = delegate.generateCertPath(certificates)
+
+    fun generateCRL(input: InputStream): X509CRL = delegate.generateCRL(input) as X509CRL
 }
 
 enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurposeId, val isCA: Boolean, val role: CertRole?) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
@@ -28,7 +28,6 @@ import org.apache.qpid.proton.framing.TransportFrame
 import org.slf4j.MDC
 import java.net.InetSocketAddress
 import java.nio.channels.ClosedChannelException
-import java.security.cert.PKIXRevocationChecker
 import java.security.cert.X509Certificate
 import javax.net.ssl.ExtendedSSLSession
 import javax.net.ssl.SNIHostName
@@ -47,7 +46,6 @@ internal class AMQPChannelHandler(private val serverMode: Boolean,
                                   private val password: String?,
                                   private val trace: Boolean,
                                   private val suppressLogs: Boolean,
-                                  private val revocationChecker: PKIXRevocationChecker,
                                   private val onOpen: (SocketChannel, ConnectionChange) -> Unit,
                                   private val onClose: (SocketChannel, ConnectionChange) -> Unit,
                                   private val onReceive: (ReceivedMessage) -> Unit) : ChannelDuplexHandler() {
@@ -169,13 +167,6 @@ internal class AMQPChannelHandler(private val serverMode: Boolean,
                     handleSuccessfulHandshake(ctx)
                 } else {
                     handleFailedHandshake(ctx, evt)
-                }
-                if (log.isDebugEnabled) {
-                    withMDC {
-                        revocationChecker.softFailExceptions.forEachIndexed { index, e ->
-                            log.debug("Revocation soft fail exception (${index + 1}/${revocationChecker.softFailExceptions.size})", e)
-                        }
-                    }
                 }
             }
         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/CrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/CrlSource.kt
@@ -3,10 +3,11 @@ package net.corda.nodeapi.internal.protonwrapper.netty
 import java.security.cert.X509CRL
 import java.security.cert.X509Certificate
 
-interface ExternalCrlSource {
+@FunctionalInterface
+interface CrlSource {
 
     /**
      * Given certificate provides a set of CRLs, potentially performing remote communication.
      */
-    fun fetch(certificate: X509Certificate) : Set<X509CRL>
+    fun fetch(certificate: X509Certificate): Set<X509CRL>
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
@@ -50,6 +50,9 @@ internal const val DP_DEFAULT_ANSWER = "NO CRLDP ext"
 
 internal val logger = LoggerFactory.getLogger("net.corda.nodeapi.internal.protonwrapper.netty.SSLHelper")
 
+/**
+ * Returns all the CRL distribution points in the certificate as [URI]s along with the CRL issuer names, if any.
+ */
 @Suppress("ComplexMethod")
 fun X509Certificate.distributionPoints(): Map<URI, List<X500Principal>?> {
     logger.debug { "Checking CRLDPs for $subjectX500Principal" }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
@@ -24,15 +24,13 @@ class CertDistPointCrlSource : CrlSource {
         private const val DEFAULT_CACHE_SIZE = 185L  // Same default as the JDK (URICertStore)
         private const val DEFAULT_CACHE_EXPIRY = 5 * 60 * 1000L
 
+        private val cache: LoadingCache<URI, X509CRL> = Caffeine.newBuilder()
+                .maximumSize(java.lang.Long.getLong("net.corda.dpcrl.cache.size", DEFAULT_CACHE_SIZE))
+                .expireAfterWrite(java.lang.Long.getLong("net.corda.dpcrl.cache.expiry", DEFAULT_CACHE_EXPIRY), TimeUnit.MILLISECONDS)
+                .build(::retrieveCRL)
+
         private val connectTimeout = Integer.getInteger("net.corda.dpcrl.connect.timeout", DEFAULT_CONNECT_TIMEOUT)
         private val readTimeout = Integer.getInteger("net.corda.dpcrl.read.timeout", DEFAULT_READ_TIMEOUT)
-        private val cacheSize = java.lang.Long.getLong("net.corda.dpcrl.cache.size", DEFAULT_CACHE_SIZE)
-        private val cacheExpiry = java.lang.Long.getLong("net.corda.dpcrl.cache.expiry", DEFAULT_CACHE_EXPIRY)
-
-        private val cache: LoadingCache<URI, X509CRL> = Caffeine.newBuilder()
-                .maximumSize(cacheSize)
-                .expireAfterWrite(cacheExpiry, TimeUnit.MILLISECONDS)
-                .build(::retrieveCRL)
 
         private fun retrieveCRL(uri: URI): X509CRL {
             val bytes = run {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
@@ -20,9 +20,11 @@ class CertDistPointCrlSource : CrlSource {
         // Keep to the same defaults as the JDK (URICertStore)
         private const val DEFAULT_CONNECT_TIMEOUT = 15_000
         private const val DEFAULT_READ_TIMEOUT = 15_000
+        private const val CACHE_SIZE = 185L
         private const val CACHE_EXPIRY = 30L
 
         private val cache: LoadingCache<URI, X509CRL> = Caffeine.newBuilder()
+                .maximumSize(CACHE_SIZE)
                 .expireAfterWrite(CACHE_EXPIRY, TimeUnit.SECONDS)
                 .build(::retrieveCRL)
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
@@ -17,9 +17,11 @@ import javax.security.auth.x500.X500Principal
  */
 class CertDistPointCrlSource : CrlSource {
     companion object {
-        // Keep to the same defaults as the JDK (URICertStore)
-        private const val DEFAULT_CONNECT_TIMEOUT = 15_000
-        private const val DEFAULT_READ_TIMEOUT = 15_000
+        // The default SSL handshake timeout is 60s (DEFAULT_SSL_HANDSHAKE_TIMEOUT). Considering there are 3 CRLs endpoints to check in a
+        // node handshake, we want to keep the total timeout within that.
+        private const val DEFAULT_CONNECT_TIMEOUT = 9_000
+        private const val DEFAULT_READ_TIMEOUT = 9_000
+        // Use the same defaults for the cache as the JDK (URICertStore)
         private const val CACHE_SIZE = 185L
         private const val CACHE_EXPIRY = 30L
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
@@ -21,17 +21,18 @@ class CertDistPointCrlSource : CrlSource {
         // node handshake, we want to keep the total timeout within that.
         private const val DEFAULT_CONNECT_TIMEOUT = 9_000
         private const val DEFAULT_READ_TIMEOUT = 9_000
-        // Use the same defaults for the cache as the JDK (URICertStore)
-        private const val CACHE_SIZE = 185L
-        private const val CACHE_EXPIRY = 30L
+        private const val DEFAULT_CACHE_SIZE = 185L  // Same default as the JDK (URICertStore)
+        private const val DEFAULT_CACHE_EXPIRY = 5 * 60 * 1000L
+
+        private val connectTimeout = Integer.getInteger("net.corda.dpcrl.connect.timeout", DEFAULT_CONNECT_TIMEOUT)
+        private val readTimeout = Integer.getInteger("net.corda.dpcrl.read.timeout", DEFAULT_READ_TIMEOUT)
+        private val cacheSize = java.lang.Long.getLong("net.corda.dpcrl.cache.size", DEFAULT_CACHE_SIZE)
+        private val cacheExpiry = java.lang.Long.getLong("net.corda.dpcrl.cache.expiry", DEFAULT_CACHE_EXPIRY)
 
         private val cache: LoadingCache<URI, X509CRL> = Caffeine.newBuilder()
-                .maximumSize(CACHE_SIZE)
-                .expireAfterWrite(CACHE_EXPIRY, TimeUnit.SECONDS)
+                .maximumSize(cacheSize)
+                .expireAfterWrite(cacheExpiry, TimeUnit.MILLISECONDS)
                 .build(::retrieveCRL)
-
-        private val connectTimeout = Integer.getInteger("net.corda.crl.connectTimeoutMs", DEFAULT_CONNECT_TIMEOUT)
-        private val readTimeout = Integer.getInteger("net.corda.crl.readTimeoutMs", DEFAULT_READ_TIMEOUT)
 
         private fun retrieveCRL(uri: URI): X509CRL {
             val bytes = run {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
@@ -1,0 +1,80 @@
+package net.corda.nodeapi.internal.revocation
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.LoadingCache
+import net.corda.core.internal.readFully
+import net.corda.nodeapi.internal.crypto.X509CertificateFactory
+import net.corda.nodeapi.internal.protonwrapper.netty.CrlSource
+import net.corda.nodeapi.internal.protonwrapper.netty.distributionPoints
+import java.net.URI
+import java.security.cert.X509CRL
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.security.auth.x500.X500Principal
+
+/**
+ * [CrlSource] which downloads CRLs from the distribution points in the X509 certificate.
+ */
+class CertDistPointCrlSource : CrlSource {
+    companion object {
+        private const val DEFAULT_CONNECT_TIMEOUT = 60_000
+        private const val DEFAULT_READ_TIMEOUT = 60_000
+        private const val CACHE_EXPIRY = 30L  // Mimick the 30s cache expiry behaviour of the JDK (URICertStore.engineGetCRLs)
+
+        private val cache: LoadingCache<URI, X509CRL> = Caffeine.newBuilder()
+                .expireAfterWrite(CACHE_EXPIRY, TimeUnit.SECONDS)
+                .build(::retrieveCRL)
+
+        private val connectTimeout = Integer.getInteger("net.corda.crl.connectTimeoutMs", DEFAULT_CONNECT_TIMEOUT)
+        private val readTimeout = Integer.getInteger("net.corda.crl.readTimeoutMs", DEFAULT_READ_TIMEOUT)
+
+        private fun retrieveCRL(uri: URI): X509CRL {
+            val bytes = run {
+                val conn = uri.toURL().openConnection()
+                conn.connectTimeout = connectTimeout
+                conn.readTimeout = readTimeout
+                // Read all bytes first and then pass them into the CertificateFactory. This may seem unnecessary when generateCRL already takes
+                // in an InputStream, but the JDK implementation (sun.security.provider.X509Factory.engineGenerateCRL) converts any IOException
+                // into CRLException and drops the cause chain.
+                conn.getInputStream().readFully()
+            }
+            return X509CertificateFactory().generateCRL(bytes.inputStream())
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun fetch(certificate: X509Certificate): Set<X509CRL> {
+        val approvedCRLs = HashSet<X509CRL>()
+        var exception: Exception? = null
+        for ((distPointUri, issuerNames) in certificate.distributionPoints()) {
+            try {
+                val possibleCRL = getPossibleCRL(distPointUri)
+                if (verifyCRL(possibleCRL, certificate, issuerNames)) {
+                    approvedCRLs += possibleCRL
+                }
+            } catch (e: Exception) {
+                if (exception == null) {
+                    exception = e
+                } else {
+                    exception.addSuppressed(e)
+                }
+            }
+        }
+        // Only throw if no CRLs are retrieved
+        if (exception != null && approvedCRLs.isEmpty()) {
+            throw exception
+        } else {
+            return approvedCRLs
+        }
+    }
+
+    private fun getPossibleCRL(uri: URI): X509CRL {
+        return cache[uri]!!
+    }
+
+    // DistributionPointFetcher.verifyCRL
+    private fun verifyCRL(crl: X509CRL, certificate: X509Certificate, issuerNames: List<X500Principal>?): Boolean {
+        val crlIssuer = crl.issuerX500Principal
+        return issuerNames?.any { it == crlIssuer } ?: (certificate.issuerX500Principal == crlIssuer)
+    }
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
@@ -17,9 +17,10 @@ import javax.security.auth.x500.X500Principal
  */
 class CertDistPointCrlSource : CrlSource {
     companion object {
-        private const val DEFAULT_CONNECT_TIMEOUT = 60_000
-        private const val DEFAULT_READ_TIMEOUT = 60_000
-        private const val CACHE_EXPIRY = 30L  // Mimick the 30s cache expiry behaviour of the JDK (URICertStore.engineGetCRLs)
+        // Keep to the same defaults as the JDK (URICertStore)
+        private const val DEFAULT_CONNECT_TIMEOUT = 15_000
+        private const val DEFAULT_READ_TIMEOUT = 15_000
+        private const val CACHE_EXPIRY = 30L
 
         private val cache: LoadingCache<URI, X509CRL> = Caffeine.newBuilder()
                 .expireAfterWrite(CACHE_EXPIRY, TimeUnit.SECONDS)
@@ -73,8 +74,8 @@ class CertDistPointCrlSource : CrlSource {
     }
 
     // DistributionPointFetcher.verifyCRL
-    private fun verifyCRL(crl: X509CRL, certificate: X509Certificate, issuerNames: List<X500Principal>?): Boolean {
+    private fun verifyCRL(crl: X509CRL, certificate: X509Certificate, distPointIssuerNames: List<X500Principal>?): Boolean {
         val crlIssuer = crl.issuerX500Principal
-        return issuerNames?.any { it == crlIssuer } ?: (certificate.issuerX500Principal == crlIssuer)
+        return distPointIssuerNames?.any { it == crlIssuer } ?: (certificate.issuerX500Principal == crlIssuer)
     }
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSourceTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSourceTest.kt
@@ -1,0 +1,51 @@
+package net.corda.nodeapi.internal.revocation
+
+import net.corda.core.crypto.Crypto
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.createDevNodeCa
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.node.internal.network.CrlServer
+import org.assertj.core.api.Assertions.assertThat
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.math.BigInteger
+
+class CertDistPointCrlSourceTest {
+    private lateinit var crlServer: CrlServer
+
+    @Before
+    fun setUp() {
+        // Do not use Security.addProvider(BouncyCastleProvider()) to avoid EdDSA signature disruption in other tests.
+        Crypto.findProvider(BouncyCastleProvider.PROVIDER_NAME)
+        crlServer = CrlServer(NetworkHostAndPort("localhost", 0))
+        crlServer.start()
+    }
+
+    @After
+    fun tearDown() {
+        if (::crlServer.isInitialized) {
+            crlServer.close()
+        }
+    }
+
+    @Test(timeout=300_000)
+	fun `happy path`() {
+        val crlSource = CertDistPointCrlSource()
+
+        with(crlSource.fetch(crlServer.intermediateCa.certificate)) {
+            assertThat(size).isEqualTo(1)
+            assertThat(single().revokedCertificates).isNull()
+        }
+
+        val nodeCaCert = crlServer.replaceNodeCertDistPoint(createDevNodeCa(crlServer.intermediateCa, ALICE_NAME).certificate)
+
+        crlServer.revokedNodeCerts += listOf(BigInteger.ONE, BigInteger.TEN)
+        with(crlSource.fetch(nodeCaCert)) {  // Use a different cert to avoid the cache
+            assertThat(size).isEqualTo(1)
+            val revokedCertificates = single().revokedCertificates
+            assertThat(revokedCertificates.map { it.serialNumber }).containsExactlyInAnyOrder(BigInteger.ONE, BigInteger.TEN)
+        }
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/revocation/CordaRevocationCheckerTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/revocation/CordaRevocationCheckerTest.kt
@@ -1,26 +1,27 @@
-package net.corda.nodeapi.internal.protonwrapper.netty.revocation
+package net.corda.nodeapi.internal.revocation
 
 import net.corda.core.utilities.Try
 import net.corda.nodeapi.internal.DEV_CA_KEY_STORE_PASS
 import net.corda.nodeapi.internal.DEV_CA_PRIVATE_KEY_PASS
 import net.corda.nodeapi.internal.config.CertificateStore
 import net.corda.nodeapi.internal.crypto.X509Utilities
-import net.corda.nodeapi.internal.protonwrapper.netty.ExternalCrlSource
+import net.corda.nodeapi.internal.protonwrapper.netty.CrlSource
 import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory
 import org.junit.Test
 import java.math.BigInteger
-
 import java.security.cert.X509CRL
 import java.security.cert.X509Certificate
-import java.sql.Date
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class ExternalSourceRevocationCheckerTest {
+class CordaRevocationCheckerTest {
 
     @Test(timeout=300_000)
 	fun checkRevoked() {
-        val checkResult = performCheckOnDate(Date.valueOf("2019-09-27"))
+        val checkResult = performCheckOnDate(LocalDate.of(2019, 9, 27))
         val failedChecks = checkResult.filterNot { it.second.isSuccess }
         assertEquals(1, failedChecks.size)
         assertEquals(BigInteger.valueOf(8310484079152632582), failedChecks.first().first.serialNumber)
@@ -28,11 +29,11 @@ class ExternalSourceRevocationCheckerTest {
 
     @Test(timeout=300_000)
 	fun checkTooEarly() {
-        val checkResult = performCheckOnDate(Date.valueOf("2019-08-27"))
+        val checkResult = performCheckOnDate(LocalDate.of(2019, 8, 27))
         assertTrue(checkResult.all { it.second.isSuccess })
     }
 
-    private fun performCheckOnDate(date: Date): List<Pair<X509Certificate, Try<Unit>>> {
+    private fun performCheckOnDate(date: LocalDate): List<Pair<X509Certificate, Try<Unit>>> {
         val certStore = CertificateStore.fromResource(
                 "net/corda/nodeapi/internal/protonwrapper/netty/sslkeystore_Revoked.jks",
                 DEV_CA_KEY_STORE_PASS, DEV_CA_PRIVATE_KEY_PASS)
@@ -40,16 +41,17 @@ class ExternalSourceRevocationCheckerTest {
         val resourceAsStream = javaClass.getResourceAsStream("/net/corda/nodeapi/internal/protonwrapper/netty/doorman.crl")
         val crl = CertificateFactory().engineGenerateCRL(resourceAsStream) as X509CRL
 
-        //val crlHolder = X509CRLHolder(resourceAsStream)
-        //crlHolder.revokedCertificates as X509CRLEntryHolder
-
-        val instance = ExternalSourceRevocationChecker(object : ExternalCrlSource {
+        val crlSource = object : CrlSource {
             override fun fetch(certificate: X509Certificate): Set<X509CRL> = setOf(crl)
-        }) { date }
+        }
+        val checker = CordaRevocationChecker(crlSource,
+                softFail = true,
+                dateSource = { Date.from(date.atStartOfDay().toInstant(ZoneOffset.UTC)) }
+        )
 
         return certStore.query {
             getCertificateChain(X509Utilities.CORDA_CLIENT_TLS).map {
-                Pair(it, Try.on { instance.check(it, mutableListOf()) })
+                Pair(it, Try.on { checker.check(it, mutableListOf()) })
             }
         }
     }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -265,7 +265,7 @@ tasks.register('integrationTest', Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
     maxParallelForks = (System.env.CORDA_NODE_INT_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_INT_TESTING_FORKS".toInteger()
     // CertificateRevocationListNodeTests
-    systemProperty 'com.sun.security.crl.timeout', '4'
+    systemProperty 'net.corda.crl.connectTimeoutMs', '4000'
 }
 
 tasks.register('slowIntegrationTest', Test) {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -265,7 +265,7 @@ tasks.register('integrationTest', Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
     maxParallelForks = (System.env.CORDA_NODE_INT_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_INT_TESTING_FORKS".toInteger()
     // CertificateRevocationListNodeTests
-    systemProperty 'net.corda.crl.connectTimeoutMs', '4000'
+    systemProperty 'net.corda.dpcrl.connect.timeout', '4000'
 }
 
 tasks.register('slowIntegrationTest', Test) {

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -69,7 +69,7 @@ class CertificateRevocationListNodeTests {
     companion object {
         private val unreachableIpCounter = AtomicInteger(1)
 
-        private val crlTimeout = Duration.ofMillis(System.getProperty("net.corda.crl.connectTimeoutMs").toLong())
+        private val crlConnectTimeout = Duration.ofMillis(System.getProperty("net.corda.dpcrl.connect.timeout").toLong())
 
         /**
          * Use this method to get a unqiue unreachable IP address. Subsequent uses of the same IP for connection timeout testing purposes
@@ -204,7 +204,7 @@ class CertificateRevocationListNodeTests {
         verifyAMQPConnection(
                 crlCheckSoftFail = true,
                 nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
-                sslHandshakeTimeout = crlTimeout * 2,
+                sslHandshakeTimeout = crlConnectTimeout * 2,
                 expectedConnectStatus = true
         )
         val timeoutExceptions = (amqpServer.softFailExceptions + amqpClient.softFailExceptions)
@@ -218,7 +218,7 @@ class CertificateRevocationListNodeTests {
         verifyAMQPConnection(
                 crlCheckSoftFail = true,
                 nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
-                sslHandshakeTimeout = crlTimeout / 2,
+                sslHandshakeTimeout = crlConnectTimeout / 2,
                 expectedConnectStatus = false
         )
     }
@@ -284,7 +284,7 @@ class CertificateRevocationListNodeTests {
                 crlCheckArtemisServer = true,
                 expectedStatus = MessageStatus.Acknowledged,
                 nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
-                sslHandshakeTimeout = crlTimeout * 3
+                sslHandshakeTimeout = crlConnectTimeout * 3
         )
     }
 
@@ -295,7 +295,7 @@ class CertificateRevocationListNodeTests {
                 crlCheckArtemisServer = true,
                 expectedConnected = false,
                 nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
-                sslHandshakeTimeout = crlTimeout / 2
+                sslHandshakeTimeout = crlConnectTimeout / 2
         )
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt
@@ -5,15 +5,14 @@ import net.corda.core.utilities.contextLogger
 import net.corda.nodeapi.internal.crypto.X509CertificateFactory
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
+import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfigImpl
 import net.corda.nodeapi.internal.protonwrapper.netty.certPathToString
 import java.security.KeyStore
 import java.security.cert.CertPathValidator
 import java.security.cert.CertPathValidatorException
 import java.security.cert.CertificateException
 import java.security.cert.PKIXBuilderParameters
-import java.security.cert.PKIXRevocationChecker
 import java.security.cert.X509CertSelector
-import java.util.EnumSet
 
 sealed class CertificateChainCheckPolicy {
     companion object {
@@ -22,7 +21,6 @@ sealed class CertificateChainCheckPolicy {
 
     @FunctionalInterface
     interface Check {
-        @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
         fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>)
     }
 
@@ -31,7 +29,6 @@ sealed class CertificateChainCheckPolicy {
     object Any : CertificateChainCheckPolicy() {
         override fun createCheck(keyStore: KeyStore, trustStore: KeyStore): Check {
             return object : Check {
-                @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
                 override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
                     // nothing to do here
                 }
@@ -44,7 +41,6 @@ sealed class CertificateChainCheckPolicy {
             val rootAliases = trustStore.aliases().asSequence().filter { it.startsWith(X509Utilities.CORDA_ROOT_CA) }
             val rootPublicKeys = rootAliases.map { trustStore.getCertificate(it).publicKey }.toSet()
             return object : Check {
-                @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
                 override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
                     val theirRoot = theirChain.last().publicKey
                     if (theirRoot !in rootPublicKeys) {
@@ -59,7 +55,6 @@ sealed class CertificateChainCheckPolicy {
         override fun createCheck(keyStore: KeyStore, trustStore: KeyStore): Check {
             val ourPublicKey = keyStore.getCertificate(X509Utilities.CORDA_CLIENT_TLS).publicKey
             return object : Check {
-                @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
                 override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
                     val theirLeaf = theirChain.first().publicKey
                     if (ourPublicKey != theirLeaf) {
@@ -74,7 +69,6 @@ sealed class CertificateChainCheckPolicy {
         override fun createCheck(keyStore: KeyStore, trustStore: KeyStore): Check {
             val trustedPublicKeys = trustedAliases.map { trustStore.getCertificate(it).publicKey }.toSet()
             return object : Check {
-                @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
                 override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
                     if (!theirChain.any { it.publicKey in trustedPublicKeys }) {
                         throw CertificateException("Their certificate chain contained none of the trusted ones")
@@ -92,7 +86,6 @@ sealed class CertificateChainCheckPolicy {
 
     class UsernameMustMatchCommonNameCheck : Check {
         lateinit var username: String
-        @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
         override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
             if (!theirChain.any { certificate -> CordaX500Name.parse(certificate.subjectDN.name).commonName == username }) {
                 throw CertificateException("Client certificate does not match login username.")
@@ -100,14 +93,12 @@ sealed class CertificateChainCheckPolicy {
         }
     }
 
-    class RevocationCheck(val revocationMode: RevocationConfig.Mode) : CertificateChainCheckPolicy() {
+    class RevocationCheck(val revocationConfig: RevocationConfig) : CertificateChainCheckPolicy() {
+        constructor(revocationMode: RevocationConfig.Mode) : this(RevocationConfigImpl(revocationMode))
+
         override fun createCheck(keyStore: KeyStore, trustStore: KeyStore): Check {
             return object : Check {
-                @Suppress("DEPRECATION")    // should use java.security.cert.X509Certificate
                 override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
-                    if (revocationMode == RevocationConfig.Mode.OFF) {
-                        return
-                    }
                     // Convert javax.security.cert.X509Certificate to java.security.cert.X509Certificate.
                     val chain = theirChain.map { X509CertificateFactory().generateCertificate(it.encoded.inputStream()) }
                     log.info("Check Client Certpath:\r\n${certPathToString(chain.toTypedArray())}")
@@ -117,17 +108,7 @@ sealed class CertificateChainCheckPolicy {
                     // See PKIXValidator.engineValidate() for reference implementation.
                     val certPath = X509Utilities.buildCertPath(chain.dropLast(1))
                     val certPathValidator = CertPathValidator.getInstance("PKIX")
-                    val pkixRevocationChecker = certPathValidator.revocationChecker as PKIXRevocationChecker
-                    pkixRevocationChecker.options = EnumSet.of(
-                            // Prefer CRL over OCSP
-                            PKIXRevocationChecker.Option.PREFER_CRLS,
-                            // Don't fall back to OCSP checking
-                            PKIXRevocationChecker.Option.NO_FALLBACK)
-                    if (revocationMode == RevocationConfig.Mode.SOFT_FAIL) {
-                        // Allow revocation check to succeed if the revocation status cannot be determined for one of
-                        // the following reasons: The CRL or OCSP response cannot be obtained because of a network error.
-                        pkixRevocationChecker.options = pkixRevocationChecker.options + PKIXRevocationChecker.Option.SOFT_FAIL
-                    }
+                    val pkixRevocationChecker = revocationConfig.createPKIXRevocationChecker()
                     val params = PKIXBuilderParameters(trustStore, X509CertSelector())
                     params.addCertPathChecker(pkixRevocationChecker)
                     try {


### PR DESCRIPTION
`ExternalSourceRevocationChecker` has now become `CordaRevocationChecker`, and is now used for all certificate revocation checks, replacing the JDK's implementation. The JDK revoker doesn't have a read timeout on the URL connection and the caching parameters can't be configured. That's been fixed with the custom implementation, which has more suitable defaults for Corda.

Also fixed a bug in the custom revoker where it didn't check the CRL issuer against the distribution point entry in the certificate.
