### PR TITLE
ENT-9962 - update compile-time dependency

### DIFF
--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -27,8 +27,7 @@ sourceSets {
 dependencies {
     compile project(':test-utils')
 
-    compile group: 'org.apache.sshd', name: 'sshd-common', version: '2.3.0'
-//    integrationTestRuntime group: 'org.apache.sshd', name: 'sshd-common', version: '2.3.0'
+    compile group: 'org.apache.sshd', name: 'sshd-common', version: '2.9.2'
 
     // Integration test helpers
     testCompile "org.assertj:assertj-core:$assertj_version"


### PR DESCRIPTION
Upgraded sshd-common compile-time dependency to stop a vulnerability being reported by Snyk.
Ran a local Snyk report on the node-driver sub-project, vulnerability is no longer reported.