### PR TITLE
ENT-9823 Rename handleDoubleSpend -> propagateDoubleSpendErrorToPeers 

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -185,9 +185,10 @@ class FinalityFlowTests : WithFinality {
         catch (e: NotaryException) {
             val stxId = (e.error as NotaryError.Conflict).txId
             assertNull(aliceNode.services.validatedTransactions.getTransactionInternal(stxId))
-            // Note: double spend error not propagated to peers by default
-            val (_, txnDsStatusBob) = bobNode.services.validatedTransactions.getTransactionInternal(stxId) ?: fail()
-            assertEquals(TransactionStatus.MISSING_NOTARY_SIG, txnDsStatusBob)
+            // Note: double spend error not propagated to peers by default (corDapp PV = 3)
+            // Un-notarised txn clean-up occurs in ReceiveFinalityFlow upon receipt of UnexpectedFlowEndException
+            assertNull(aliceNode.services.validatedTransactions.getTransactionInternal(stxId))
+            assertTxnRemovedFromDatabase(aliceNode, stxId)
         }
     }
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -203,7 +203,7 @@ class FinalityFlowTests : WithFinality {
         assertEquals(TransactionStatus.VERIFIED, txnStatusBob)
 
         try {
-            aliceNode.startFlowAndRunNetwork(SpendFlow(ref, bobNode.info.singleIdentity(), handleDoubleSpend = true)).resultFuture.getOrThrow()
+            aliceNode.startFlowAndRunNetwork(SpendFlow(ref, bobNode.info.singleIdentity(), propagateDoubleSpendErrorToPeers = true)).resultFuture.getOrThrow()
         }
         catch (e: NotaryException) {
             val stxId = (e.error as NotaryError.Conflict).txId
@@ -320,7 +320,7 @@ class FinalityFlowTests : WithFinality {
     @StartableByRPC
     @InitiatingFlow
     class SpendFlow(private val stateAndRef: StateAndRef<DummyContract.SingleOwnerState>, private val newOwner: Party,
-                    private val handleDoubleSpend: Boolean? = null) : FlowLogic<SignedTransaction>() {
+                    private val propagateDoubleSpendErrorToPeers: Boolean? = null) : FlowLogic<SignedTransaction>() {
 
         @Suspendable
         override fun call(): SignedTransaction {
@@ -328,7 +328,7 @@ class FinalityFlowTests : WithFinality {
             val signedTransaction = serviceHub.signInitialTransaction(txBuilder, ourIdentity.owningKey)
             val sessionWithCounterParty = initiateFlow(newOwner)
             sessionWithCounterParty.sendAndReceive<String>("initial-message")
-            return subFlow(FinalityFlow(signedTransaction, setOf(sessionWithCounterParty), handleDoubleSpend = handleDoubleSpend))
+            return subFlow(FinalityFlow(signedTransaction, setOf(sessionWithCounterParty), propagateDoubleSpendErrorToPeers = propagateDoubleSpendErrorToPeers))
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -237,9 +237,9 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
         catch (e: NotaryException) {
             if (e.error is NotaryError.Conflict && useTwoPhaseFinality) {
                 (serviceHub as ServiceHubCoreInternal).removeUnnotarisedTransaction(e.error.txId)
-                val overrideHandleDoubleSpend = propagateDoubleSpendErrorToPeers ?:
+                val overridePropagateDoubleSpendErrorToPeers = propagateDoubleSpendErrorToPeers ?:
                     (serviceHub.cordappProvider.getAppContext().cordapp.targetPlatformVersion >= PlatformVersionSwitches.TWO_PHASE_FINALITY)
-                if (overrideHandleDoubleSpend && newPlatformSessions.isNotEmpty()) {
+                if (overridePropagateDoubleSpendErrorToPeers && newPlatformSessions.isNotEmpty()) {
                     broadcastDoubleSpendError(newPlatformSessions, e)
                 } else sleep(Duration.ZERO) // force checkpoint to persist db update.
             }


### PR DESCRIPTION
Additional clean-up of un-notarised transaction in `ReceiverFinalityFlow` upon `UnexpectedFlowEndException` + test.