### PR TITLE
ENT-9842 Re-factor 2PF to support issuance transactions (no notarisation) with observers.

### DIFF
--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -92,6 +92,8 @@ dependencies {
     smokeTestCompile project(':smoke-test-utils')
     smokeTestCompile "org.assertj:assertj-core:${assertj_version}"
 
+    // used by FinalityFlowTests
+    testCompile project(':testing:cordapps:cashobservers')
 }
 
 configurations {

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -298,7 +298,7 @@ class FinalityFlowTests : WithFinality {
         val (_, txnStatusAlice) = aliceNode.services.validatedTransactions.getTransactionInternal(notarisedStxn1.id) ?: fail()
         assertEquals(TransactionStatus.VERIFIED, txnStatusAlice)
         val (_, txnStatusBob) = bobNode.services.validatedTransactions.getTransactionInternal(notarisedStxn1.id) ?: fail()
-        assertEquals(TransactionStatus.MISSING_NOTARY_SIG, txnStatusBob)
+        assertEquals(TransactionStatus.IN_FLIGHT, txnStatusBob)
 
         // now lets attempt a new spend with the new output of the previous transaction
         val newStateRef = notarisedStxn1.coreTransaction.outRef<DummyContract.SingleOwnerState>(1)
@@ -312,7 +312,7 @@ class FinalityFlowTests : WithFinality {
         val (_, txnStatusAlice2) = aliceNode.services.validatedTransactions.getTransactionInternal(notarisedStxn2.id) ?: fail()
         assertEquals(TransactionStatus.VERIFIED, txnStatusAlice2)
         val (_, txnStatusBob2) = bobNode.services.validatedTransactions.getTransactionInternal(notarisedStxn2.id) ?: fail()
-        assertEquals(TransactionStatus.MISSING_NOTARY_SIG, txnStatusBob2)
+        assertEquals(TransactionStatus.IN_FLIGHT, txnStatusBob2)
 
         // Validate attempt at flow finalisation by Bob has no effect on outcome.
         val finaliseStxn1 =  bobNode.startFlowAndRunNetwork(FinaliseSpeedySpendFlow(notarisedStxn1.id, notarisedStxn1.sigs)).resultFuture.getOrThrow()

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -224,7 +224,7 @@ class FinalityFlowTests : WithFinality {
             assertNull(aliceNode.services.validatedTransactions.getTransactionInternal(stxId))
             assertTxnRemovedFromDatabase(aliceNode, stxId)
             val (_, txnStatus) = bobNode.services.validatedTransactions.getTransactionInternal(stxId) ?: fail()
-            assertEquals(TransactionStatus.MISSING_NOTARY_SIG, txnStatus)
+            assertEquals(TransactionStatus.IN_FLIGHT, txnStatus)
         }
     }
 
@@ -329,7 +329,7 @@ class FinalityFlowTests : WithFinality {
         catch (e: UnexpectedFlowEndException) {
             val stxId = SecureHash.parse(e.message)
             val (_, txnStatusBob) = bobNode.services.validatedTransactions.getTransactionInternal(stxId) ?: fail()
-            assertEquals(TransactionStatus.MISSING_NOTARY_SIG, txnStatusBob)
+            assertEquals(TransactionStatus.IN_FLIGHT, txnStatusBob)
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -314,7 +314,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
         progressTracker.currentStep = FINALISING_TRANSACTION
         serviceHub.telemetryServiceInternal.span("${this::class.java.name}#finaliseLocally", flowLogic = this) {
             if (notarySignatures.isEmpty()) {
-                (serviceHub as ServiceHubCoreInternal).finalizeTransaction(stx, statesToRecord, metadata)
+                (serviceHub as ServiceHubCoreInternal).finalizeTransaction(stx, statesToRecord, metadata!!)
                 logger.info("Finalised transaction locally.")
             } else {
                 (serviceHub as ServiceHubCoreInternal).finalizeTransactionWithExtraSignatures(stx, notarySignatures, statesToRecord)

--- a/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
@@ -33,5 +33,5 @@ data class FlowTransactionMetadata(
 enum class TransactionStatus {
     UNVERIFIED,
     VERIFIED,
-    MISSING_NOTARY_SIG;
+    IN_FLIGHT;
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -54,6 +54,14 @@ interface ServiceHubCoreInternal : ServiceHub {
      * @param statesToRecord how the vault should treat the output states of the transaction.
      */
     fun finalizeTransactionWithExtraSignatures(txn: SignedTransaction, sigs: Collection<TransactionSignature>, statesToRecord: StatesToRecord)
+
+    /**
+     * Stores or updates a [SignedTransaction] with a status of VERIFIED.
+     *
+     * @param txn The transaction to record.
+     * @param statesToRecord how the vault should treat the output states of the transaction.
+     */
+    fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord)
 }
 
 interface TransactionsResolver {

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -35,6 +35,7 @@ interface ServiceHubCoreInternal : ServiceHub {
      * This is expected to be run within a database transaction.
      *
      * @param txn The transaction to record.
+     * @param metadata Finality flow recovery metadata.
      */
     fun recordUnnotarisedTransaction(txn: SignedTransaction, metadata: FlowTransactionMetadata?= null)
 
@@ -61,6 +62,7 @@ interface ServiceHubCoreInternal : ServiceHub {
      *
      * @param txn The transaction to record.
      * @param statesToRecord how the vault should treat the output states of the transaction.
+     * @param metadata Finality flow recovery metadata.
      */
     fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata?= null)
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -56,12 +56,13 @@ interface ServiceHubCoreInternal : ServiceHub {
     fun finalizeTransactionWithExtraSignatures(txn: SignedTransaction, sigs: Collection<TransactionSignature>, statesToRecord: StatesToRecord)
 
     /**
-     * Stores or updates a [SignedTransaction] with a status of VERIFIED.
+     * Stores or updates a [SignedTransaction] to a status of VERIFIED.
+     * Optionally add finality flow recovery metadata.
      *
      * @param txn The transaction to record.
      * @param statesToRecord how the vault should treat the output states of the transaction.
      */
-    fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord)
+    fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata?= null)
 }
 
 interface TransactionsResolver {

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -30,14 +30,14 @@ interface ServiceHubCoreInternal : ServiceHub {
     val attachmentsClassLoaderCache: AttachmentsClassLoaderCache
 
     /**
-     * Stores [SignedTransaction] and participant signatures without the notary signature in the local transaction storage.
-     * Optionally add finality flow recovery metadata.
+     * Stores [SignedTransaction] and participant signatures without the notary signature in the local transaction storage,
+     * inclusive of flow recovery metadata.
      * This is expected to be run within a database transaction.
      *
      * @param txn The transaction to record.
      * @param metadata Finality flow recovery metadata.
      */
-    fun recordUnnotarisedTransaction(txn: SignedTransaction, metadata: FlowTransactionMetadata?= null)
+    fun recordUnnotarisedTransaction(txn: SignedTransaction, metadata: FlowTransactionMetadata)
 
     /**
      * Removes transaction from data store.
@@ -57,14 +57,13 @@ interface ServiceHubCoreInternal : ServiceHub {
     fun finalizeTransactionWithExtraSignatures(txn: SignedTransaction, sigs: Collection<TransactionSignature>, statesToRecord: StatesToRecord)
 
     /**
-     * Stores or updates a [SignedTransaction] to a status of VERIFIED.
-     * Optionally add finality flow recovery metadata.
+     * Records a [SignedTransaction] as VERIFIED with flow recovery metadata.
      *
      * @param txn The transaction to record.
      * @param statesToRecord how the vault should treat the output states of the transaction.
      * @param metadata Finality flow recovery metadata.
      */
-    fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata?= null)
+    fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata)
 }
 
 interface TransactionsResolver {

--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueWithObserversFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashIssueWithObserversFlow.kt
@@ -1,0 +1,47 @@
+package net.corda.finance.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.Amount
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveFinalityFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.issuedBy
+import java.util.Currency
+
+@StartableByRPC
+@InitiatingFlow
+class CashIssueWithObserversFlow(private val amount: Amount<Currency>,
+                                 private val issuerBankPartyRef: OpaqueBytes,
+                                 private val notary: Party,
+                                 private val observers: Set<Party>) : AbstractCashFlow<AbstractCashFlow.Result>(tracker()) {
+    @Suspendable
+    override fun call(): Result {
+        progressTracker.currentStep = Companion.GENERATING_TX
+        val builder = TransactionBuilder(notary)
+        val issuer = ourIdentity.ref(issuerBankPartyRef)
+        val signers = Cash().generateIssue(builder, amount.issuedBy(issuer), ourIdentity, notary)
+        progressTracker.currentStep = Companion.SIGNING_TX
+        val tx = serviceHub.signInitialTransaction(builder, signers)
+        progressTracker.currentStep = Companion.FINALISING_TX
+        val observerSessions = observers.map { initiateFlow(it) }
+        val notarised = finaliseTx(tx, observerSessions, "Unable to notarise issue")
+        return Result(notarised, ourIdentity)
+    }
+}
+
+@InitiatedBy(CashIssueWithObserversFlow::class)
+class CashIssueReceiverFlowWithObservers(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        if (!serviceHub.myInfo.isLegalIdentity(otherSide.counterparty)) {
+            subFlow(ReceiveFinalityFlow(otherSide))
+        }
+    }
+}

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -251,6 +251,9 @@ dependencies {
     integrationTestCompile(project(":testing:cordapps:missingmigration"))
 
     testCompile project(':testing:cordapps:dbfailure:dbfworkflows')
+
+    // used by FinalityFlowErrorHandlingTest
+    slowIntegrationTestCompile project(':testing:cordapps:cashobservers')
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -11,7 +11,7 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
 import net.corda.finance.DOLLARS
-import net.corda.finance.flows.CashIssueWithObserversFlow
+import net.corda.finance.test.flows.CashIssueWithObserversFlow
 import net.corda.node.services.statemachine.StateMachineErrorHandlingTest
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.CHARLIE_NAME

--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -77,9 +77,6 @@ class FinalityFlowErrorHandlingTest : StateMachineErrorHandlingTest() {
                     assertEquals(ALICE_NAME.toString(), this.second)    // initiator
                     assertEquals(CHARLIE_NAME.toString(), this.third)   // peers
                 }
-//                assertThrows<SQLException> {
-//                    charlie.rpc.startFlow(::GetFlowTransaction, txId).returnValue.getOrThrow()
-//                }
             }
         }
     }

--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -1,0 +1,100 @@
+package net.corda.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.CordaRuntimeException
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.finance.DOLLARS
+import net.corda.finance.flows.CashIssueWithObserversFlow
+import net.corda.node.services.statemachine.StateMachineErrorHandlingTest
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.CHARLIE_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.flows.waitForAllFlowsToComplete
+import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.internal.FINANCE_CORDAPPS
+import net.corda.testing.node.internal.enclosedCordapp
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class FinalityFlowErrorHandlingTest : StateMachineErrorHandlingTest() {
+
+    /**
+     * Throws an exception after recording an issuance transaction but before broadcasting the transaction to observer sessions.
+     *
+     */
+    @Test(timeout = 300_000)
+    fun `error after recording an issuance transaction inside of FinalityFlow generates recovery metadata`() {
+        startDriver(notarySpec = NotarySpec(DUMMY_NOTARY_NAME, validating = false),
+                    extraCordappPackagesToScan = listOf("net.corda.node.flows")) {
+            val (charlie, alice, port) = createNodeAndBytemanNode(CHARLIE_NAME, ALICE_NAME, FINANCE_CORDAPPS + enclosedCordapp())
+
+            // could not get rule for FinalityDoctor + observation counter to work
+            val rules = """
+                RULE Set flag when entering receive finality flow
+                CLASS ${FinalityFlow::class.java.name}
+                METHOD call
+                AT ENTRY
+                IF !flagged("finality_flag")
+                DO flag("finality_flag"); traceln("Setting finality flag")
+                ENDRULE
+
+                RULE Throw exception when recording transaction
+                CLASS ${FinalityFlow::class.java.name}
+                METHOD recordLocallyAndBroadcast
+                AT EXIT
+                IF flagged("finality_flag")
+                DO traceln("Throwing exception"); 
+                    throw new java.lang.RuntimeException("die dammit die")
+                ENDRULE
+            """.trimIndent()
+
+            submitBytemanRules(rules, port)
+
+            try {
+                alice.rpc.startFlow(
+                        ::CashIssueWithObserversFlow,
+                        500.DOLLARS,
+                        OpaqueBytes.of(0x01),
+                        defaultNotaryIdentity,
+                        setOf(charlie.nodeInfo.singleIdentity())
+                ).returnValue.getOrThrow(30.seconds)
+            }
+            catch (e: CordaRuntimeException) {
+                waitForAllFlowsToComplete(alice)
+                val txId = alice.rpc.stateMachineRecordedTransactionMappingSnapshot().single().transactionId
+
+                alice.rpc.startFlow(::GetFlowTransaction, txId).returnValue.getOrThrow().apply {
+                    assertEquals("M", this.first)              // "M" -> MISSING_NOTARY_SIG
+                    assertEquals(ALICE_NAME.toString(), this.second)    // initiator
+                    assertEquals(CHARLIE_NAME.toString(), this.third)   // peers
+                }
+            }
+        }
+    }
+}
+
+// Internal use for testing only!!
+@StartableByRPC
+class GetFlowTransaction(private val txId: SecureHash) : FlowLogic<Triple<String, String, String>>() {
+    @Suspendable
+    override fun call(): Triple<String, String, String> {
+        return serviceHub.jdbcSession().prepareStatement("select * from node_transactions where tx_id = ?")
+                .apply { setString(1, txId.toString()) }
+                .use { ps ->
+                    ps.executeQuery().use { rs ->
+                        rs.next()
+                        Triple(rs.getString(4),   // TransactionStatus
+                               rs.getString(7),   // initiator
+                               rs.getString(8))   // participants
+                    }
+                }
+    }
+}

--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -72,7 +72,7 @@ class FinalityFlowErrorHandlingTest : StateMachineErrorHandlingTest() {
                 val txId = alice.rpc.stateMachineRecordedTransactionMappingSnapshot().single().transactionId
 
                 alice.rpc.startFlow(::GetFlowTransaction, txId).returnValue.getOrThrow().apply {
-                    assertEquals("M", this.first)              // "M" -> MISSING_NOTARY_SIG
+                    assertEquals("F", this.first)              // "F" -> IN_FLIGHT
                     assertEquals(ALICE_NAME.toString(), this.second)    // initiator
                     assertEquals(CHARLIE_NAME.toString(), this.third)   // peers
                 }

--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -34,7 +34,7 @@ class FinalityFlowErrorHandlingTest : StateMachineErrorHandlingTest() {
     @Test(timeout = 300_000)
     fun `error after recording an issuance transaction inside of FinalityFlow generates recovery metadata`() {
         startDriver(notarySpec = NotarySpec(DUMMY_NOTARY_NAME, validating = false),
-                    extraCordappPackagesToScan = listOf("net.corda.node.flows")) {
+                    extraCordappPackagesToScan = listOf("net.corda.node.flows", "net.corda.finance.test.flows")) {
             val (charlie, alice, port) = createNodeAndBytemanNode(CHARLIE_NAME, ALICE_NAME, FINANCE_CORDAPPS + enclosedCordapp())
 
             val rules = """

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineErrorHandlingTest.kt
@@ -49,13 +49,16 @@ abstract class StateMachineErrorHandlingTest {
         counter = 0
     }
 
-    internal fun startDriver(notarySpec: NotarySpec = NotarySpec(DUMMY_NOTARY_NAME), dsl: DriverDSL.() -> Unit) {
+    internal fun startDriver(notarySpec: NotarySpec = NotarySpec(DUMMY_NOTARY_NAME),
+                             extraCordappPackagesToScan: List<String> = emptyList(),
+                             dsl: DriverDSL.() -> Unit) {
         driver(
             DriverParameters(
                 notarySpecs = listOf(notarySpec),
                 startNodesInProcess = false,
                 inMemoryDB = false,
-                systemProperties = mapOf("co.paralleluniverse.fibers.verifyInstrumentation" to "true")
+                systemProperties = mapOf("co.paralleluniverse.fibers.verifyInstrumentation" to "true"),
+                extraCordappPackagesToScan = extraCordappPackagesToScan
             )
         ) {
             dsl()

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowHospitalTest.kt
@@ -249,6 +249,7 @@ class FlowHospitalTest {
                 it.startFlow(::SpendStateAndCatchDoubleSpendFlow, nodeBHandle.nodeInfo.singleIdentity(), ref).returnValue.getOrThrow(20.seconds)
             }
             waitForAllFlowsToComplete(nodeAHandle)
+            waitForAllFlowsToComplete(nodeBHandle)
         }
         // 1 is the notary failing to notarise and propagating the error
         // 2 is the receiving flow failing due to the unexpected session end error
@@ -321,6 +322,8 @@ class FlowHospitalTest {
                 it.startFlow(::SpendStateAndCatchDoubleSpendOldFinalityFlow, nodeBHandle.nodeInfo.singleIdentity(), ref).returnValue.getOrThrow(20.seconds)
                 it.startFlow(::SpendStateAndCatchDoubleSpendOldFinalityFlow, nodeBHandle.nodeInfo.singleIdentity(), ref).returnValue.getOrThrow(20.seconds)
             }
+            waitForAllFlowsToComplete(nodeAHandle)
+            waitForAllFlowsToComplete(nodeBHandle)
         }
         // 1 is the notary failing to notarise and propagating the error
         // 2 is the receiving flow failing due to the unexpected session end error
@@ -351,6 +354,7 @@ class FlowHospitalTest {
                 it.startFlow(::CreateTransactionButDontFinalizeFlow, nodeBHandle.nodeInfo.singleIdentity(), ref3).returnValue.getOrThrow(20.seconds)
             }
             waitForAllFlowsToComplete(nodeAHandle)
+            waitForAllFlowsToComplete(nodeBHandle)
         }
         assertEquals(0, dischargedCounter)
         assertEquals(1, observationCounter)
@@ -378,6 +382,7 @@ class FlowHospitalTest {
                 it.startFlow(::SpendStateAndCatchDoubleSpendFlow, nodeBHandle.nodeInfo.singleIdentity(), ref, true).returnValue.getOrThrow(20.seconds)
             }
             waitForAllFlowsToComplete(nodeAHandle)
+            waitForAllFlowsToComplete(nodeBHandle)
         }
         // 1 is the notary failing to notarise and propagating the error
         assertEquals(1, dischargedCounter)

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -244,9 +244,10 @@ interface ServiceHubInternal : ServiceHubCoreInternal {
         requireSupportedHashType(txn)
         if (txn.coreTransaction is WireTransaction)
             txn.verifyRequiredSignatures()
-
         database.transaction {
-            validatedTransactions.finalizeTransaction(txn, metadata)
+            recordTransactions(statesToRecord, listOf(txn), validatedTransactions, stateMachineRecordedTransactionMapping, vaultService, database) {
+                validatedTransactions.finalizeTransaction(txn, metadata)
+            }
         }
     }
 
@@ -369,7 +370,7 @@ interface WritableTransactionStorage : TransactionStorage {
     fun removeUnnotarisedTransaction(id: SecureHash): Boolean
 
     /**
-     * Add a finalised transaction to the store with recovery metadata
+     * Add a finalised transaction to the store.
      * Optionally add finality flow recovery metadata.
      * @param transaction The transaction to be recorded.
      * @param metadata Finality flow recovery metadata.

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -240,7 +240,7 @@ interface ServiceHubInternal : ServiceHubCoreInternal {
         )
     }
 
-    override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata?) {
+    override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata) {
         requireSupportedHashType(txn)
         if (txn.coreTransaction is WireTransaction)
             txn.verifyRequiredSignatures()
@@ -251,7 +251,7 @@ interface ServiceHubInternal : ServiceHubCoreInternal {
         }
     }
 
-    override fun recordUnnotarisedTransaction(txn: SignedTransaction, metadata: FlowTransactionMetadata?) {
+    override fun recordUnnotarisedTransaction(txn: SignedTransaction, metadata: FlowTransactionMetadata) {
         if (txn.coreTransaction is WireTransaction) {
             txn.notary?.let { notary ->
                 txn.verifySignaturesExcept(notary.owningKey)
@@ -355,13 +355,13 @@ interface WritableTransactionStorage : TransactionStorage {
     fun addTransaction(transaction: SignedTransaction): Boolean
 
     /**
-     * Add an un-notarised transaction to the store with a status of *MISSING_TRANSACTION_SIG*.
-     * Optionally add finality flow recovery metadata.
+     * Add an un-notarised transaction to the store with a status of *MISSING_TRANSACTION_SIG* and inclusive of flow recovery metadata.
+     *
      * @param transaction The transaction to be recorded.
      * @param metadata Finality flow recovery metadata.
      * @return true if the transaction was recorded as a *new* transaction, false if the transaction already exists.
      */
-    fun addUnnotarisedTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata? = null): Boolean
+    fun addUnnotarisedTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata): Boolean
 
     /**
      * Removes an un-notarised transaction (with a status of *MISSING_TRANSACTION_SIG*) from the data store.
@@ -370,13 +370,13 @@ interface WritableTransactionStorage : TransactionStorage {
     fun removeUnnotarisedTransaction(id: SecureHash): Boolean
 
     /**
-     * Add a finalised transaction to the store.
-     * Optionally add finality flow recovery metadata.
+     * Add a finalised transaction to the store with flow recovery metadata.
+     *
      * @param transaction The transaction to be recorded.
      * @param metadata Finality flow recovery metadata.
      * @return true if the transaction was recorded as a *new* transaction, false if the transaction already exists.
      */
-    fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean
+    fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata): Boolean
 
     /**
      * Update a previously un-notarised transaction including associated notary signatures.

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -240,8 +240,7 @@ interface ServiceHubInternal : ServiceHubCoreInternal {
         )
     }
 
-    override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord,
-                                     metadata: FlowTransactionMetadata?) {
+    override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata?) {
         requireSupportedHashType(txn)
         if (txn.coreTransaction is WireTransaction)
             txn.verifyRequiredSignatures()

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -299,7 +299,9 @@ class DBTransactionStorage(private val database: CordaPersistence, cacheFactory:
                 val addedOrUpdated = addOrUpdate(transaction.id, cachedValue) { k, _ -> updateFn(k) }
                 if (addedOrUpdated) {
                     logger.debug { "Transaction ${transaction.id} has been recorded as $status" }
-                    onNewTx(transaction)
+                    if (status.isVerified())
+                        onNewTx(transaction)
+                    true
                 } else {
                     logger.debug { "Transaction ${transaction.id} is already recorded as $status, so no need to re-record" }
                     false

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -815,6 +815,13 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             }
         }
 
+        override fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean {
+            database.transaction {
+                delegate.finalizeTransaction(transaction, metadata)
+            }
+            return true
+        }
+
         override fun finalizeTransactionWithExtraSignatures(transaction: SignedTransaction, signatures: Collection<TransactionSignature>) : Boolean {
             database.transaction {
                 delegate.finalizeTransactionWithExtraSignatures(transaction, signatures)

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -801,10 +801,10 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             return true
         }
 
-        override fun addUnnotarisedTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean {
+        override fun addUnnotarisedTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata): Boolean {
             database.transaction {
                 records.add(TxRecord.Add(transaction))
-                delegate.addUnnotarisedTransaction(transaction)
+                delegate.addUnnotarisedTransaction(transaction, metadata)
             }
             return true
         }
@@ -815,7 +815,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             }
         }
 
-        override fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean {
+        override fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata): Boolean {
             database.transaction {
                 delegate.finalizeTransaction(transaction, metadata)
             }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -113,7 +113,7 @@ class DBTransactionStorageTests {
         val transactionClock = TransactionClock(now)
         newTransactionStorage(clock = transactionClock)
         val transaction = newTransaction()
-        transactionStorage.addUnnotarisedTransaction(transaction)
+        transactionStorage.addUnnotarisedTransaction(transaction, FlowTransactionMetadata(ALICE.party.name))
         assertEquals(IN_FLIGHT, readTransactionFromDB(transaction.id).status)
     }
 
@@ -150,7 +150,7 @@ class DBTransactionStorageTests {
         val transactionClock = TransactionClock(now)
         newTransactionStorage(clock = transactionClock)
         val transaction = newTransaction(notarySig = false)
-        transactionStorage.addUnnotarisedTransaction(transaction)
+        transactionStorage.addUnnotarisedTransaction(transaction, FlowTransactionMetadata(ALICE.party.name))
         assertNull(transactionStorage.getTransaction(transaction.id))
         assertEquals(IN_FLIGHT, readTransactionFromDB(transaction.id).status)
         transactionStorage.finalizeTransactionWithExtraSignatures(transaction, emptyList())
@@ -181,7 +181,7 @@ class DBTransactionStorageTests {
         val transactionClock = TransactionClock(now)
         newTransactionStorage(clock = transactionClock)
         val transaction = newTransaction(notarySig = false)
-        transactionStorage.addUnnotarisedTransaction(transaction)
+        transactionStorage.addUnnotarisedTransaction(transaction, FlowTransactionMetadata(ALICE.party.name))
         assertNull(transactionStorage.getTransaction(transaction.id))
         assertEquals(IN_FLIGHT, readTransactionFromDB(transaction.id).status)
         val notarySig = notarySig(transaction.id)
@@ -198,7 +198,7 @@ class DBTransactionStorageTests {
         val transactionClock = TransactionClock(now)
         newTransactionStorage(clock = transactionClock)
         val transaction = newTransaction(notarySig = false)
-        transactionStorage.addUnnotarisedTransaction(transaction)
+        transactionStorage.addUnnotarisedTransaction(transaction, FlowTransactionMetadata(ALICE.party.name))
         assertNull(transactionStorage.getTransaction(transaction.id))
         assertEquals(IN_FLIGHT, readTransactionFromDB(transaction.id).status)
 
@@ -232,7 +232,7 @@ class DBTransactionStorageTests {
         val transactionWithoutNotarySig = newTransaction(notarySig = false)
 
         // txn recorded as un-notarised (simulate ReceiverFinalityFlow in initial flow)
-        transactionStorage.addUnnotarisedTransaction(transactionWithoutNotarySig)
+        transactionStorage.addUnnotarisedTransaction(transactionWithoutNotarySig, FlowTransactionMetadata(ALICE.party.name))
         assertEquals(IN_FLIGHT, readTransactionFromDB(transactionWithoutNotarySig.id).status)
 
         // txn then recorded as unverified (simulate ResolveTransactionFlow in follow-up flow)
@@ -263,7 +263,7 @@ class DBTransactionStorageTests {
         val transactionWithoutNotarySigs = newTransaction(notarySig = false)
 
         // txn recorded as un-notarised (simulate ReceiverFinalityFlow in initial flow)
-        transactionStorage.addUnnotarisedTransaction(transactionWithoutNotarySigs)
+        transactionStorage.addUnnotarisedTransaction(transactionWithoutNotarySigs, FlowTransactionMetadata(ALICE.party.name))
         assertEquals(IN_FLIGHT, readTransactionFromDB(transactionWithoutNotarySigs.id).status)
 
         // txn then recorded as unverified (simulate ResolveTransactionFlow in follow-up flow)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -161,6 +161,21 @@ class DBTransactionStorageTests {
     }
 
     @Test(timeout = 300_000)
+    fun `finalize transaction with recovery metadata`() {
+        val now = Instant.ofEpochSecond(333444555L)
+        val transactionClock = TransactionClock(now)
+        newTransactionStorage(clock = transactionClock)
+        val transaction = newTransaction(notarySig = false)
+        transactionStorage.finalizeTransaction(transaction,
+                FlowTransactionMetadata(ALICE_NAME))
+        readTransactionFromDB(transaction.id).let {
+            assertEquals(VERIFIED, it.status)
+            assertEquals(ALICE_NAME.toString(), it.initiator)
+            assertEquals(StatesToRecord.ONLY_RELEVANT, it.statesToRecord)
+        }
+    }
+
+    @Test(timeout = 300_000)
     fun `finalize transaction with extra signatures after recording transaction as un-notarised`() {
         val now = Instant.ofEpochSecond(333444555L)
         val transactionClock = TransactionClock(now)

--- a/settings.gradle
+++ b/settings.gradle
@@ -102,6 +102,7 @@ include 'testing:cordapps:dbfailure:dbfcontracts'
 include 'testing:cordapps:dbfailure:dbfworkflows'
 include 'testing:cordapps:missingmigration'
 include 'testing:cordapps:sleeping'
+include 'testing:cordapps:cashobservers'
 
 // Common libraries - start
 include 'common-validation'

--- a/testing/cordapps/cashobservers/build.gradle
+++ b/testing/cordapps/cashobservers/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'kotlin'
+//apply plugin: 'net.corda.plugins.cordapp'
+//apply plugin: 'net.corda.plugins.quasar-utils'
+
+dependencies {
+    compile project(":core")
+    compile project(':finance:workflows')
+}
+
+jar {
+    baseName "testing-cashobservers-cordapp"
+    manifest {
+        // This JAR is part of Corda's testing framework.
+        // Driver will not include it as part of an out-of-process node.
+        attributes('Corda-Testing': true)
+    }
+}

--- a/testing/cordapps/cashobservers/src/main/kotlin/net/corda/finance/test/flows/CashIssueWithObserversFlow.kt
+++ b/testing/cordapps/cashobservers/src/main/kotlin/net/corda/finance/test/flows/CashIssueWithObserversFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.finance.flows
+package net.corda.finance.test.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
@@ -12,6 +12,7 @@ import net.corda.core.identity.Party
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.flows.AbstractCashFlow
 import net.corda.finance.issuedBy
 import java.util.Currency
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
@@ -63,6 +63,15 @@ open class MockTransactionStorage : WritableTransactionStorage, SingletonSeriali
         return txns.remove(id) != null
     }
 
+    override fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean {
+        val current = txns.replace(transaction.id, TxHolder(transaction, status = TransactionStatus.VERIFIED))
+        return if (current != null) {
+            notify(transaction)
+        } else {
+            false
+        }
+    }
+
     override fun finalizeTransactionWithExtraSignatures(transaction: SignedTransaction, signatures: Collection<TransactionSignature>): Boolean {
         val current = txns.replace(transaction.id, TxHolder(transaction, status = TransactionStatus.VERIFIED))
         return if (current != null) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
@@ -56,7 +56,7 @@ open class MockTransactionStorage : WritableTransactionStorage, SingletonSeriali
     }
 
     override fun addUnnotarisedTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean {
-        return txns.putIfAbsent(transaction.id, TxHolder(transaction, status = TransactionStatus.MISSING_NOTARY_SIG)) == null
+        return txns.putIfAbsent(transaction.id, TxHolder(transaction, status = TransactionStatus.IN_FLIGHT)) == null
     }
 
     override fun removeUnnotarisedTransaction(id: SecureHash): Boolean {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
@@ -55,7 +55,7 @@ open class MockTransactionStorage : WritableTransactionStorage, SingletonSeriali
         }
     }
 
-    override fun addUnnotarisedTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean {
+    override fun addUnnotarisedTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata): Boolean {
         return txns.putIfAbsent(transaction.id, TxHolder(transaction, status = TransactionStatus.IN_FLIGHT)) == null
     }
 
@@ -63,14 +63,8 @@ open class MockTransactionStorage : WritableTransactionStorage, SingletonSeriali
         return txns.remove(id) != null
     }
 
-    override fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata?): Boolean {
-        val current = txns.replace(transaction.id, TxHolder(transaction, status = TransactionStatus.VERIFIED))
-        return if (current != null) {
-            notify(transaction)
-        } else {
-            false
-        }
-    }
+    override fun finalizeTransaction(transaction: SignedTransaction, metadata: FlowTransactionMetadata) =
+            addTransaction(transaction)
 
     override fun finalizeTransactionWithExtraSignatures(transaction: SignedTransaction, signatures: Collection<TransactionSignature>): Boolean {
         val current = txns.replace(transaction.id, TxHolder(transaction, status = TransactionStatus.VERIFIED))

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -139,13 +139,13 @@ data class TestTransactionDSLInterpreter private constructor(
 
         override val attachmentsClassLoaderCache: AttachmentsClassLoaderCache = AttachmentsClassLoaderCacheImpl(TestingNamedCacheFactory())
 
-        override fun recordUnnotarisedTransaction(txn: SignedTransaction, metadata: FlowTransactionMetadata?) {}
+        override fun recordUnnotarisedTransaction(txn: SignedTransaction, metadata: FlowTransactionMetadata) {}
 
         override fun removeUnnotarisedTransaction(id: SecureHash) {}
 
         override fun finalizeTransactionWithExtraSignatures(txn: SignedTransaction, sigs: Collection<TransactionSignature>, statesToRecord: StatesToRecord) {}
 
-        override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata?) {}
+        override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata) {}
     }
 
     private fun copy(): TestTransactionDSLInterpreter =

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -144,6 +144,8 @@ data class TestTransactionDSLInterpreter private constructor(
         override fun removeUnnotarisedTransaction(id: SecureHash) {}
 
         override fun finalizeTransactionWithExtraSignatures(txn: SignedTransaction, sigs: Collection<TransactionSignature>, statesToRecord: StatesToRecord) {}
+
+        override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord) {}
     }
 
     private fun copy(): TestTransactionDSLInterpreter =

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -145,7 +145,7 @@ data class TestTransactionDSLInterpreter private constructor(
 
         override fun finalizeTransactionWithExtraSignatures(txn: SignedTransaction, sigs: Collection<TransactionSignature>, statesToRecord: StatesToRecord) {}
 
-        override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord) {}
+        override fun finalizeTransaction(txn: SignedTransaction, statesToRecord: StatesToRecord, metadata: FlowTransactionMetadata?) {}
     }
 
     private fun copy(): TestTransactionDSLInterpreter =


### PR DESCRIPTION
Two Phase Finality will now record all transactions as `IN-FLIGHT` (whether requiring notarisation or not).
This enables recoverability of issuance transactions with observers in the scenario where the initiator fails before the observers receive a copy of the  transaction.

- `MISSING_NOTARY_SIG` renamed to `IN_FLIGHT` 