### PR TITLE
ES-93: use standard AMI agent for builds 

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -30,7 +30,7 @@ String COMMON_GRADLE_PARAMS = [
 ].join(' ')
 
 pipeline {
-    agent { label 'standard-latest-ami' }
+    agent { label 'standard' }
 
     /*
      * List options in alphabetical order


### PR DESCRIPTION
This change removes a previous workaround where we used the `standard-latest-ami` label.

Due to a recent re work of our AWS AMIs this is no longer necessary and we should revert to `standard` 

Also 
- add ES project to Title check workflow and remove NOTICKs