### PR TITLE
ES-93: use standard AMI agent for build 

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -31,7 +31,7 @@ String COMMON_GRADLE_PARAMS = [
 ].join(' ')
 
 pipeline {
-    agent { label 'standard-latest-ami' }
+    agent { label 'standard' }
 
     /*
      * List options in alphabetical order

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS)-\d+|NOTICK)(.*)'
+          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS|ES)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This change removes a previous workaround where we used the standard-latest-ami label.

Due to a recent rework of our AWS AMIs this is no longer necessary and we should revert to `standard`