### PR TITLE
ENT-9583 Public key caching of encoded form (OS)

### DIFF
--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -82,6 +82,7 @@ def patchCore = tasks.register('patchCore', Zip) {
         exclude 'net/corda/core/serialization/internal/CheckpointSerializationFactory*.class'
         exclude 'net/corda/core/internal/rules/*.class'
         exclude 'net/corda/core/internal/utilities/PrivateInterner*.class'
+        exclude 'net/corda/core/crypto/internal/PublicKeyCache*.class'
     }
 
     reproducibleFileOrder = true

--- a/core-deterministic/src/main/kotlin/net/corda/core/crypto/internal/PublicKeyCache.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/crypto/internal/PublicKeyCache.kt
@@ -1,0 +1,21 @@
+package net.corda.core.crypto.internal
+
+import net.corda.core.utilities.ByteSequence
+import java.security.PublicKey
+
+@Suppress("unused")
+object PublicKeyCache {
+    @Suppress("UNUSED_PARAMETER")
+    fun bytesForCachedPublicKey(key: PublicKey): ByteSequence? {
+        return null
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun publicKeyForCachedBytes(bytes: ByteSequence): PublicKey? {
+        return null
+    }
+
+    fun cachePublicKey(key: PublicKey): PublicKey {
+        return key
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -4,7 +4,14 @@ import net.corda.core.KeepForDJVM
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.exactAdd
 import net.corda.core.utilities.sequence
-import org.bouncycastle.asn1.*
+import org.bouncycastle.asn1.ASN1EncodableVector
+import org.bouncycastle.asn1.ASN1Encoding
+import org.bouncycastle.asn1.ASN1Integer
+import org.bouncycastle.asn1.ASN1Object
+import org.bouncycastle.asn1.ASN1Primitive
+import org.bouncycastle.asn1.ASN1Sequence
+import org.bouncycastle.asn1.DERBitString
+import org.bouncycastle.asn1.DERSequence
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import java.security.PublicKey
@@ -162,7 +169,7 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
 
         override fun toASN1Primitive(): ASN1Primitive {
             val vector = ASN1EncodableVector()
-            vector.add(DERBitString(node.encoded))
+            vector.add(DERBitString(Crypto.encodePublicKey(node)))
             vector.add(ASN1Integer(weight.toLong()))
             return DERSequence(vector)
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -285,7 +285,7 @@ object Crypto {
      */
     @JvmStatic
     fun findSignatureScheme(key: PublicKey): SignatureScheme {
-        val keyInfo = SubjectPublicKeyInfo.getInstance(key.encoded)
+        val keyInfo = SubjectPublicKeyInfo.getInstance(encodePublicKey(key))
         return findSignatureScheme(keyInfo.algorithm)
     }
 

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -5,6 +5,7 @@ import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.crypto.internal.AliasPrivateKey
 import net.corda.core.crypto.internal.Instances.withSignature
+import net.corda.core.crypto.internal.PublicKeyCache
 import net.corda.core.crypto.internal.bouncyCastlePQCProvider
 import net.corda.core.crypto.internal.cordaBouncyCastleProvider
 import net.corda.core.crypto.internal.cordaSecurityProvider
@@ -53,8 +54,6 @@ import org.bouncycastle.math.ec.WNafUtil
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PrivateKey
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PublicKey
 import org.bouncycastle.pqc.jcajce.spec.SPHINCS256KeyGenParameterSpec
-import java.lang.ref.ReferenceQueue
-import java.lang.ref.WeakReference
 import java.math.BigInteger
 import java.security.InvalidKeyException
 import java.security.Key
@@ -68,7 +67,6 @@ import java.security.SignatureException
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
-import java.util.concurrent.ConcurrentHashMap
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -377,7 +375,7 @@ object Crypto {
      */
     @JvmStatic
     fun decodePublicKey(encodedKey: ByteArray): PublicKey {
-        return publicKeyForCachedBytes(ByteSequence.of(encodedKey)) ?: {
+        return PublicKeyCache.publicKeyForCachedBytes(ByteSequence.of(encodedKey)) ?: {
             val subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(encodedKey)
             val signatureScheme = findSignatureScheme(subjectPublicKeyInfo.algorithm)
             val keyFactory = keyFactory(signatureScheme)
@@ -387,7 +385,7 @@ object Crypto {
 
     @JvmStatic
     fun encodePublicKey(key: PublicKey): ByteArray {
-        return bytesForCachedPublicKey(key)?.bytes ?: key.encoded
+        return PublicKeyCache.bytesForCachedPublicKey(key)?.bytes ?: key.encoded
     }
 
     /**
@@ -1004,51 +1002,8 @@ object Crypto {
     }
 
     private val interner = PrivateInterner<PublicKey>()
-    private fun internPublicKey(key: PublicKey): PublicKey = cachePublicKey(interner.intern(key))
+    private fun internPublicKey(key: PublicKey): PublicKey = PublicKeyCache.cachePublicKey(interner.intern(key))
 
-    private val collectedWeakPubKeys = ReferenceQueue<PublicKey>()
-    private class WeakPubKey(key: PublicKey, val bytes: ByteSequence? = null) : WeakReference<PublicKey>(key, collectedWeakPubKeys) {
-        private val hashCode = key.hashCode()
-
-        override fun hashCode(): Int = hashCode
-        override fun equals(other: Any?): Boolean {
-            if(this === other) return true
-            if(other !is WeakPubKey) return false
-            if(this.hashCode != other.hashCode) return false
-            val thisGet = this.get()
-            val otherGet = other.get()
-            if(thisGet == null || otherGet == null) return false
-            return thisGet == otherGet
-        }
-    }
-
-    private val pubKeyToBytes = ConcurrentHashMap<WeakPubKey, ByteSequence>()
-    private val bytesToPubKey = ConcurrentHashMap<ByteSequence, WeakPubKey>()
-
-    private fun reapCollectedWeakPubKeys() {
-        while(true) {
-            val weakPubKey = (collectedWeakPubKeys.poll() as? WeakPubKey) ?: break
-            pubKeyToBytes.remove(weakPubKey)
-            bytesToPubKey.remove(weakPubKey.bytes!!)
-        }
-    }
-
-    private fun bytesForCachedPublicKey(key: PublicKey): ByteSequence? {
-        val weakPubKey = WeakPubKey(key)
-        return pubKeyToBytes[weakPubKey]
-    }
-
-    private fun publicKeyForCachedBytes(bytes: ByteSequence): PublicKey? {
-        return bytesToPubKey[bytes]?.get()
-    }
-
-    private fun cachePublicKey(key: PublicKey): PublicKey {
-        reapCollectedWeakPubKeys()
-        val weakPubKey = WeakPubKey(key, ByteSequence.of(key.encoded))
-        pubKeyToBytes.putIfAbsent(weakPubKey, weakPubKey.bytes!!)
-        bytesToPubKey.putIfAbsent(weakPubKey.bytes!!, weakPubKey)
-        return key
-    }
 
     private fun convertIfBCEdDSAPublicKey(key: PublicKey): PublicKey {
         return internPublicKey(when (key) {

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -26,18 +26,21 @@ import java.util.function.Supplier
 @CordaSerializable
 sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
     /** SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes). */
-    @Suppress("EqualsWithHashCodeExist")
     class SHA256(bytes: ByteArray) : SecureHash(bytes) {
         init {
             require(bytes.size == 32) { "Invalid hash size, must be 32 bytes" }
         }
 
-        // Hash code not overridden on purpose (super class impl will do).
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is SHA256) return false
             if (!super.equals(other)) return false
             return true
+        }
+
+        override fun hashCode(): Int {
+            // Hash code not overridden on purpose (super class impl will do), but don't delete or have to deal with detekt and API checker.
+            return super.hashCode()
         }
 
         /**
@@ -52,13 +55,17 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
 
     @Suppress("EqualsWithHashCodeExist")
     class HASH(val algorithm: String, bytes: ByteArray) : SecureHash(bytes) {
-        // Hash code not overridden on purpose (super class impl will do).
         override fun equals(other: Any?): Boolean {
             return when {
                 this === other -> true
                 other !is HASH -> false
                 else -> algorithm == other.algorithm && super.equals(other)
             }
+        }
+
+        override fun hashCode(): Int {
+            // Hash code not overridden on purpose (super class impl will do), but don't delete or have to deal with detekt and API checker.
+            return super.hashCode()
         }
 
         override fun toString(): String {

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -26,11 +26,13 @@ import java.util.function.Supplier
 @CordaSerializable
 sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
     /** SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes). */
+    @Suppress("EqualsWithHashCodeExist")
     class SHA256(bytes: ByteArray) : SecureHash(bytes) {
         init {
             require(bytes.size == 32) { "Invalid hash size, must be 32 bytes" }
         }
 
+        // Hash code not overridden on purpose (super class impl will do).
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is SHA256) return false
@@ -48,7 +50,9 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         }
     }
 
+    @Suppress("EqualsWithHashCodeExist")
     class HASH(val algorithm: String, bytes: ByteArray) : SecureHash(bytes) {
+        // Hash code not overridden on purpose (super class impl will do).
         override fun equals(other: Any?): Boolean {
             return when {
                 this === other -> true

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -13,7 +13,6 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.parseAsHex
 import net.corda.core.utilities.toHexString
-import java.nio.ByteBuffer
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -39,10 +38,6 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
             return true
         }
 
-        // This is an efficient hashCode, because there is no point in performing a hash calculation on a cryptographic hash.
-        // It just takes the first 4 bytes and transforms them into an Int.
-        override fun hashCode() = ByteBuffer.wrap(bytes).int
-
         /**
          * Convert the hash value to an uppercase hexadecimal [String].
          */
@@ -61,8 +56,6 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
                 else -> algorithm == other.algorithm && super.equals(other)
             }
         }
-
-        override fun hashCode() = ByteBuffer.wrap(bytes).int
 
         override fun toString(): String {
             return "$algorithm$DELIMITER${toHexString()}"

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -53,7 +53,6 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         }
     }
 
-    @Suppress("EqualsWithHashCodeExist")
     class HASH(val algorithm: String, bytes: ByteArray) : SecureHash(bytes) {
         override fun equals(other: Any?): Boolean {
             return when {

--- a/core/src/main/kotlin/net/corda/core/crypto/internal/PublicKeyCache.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/PublicKeyCache.kt
@@ -1,0 +1,54 @@
+package net.corda.core.crypto.internal
+
+import net.corda.core.utilities.ByteSequence
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.security.PublicKey
+import java.util.concurrent.ConcurrentHashMap
+
+object PublicKeyCache {
+    private val collectedWeakPubKeys = ReferenceQueue<PublicKey>()
+
+    private class WeakPubKey(key: PublicKey, val bytes: ByteSequence? = null) : WeakReference<PublicKey>(key, collectedWeakPubKeys) {
+        private val hashCode = key.hashCode()
+
+        override fun hashCode(): Int = hashCode
+        override fun equals(other: Any?): Boolean {
+            if(this === other) return true
+            if(other !is WeakPubKey) return false
+            if(this.hashCode != other.hashCode) return false
+            val thisGet = this.get()
+            val otherGet = other.get()
+            if(thisGet == null || otherGet == null) return false
+            return thisGet == otherGet
+        }
+    }
+
+    private val pubKeyToBytes = ConcurrentHashMap<WeakPubKey, ByteSequence>()
+    private val bytesToPubKey = ConcurrentHashMap<ByteSequence, WeakPubKey>()
+
+    private fun reapCollectedWeakPubKeys() {
+        while(true) {
+            val weakPubKey = (collectedWeakPubKeys.poll() as? WeakPubKey) ?: break
+            pubKeyToBytes.remove(weakPubKey)
+            bytesToPubKey.remove(weakPubKey.bytes!!)
+        }
+    }
+
+    fun bytesForCachedPublicKey(key: PublicKey): ByteSequence? {
+        val weakPubKey = WeakPubKey(key)
+        return pubKeyToBytes[weakPubKey]
+    }
+
+    fun publicKeyForCachedBytes(bytes: ByteSequence): PublicKey? {
+        return bytesToPubKey[bytes]?.get()
+    }
+
+    fun cachePublicKey(key: PublicKey): PublicKey {
+        reapCollectedWeakPubKeys()
+        val weakPubKey = WeakPubKey(key, ByteSequence.of(key.encoded))
+        pubKeyToBytes.putIfAbsent(weakPubKey, weakPubKey.bytes!!)
+        bytesToPubKey.putIfAbsent(weakPubKey.bytes, weakPubKey)
+        return key
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -555,7 +555,7 @@ fun <T : Any> SerializedBytes<T>.sign(keyPair: KeyPair): SignedData<T> = SignedD
 
 fun ByteBuffer.copyBytes(): ByteArray = ByteArray(remaining()).also { get(it) }
 
-val PublicKey.hash: SecureHash get() = encoded.sha256()
+val PublicKey.hash: SecureHash get() = Crypto.encodePublicKey(this).sha256()
 
 /**
  * Extension method for providing a sumBy method that processes and returns a Long

--- a/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt
@@ -1,9 +1,16 @@
 package net.corda.core.internal
 
 import net.corda.core.DeleteForDJVM
+import net.corda.core.crypto.Crypto
 import net.i2p.crypto.eddsa.EdDSAEngine
 import net.i2p.crypto.eddsa.EdDSAPublicKey
-import java.security.*
+import java.security.AlgorithmParameters
+import java.security.InvalidKeyException
+import java.security.MessageDigest
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.SecureRandom
+import java.security.Signature
 import java.security.spec.AlgorithmParameterSpec
 import java.security.spec.X509EncodedKeySpec
 
@@ -30,7 +37,7 @@ class X509EdDSAEngine : Signature {
 
     override fun engineInitVerify(publicKey: PublicKey) {
         val parsedKey = try {
-            publicKey as? EdDSAPublicKey ?: EdDSAPublicKey(X509EncodedKeySpec(publicKey.encoded))
+            publicKey as? EdDSAPublicKey ?: EdDSAPublicKey(X509EncodedKeySpec(Crypto.encodePublicKey(publicKey)))
         } catch (e: Exception) {
             throw (InvalidKeyException(e.message))
         }

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -166,7 +166,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
         fun data(): ByteArray? {
             return when (type()) {
                 Type.HASH -> (constraint as HashAttachmentConstraint).attachmentId.bytes
-                Type.SIGNATURE -> (constraint as SignatureAttachmentConstraint).key.encoded
+                Type.SIGNATURE -> Crypto.encodePublicKey((constraint as SignatureAttachmentConstraint).key)
                 else -> null
             }
         }

--- a/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
@@ -112,6 +112,7 @@ sealed class ByteSequence(private val _bytes: ByteArray, val offset: Int, val si
         if (this === other) return true
         if (other !is ByteSequence) return false
         if (this.size != other.size) return false
+        if (this.hashCode() != other.hashCode()) return false
         return subArraysEqual(this._bytes, this.offset, this.size, other._bytes, other.offset)
     }
 
@@ -125,13 +126,18 @@ sealed class ByteSequence(private val _bytes: ByteArray, val offset: Int, val si
         return true
     }
 
+    private var _hashCode: Int = 0;
+
     override fun hashCode(): Int {
-        val thisBytes = _bytes
-        var result = 1
-        for (index in offset until (offset + size)) {
-            result = 31 * result + thisBytes[index]
-        }
-        return result
+        return if (_hashCode == 0) {
+            val thisBytes = _bytes
+            var result = 1
+            for (index in offset until (offset + size)) {
+                result = 31 * result + thisBytes[index]
+            }
+            _hashCode = result
+            result
+        } else _hashCode
     }
 
     override fun toString(): String = "[${copyBytes().toHexString()}]"

--- a/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt
@@ -9,7 +9,7 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.internal.hash
 import java.nio.charset.Charset
 import java.security.PublicKey
-import java.util.*
+import java.util.Base64
 
 // This file includes useful encoding methods and extension functions for the most common encoding/decoding operations.
 
@@ -81,7 +81,7 @@ fun String.hexToBase64(): String = hexToByteArray().toBase64()
 fun parsePublicKeyBase58(base58String: String): PublicKey = Crypto.decodePublicKey(base58String.base58ToByteArray())
 
 /** Return the Base58 representation of the serialised public key. */
-fun PublicKey.toBase58String(): String = this.encoded.toBase58()
+fun PublicKey.toBase58String(): String = Crypto.encodePublicKey(this).toBase58()
 
 /** Return the bytes of the SHA-256 output for this public key. */
 fun PublicKey.toSHA256Bytes(): ByteArray = this.hash.bytes

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -52,6 +52,7 @@ import java.security.cert.Certificate
 import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
 import java.security.cert.TrustAnchor
+import java.security.cert.X509CRL
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.time.Instant

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
@@ -1,6 +1,10 @@
 package net.corda.nodeapi.internal.serialization.kryo
 
-import com.esotericsoftware.kryo.*
+import com.esotericsoftware.kryo.ClassResolver
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.KryoException
+import com.esotericsoftware.kryo.Registration
+import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.factories.ReflectionSerializerFactory
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
@@ -17,7 +21,13 @@ import net.corda.core.internal.LazyMappedList
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.SerializeAsTokenContext
 import net.corda.core.serialization.SerializedBytes
-import net.corda.core.transactions.*
+import net.corda.core.transactions.ComponentGroup
+import net.corda.core.transactions.ContractUpgradeFilteredTransaction
+import net.corda.core.transactions.ContractUpgradeWireTransaction
+import net.corda.core.transactions.CoreTransaction
+import net.corda.core.transactions.NotaryChangeWireTransaction
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.SgxSupport
 import net.corda.serialization.internal.serializationContextKey
@@ -302,7 +312,7 @@ object PrivateKeySerializer : Serializer<PrivateKey>() {
 object PublicKeySerializer : Serializer<PublicKey>() {
     override fun write(kryo: Kryo, output: Output, obj: PublicKey) {
         // TODO: Instead of encoding to the default X509 format, we could have a custom per key type (space-efficient) serialiser.
-        output.writeBytesWithLength(obj.encoded)
+        output.writeBytesWithLength(Crypto.encodePublicKey(obj))
     }
 
     override fun read(kryo: Kryo, input: Input, type: Class<PublicKey>): PublicKey {

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -47,7 +47,9 @@ import java.security.cert.CertificateNotYetValidException
 import java.security.cert.CollectionCertStoreParameters
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
-import java.util.*
+import java.util.HashSet
+import java.util.Optional
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.stream.Stream
@@ -136,7 +138,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
                         )
                     },
                     toPersistentEntity = { key: String, value: PublicKey ->
-                        PersistentHashToPublicKey(key, value.encoded)
+                        PersistentHashToPublicKey(key, Crypto.encodePublicKey(value))
                     },
                     persistentEntityClass = PersistentHashToPublicKey::class.java)
         }

--- a/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
@@ -1,6 +1,14 @@
 package net.corda.node.services.keys
 
-import net.corda.core.crypto.*
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.SignableData
+import net.corda.core.crypto.SignatureScheme
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.generateKeyPair
+import net.corda.core.crypto.keys
+import net.corda.core.crypto.sign
+import net.corda.core.crypto.toStringShort
 import net.corda.core.internal.NamedCacheFactory
 import net.corda.core.internal.telemetry.TelemetryServiceImpl
 import net.corda.core.serialization.SingletonSerializeAsToken
@@ -16,9 +24,12 @@ import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
-import java.util.*
-import javax.persistence.*
-import kotlin.collections.LinkedHashSet
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Lob
+import javax.persistence.Table
 
 /**
  * A persistent implementation of [KeyManagementServiceInternal] to support CryptoService for initial keys and
@@ -52,7 +63,7 @@ class BasicHSMKeyManagementService(
             var privateKey: ByteArray = EMPTY_BYTE_ARRAY
     ) {
         constructor(publicKey: PublicKey, privateKey: PrivateKey)
-            : this(publicKey.toStringShort(), publicKey.encoded, privateKey.encoded)
+            : this(publicKey.toStringShort(), Crypto.encodePublicKey(publicKey), privateKey.encoded)
     }
 
     private companion object {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/PublicKeyToTextConverter.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/PublicKeyToTextConverter.kt
@@ -13,6 +13,6 @@ import javax.persistence.Converter
  */
 @Converter(autoApply = true)
 class PublicKeyToTextConverter : AttributeConverter<PublicKey, String> {
-    override fun convertToDatabaseColumn(key: PublicKey?): String? = key?.encoded?.toHex()
+    override fun convertToDatabaseColumn(key: PublicKey?): String? = key?.let { Crypto.encodePublicKey(key).toHex() }
     override fun convertToEntityAttribute(text: String?): PublicKey? = text?.let { Crypto.decodePublicKey(it.hexToByteArray()) }
 }

--- a/node/src/main/kotlin/sandbox/net/corda/core/crypto/Crypto.kt
+++ b/node/src/main/kotlin/sandbox/net/corda/core/crypto/Crypto.kt
@@ -1,7 +1,6 @@
 package sandbox.net.corda.core.crypto
 
-import sandbox.net.corda.core.crypto.DJVM.fromDJVM
-import sandbox.net.corda.core.crypto.DJVM.toDJVM
+import sandbox.java.lang.Object
 import sandbox.java.lang.String
 import sandbox.java.lang.doCatch
 import sandbox.java.math.BigInteger
@@ -10,7 +9,8 @@ import sandbox.java.security.PrivateKey
 import sandbox.java.security.PublicKey
 import sandbox.java.util.ArrayList
 import sandbox.java.util.List
-import sandbox.java.lang.Object
+import sandbox.net.corda.core.crypto.DJVM.fromDJVM
+import sandbox.net.corda.core.crypto.DJVM.toDJVM
 import sandbox.org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import sandbox.org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import java.security.GeneralSecurityException
@@ -147,6 +147,11 @@ object Crypto : Object() {
     @JvmStatic
     fun decodePublicKey(signatureScheme: SignatureScheme, encodedKey: ByteArray): PublicKey {
         return decodePublicKey(signatureScheme.schemeCodeName, encodedKey)
+    }
+
+    @JvmStatic
+    fun encodePublicKey(key: java.security.PublicKey): ByteArray {
+        return key.encoded
     }
 
     @JvmStatic

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt
@@ -3,7 +3,13 @@ package net.corda.serialization.internal.amqp.custom
 import net.corda.core.crypto.Crypto
 import net.corda.core.serialization.DESERIALIZATION_CACHE_PROPERTY
 import net.corda.core.serialization.SerializationContext
-import net.corda.serialization.internal.amqp.*
+import net.corda.serialization.internal.amqp.AMQPTypeIdentifiers
+import net.corda.serialization.internal.amqp.CustomSerializer
+import net.corda.serialization.internal.amqp.DeserializationInput
+import net.corda.serialization.internal.amqp.RestrictedType
+import net.corda.serialization.internal.amqp.Schema
+import net.corda.serialization.internal.amqp.SerializationOutput
+import net.corda.serialization.internal.amqp.SerializationSchemas
 import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 import java.security.PublicKey
@@ -28,7 +34,7 @@ object PublicKeySerializer
                                       context: SerializationContext
     ) {
         // TODO: Instead of encoding to the default X509 format, we could have a custom per key type (space-efficient) serialiser.
-        output.writeObject(obj.encoded, data, clazz, context)
+        output.writeObject(Crypto.encodePublicKey(obj), data, clazz, context)
     }
 
     override fun readObject(obj: Any, schemas: SerializationSchemas, input: DeserializationInput,


### PR DESCRIPTION
Added caching of public keys vs. encoded byte arrays using weak references so we only cache for public keys that are reachable by other means. This is then used everywhere we `encode` currently (and our existing decode logic enhanced).  Will have to make some subsequent changes in Enterprise codebase once merged.

There was about 5% thoughput benefit in the performance cluster to doing this.

While I was at it, I made `ByteSequence` cache the hashCode result, since we are using it or subclasses as a key in lots of places and thus it ends up in hash maps, including here.

I changed the `hashCode()` implementation of `SecureHash` while I was at it to inherit this caching logic, rather than generating a `ByteBuffer` every time it is called.  Whilst the method looks redundant (calling `super`), detekt complains if I remove it, requiring suppressions, as does the API checker, so less code and change to just keep it.