### PR TITLE
ENT-9806: Netty threads no longer blocked if CRL endpoints are unresponsive

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/internal/ProviderMapTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/internal/ProviderMapTest.kt
@@ -1,0 +1,29 @@
+package net.corda.coretests.crypto.internal
+
+import net.corda.coretesting.internal.DEV_ROOT_CA
+import net.corda.testing.core.createCRL
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.junit.Test
+
+class ProviderMapTest {
+    // https://github.com/corda/corda/pull/3997
+    @Test(timeout = 300_000)
+    fun `verify CRL algorithms`() {
+        val crl = createCRL(
+                issuer = DEV_ROOT_CA,
+                revokedCerts = emptyList(),
+                signatureAlgorithm = "SHA256withECDSA"
+        )
+        // This should pass.
+        crl.verify(DEV_ROOT_CA.keyPair.public)
+
+        // Try changing the algorithm to EC will fail.
+        assertThatIllegalArgumentException().isThrownBy {
+            createCRL(
+                    issuer = DEV_ROOT_CA,
+                    revokedCerts = emptyList(),
+                    signatureAlgorithm = "EC"
+            )
+        }.withMessage("Unknown signature type requested: EC")
+    }
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
@@ -1,16 +1,18 @@
+@file:Suppress("LongParameterList")
+
 package net.corda.nodeapi.internal
 
 import net.corda.core.messaging.ClientRpcSslOptions
 import net.corda.core.serialization.internal.nodeSerializationEnv
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.nodeapi.BrokerRpcSslOptions
-import net.corda.nodeapi.internal.config.CertificateStore
 import net.corda.nodeapi.internal.config.DEFAULT_SSL_HANDSHAKE_TIMEOUT
 import net.corda.nodeapi.internal.config.MutualSslConfiguration
 import net.corda.nodeapi.internal.config.SslConfiguration
+import net.corda.nodeapi.internal.protonwrapper.netty.trustManagerFactory
 import org.apache.activemq.artemis.api.core.TransportConfiguration
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants
-import java.nio.file.Path
+import javax.net.ssl.TrustManagerFactory
 
 @Suppress("LongParameterList")
 class ArtemisTcpTransport {
@@ -23,6 +25,7 @@ class ArtemisTcpTransport {
         val TLS_VERSIONS = listOf("TLSv1.2")
 
         const val SSL_HANDSHAKE_TIMEOUT_NAME = "Corda-SSLHandshakeTimeout"
+        const val TRUST_MANAGER_FACTORY_NAME = "Corda-TrustManagerFactory"
         const val TRACE_NAME = "Corda-Trace"
         const val THREAD_POOL_NAME_NAME = "Corda-ThreadPoolName"
 
@@ -30,7 +33,6 @@ class ArtemisTcpTransport {
         // Unfortunately we cannot disable core protocol as artemis only uses AMQP for interop.
         // It does not use AMQP messages for its own messages e.g. topology and heartbeats.
         private const val P2P_PROTOCOLS = "CORE,AMQP"
-
         private const val RPC_PROTOCOLS = "CORE"
 
         private fun defaultArtemisOptions(hostAndPort: NetworkHostAndPort, protocols: String) = mapOf(
@@ -39,45 +41,34 @@ class ArtemisTcpTransport {
                 TransportConstants.PORT_PROP_NAME to hostAndPort.port,
                 TransportConstants.PROTOCOLS_PROP_NAME to protocols,
                 TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME to (nodeSerializationEnv != null),
-                TransportConstants.REMOTING_THREADS_PROPNAME to (if (nodeSerializationEnv != null) -1 else 1),
                 // turn off direct delivery in Artemis - this is latency optimisation that can lead to
                 //hick-ups under high load (CORDA-1336)
                 TransportConstants.DIRECT_DELIVER to false)
 
-        private val defaultSSLOptions = mapOf(
-                TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME to CIPHER_SUITES.joinToString(","),
-                TransportConstants.ENABLED_PROTOCOLS_PROP_NAME to TLS_VERSIONS.joinToString(","))
-
         private fun SslConfiguration.addToTransportOptions(options: MutableMap<String, Any>) {
+            if (keyStore != null || trustStore != null) {
+                options[TransportConstants.SSL_ENABLED_PROP_NAME] = true
+                options[TransportConstants.NEED_CLIENT_AUTH_PROP_NAME] = true
+            }
             keyStore?.let {
                 with (it) {
                     path.requireOnDefaultFileSystem()
-                    options.putAll(get().toKeyStoreTransportOptions(path))
+                    options[TransportConstants.KEYSTORE_PROVIDER_PROP_NAME] = "JKS"
+                    options[TransportConstants.KEYSTORE_PATH_PROP_NAME] = path
+                    options[TransportConstants.KEYSTORE_PASSWORD_PROP_NAME] = get().password
                 }
             }
             trustStore?.let {
                 with (it) {
                     path.requireOnDefaultFileSystem()
-                    options.putAll(get().toTrustStoreTransportOptions(path))
+                    options[TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME] = "JKS"
+                    options[TransportConstants.TRUSTSTORE_PATH_PROP_NAME] = path
+                    options[TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME] = get().password
                 }
             }
             options[TransportConstants.SSL_PROVIDER] = if (useOpenSsl) TransportConstants.OPENSSL_PROVIDER else TransportConstants.DEFAULT_SSL_PROVIDER
             options[SSL_HANDSHAKE_TIMEOUT_NAME] = handshakeTimeout ?: DEFAULT_SSL_HANDSHAKE_TIMEOUT
         }
-
-        private fun CertificateStore.toKeyStoreTransportOptions(path: Path) = mapOf(
-                TransportConstants.SSL_ENABLED_PROP_NAME to true,
-                TransportConstants.KEYSTORE_PROVIDER_PROP_NAME to "JKS",
-                TransportConstants.KEYSTORE_PATH_PROP_NAME to path,
-                TransportConstants.KEYSTORE_PASSWORD_PROP_NAME to password,
-                TransportConstants.NEED_CLIENT_AUTH_PROP_NAME to true)
-
-        private fun CertificateStore.toTrustStoreTransportOptions(path: Path) = mapOf(
-                TransportConstants.SSL_ENABLED_PROP_NAME to true,
-                TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME to "JKS",
-                TransportConstants.TRUSTSTORE_PATH_PROP_NAME to path,
-                TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME to password,
-                TransportConstants.NEED_CLIENT_AUTH_PROP_NAME to true)
 
         private fun ClientRpcSslOptions.toTransportOptions() = mapOf(
                 TransportConstants.SSL_ENABLED_PROP_NAME to true,
@@ -94,50 +85,64 @@ class ArtemisTcpTransport {
 
         fun p2pAcceptorTcpTransport(hostAndPort: NetworkHostAndPort,
                                     config: MutualSslConfiguration?,
+                                    trustManagerFactory: TrustManagerFactory?,
                                     enableSSL: Boolean = true,
                                     threadPoolName: String = "P2PServer",
-                                    trace: Boolean = false): TransportConfiguration {
+                                    trace: Boolean = false,
+                                    remotingThreads: Int? = null): TransportConfiguration {
             val options = mutableMapOf<String, Any>()
             if (enableSSL) {
                 config?.addToTransportOptions(options)
             }
-            return createAcceptorTransport(hostAndPort, P2P_PROTOCOLS, options, enableSSL, threadPoolName, trace)
+            return createAcceptorTransport(
+                    hostAndPort,
+                    P2P_PROTOCOLS,
+                    options,
+                    trustManagerFactory,
+                    enableSSL,
+                    threadPoolName,
+                    trace,
+                    remotingThreads
+            )
         }
 
         fun p2pConnectorTcpTransport(hostAndPort: NetworkHostAndPort,
                                      config: MutualSslConfiguration?,
                                      enableSSL: Boolean = true,
                                      threadPoolName: String = "P2PClient",
-                                     trace: Boolean = false): TransportConfiguration {
+                                     trace: Boolean = false,
+                                     remotingThreads: Int? = null): TransportConfiguration {
             val options = mutableMapOf<String, Any>()
             if (enableSSL) {
                 config?.addToTransportOptions(options)
             }
-            return createConnectorTransport(hostAndPort, P2P_PROTOCOLS, options, enableSSL, threadPoolName, trace)
+            return createConnectorTransport(hostAndPort, P2P_PROTOCOLS, options, enableSSL, threadPoolName, trace, remotingThreads)
         }
 
         fun rpcAcceptorTcpTransport(hostAndPort: NetworkHostAndPort,
                                     config: BrokerRpcSslOptions?,
                                     enableSSL: Boolean = true,
-                                    trace: Boolean = false): TransportConfiguration {
+                                    trace: Boolean = false,
+                                    remotingThreads: Int? = null): TransportConfiguration {
             val options = mutableMapOf<String, Any>()
             if (config != null && enableSSL) {
                 config.keyStorePath.requireOnDefaultFileSystem()
                 options.putAll(config.toTransportOptions())
             }
-            return createAcceptorTransport(hostAndPort, RPC_PROTOCOLS, options, enableSSL, "RPCServer", trace)
+            return createAcceptorTransport(hostAndPort, RPC_PROTOCOLS, options, null, enableSSL, "RPCServer", trace, remotingThreads)
         }
 
         fun rpcConnectorTcpTransport(hostAndPort: NetworkHostAndPort,
                                      config: ClientRpcSslOptions?,
                                      enableSSL: Boolean = true,
-                                     trace: Boolean = false): TransportConfiguration {
+                                     trace: Boolean = false,
+                                     remotingThreads: Int? = null): TransportConfiguration {
             val options = mutableMapOf<String, Any>()
             if (config != null && enableSSL) {
                 config.trustStorePath.requireOnDefaultFileSystem()
                 options.putAll(config.toTransportOptions())
             }
-            return createConnectorTransport(hostAndPort, RPC_PROTOCOLS, options, enableSSL, "RPCClient", trace)
+            return createConnectorTransport(hostAndPort, RPC_PROTOCOLS, options, enableSSL, "RPCClient", trace, remotingThreads)
         }
 
         fun rpcInternalClientTcpTransport(hostAndPort: NetworkHostAndPort,
@@ -145,25 +150,45 @@ class ArtemisTcpTransport {
                                           trace: Boolean = false): TransportConfiguration {
             val options = mutableMapOf<String, Any>()
             config.addToTransportOptions(options)
-            return createConnectorTransport(hostAndPort, RPC_PROTOCOLS, options, true, "Internal-RPCClient", trace)
+            return createConnectorTransport(hostAndPort, RPC_PROTOCOLS, options, true, "Internal-RPCClient", trace, null)
         }
 
         fun rpcInternalAcceptorTcpTransport(hostAndPort: NetworkHostAndPort,
                                             config: SslConfiguration,
-                                            trace: Boolean = false): TransportConfiguration {
+                                            trace: Boolean = false,
+                                            remotingThreads: Int? = null): TransportConfiguration {
             val options = mutableMapOf<String, Any>()
             config.addToTransportOptions(options)
-            return createAcceptorTransport(hostAndPort, RPC_PROTOCOLS, options, true, "Internal-RPCServer", trace)
+            return createAcceptorTransport(
+                    hostAndPort,
+                    RPC_PROTOCOLS,
+                    options,
+                    trustManagerFactory(requireNotNull(config.trustStore).get()),
+                    true,
+                    "Internal-RPCServer",
+                    trace,
+                    remotingThreads
+            )
         }
 
         private fun createAcceptorTransport(hostAndPort: NetworkHostAndPort,
                                             protocols: String,
                                             options: MutableMap<String, Any>,
+                                            trustManagerFactory: TrustManagerFactory?,
                                             enableSSL: Boolean,
                                             threadPoolName: String,
-                                            trace: Boolean): TransportConfiguration {
+                                            trace: Boolean,
+                                            remotingThreads: Int?): TransportConfiguration {
             // Suppress core.server.lambda$channelActive$0 - AMQ224088 error from load balancer type connections
             options[TransportConstants.HANDSHAKE_TIMEOUT] = 0
+            if (trustManagerFactory != null) {
+                // NettyAcceptor only creates default TrustManagerFactorys with the provided trust store details. However, we need to use
+                // more customised instances which use our revocation checkers, which we pass directly into NodeNettyAcceptorFactory.
+                //
+                // This, however, requires copying a lot of code from NettyAcceptor into NodeNettyAcceptor. The version of Artemis in
+                // Corda 4.9 solves this problem by introducing a "trustManagerFactoryPlugin" config option.
+                options[TRUST_MANAGER_FACTORY_NAME] = trustManagerFactory
+            }
             return createTransport(
                     "net.corda.node.services.messaging.NodeNettyAcceptorFactory",
                     hostAndPort,
@@ -171,7 +196,8 @@ class ArtemisTcpTransport {
                     options,
                     enableSSL,
                     threadPoolName,
-                    trace
+                    trace,
+                    remotingThreads
             )
         }
 
@@ -180,7 +206,8 @@ class ArtemisTcpTransport {
                                              options: MutableMap<String, Any>,
                                              enableSSL: Boolean,
                                              threadPoolName: String,
-                                             trace: Boolean): TransportConfiguration {
+                                             trace: Boolean,
+                                             remotingThreads: Int?): TransportConfiguration {
             return createTransport(
                     "net.corda.node.services.messaging.NodeNettyConnectorFactory",
                     hostAndPort,
@@ -188,7 +215,8 @@ class ArtemisTcpTransport {
                     options,
                     enableSSL,
                     threadPoolName,
-                    trace
+                    trace,
+                    remotingThreads
             )
         }
 
@@ -198,11 +226,15 @@ class ArtemisTcpTransport {
                                     options: MutableMap<String, Any>,
                                     enableSSL: Boolean,
                                     threadPoolName: String,
-                                    trace: Boolean): TransportConfiguration {
+                                    trace: Boolean,
+                                    remotingThreads: Int?): TransportConfiguration {
             options += defaultArtemisOptions(hostAndPort, protocols)
             if (enableSSL) {
-                options += defaultSSLOptions
+                options[TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME] = CIPHER_SUITES.joinToString(",")
+                options[TransportConstants.ENABLED_PROTOCOLS_PROP_NAME] = TLS_VERSIONS.joinToString(",")
             }
+            // By default, use only one remoting thread in tests (https://github.com/corda/corda/pull/2357)
+            options[TransportConstants.REMOTING_THREADS_PROPNAME] = remotingThreads ?: if (nodeSerializationEnv == null) 1 else -1
             options[THREAD_POOL_NAME_NAME] = threadPoolName
             options[TRACE_NAME] = trace
             return TransportConfiguration(className, options)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NodeApiUtils.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NodeApiUtils.kt
@@ -1,0 +1,32 @@
+@file:Suppress("LongParameterList", "MagicNumber")
+
+package net.corda.nodeapi.internal
+
+import io.netty.util.concurrent.DefaultThreadFactory
+import net.corda.core.utilities.seconds
+import java.time.Duration
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Creates a [ThreadPoolExecutor] which will use a maximum of [maxPoolSize] threads at any given time and will by default idle down to 0
+ * threads.
+ */
+fun namedThreadPoolExecutor(maxPoolSize: Int,
+                            corePoolSize: Int = 0,
+                            idleKeepAlive: Duration = 30.seconds,
+                            workQueue: BlockingQueue<Runnable> = LinkedBlockingQueue(),
+                            poolName: String = "pool",
+                            daemonThreads: Boolean = false,
+                            threadPriority: Int = Thread.NORM_PRIORITY): ThreadPoolExecutor {
+    return ThreadPoolExecutor(
+            corePoolSize,
+            maxPoolSize,
+            idleKeepAlive.toNanos(),
+            TimeUnit.NANOSECONDS,
+            workQueue,
+            DefaultThreadFactory(poolName, daemonThreads, threadPriority)
+    )
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AllowAllRevocationChecker.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AllowAllRevocationChecker.kt
@@ -31,4 +31,6 @@ object AllowAllRevocationChecker : PKIXRevocationChecker() {
     override fun getSoftFailExceptions(): List<CertPathValidatorException> {
         return Collections.emptyList()
     }
+
+    override fun clone(): AllowAllRevocationChecker = this
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/RevocationConfig.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/RevocationConfig.kt
@@ -3,9 +3,6 @@ package net.corda.nodeapi.internal.protonwrapper.netty
 import com.typesafe.config.Config
 import net.corda.nodeapi.internal.config.ConfigParser
 import net.corda.nodeapi.internal.config.CustomConfigParser
-import net.corda.nodeapi.internal.revocation.CertDistPointCrlSource
-import net.corda.nodeapi.internal.revocation.CordaRevocationChecker
-import java.security.cert.PKIXRevocationChecker
 
 /**
  * Data structure for controlling the way how Certificate Revocation Lists are handled.
@@ -45,18 +42,6 @@ interface RevocationConfig {
      * Optional [CrlSource] which only makes sense with `mode` = `EXTERNAL_SOURCE`
      */
     val externalCrlSource: CrlSource?
-
-    fun createPKIXRevocationChecker(): PKIXRevocationChecker {
-        return when (mode) {
-            Mode.OFF -> AllowAllRevocationChecker
-            Mode.EXTERNAL_SOURCE -> {
-                val externalCrlSource = requireNotNull(externalCrlSource) { "externalCrlSource must be specfied for EXTERNAL_SOURCE" }
-                CordaRevocationChecker(externalCrlSource, softFail = true)
-            }
-            Mode.SOFT_FAIL -> CordaRevocationChecker(CertDistPointCrlSource(), softFail = true)
-            Mode.HARD_FAIL -> CordaRevocationChecker(CertDistPointCrlSource(), softFail = false)
-        }
-    }
 }
 
 /**

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ComplexMethod", "LongParameterList")
+
 package net.corda.nodeapi.internal.protonwrapper.netty
 
 import io.netty.buffer.ByteBufAllocator
@@ -18,6 +20,8 @@ import net.corda.nodeapi.internal.ArtemisTcpTransport
 import net.corda.nodeapi.internal.config.CertificateStore
 import net.corda.nodeapi.internal.crypto.toSimpleString
 import net.corda.nodeapi.internal.crypto.x509
+import net.corda.nodeapi.internal.namedThreadPoolExecutor
+import net.corda.nodeapi.internal.revocation.CordaRevocationChecker
 import org.bouncycastle.asn1.ASN1InputStream
 import org.bouncycastle.asn1.ASN1Primitive
 import org.bouncycastle.asn1.DERIA5String
@@ -34,10 +38,10 @@ import java.net.URI
 import java.security.KeyStore
 import java.security.cert.CertificateException
 import java.security.cert.PKIXBuilderParameters
-import java.security.cert.PKIXRevocationChecker
 import java.security.cert.X509CertSelector
 import java.security.cert.X509Certificate
 import java.util.concurrent.Executor
+import java.util.concurrent.ThreadPoolExecutor
 import javax.net.ssl.CertPathTrustManagerParameters
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SNIHostName
@@ -46,7 +50,6 @@ import javax.net.ssl.SSLEngine
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509ExtendedTrustManager
 import javax.security.auth.x500.X500Principal
-import kotlin.system.measureTimeMillis
 
 private const val HOSTNAME_FORMAT = "%s.corda.net"
 internal const val DEFAULT = "default"
@@ -58,7 +61,6 @@ internal val logger = LoggerFactory.getLogger("net.corda.nodeapi.internal.proton
 /**
  * Returns all the CRL distribution points in the certificate as [URI]s along with the CRL issuer names, if any.
  */
-@Suppress("ComplexMethod")
 fun X509Certificate.distributionPoints(): Map<URI, List<X500Principal>?> {
     logger.debug { "Checking CRLDPs for $subjectX500Principal" }
 
@@ -115,6 +117,14 @@ fun certPathToString(certPath: Array<out X509Certificate>?): String {
         return "<empty certpath>"
     }
     return certPath.joinToString(System.lineSeparator()) { "  ${it.toSimpleString()}" }
+}
+
+/**
+ * Create an executor for processing SSL handshake tasks asynchronously (see [SSLEngine.getDelegatedTask]). The max number of threads is 3,
+ * which is the typical number of CRLs expected in a Corda TLS cert path. The executor needs to be passed to the [SslHandler] constructor.
+ */
+fun sslDelegatedTaskExecutor(parentPoolName: String): ThreadPoolExecutor {
+    return namedThreadPoolExecutor(maxPoolSize = 3, poolName = "$parentPoolName-ssltask")
 }
 
 @VisibleForTesting
@@ -179,32 +189,11 @@ class LoggingTrustManagerWrapper(val wrapped: X509ExtendedTrustManager) : X509Ex
 
 }
 
-private object LoggingImmediateExecutor : Executor {
-
-    override fun execute(command: Runnable) {
-        val log = LoggerFactory.getLogger(javaClass)
-
-        @Suppress("TooGenericExceptionCaught", "MagicNumber") // log and rethrow all exceptions
-        try {
-            val commandName = command::class.qualifiedName?.let { "[$it]" } ?: ""
-            log.debug("Entering SSL command $commandName")
-            val elapsedTime = measureTimeMillis { command.run() }
-            log.debug("Exiting SSL command $elapsedTime millis")
-            if (elapsedTime > 100) {
-                log.info("Command: $commandName took $elapsedTime millis to execute")
-            }
-        }
-        catch (ex: Exception) {
-            log.error("Caught exception in SSL handler executor", ex)
-            throw ex
-        }
-    }
-}
-
 internal fun createClientSslHandler(target: NetworkHostAndPort,
                                     expectedRemoteLegalNames: Set<CordaX500Name>,
                                     keyManagerFactory: KeyManagerFactory,
-                                    trustManagerFactory: TrustManagerFactory): SslHandler {
+                                    trustManagerFactory: TrustManagerFactory,
+                                    delegateTaskExecutor: Executor): SslHandler {
     val sslContext = createAndInitSslContext(keyManagerFactory, trustManagerFactory)
     val sslEngine = sslContext.createSSLEngine(target.host, target.port)
     sslEngine.useClientMode = true
@@ -216,14 +205,15 @@ internal fun createClientSslHandler(target: NetworkHostAndPort,
         sslParameters.serverNames = listOf(SNIHostName(x500toHostName(expectedRemoteLegalNames.single())))
         sslEngine.sslParameters = sslParameters
     }
-    return SslHandler(sslEngine, false, LoggingImmediateExecutor)
+    return SslHandler(sslEngine, false, delegateTaskExecutor)
 }
 
 internal fun createClientOpenSslHandler(target: NetworkHostAndPort,
                                         expectedRemoteLegalNames: Set<CordaX500Name>,
                                         keyManagerFactory: KeyManagerFactory,
                                         trustManagerFactory: TrustManagerFactory,
-                                        alloc: ByteBufAllocator): SslHandler {
+                                        alloc: ByteBufAllocator,
+                                        delegateTaskExecutor: Executor): SslHandler {
     val sslContext = SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL).keyManager(keyManagerFactory).trustManager(LoggingTrustManagerFactoryWrapper(trustManagerFactory)).build()
     val sslEngine = sslContext.newEngine(alloc, target.host, target.port)
     sslEngine.enabledProtocols = ArtemisTcpTransport.TLS_VERSIONS.toTypedArray()
@@ -233,12 +223,13 @@ internal fun createClientOpenSslHandler(target: NetworkHostAndPort,
         sslParameters.serverNames = listOf(SNIHostName(x500toHostName(expectedRemoteLegalNames.single())))
         sslEngine.sslParameters = sslParameters
     }
-    return SslHandler(sslEngine, false, LoggingImmediateExecutor)
+    return SslHandler(sslEngine, false, delegateTaskExecutor)
 }
 
 internal fun createServerSslHandler(keyStore: CertificateStore,
                                     keyManagerFactory: KeyManagerFactory,
-                                    trustManagerFactory: TrustManagerFactory): SslHandler {
+                                    trustManagerFactory: TrustManagerFactory,
+                                    delegateTaskExecutor: Executor): SslHandler {
     val sslContext = createAndInitSslContext(keyManagerFactory, trustManagerFactory)
     val sslEngine = sslContext.createSSLEngine()
     sslEngine.useClientMode = false
@@ -249,37 +240,27 @@ internal fun createServerSslHandler(keyStore: CertificateStore,
     val sslParameters = sslEngine.sslParameters
     sslParameters.sniMatchers = listOf(ServerSNIMatcher(keyStore))
     sslEngine.sslParameters = sslParameters
-    return SslHandler(sslEngine, false, LoggingImmediateExecutor)
+    return SslHandler(sslEngine, false, delegateTaskExecutor)
 }
 
 internal fun createServerOpenSslHandler(keyManagerFactory: KeyManagerFactory,
                                         trustManagerFactory: TrustManagerFactory,
-                                        alloc: ByteBufAllocator): SslHandler {
+                                        alloc: ByteBufAllocator,
+                                        delegateTaskExecutor: Executor): SslHandler {
     val sslContext = getServerSslContextBuilder(keyManagerFactory, trustManagerFactory).build()
     val sslEngine = sslContext.newEngine(alloc)
     sslEngine.useClientMode = false
-    return SslHandler(sslEngine, false, LoggingImmediateExecutor)
+    return SslHandler(sslEngine, false, delegateTaskExecutor)
 }
 
-fun createAndInitSslContext(keyManagerFactory: KeyManagerFactory, trustManagerFactory: TrustManagerFactory): SSLContext {
+fun createAndInitSslContext(keyManagerFactory: KeyManagerFactory, trustManagerFactory: TrustManagerFactory?): SSLContext {
     val sslContext = SSLContext.getInstance("TLS")
-    val keyManagers = keyManagerFactory.keyManagers
-    val trustManagers = trustManagerFactory.trustManagers.filterIsInstance(X509ExtendedTrustManager::class.java)
-            .map { LoggingTrustManagerWrapper(it) }.toTypedArray()
-    sslContext.init(keyManagers, trustManagers, newSecureRandom())
+    val trustManagers = trustManagerFactory
+            ?.trustManagers
+            ?.map { if (it is X509ExtendedTrustManager) LoggingTrustManagerWrapper(it) else it }
+            ?.toTypedArray()
+    sslContext.init(keyManagerFactory.keyManagers, trustManagers, newSecureRandom())
     return sslContext
-}
-
-fun initialiseTrustStoreAndEnableCrlChecking(trustStore: CertificateStore,
-                                             revocationConfig: RevocationConfig): CertPathTrustManagerParameters {
-    return initialiseTrustStoreAndEnableCrlChecking(trustStore, revocationConfig.createPKIXRevocationChecker())
-}
-
-fun initialiseTrustStoreAndEnableCrlChecking(trustStore: CertificateStore,
-                                             revocationChecker: PKIXRevocationChecker): CertPathTrustManagerParameters {
-    val pkixParams = PKIXBuilderParameters(trustStore.value.internal, X509CertSelector())
-    pkixParams.addCertPathChecker(revocationChecker)
-    return CertPathTrustManagerParameters(pkixParams)
 }
 
 /**
@@ -296,14 +277,13 @@ internal fun createServerSNIOpenSniHandler(keyManagerFactoriesMap: Map<String, K
     return SniHandler(mapping.build())
 }
 
-@Suppress("SpreadOperator")
 private fun getServerSslContextBuilder(keyManagerFactory: KeyManagerFactory, trustManagerFactory: TrustManagerFactory): SslContextBuilder {
     return SslContextBuilder.forServer(keyManagerFactory)
             .sslProvider(SslProvider.OPENSSL)
             .trustManager(LoggingTrustManagerFactoryWrapper(trustManagerFactory))
             .clientAuth(ClientAuth.REQUIRE)
             .ciphers(ArtemisTcpTransport.CIPHER_SUITES)
-            .protocols(*ArtemisTcpTransport.TLS_VERSIONS.toTypedArray())
+            .protocols(ArtemisTcpTransport.TLS_VERSIONS)
 }
 
 internal fun splitKeystore(config: AMQPConfiguration): Map<String, CertHoldingKeyManagerFactoryWrapper> {
@@ -325,9 +305,38 @@ internal fun splitKeystore(config: AMQPConfiguration): Map<String, CertHoldingKe
 
 // As per Javadoc in: https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/KeyManagerFactory.html `init` method
 // 2nd parameter `password` - the password for recovering keys in the KeyStore
-fun KeyManagerFactory.init(keyStore: CertificateStore) = init(keyStore.value.internal, keyStore.entryPassword.toCharArray())
+fun keyManagerFactory(keyStore: CertificateStore): KeyManagerFactory {
+    val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+    keyManagerFactory.init(keyStore.value.internal, keyStore.entryPassword.toCharArray())
+    return keyManagerFactory
+}
 
-fun TrustManagerFactory.init(trustStore: CertificateStore) = init(trustStore.value.internal)
+fun trustManagerFactory(trustStore: CertificateStore): TrustManagerFactory {
+    val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    trustManagerFactory.init(trustStore.value.internal)
+    return trustManagerFactory
+}
+
+fun trustManagerFactoryWithRevocation(trustStore: CertificateStore,
+                                      revocationConfig: RevocationConfig,
+                                      crlSource: CrlSource): TrustManagerFactory {
+    val revocationChecker = when (revocationConfig.mode) {
+        RevocationConfig.Mode.OFF -> AllowAllRevocationChecker
+        RevocationConfig.Mode.EXTERNAL_SOURCE -> {
+            val externalCrlSource = requireNotNull(revocationConfig.externalCrlSource) {
+                "externalCrlSource must be specfied for EXTERNAL_SOURCE"
+            }
+            CordaRevocationChecker(externalCrlSource, softFail = true)
+        }
+        RevocationConfig.Mode.SOFT_FAIL -> CordaRevocationChecker(crlSource, softFail = true)
+        RevocationConfig.Mode.HARD_FAIL -> CordaRevocationChecker(crlSource, softFail = false)
+    }
+    val pkixParams = PKIXBuilderParameters(trustStore.value.internal, X509CertSelector())
+    pkixParams.addCertPathChecker(revocationChecker)
+    val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    trustManagerFactory.init(CertPathTrustManagerParameters(pkixParams))
+    return trustManagerFactory
+}
 
 /**
  * Method that converts a [CordaX500Name] to a a valid hostname (RFC-1035). It's used for SNI to indicate the target

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/TlsDiffAlgorithmsTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/TlsDiffAlgorithmsTest.kt
@@ -4,7 +4,8 @@ import net.corda.core.crypto.newSecureRandom
 import net.corda.core.utilities.Try
 import net.corda.core.utilities.contextLogger
 import net.corda.nodeapi.internal.config.CertificateStore
-import net.corda.nodeapi.internal.protonwrapper.netty.init
+import net.corda.nodeapi.internal.protonwrapper.netty.keyManagerFactory
+import net.corda.nodeapi.internal.protonwrapper.netty.trustManagerFactory
 import org.assertj.core.api.Assertions
 import org.junit.Rule
 import org.junit.Test
@@ -161,11 +162,9 @@ class TlsDiffAlgorithmsTest(private val serverAlgo: String, private val clientAl
 
     private fun createSslContext(keyStore: CertificateStore, trustStore: CertificateStore): SSLContext {
         return SSLContext.getInstance("TLS").apply {
-            val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
-            keyManagerFactory.init(keyStore)
+            val keyManagerFactory = keyManagerFactory(keyStore)
             val keyManagers = keyManagerFactory.keyManagers
-            val trustMgrFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-            trustMgrFactory.init(trustStore)
+            val trustMgrFactory = trustManagerFactory(trustStore)
             val trustManagers = trustMgrFactory.trustManagers
             init(keyManagers, trustManagers, newSecureRandom())
         }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/TlsDiffProtocolsTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/TlsDiffProtocolsTest.kt
@@ -4,7 +4,8 @@ import net.corda.core.crypto.newSecureRandom
 import net.corda.core.utilities.Try
 import net.corda.core.utilities.contextLogger
 import net.corda.nodeapi.internal.config.CertificateStore
-import net.corda.nodeapi.internal.protonwrapper.netty.init
+import net.corda.nodeapi.internal.protonwrapper.netty.keyManagerFactory
+import net.corda.nodeapi.internal.protonwrapper.netty.trustManagerFactory
 import org.assertj.core.api.Assertions
 import org.junit.Ignore
 import org.junit.Rule
@@ -18,7 +19,6 @@ import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import javax.net.ssl.*
-import javax.net.ssl.SNIHostName
 import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -209,11 +209,9 @@ class TlsDiffProtocolsTest(private val serverAlgo: String, private val clientAlg
 
     private fun createSslContext(keyStore: CertificateStore, trustStore: CertificateStore): SSLContext {
         return SSLContext.getInstance("TLS").apply {
-            val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
-            keyManagerFactory.init(keyStore)
+            val keyManagerFactory = keyManagerFactory(keyStore)
             val keyManagers = keyManagerFactory.keyManagers
-            val trustMgrFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-            trustMgrFactory.init(trustStore)
+            val trustMgrFactory = trustManagerFactory(trustStore)
             val trustManagers = trustMgrFactory.trustManagers
             init(keyManagers, trustManagers, newSecureRandom())
         }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/revocation/CordaRevocationCheckerTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/revocation/CordaRevocationCheckerTest.kt
@@ -5,7 +5,7 @@ import net.corda.nodeapi.internal.DEV_CA_KEY_STORE_PASS
 import net.corda.nodeapi.internal.DEV_CA_PRIVATE_KEY_PASS
 import net.corda.nodeapi.internal.config.CertificateStore
 import net.corda.nodeapi.internal.crypto.X509Utilities
-import net.corda.nodeapi.internal.protonwrapper.netty.CrlSource
+import net.corda.testing.internal.fixedCrlSource
 import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory
 import org.junit.Test
 import java.math.BigInteger
@@ -41,10 +41,8 @@ class CordaRevocationCheckerTest {
         val resourceAsStream = javaClass.getResourceAsStream("/net/corda/nodeapi/internal/protonwrapper/netty/doorman.crl")
         val crl = CertificateFactory().engineGenerateCRL(resourceAsStream) as X509CRL
 
-        val crlSource = object : CrlSource {
-            override fun fetch(certificate: X509Certificate): Set<X509CRL> = setOf(crl)
-        }
-        val checker = CordaRevocationChecker(crlSource,
+        val checker = CordaRevocationChecker(
+                crlSource = fixedCrlSource(setOf(crl)),
                 softFail = true,
                 dateSource = { Date.from(date.atStartOfDay().toInstant(ZoneOffset.UTC)) }
         )

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -264,8 +264,6 @@ tasks.register('integrationTest', Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     maxParallelForks = (System.env.CORDA_NODE_INT_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_INT_TESTING_FORKS".toInteger()
-    // CertificateRevocationListNodeTests
-    systemProperty 'net.corda.dpcrl.connect.timeout', '4000'
 }
 
 tasks.register('slowIntegrationTest', Test) {

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
@@ -14,12 +14,15 @@ import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.configureWithDevSSLCertificate
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPClient
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPConfiguration
-import net.corda.nodeapi.internal.protonwrapper.netty.init
-import net.corda.nodeapi.internal.protonwrapper.netty.initialiseTrustStoreAndEnableCrlChecking
+import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
+import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfigImpl
+import net.corda.nodeapi.internal.protonwrapper.netty.keyManagerFactory
 import net.corda.nodeapi.internal.protonwrapper.netty.toRevocationConfig
+import net.corda.nodeapi.internal.protonwrapper.netty.trustManagerFactoryWithRevocation
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.driver.internal.incrementalPortAllocation
+import net.corda.testing.internal.fixedCrlSource
 import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Rule
@@ -96,11 +99,13 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
             override val maxMessageSize: Int = MAX_MESSAGE_SIZE
         }
 
-        serverKeyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
-        serverTrustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        serverKeyManagerFactory = keyManagerFactory(keyStore)
 
-        serverKeyManagerFactory.init(keyStore)
-        serverTrustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(serverAmqpConfig.trustStore, serverAmqpConfig.revocationConfig))
+        serverTrustManagerFactory = trustManagerFactoryWithRevocation(
+                serverAmqpConfig.trustStore,
+                RevocationConfigImpl(RevocationConfig.Mode.SOFT_FAIL),
+                fixedCrlSource(emptySet())
+        )
     }
 
     private fun setupClientCertificates() {
@@ -127,11 +132,13 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
             override val sslHandshakeTimeout: Duration = 3.seconds
         }
 
-        clientKeyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
-        clientTrustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        clientKeyManagerFactory = keyManagerFactory(keyStore)
 
-        clientKeyManagerFactory.init(keyStore)
-        clientTrustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(clientAmqpConfig.trustStore, clientAmqpConfig.revocationConfig))
+        clientTrustManagerFactory = trustManagerFactoryWithRevocation(
+                clientAmqpConfig.trustStore,
+                RevocationConfigImpl(RevocationConfig.Mode.SOFT_FAIL),
+                fixedCrlSource(emptySet())
+        )
     }
 
     @Test(timeout = 300_000)

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LongParameterList")
+
 package net.corda.node.amqp
 
 import com.nhaarman.mockito_kotlin.doReturn
@@ -5,10 +7,10 @@ import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.crypto.Crypto
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.div
-import net.corda.core.internal.rootCause
 import net.corda.core.internal.times
-import net.corda.core.toFuture
 import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.core.utilities.minutes
+import net.corda.core.utilities.seconds
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.coretesting.internal.stubs.CertificateStoreStubs
 import net.corda.node.services.config.NodeConfiguration
@@ -18,63 +20,67 @@ import net.corda.nodeapi.internal.ArtemisMessagingClient
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_PREFIX
 import net.corda.nodeapi.internal.config.CertificateStoreSupplier
 import net.corda.nodeapi.internal.config.MutualSslConfiguration
-import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_CLIENT_CA
+import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_CLIENT_TLS
 import net.corda.nodeapi.internal.protonwrapper.messages.MessageStatus
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPClient
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPConfiguration
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPServer
+import net.corda.nodeapi.internal.protonwrapper.netty.ConnectionChange
 import net.corda.nodeapi.internal.protonwrapper.netty.toRevocationConfig
+import net.corda.nodeapi.internal.revocation.CertDistPointCrlSource
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.MAX_MESSAGE_SIZE
 import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.internal.network.CrlServer
 import net.corda.testing.node.internal.network.CrlServer.Companion.EMPTY_CRL
-import net.corda.testing.node.internal.network.CrlServer.Companion.FORBIDDEN_CRL
 import net.corda.testing.node.internal.network.CrlServer.Companion.NODE_CRL
 import net.corda.testing.node.internal.network.CrlServer.Companion.withCrlDistPoint
 import org.apache.activemq.artemis.api.core.RoutingType
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.net.SocketTimeoutException
+import java.io.Closeable
 import java.security.cert.X509Certificate
 import java.time.Duration
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.assertEquals
+import java.util.stream.IntStream
 
-@Suppress("LongParameterList")
-class CertificateRevocationListNodeTests {
+abstract class AbstractServerRevocationTest {
     @Rule
     @JvmField
     val temporaryFolder = TemporaryFolder()
 
     private val portAllocation = incrementalPortAllocation()
-    private val serverPort = portAllocation.nextPort()
+    protected val serverPort = portAllocation.nextPort()
 
-    private lateinit var crlServer: CrlServer
-    private lateinit var amqpServer: AMQPServer
-    private lateinit var amqpClient: AMQPClient
+    protected lateinit var crlServer: CrlServer
+    private val amqpClients = ArrayList<AMQPClient>()
 
-    private abstract class AbstractNodeConfiguration : NodeConfiguration
+    protected lateinit var defaultCrlDistPoints: CrlDistPoints
+
+    protected abstract class AbstractNodeConfiguration : NodeConfiguration
 
     companion object {
         private val unreachableIpCounter = AtomicInteger(1)
 
-        private val crlConnectTimeout = Duration.ofMillis(System.getProperty("net.corda.dpcrl.connect.timeout").toLong())
+         val crlConnectTimeout = 2.seconds
 
         /**
          * Use this method to get a unqiue unreachable IP address. Subsequent uses of the same IP for connection timeout testing purposes
          * may not work as the OS process may cache the timeout result.
          */
-        private fun newUnreachableIpAddress(): String {
+        private fun newUnreachableIpAddress(): NetworkHostAndPort {
             check(unreachableIpCounter.get() != 255)
-            return "10.255.255.${unreachableIpCounter.getAndIncrement()}"
+            return NetworkHostAndPort("10.255.255", unreachableIpCounter.getAndIncrement())
         }
     }
 
@@ -84,252 +90,190 @@ class CertificateRevocationListNodeTests {
         Crypto.findProvider(BouncyCastleProvider.PROVIDER_NAME)
         crlServer = CrlServer(NetworkHostAndPort("localhost", 0))
         crlServer.start()
+        defaultCrlDistPoints = CrlDistPoints(crlServer.hostAndPort)
     }
 
     @After
     fun tearDown() {
-        if (::amqpClient.isInitialized) {
-            amqpClient.close()
-        }
-        if (::amqpServer.isInitialized) {
-            amqpServer.close()
-        }
+        amqpClients.parallelStream().forEach(AMQPClient::close)
         if (::crlServer.isInitialized) {
             crlServer.close()
         }
     }
 
     @Test(timeout=300_000)
-	fun `AMQP server connection works and soft fail is enabled`() {
-        verifyAMQPConnection(
+	fun `connection succeeds when soft fail is enabled`() {
+        verifyConnection(
                 crlCheckSoftFail = true,
-                expectedConnectStatus = true
+                expectedConnectedStatus = true
         )
     }
 
     @Test(timeout=300_000)
-	fun `AMQP server connection works and soft fail is disabled`() {
-        verifyAMQPConnection(
+	fun `connection succeeds when soft fail is disabled`() {
+        verifyConnection(
                 crlCheckSoftFail = false,
-                expectedConnectStatus = true
+                expectedConnectedStatus = true
         )
     }
 
     @Test(timeout=300_000)
-	fun `AMQP server connection fails when client's certificate is revoked and soft fail is enabled`() {
-        verifyAMQPConnection(
+	fun `connection fails when client's certificate is revoked and soft fail is enabled`() {
+        verifyConnection(
                 crlCheckSoftFail = true,
                 revokeClientCert = true,
-                expectedConnectStatus = false
+                expectedConnectedStatus = false
         )
     }
 
     @Test(timeout=300_000)
-	fun `AMQP server connection fails when client's certificate is revoked and soft fail is disabled`() {
-        verifyAMQPConnection(
+	fun `connection fails when client's certificate is revoked and soft fail is disabled`() {
+        verifyConnection(
                 crlCheckSoftFail = false,
                 revokeClientCert = true,
-                expectedConnectStatus = false
+                expectedConnectedStatus = false
         )
     }
 
     @Test(timeout=300_000)
-	fun `AMQP server connection fails when servers's certificate is revoked and soft fail is enabled`() {
-        verifyAMQPConnection(
+	fun `connection fails when server's certificate is revoked and soft fail is enabled`() {
+        verifyConnection(
                 crlCheckSoftFail = true,
                 revokeServerCert = true,
-                expectedConnectStatus = false
+                expectedConnectedStatus = false
         )
     }
 
     @Test(timeout=300_000)
-    fun `AMQP server connection fails when servers's certificate is revoked and soft fail is disabled`() {
-        verifyAMQPConnection(
+    fun `connection fails when server's certificate is revoked and soft fail is disabled`() {
+        verifyConnection(
                 crlCheckSoftFail = false,
                 revokeServerCert = true,
-                expectedConnectStatus = false
+                expectedConnectedStatus = false
         )
     }
 
     @Test(timeout=300_000)
-	fun `AMQP server connection succeeds when CRL cannot be obtained and soft fail is enabled`() {
-        verifyAMQPConnection(
+	fun `connection succeeds when CRL cannot be obtained and soft fail is enabled`() {
+        verifyConnection(
                 crlCheckSoftFail = true,
-                nodeCrlDistPoint = "http://${crlServer.hostAndPort}/crl/invalid.crl",
-                expectedConnectStatus = true
+                clientCrlDistPoints = defaultCrlDistPoints.copy(nodeCa = "non-existent.crl"),
+                expectedConnectedStatus = true
         )
     }
 
     @Test(timeout=300_000)
-    fun `AMQP server connection fails when CRL cannot be obtained and soft fail is disabled`() {
-        verifyAMQPConnection(
+    fun `connection fails when CRL cannot be obtained and soft fail is disabled`() {
+        verifyConnection(
                 crlCheckSoftFail = false,
-                nodeCrlDistPoint = "http://${crlServer.hostAndPort}/crl/invalid.crl",
-                expectedConnectStatus = false
+                clientCrlDistPoints = defaultCrlDistPoints.copy(nodeCa = "non-existent.crl"),
+                expectedConnectedStatus = false
         )
     }
 
     @Test(timeout=300_000)
-    fun `AMQP server connection succeeds when CRL is not defined and soft fail is enabled`() {
-        verifyAMQPConnection(
+    fun `connection succeeds when CRL is not defined for node CA cert and soft fail is enabled`() {
+        verifyConnection(
                 crlCheckSoftFail = true,
-                nodeCrlDistPoint = null,
-                expectedConnectStatus = true
+                clientCrlDistPoints = defaultCrlDistPoints.copy(nodeCa = null),
+                expectedConnectedStatus = true
         )
     }
 
     @Test(timeout=300_000)
-	fun `AMQP server connection fails when CRL is not defined and soft fail is disabled`() {
-        verifyAMQPConnection(
+	fun `connection fails when CRL is not defined for node CA cert and soft fail is disabled`() {
+        verifyConnection(
                 crlCheckSoftFail = false,
-                nodeCrlDistPoint = null,
-                expectedConnectStatus = false
+                clientCrlDistPoints = defaultCrlDistPoints.copy(nodeCa = null),
+                expectedConnectedStatus = false
         )
     }
 
     @Test(timeout=300_000)
-    fun `AMQP server connection succeeds when CRL retrieval is forbidden and soft fail is enabled`() {
-        verifyAMQPConnection(
+    fun `connection succeeds when CRL is not defined for TLS cert and soft fail is enabled`() {
+        verifyConnection(
                 crlCheckSoftFail = true,
-                nodeCrlDistPoint = "http://${crlServer.hostAndPort}/crl/$FORBIDDEN_CRL",
-                expectedConnectStatus = true
+                clientCrlDistPoints = defaultCrlDistPoints.copy(tls = null),
+                expectedConnectedStatus = true
         )
     }
 
     @Test(timeout=300_000)
-    fun `AMQP server connection succeeds when CRL endpoint is unreachable, soft fail is enabled and CRL timeouts are within SSL handshake timeout`() {
-        verifyAMQPConnection(
-                crlCheckSoftFail = true,
-                nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
-                sslHandshakeTimeout = crlConnectTimeout * 3,
-                expectedConnectStatus = true
+    fun `connection fails when CRL is not defined for TLS cert and soft fail is disabled`() {
+        verifyConnection(
+                crlCheckSoftFail = false,
+                clientCrlDistPoints = defaultCrlDistPoints.copy(tls = null),
+                expectedConnectedStatus = false
         )
-        val timeoutExceptions = (amqpServer.softFailExceptions + amqpClient.softFailExceptions)
-                .map { it.rootCause }
-                .filterIsInstance<SocketTimeoutException>()
-        assertThat(timeoutExceptions).isNotEmpty
     }
 
     @Test(timeout=300_000)
-    fun `AMQP server connection fails when CRL endpoint is unreachable, despite soft fail enabled, when CRL timeouts are not within SSL handshake timeout`() {
-        verifyAMQPConnection(
+    fun `connection succeeds when CRL endpoint is unreachable, soft fail is enabled and CRL timeouts are within SSL handshake timeout`() {
+        verifyConnection(
                 crlCheckSoftFail = true,
-                nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
+                sslHandshakeTimeout = crlConnectTimeout * 4,
+                clientCrlDistPoints = defaultCrlDistPoints.copy(crlServerAddress = newUnreachableIpAddress()),
+                expectedConnectedStatus = true
+        )
+    }
+
+    @Test(timeout=300_000)
+    fun `connection fails when CRL endpoint is unreachable, despite soft fail enabled, when CRL timeouts are not within SSL handshake timeout`() {
+        verifyConnection(
+                crlCheckSoftFail = true,
                 sslHandshakeTimeout = crlConnectTimeout / 2,
-                expectedConnectStatus = false
+                clientCrlDistPoints = defaultCrlDistPoints.copy(crlServerAddress = newUnreachableIpAddress()),
+                expectedConnectedStatus = false
         )
     }
 
-    @Test(timeout=300_000)
-	fun `verify CRL algorithms`() {
-        val crl = crlServer.createRevocationList(
-                "SHA256withECDSA",
-                crlServer.rootCa,
-                EMPTY_CRL,
-                true,
-                emptyList()
+    @Test(timeout = 300_000)
+    fun `influx of new clients during CRL endpoint downtime does not cause existing connections to drop`() {
+        val serverCrlSource = CertDistPointCrlSource()
+        // Start the server and verify the first client has connected
+        val firstClientConnectionChangeStatus = verifyConnection(
+                crlCheckSoftFail = true,
+                crlSource = serverCrlSource,
+                // In general, N remoting threads will naturally support N-1 new handshaking clients plus one thread for heartbeating with
+                // existing clients. The trick is to make sure at least N new clients are also supported.
+                remotingThreads = 2,
+                expectedConnectedStatus = true
         )
-        // This should pass.
-        crl.verify(crlServer.rootCa.keyPair.public)
 
-        // Try changing the algorithm to EC will fail.
-        assertThatIllegalArgumentException().isThrownBy {
-            crlServer.createRevocationList(
-                    "EC",
-                    crlServer.rootCa,
-                    EMPTY_CRL,
-                    true,
-                    emptyList()
+        // Now simulate the CRL endpoint becoming very slow/unreachable
+        crlServer.delay = 10.minutes
+        // And pretend enough time has elapsed that the cached CRLs have expired and need downloading again
+        serverCrlSource.clearCache()
+
+        // Now a bunch of new clients have arrived and want to handshake with the server, which will potentially cause the server's Netty
+        // threads to be tied up in trying to download the CRLs.
+        IntStream.range(0, 2).parallel().forEach { clientIndex ->
+            val (newClient, _) = createAMQPClient(
+                    serverPort,
+                    crlCheckSoftFail = true,
+                    legalName = CordaX500Name("NewClient$clientIndex", "London", "GB"),
+                    crlDistPoints = defaultCrlDistPoints
             )
-        }.withMessage("Unknown signature type requested: EC")
+            newClient.start()
+        }
+
+        // Make sure there are no further connection change updates, i.e. the first client stays connected throughout this whole saga
+        assertThat(firstClientConnectionChangeStatus.poll(30, TimeUnit.SECONDS)).isNull()
     }
 
-    @Test(timeout = 300_000)
-    fun `Artemis server connection succeeds with soft fail CRL check`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = true,
-                crlCheckArtemisServer = true,
-                expectedStatus = MessageStatus.Acknowledged
-        )
-    }
+    protected abstract fun verifyConnection(crlCheckSoftFail: Boolean,
+                                            crlSource: CertDistPointCrlSource = CertDistPointCrlSource(connectTimeout = crlConnectTimeout),
+                                            sslHandshakeTimeout: Duration? = null,
+                                            remotingThreads: Int? = null,
+                                            clientCrlDistPoints: CrlDistPoints = defaultCrlDistPoints,
+                                            revokeClientCert: Boolean = false,
+                                            revokeServerCert: Boolean = false,
+                                            expectedConnectedStatus: Boolean): BlockingQueue<ConnectionChange>
 
-    @Test(timeout = 300_000)
-    fun `Artemis server connection succeeds with hard fail CRL check`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = false,
-                crlCheckArtemisServer = true,
-                expectedStatus = MessageStatus.Acknowledged
-        )
-    }
-
-    @Test(timeout = 300_000)
-    fun `Artemis server connection succeeds with soft fail CRL check on unavailable URL`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = true,
-                crlCheckArtemisServer = true,
-                expectedStatus = MessageStatus.Acknowledged,
-                nodeCrlDistPoint = "http://${crlServer.hostAndPort}/crl/$FORBIDDEN_CRL"
-        )
-    }
-
-    @Test(timeout = 300_000)
-    fun `Artemis server connection succeeds with soft fail CRL check on unreachable URL if CRL timeout is within SSL handshake timeout`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = true,
-                crlCheckArtemisServer = true,
-                expectedStatus = MessageStatus.Acknowledged,
-                nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
-                sslHandshakeTimeout = crlConnectTimeout * 3
-        )
-    }
-
-    @Test(timeout = 300_000)
-    fun `Artemis server connection fails with soft fail CRL check on unreachable URL if CRL timeout is not within SSL handshake timeout`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = true,
-                crlCheckArtemisServer = true,
-                expectedConnected = false,
-                nodeCrlDistPoint = "http://${newUnreachableIpAddress()}/crl/unreachable.crl",
-                sslHandshakeTimeout = crlConnectTimeout / 2
-        )
-    }
-
-    @Test(timeout = 300_000)
-    fun `Artemis server connection fails with hard fail CRL check on unavailable URL`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = false,
-                crlCheckArtemisServer = true,
-                expectedStatus = MessageStatus.Rejected,
-                nodeCrlDistPoint = "http://${crlServer.hostAndPort}/crl/$FORBIDDEN_CRL"
-        )
-    }
-
-    @Test(timeout = 300_000)
-    fun `Artemis server connection fails with soft fail CRL check on revoked node certificate`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = true,
-                crlCheckArtemisServer = true,
-                expectedStatus = MessageStatus.Rejected,
-                revokedNodeCert = true
-        )
-    }
-
-    @Test(timeout = 300_000)
-    fun `Artemis server connection succeeds with disabled CRL check on revoked node certificate`() {
-        verifyArtemisConnection(
-                crlCheckSoftFail = false,
-                crlCheckArtemisServer = false,
-                expectedStatus = MessageStatus.Acknowledged,
-                revokedNodeCert = true
-        )
-    }
-
-    private fun createAMQPClient(targetPort: Int,
-                                 crlCheckSoftFail: Boolean,
-                                 legalName: CordaX500Name,
-                                 nodeCrlDistPoint: String? = "http://${crlServer.hostAndPort}/crl/$NODE_CRL",
-                                 tlsCrlDistPoint: String? = "http://${crlServer.hostAndPort}/crl/$EMPTY_CRL",
-                                 maxMessageSize: Int = MAX_MESSAGE_SIZE): X509Certificate {
+    protected fun createAMQPClient(targetPort: Int,
+                                   crlCheckSoftFail: Boolean,
+                                   legalName: CordaX500Name,
+                                   crlDistPoints: CrlDistPoints): Pair<AMQPClient, X509Certificate> {
         val baseDirectory = temporaryFolder.root.toPath() / legalName.organisation
         val certificatesDirectory = baseDirectory / "certificates"
         val p2pSslConfiguration = CertificateStoreStubs.P2P.withCertificatesDirectory(certificatesDirectory)
@@ -343,31 +287,128 @@ class CertificateRevocationListNodeTests {
             doReturn(crlCheckSoftFail).whenever(it).crlCheckSoftFail
         }
         clientConfig.configureWithDevSSLCertificate()
-        val nodeCert = recreateNodeCaAndTlsCertificates(signingCertificateStore, p2pSslConfiguration, nodeCrlDistPoint, tlsCrlDistPoint)
+        val nodeCert = crlDistPoints.recreateNodeCaAndTlsCertificates(signingCertificateStore, p2pSslConfiguration, crlServer)
         val keyStore = clientConfig.p2pSslOptions.keyStore.get()
 
         val amqpConfig = object : AMQPConfiguration {
             override val keyStore = keyStore
             override val trustStore = clientConfig.p2pSslOptions.trustStore.get()
-            override val maxMessageSize: Int = maxMessageSize
+            override val maxMessageSize: Int = MAX_MESSAGE_SIZE
+            override val trace: Boolean = true
         }
-        amqpClient = AMQPClient(
+        val amqpClient = AMQPClient(
                 listOf(NetworkHostAndPort("localhost", targetPort)),
                 setOf(CHARLIE_NAME),
                 amqpConfig,
-                threadPoolName = legalName.organisation
+                threadPoolName = legalName.organisation,
+                distPointCrlSource = CertDistPointCrlSource(connectTimeout = crlConnectTimeout)
         )
+        amqpClients += amqpClient
+        return Pair(amqpClient, nodeCert)
+    }
 
-        return nodeCert
+    protected fun AMQPClient.waitForInitialConnectionAndCaptureChanges(expectedConnectedStatus: Boolean): BlockingQueue<ConnectionChange> {
+        val connectionChangeStatus = LinkedBlockingQueue<ConnectionChange>()
+        onConnection.subscribe { connectionChangeStatus.add(it) }
+        start()
+        assertThat(connectionChangeStatus.take().connected).isEqualTo(expectedConnectedStatus)
+        return connectionChangeStatus
+    }
+
+    protected data class CrlDistPoints(val crlServerAddress: NetworkHostAndPort,
+                                       val nodeCa: String? = NODE_CRL,
+                                       val tls: String? = EMPTY_CRL) {
+        private val nodeCaCertCrlDistPoint: String? get() = nodeCa?.let { "http://$crlServerAddress/crl/$it" }
+        private val tlsCertCrlDistPoint: String? get() = tls?.let { "http://$crlServerAddress/crl/$it" }
+
+        fun recreateNodeCaAndTlsCertificates(signingCertificateStore: CertificateStoreSupplier,
+                                             p2pSslConfiguration: MutualSslConfiguration,
+                                             crlServer: CrlServer): X509Certificate {
+            val nodeKeyStore = signingCertificateStore.get()
+            val (nodeCert, nodeKeys) = nodeKeyStore.query { getCertificateAndKeyPair(CORDA_CLIENT_CA, nodeKeyStore.entryPassword) }
+            val newNodeCert = crlServer.replaceNodeCertDistPoint(nodeCert, nodeCaCertCrlDistPoint)
+            val nodeCertChain = listOf(newNodeCert, crlServer.intermediateCa.certificate) +
+                    nodeKeyStore.query { getCertificateChain(CORDA_CLIENT_CA) }.drop(2)
+
+            nodeKeyStore.update {
+                internal.deleteEntry(CORDA_CLIENT_CA)
+            }
+            nodeKeyStore.update {
+                setPrivateKey(CORDA_CLIENT_CA, nodeKeys.private, nodeCertChain, nodeKeyStore.entryPassword)
+            }
+
+            val sslKeyStore = p2pSslConfiguration.keyStore.get()
+            val (tlsCert, tlsKeys) = sslKeyStore.query { getCertificateAndKeyPair(CORDA_CLIENT_TLS, sslKeyStore.entryPassword) }
+            val newTlsCert = tlsCert.withCrlDistPoint(nodeKeys, tlsCertCrlDistPoint, crlServer.rootCa.certificate.subjectX500Principal)
+            val sslCertChain = listOf(newTlsCert, newNodeCert, crlServer.intermediateCa.certificate) +
+                    sslKeyStore.query { getCertificateChain(CORDA_CLIENT_TLS) }.drop(3)
+
+            sslKeyStore.update {
+                internal.deleteEntry(CORDA_CLIENT_TLS)
+            }
+            sslKeyStore.update {
+                setPrivateKey(CORDA_CLIENT_TLS, tlsKeys.private, sslCertChain, sslKeyStore.entryPassword)
+            }
+            return newNodeCert
+        }
+    }
+}
+
+
+class AMQPServerRevocationTest : AbstractServerRevocationTest() {
+    private lateinit var amqpServer: AMQPServer
+
+    @After
+    fun shutDown() {
+        if (::amqpServer.isInitialized) {
+            amqpServer.close()
+        }
+    }
+
+    override fun verifyConnection(crlCheckSoftFail: Boolean,
+                                  crlSource: CertDistPointCrlSource,
+                                  sslHandshakeTimeout: Duration?,
+                                  remotingThreads: Int?,
+                                  clientCrlDistPoints: CrlDistPoints,
+                                  revokeClientCert: Boolean,
+                                  revokeServerCert: Boolean,
+                                  expectedConnectedStatus: Boolean): BlockingQueue<ConnectionChange> {
+        val serverCert = createAMQPServer(
+                serverPort,
+                CHARLIE_NAME,
+                crlCheckSoftFail,
+                defaultCrlDistPoints,
+                crlSource,
+                sslHandshakeTimeout,
+                remotingThreads
+        )
+        if (revokeServerCert) {
+            crlServer.revokedNodeCerts.add(serverCert)
+        }
+        amqpServer.start()
+        amqpServer.onReceive.subscribe {
+            it.complete(true)
+        }
+        val (client, clientCert) = createAMQPClient(
+                serverPort,
+                crlCheckSoftFail = crlCheckSoftFail,
+                legalName = ALICE_NAME,
+                crlDistPoints = clientCrlDistPoints
+        )
+        if (revokeClientCert) {
+            crlServer.revokedNodeCerts.add(clientCert)
+        }
+
+        return client.waitForInitialConnectionAndCaptureChanges(expectedConnectedStatus)
     }
 
     private fun createAMQPServer(port: Int,
                                  legalName: CordaX500Name,
                                  crlCheckSoftFail: Boolean,
-                                 nodeCrlDistPoint: String? = "http://${crlServer.hostAndPort}/crl/$NODE_CRL",
-                                 tlsCrlDistPoint: String? = "http://${crlServer.hostAndPort}/crl/$EMPTY_CRL",
-                                 maxMessageSize: Int = MAX_MESSAGE_SIZE,
-                                 sslHandshakeTimeout: Duration? = null): X509Certificate {
+                                 crlDistPoints: CrlDistPoints,
+                                 distPointCrlSource: CertDistPointCrlSource,
+                                 sslHandshakeTimeout: Duration?,
+                                 remotingThreads: Int?): X509Certificate {
         check(!::amqpServer.isInitialized)
         val baseDirectory = temporaryFolder.root.toPath() / legalName.organisation
         val certificatesDirectory = baseDirectory / "certificates"
@@ -381,92 +422,101 @@ class CertificateRevocationListNodeTests {
             doReturn(signingCertificateStore).whenever(it).signingCertificateStore
         }
         serverConfig.configureWithDevSSLCertificate()
-        val nodeCert = recreateNodeCaAndTlsCertificates(signingCertificateStore, p2pSslConfiguration, nodeCrlDistPoint, tlsCrlDistPoint)
+        val serverCert = crlDistPoints.recreateNodeCaAndTlsCertificates(signingCertificateStore, p2pSslConfiguration, crlServer)
         val keyStore = serverConfig.p2pSslOptions.keyStore.get()
         val amqpConfig = object : AMQPConfiguration {
             override val keyStore = keyStore
             override val trustStore = serverConfig.p2pSslOptions.trustStore.get()
             override val revocationConfig = crlCheckSoftFail.toRevocationConfig()
-            override val maxMessageSize: Int = maxMessageSize
+            override val maxMessageSize: Int = MAX_MESSAGE_SIZE
             override val sslHandshakeTimeout: Duration = sslHandshakeTimeout ?: super.sslHandshakeTimeout
         }
-        amqpServer = AMQPServer("0.0.0.0", port, amqpConfig, threadPoolName = legalName.organisation)
-        return nodeCert
-    }
-
-    private fun recreateNodeCaAndTlsCertificates(signingCertificateStore: CertificateStoreSupplier,
-                                                 p2pSslConfiguration: MutualSslConfiguration,
-                                                 nodeCaCrlDistPoint: String?,
-                                                 tlsCrlDistPoint: String?): X509Certificate {
-        val nodeKeyStore = signingCertificateStore.get()
-        val (nodeCert, nodeKeys) = nodeKeyStore.query { getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA, nodeKeyStore.entryPassword) }
-        val newNodeCert = crlServer.replaceNodeCertDistPoint(nodeCert, nodeCaCrlDistPoint)
-        val nodeCertChain = listOf(newNodeCert, crlServer.intermediateCa.certificate) +
-                nodeKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_CA) }.drop(2)
-
-        nodeKeyStore.update {
-            internal.deleteEntry(X509Utilities.CORDA_CLIENT_CA)
-        }
-        nodeKeyStore.update {
-            setPrivateKey(X509Utilities.CORDA_CLIENT_CA, nodeKeys.private, nodeCertChain, nodeKeyStore.entryPassword)
-        }
-
-        val sslKeyStore = p2pSslConfiguration.keyStore.get()
-        val (tlsCert, tlsKeys) = sslKeyStore.query { getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_TLS, sslKeyStore.entryPassword) }
-        val newTlsCert = tlsCert.withCrlDistPoint(nodeKeys, tlsCrlDistPoint, crlServer.rootCa.certificate.subjectX500Principal)
-        val sslCertChain = listOf(newTlsCert, newNodeCert, crlServer.intermediateCa.certificate) +
-                sslKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_TLS) }.drop(3)
-
-        sslKeyStore.update {
-            internal.deleteEntry(X509Utilities.CORDA_CLIENT_TLS)
-        }
-        sslKeyStore.update {
-            setPrivateKey(X509Utilities.CORDA_CLIENT_TLS, tlsKeys.private, sslCertChain, sslKeyStore.entryPassword)
-        }
-        return newNodeCert
-    }
-
-    private fun verifyAMQPConnection(crlCheckSoftFail: Boolean,
-                                     nodeCrlDistPoint: String? = "http://${crlServer.hostAndPort}/crl/$NODE_CRL",
-                                     revokeServerCert: Boolean = false,
-                                     revokeClientCert: Boolean = false,
-                                     sslHandshakeTimeout: Duration? = null,
-                                     expectedConnectStatus: Boolean) {
-        val serverCert = createAMQPServer(
-                serverPort,
-                CHARLIE_NAME,
-                crlCheckSoftFail = crlCheckSoftFail,
-                nodeCrlDistPoint = nodeCrlDistPoint,
-                sslHandshakeTimeout = sslHandshakeTimeout
+        amqpServer = AMQPServer(
+                "0.0.0.0",
+                port,
+                amqpConfig,
+                threadPoolName = legalName.organisation,
+                distPointCrlSource = distPointCrlSource,
+                remotingThreads = remotingThreads
         )
-        if (revokeServerCert) {
-            crlServer.revokedNodeCerts.add(serverCert.serialNumber)
+        return serverCert
+    }
+}
+
+
+class ArtemisServerRevocationTest : AbstractServerRevocationTest() {
+    private lateinit var artemisNode: ArtemisNode
+    private var crlCheckArtemisServer = true
+
+    @After
+    fun shutDown() {
+        if (::artemisNode.isInitialized) {
+            artemisNode.close()
         }
-        amqpServer.start()
-        amqpServer.onReceive.subscribe {
-            it.complete(true)
-        }
-        val clientCert = createAMQPClient(
+    }
+
+    @Test(timeout = 300_000)
+    fun `connection succeeds with disabled CRL check on revoked node certificate`() {
+        crlCheckArtemisServer = false
+        verifyConnection(
+                crlCheckSoftFail = false,
+                revokeClientCert = true,
+                expectedConnectedStatus = true
+        )
+    }
+
+    override fun verifyConnection(crlCheckSoftFail: Boolean,
+                                  crlSource: CertDistPointCrlSource,
+                                  sslHandshakeTimeout: Duration?,
+                                  remotingThreads: Int?,
+                                  clientCrlDistPoints: CrlDistPoints,
+                                  revokeClientCert: Boolean,
+                                  revokeServerCert: Boolean,
+                                  expectedConnectedStatus: Boolean): BlockingQueue<ConnectionChange> {
+        val (client, clientCert) = createAMQPClient(
                 serverPort,
-                crlCheckSoftFail = crlCheckSoftFail,
+                crlCheckSoftFail = true,
                 legalName = ALICE_NAME,
-                nodeCrlDistPoint = nodeCrlDistPoint
+                crlDistPoints = clientCrlDistPoints
         )
         if (revokeClientCert) {
-            crlServer.revokedNodeCerts.add(clientCert.serialNumber)
+            crlServer.revokedNodeCerts.add(clientCert)
         }
-        val serverConnected = amqpServer.onConnection.toFuture()
-        amqpClient.start()
-        val serverConnect = serverConnected.get()
-        assertThat(serverConnect.connected).isEqualTo(expectedConnectStatus)
+
+        val nodeCert = startArtemisNode(
+                CHARLIE_NAME,
+                crlCheckSoftFail,
+                defaultCrlDistPoints,
+                crlSource,
+                sslHandshakeTimeout,
+                remotingThreads
+        )
+        if (revokeServerCert) {
+            crlServer.revokedNodeCerts.add(nodeCert)
+        }
+
+        val queueName = "${P2P_PREFIX}Test"
+        artemisNode.client.started!!.session.createQueue(queueName, RoutingType.ANYCAST, queueName, true)
+
+        val clientConnectionChangeStatus = client.waitForInitialConnectionAndCaptureChanges(expectedConnectedStatus)
+
+        if (expectedConnectedStatus) {
+            val msg = client.createMessage("Test".toByteArray(), queueName, CHARLIE_NAME.toString(), emptyMap())
+            client.write(msg)
+            assertThat(msg.onComplete.get()).isEqualTo(MessageStatus.Acknowledged)
+        }
+
+        return clientConnectionChangeStatus
     }
 
-    private fun createArtemisServerAndClient(legalName: CordaX500Name,
-                                             crlCheckSoftFail: Boolean,
-                                             crlCheckArtemisServer: Boolean,
-                                             nodeCrlDistPoint: String,
-                                             sslHandshakeTimeout: Duration?): Pair<ArtemisMessagingServer, ArtemisMessagingClient> {
-        val baseDirectory = temporaryFolder.root.toPath() / "artemis"
+    private fun startArtemisNode(legalName: CordaX500Name,
+                                 crlCheckSoftFail: Boolean,
+                                 crlDistPoints: CrlDistPoints,
+                                 distPointCrlSource: CertDistPointCrlSource,
+                                 sslHandshakeTimeout: Duration?,
+                                 remotingThreads: Int?): X509Certificate {
+        check(!::artemisNode.isInitialized)
+        val baseDirectory = temporaryFolder.root.toPath() / legalName.organisation
         val certificatesDirectory = baseDirectory / "certificates"
         val signingCertificateStore = CertificateStoreStubs.Signing.withCertificatesDirectory(certificatesDirectory)
         val p2pSslConfiguration = CertificateStoreStubs.P2P.withCertificatesDirectory(certificatesDirectory, sslHandshakeTimeout = sslHandshakeTimeout)
@@ -482,60 +532,34 @@ class CertificateRevocationListNodeTests {
             doReturn(crlCheckArtemisServer).whenever(it).crlCheckArtemisServer
         }
         artemisConfig.configureWithDevSSLCertificate()
-        recreateNodeCaAndTlsCertificates(signingCertificateStore, p2pSslConfiguration, nodeCrlDistPoint, null)
+        val nodeCert = crlDistPoints.recreateNodeCaAndTlsCertificates(signingCertificateStore, p2pSslConfiguration, crlServer)
 
         val server = ArtemisMessagingServer(
                 artemisConfig,
                 artemisConfig.p2pAddress,
                 MAX_MESSAGE_SIZE,
                 threadPoolName = "${legalName.organisation}-server",
-                trace = true
+                trace = true,
+                distPointCrlSource = distPointCrlSource,
+                remotingThreads = remotingThreads
         )
         val client = ArtemisMessagingClient(
                 artemisConfig.p2pSslOptions,
                 artemisConfig.p2pAddress,
                 MAX_MESSAGE_SIZE,
-                threadPoolName = "${legalName.organisation}-client",
-                trace = true
+                threadPoolName = "${legalName.organisation}-client"
         )
         server.start()
         client.start()
-        return server to client
+        val artemisNode = ArtemisNode(server, client)
+        this.artemisNode = artemisNode
+        return nodeCert
     }
 
-    private fun verifyArtemisConnection(crlCheckSoftFail: Boolean,
-                                        crlCheckArtemisServer: Boolean,
-                                        expectedConnected: Boolean = true,
-                                        expectedStatus: MessageStatus? = null,
-                                        revokedNodeCert: Boolean = false,
-                                        nodeCrlDistPoint: String = "http://${crlServer.hostAndPort}/crl/$NODE_CRL",
-                                        sslHandshakeTimeout: Duration? = null) {
-        val queueName = P2P_PREFIX + "Test"
-        val (artemisServer, artemisClient) = createArtemisServerAndClient(
-                CHARLIE_NAME,
-                crlCheckSoftFail,
-                crlCheckArtemisServer,
-                nodeCrlDistPoint,
-                sslHandshakeTimeout
-        )
-        artemisServer.use {
-            artemisClient.started!!.session.createQueue(queueName, RoutingType.ANYCAST, queueName, true)
-
-            val nodeCert = createAMQPClient(serverPort, true, ALICE_NAME, nodeCrlDistPoint)
-            if (revokedNodeCert) {
-                crlServer.revokedNodeCerts.add(nodeCert.serialNumber)
-            }
-            val clientConnected = amqpClient.onConnection.toFuture()
-            amqpClient.start()
-            val clientConnect = clientConnected.get()
-            assertThat(clientConnect.connected).isEqualTo(expectedConnected)
-
-            if (expectedConnected) {
-                val msg = amqpClient.createMessage("Test".toByteArray(), queueName, CHARLIE_NAME.toString(), emptyMap())
-                amqpClient.write(msg)
-                assertEquals(expectedStatus, msg.onComplete.get())
-            }
-            artemisClient.stop()
+    private class ArtemisNode(val server: ArtemisMessagingServer, val client: ArtemisMessagingClient) : Closeable {
+        override fun close() {
+            client.stop()
+            server.close()
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -4,7 +4,6 @@ import co.paralleluniverse.fibers.instrument.Retransform
 import com.codahale.metrics.MetricRegistry
 import com.google.common.collect.MutableClassToInstanceMap
 import com.google.common.util.concurrent.MoreExecutors
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.zaxxer.hikari.pool.HikariPool
 import net.corda.common.logging.errorReporting.NodeDatabaseErrors
 import net.corda.confidential.SwapIdentitiesFlow
@@ -67,6 +66,7 @@ import net.corda.core.toFuture
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.days
+import net.corda.core.utilities.millis
 import net.corda.core.utilities.minutes
 import net.corda.djvm.source.ApiSource
 import net.corda.djvm.source.EmptyApi
@@ -166,6 +166,7 @@ import net.corda.nodeapi.internal.persistence.RestrictedEntityManager
 import net.corda.nodeapi.internal.persistence.SchemaMigration
 import net.corda.nodeapi.internal.persistence.contextDatabase
 import net.corda.nodeapi.internal.persistence.withoutDatabaseAccess
+import net.corda.nodeapi.internal.namedThreadPoolExecutor
 import net.corda.tools.shell.InteractiveShell
 import org.apache.activemq.artemis.utils.ReusableLatch
 import org.jolokia.jvmagent.JolokiaServer
@@ -181,9 +182,6 @@ import java.time.format.DateTimeParseException
 import java.util.Properties
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MINUTES
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.function.Consumer
@@ -881,13 +879,12 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         }
         // Start with 1 thread and scale up to the configured thread pool size if needed
         // Parameters of [ThreadPoolExecutor] based on [Executors.newFixedThreadPool]
-        return ThreadPoolExecutor(
-            1,
-            numberOfThreads,
-            0L,
-            TimeUnit.MILLISECONDS,
-            LinkedBlockingQueue<Runnable>(),
-            ThreadFactoryBuilder().setNameFormat("flow-external-operation-thread").setDaemon(true).build()
+        return namedThreadPoolExecutor(
+                corePoolSize = 1,
+                maxPoolSize = numberOfThreads,
+                idleKeepAlive = 0.millis,
+                poolName = "flow-external-operation-thread",
+                daemonThreads = true
         )
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/artemis/BrokerJaasLoginModule.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/artemis/BrokerJaasLoginModule.kt
@@ -135,12 +135,12 @@ class BrokerJaasLoginModule : BaseBrokerJaasLoginModule() {
                 Pair(ArtemisMessagingComponent.NODE_RPC_USER, listOf(RolePrincipal(NODE_RPC_ROLE)))
             }
             ArtemisMessagingComponent.PEER_USER -> {
-                requireNotNull(p2pJaasConfig) { "Attempted to connect as a peer to the rpc broker." }
+                val p2pJaasConfig = requireNotNull(p2pJaasConfig) { "Attempted to connect as a peer to the rpc broker." }
                 requireTls(certificates)
                 // This check is redundant as it was performed already during the SSL handshake
-                CertificateChainCheckPolicy.RootMustMatch.createCheck(p2pJaasConfig!!.keyStore, p2pJaasConfig!!.trustStore).checkCertificateChain(certificates!!)
-                CertificateChainCheckPolicy.RevocationCheck(p2pJaasConfig!!.revocationMode)
-                        .createCheck(p2pJaasConfig!!.keyStore, p2pJaasConfig!!.trustStore).checkCertificateChain(certificates)
+                CertificateChainCheckPolicy.RootMustMatch
+                        .createCheck(p2pJaasConfig.keyStore, p2pJaasConfig.trustStore)
+                        .checkCertificateChain(certificates!!)
                 Pair(certificates.first().subjectDN.name, listOf(RolePrincipal(PEER_ROLE)))
             }
             else -> {

--- a/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt
@@ -2,17 +2,9 @@ package net.corda.node.internal.artemis
 
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.contextLogger
-import net.corda.nodeapi.internal.crypto.X509CertificateFactory
 import net.corda.nodeapi.internal.crypto.X509Utilities
-import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
-import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfigImpl
-import net.corda.nodeapi.internal.protonwrapper.netty.certPathToString
 import java.security.KeyStore
-import java.security.cert.CertPathValidator
-import java.security.cert.CertPathValidatorException
 import java.security.cert.CertificateException
-import java.security.cert.PKIXBuilderParameters
-import java.security.cert.X509CertSelector
 
 sealed class CertificateChainCheckPolicy {
     companion object {
@@ -89,35 +81,6 @@ sealed class CertificateChainCheckPolicy {
         override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
             if (!theirChain.any { certificate -> CordaX500Name.parse(certificate.subjectDN.name).commonName == username }) {
                 throw CertificateException("Client certificate does not match login username.")
-            }
-        }
-    }
-
-    class RevocationCheck(val revocationConfig: RevocationConfig) : CertificateChainCheckPolicy() {
-        constructor(revocationMode: RevocationConfig.Mode) : this(RevocationConfigImpl(revocationMode))
-
-        override fun createCheck(keyStore: KeyStore, trustStore: KeyStore): Check {
-            return object : Check {
-                override fun checkCertificateChain(theirChain: Array<javax.security.cert.X509Certificate>) {
-                    // Convert javax.security.cert.X509Certificate to java.security.cert.X509Certificate.
-                    val chain = theirChain.map { X509CertificateFactory().generateCertificate(it.encoded.inputStream()) }
-                    log.info("Check Client Certpath:\r\n${certPathToString(chain.toTypedArray())}")
-
-                    // Drop the last certificate which must be a trusted root (validated by RootMustMatch).
-                    // Assume that there is no more trusted roots (or corresponding public keys) in the remaining chain.
-                    // See PKIXValidator.engineValidate() for reference implementation.
-                    val certPath = X509Utilities.buildCertPath(chain.dropLast(1))
-                    val certPathValidator = CertPathValidator.getInstance("PKIX")
-                    val pkixRevocationChecker = revocationConfig.createPKIXRevocationChecker()
-                    val params = PKIXBuilderParameters(trustStore, X509CertSelector())
-                    params.addCertPathChecker(pkixRevocationChecker)
-                    try {
-                        certPathValidator.validate(certPath, params)
-                    } catch (ex: CertPathValidatorException) {
-                        log.error("Bad certificate path", ex)
-                        throw ex
-                    }
-                }
             }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -7,9 +7,16 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
-import net.corda.node.internal.artemis.*
+import net.corda.node.internal.artemis.ArtemisBroker
+import net.corda.node.internal.artemis.BrokerAddresses
+import net.corda.node.internal.artemis.BrokerJaasLoginModule
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.NODE_P2P_ROLE
 import net.corda.node.internal.artemis.BrokerJaasLoginModule.Companion.PEER_ROLE
+import net.corda.node.internal.artemis.NodeJaasConfig
+import net.corda.node.internal.artemis.P2PJaasConfig
+import net.corda.node.internal.artemis.SecureArtemisConfiguration
+import net.corda.node.internal.artemis.UserValidationPlugin
+import net.corda.node.internal.artemis.isBindingError
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.nodeapi.internal.AmqpMessageSizeChecksInterceptor
 import net.corda.nodeapi.internal.ArtemisMessageSizeChecksInterceptor
@@ -20,7 +27,10 @@ import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_PREFIX
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.SECURITY_INVALIDATION_INTERVAL
 import net.corda.nodeapi.internal.ArtemisTcpTransport.Companion.p2pAcceptorTcpTransport
 import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfig
+import net.corda.nodeapi.internal.protonwrapper.netty.RevocationConfigImpl
+import net.corda.nodeapi.internal.protonwrapper.netty.trustManagerFactoryWithRevocation
 import net.corda.nodeapi.internal.requireOnDefaultFileSystem
+import net.corda.nodeapi.internal.revocation.CertDistPointCrlSource
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
@@ -33,7 +43,6 @@ import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager
 import java.io.IOException
 import java.lang.Long.max
-import java.security.KeyStoreException
 import javax.annotation.concurrent.ThreadSafe
 import javax.security.auth.login.AppConfigurationEntry
 import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.REQUIRED
@@ -57,7 +66,9 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
                              private val maxMessageSize: Int,
                              private val journalBufferTimeout : Int? = null,
                              private val threadPoolName: String = "ArtemisServer",
-                             private val trace: Boolean = false) : ArtemisBroker, SingletonSerializeAsToken() {
+                             private val trace: Boolean = false,
+                             private val distPointCrlSource: CertDistPointCrlSource = CertDistPointCrlSource.SINGLETON,
+                             private val remotingThreads: Int? = null) : ArtemisBroker, SingletonSerializeAsToken() {
     companion object {
         private val log = contextLogger()
     }
@@ -91,9 +102,7 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
     override val started: Boolean
         get() = activeMQServer.isStarted
 
-    // TODO: Maybe wrap [IOException] on a key store load error so that it's clearly splitting key store loading from
-    // Artemis IO errors
-    @Throws(IOException::class, AddressBindingException::class, KeyStoreException::class)
+    @Suppress("ThrowsCount")
     private fun configureAndStartServer() {
         val artemisConfig = createArtemisConfig()
         val securityManager = createArtemisSecurityManager()
@@ -133,11 +142,23 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
         // The transaction cache is configurable, and drives other cache sizes.
         globalMaxSize = max(config.transactionCacheSizeBytes, 10L * maxMessageSize)
 
+        val revocationMode = if (config.crlCheckArtemisServer) {
+            if (config.crlCheckSoftFail) RevocationConfig.Mode.SOFT_FAIL else RevocationConfig.Mode.HARD_FAIL
+        } else {
+            RevocationConfig.Mode.OFF
+        }
+        val trustManagerFactory = trustManagerFactoryWithRevocation(
+                config.p2pSslOptions.trustStore.get(),
+                RevocationConfigImpl(revocationMode),
+                distPointCrlSource
+        )
         addAcceptorConfiguration(p2pAcceptorTcpTransport(
                 NetworkHostAndPort(messagingServerAddress.host, messagingServerAddress.port),
                 config.p2pSslOptions,
+                trustManagerFactory,
                 threadPoolName = threadPoolName,
-                trace = trace
+                trace = trace,
+                remotingThreads = remotingThreads
         ))
         // Enable built in message deduplication. Note we still have to do our own as the delayed commits
         // and our own definition of commit mean that the built in deduplication cannot remove all duplicates.

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
@@ -30,7 +30,7 @@ internal class RpcBrokerConfiguration(baseDirectory: Path, maxMessageSize: Int, 
         setDirectories(baseDirectory)
 
         val acceptorConfigurationsSet = mutableSetOf(
-                rpcAcceptorTcpTransport(address, sslOptions, useSsl)
+                rpcAcceptorTcpTransport(address, sslOptions, enableSSL = useSsl)
         )
         adminAddress?.let {
             acceptorConfigurationsSet += rpcInternalAcceptorTcpTransport(it, nodeConfiguration)

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -42,6 +42,7 @@ import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.nodeapi.internal.persistence.SchemaMigration
+import net.corda.nodeapi.internal.protonwrapper.netty.CrlSource
 import net.corda.nodeapi.internal.registerDevP2pCertificates
 import net.corda.serialization.internal.amqp.AMQP_ENABLED
 import net.corda.testing.core.ALICE_NAME
@@ -52,6 +53,8 @@ import java.io.IOException
 import java.net.ServerSocket
 import java.nio.file.Path
 import java.security.KeyPair
+import java.security.cert.X509CRL
+import java.security.cert.X509Certificate
 import java.util.*
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
@@ -145,6 +148,12 @@ fun p2pSslOptions(path: Path, name: CordaX500Name = CordaX500Name("MegaCorp", "L
     val trustStore = sslConfig.trustStore.get(true)
     trustStore[X509Utilities.CORDA_ROOT_CA] = rootCa.certificate
     return sslConfig
+}
+
+fun fixedCrlSource(crls: Set<X509CRL>): CrlSource {
+    return object : CrlSource {
+        override fun fetch(certificate: X509Certificate): Set<X509CRL> = crls
+    }
 }
 
 /** This is the same as the deprecated [WireTransaction] c'tor but avoids the deprecation warning. */


### PR DESCRIPTION
The default Netty configuration is susceptible to all its threads being blocked during SSL handshake if the CRL endpoints are unreachable (or very slow). This causes existing connections to be dropped since they can no longer heartbeat.

Rather than using the default immediate executor for the `SSLEngine.getDelegatedTask()`, a normal asynchronous executor is passed into the `SslHandler` instead. This frees up the Netty event loop threads to process other connections and messages. This is a straightforward fix for `AMQPServer` and `AMQPClient`.

With the embedded Artemis server, just changing to the asynchronous executor is not enough. The revocation checking is not done during SSL handshake but rather during user authentication (https://github.com/corda/corda/pull/6154), due to lack of customisability. This means the download of the CRLs is still done on the Netty event loop threads. To be able move the revocation check into the SSL handshake required injecting in the custom `TrustManagerFactory` into `NodeNettyAcceptor` and wiring it up to the `SslHandler`. However the relevant methods are private in `NettyAcceptor` and so  `NettyAcceptor.getSslHandler()` and its dependents had to be copied into `NodeNettyAcceptor`. (The version of Artemis in Corda 4.9 provides the necessary injection points so this won't be necessary in 4.9 and onwards).

To be able to test this properly, the cache in `CertDistPointCrlSource` is no longer a singleton. The default is a `SINGLETON` instance to ensure the CRL cache remains global in a Corda node.