### PR TITLE
NOTICK Fix failing StateMachineFinalityErrorHandlingTest's.

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
@@ -57,7 +57,7 @@ class StateMachineFinalityErrorHandlingTest : StateMachineErrorHandlingTest() {
 
                 RULE Throw exception when recording transaction
                 INTERFACE ${ServiceHubInternal::class.java.name}
-                METHOD recordTransactions
+                METHOD finalizeTransactionWithExtraSignatures
                 AT ENTRY
                 IF flagged("finality_flag") && flagged("resolve_tx_flag")
                 DO traceln("Throwing exception"); 
@@ -118,7 +118,7 @@ class StateMachineFinalityErrorHandlingTest : StateMachineErrorHandlingTest() {
 
                 RULE Throw exception when recording transaction
                 INTERFACE ${ServiceHubInternal::class.java.name}
-                METHOD recordTransactions
+                METHOD finalizeTransactionWithExtraSignatures
                 AT ENTRY
                 IF flagged("finality_flag") && flagged("resolve_tx_flag")
                 DO traceln("Throwing exception"); 


### PR DESCRIPTION
Observed in failing [Corda Open Source / Release Branch Builds](https://ci01.dev.r3.com/job/Corda-Open-Source/job/Corda-OS-Release-Branch-Tests/job/corda/job/release%252Fos%252F4.11/15/)