### PR TITLE
ENT-9793: Added Page.previousPageAnchor to allow detection of vault changes whilst pages are loaded

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1181,7 +1181,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                                                  networkParameters: NetworkParameters)
 
     protected open fun makeVaultService(keyManagementService: KeyManagementService,
-                                        services: ServicesForResolution,
+                                        services: NodeServicesForResolution,
                                         database: CordaPersistence,
                                         cordappLoader: CordappLoader): VaultServiceInternal {
         return NodeVaultService(platformClock, keyManagementService, services, database, schemaService, cordappLoader.appClassLoader)

--- a/node/src/main/kotlin/net/corda/node/internal/NodeServicesForResolution.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeServicesForResolution.kt
@@ -1,0 +1,15 @@
+package net.corda.node.internal
+
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionResolutionException
+import net.corda.core.node.ServicesForResolution
+import java.util.LinkedHashSet
+
+interface NodeServicesForResolution : ServicesForResolution {
+    @Throws(TransactionResolutionException::class)
+    override fun loadStates(stateRefs: Set<StateRef>): Set<StateAndRef<ContractState>> = loadStates(stateRefs, LinkedHashSet())
+
+    fun <T : ContractState, C : MutableCollection<StateAndRef<T>>> loadStates(input: Iterable<StateRef>, output: C): C
+}

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -2,7 +2,6 @@ package net.corda.node.migration
 
 import liquibase.database.Database
 import net.corda.core.contracts.*
-import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.node.services.Vault
 import net.corda.core.schemas.MappedSchema
@@ -19,6 +18,7 @@ import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.services.vault.VaultSchemaV1
+import net.corda.node.services.vault.toStateRef
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseTransaction
 import net.corda.nodeapi.internal.persistence.SchemaMigration
@@ -62,8 +62,7 @@ class VaultStateMigration : CordaMigration() {
     private fun getStateAndRef(persistentState: VaultSchemaV1.VaultStates): StateAndRef<ContractState> {
         val persistentStateRef = persistentState.stateRef ?:
                 throw VaultStateMigrationException("Persistent state ref missing from state")
-        val txHash = SecureHash.create(persistentStateRef.txId)
-        val stateRef = StateRef(txHash, persistentStateRef.index)
+        val stateRef = persistentStateRef.toStateRef()
         val state = try {
             servicesForResolution.loadState(stateRef)
         } catch (e: Exception) {

--- a/node/src/main/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepository.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepository.kt
@@ -2,8 +2,8 @@ package net.corda.node.services.events
 
 import net.corda.core.contracts.ScheduledStateRef
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.SecureHash
 import net.corda.core.schemas.PersistentStateRef
+import net.corda.node.services.vault.toStateRef
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 
 interface ScheduledFlowRepository {
@@ -25,9 +25,8 @@ class PersistentScheduledFlowRepository(val database: CordaPersistence) : Schedu
     }
 
     private fun fromPersistentEntity(scheduledStateRecord: NodeSchedulerService.PersistentScheduledState): Pair<StateRef, ScheduledStateRef> {
-        val txId = scheduledStateRecord.output.txId
-        val index = scheduledStateRecord.output.index
-        return Pair(StateRef(SecureHash.create(txId), index), ScheduledStateRef(StateRef(SecureHash.create(txId), index), scheduledStateRecord.scheduledAt))
+        val stateRef = scheduledStateRecord.output.toStateRef()
+        return Pair(stateRef, ScheduledStateRef(stateRef, scheduledStateRecord.scheduledAt))
     }
 
     override fun delete(key: StateRef): Boolean {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -25,6 +25,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
+import net.corda.node.services.vault.toStateRef
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
@@ -157,13 +158,7 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
                         toPersistentEntityKey = { PersistentStateRef(it.txhash.toString(), it.index) },
                         fromPersistentEntity = {
                             //TODO null check will become obsolete after making DB/JPA columns not nullable
-                            val txId = it.id.txId
-                            val index = it.id.index
-                            Pair(
-                                    StateRef(txhash = SecureHash.create(txId), index = index),
-                                    SecureHash.create(it.consumingTxHash)
-                            )
-
+                            Pair(it.id.toStateRef(), SecureHash.create(it.consumingTxHash))
                         },
                         toPersistentEntity = { (txHash, index): StateRef, id: SecureHash ->
                             CommittedState(

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -2,7 +2,9 @@ package net.corda.node.services.vault
 
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.MAX_ISSUER_REF_SIZE
+import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
@@ -192,3 +194,19 @@ object VaultSchemaV1 : MappedSchema(
     ) : IndirectStatePersistable<PersistentStateRefAndKey>
 }
 
+fun PersistentStateRef.toStateRef(): StateRef = StateRef(SecureHash.create(txId), index)
+
+fun VaultSchemaV1.VaultStates.toStateMetadata(): Vault.StateMetadata {
+    return Vault.StateMetadata(
+            stateRef!!.toStateRef(),
+            contractStateClassName,
+            recordedTime,
+            consumedTime,
+            stateStatus,
+            notary,
+            lockId,
+            lockUpdateTime,
+            relevancyStatus,
+            Vault.ConstraintInfo.constraintInfo(constraintType, constraintData)
+    )
+}

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -20,7 +20,6 @@ import net.corda.finance.*
 import net.corda.finance.contracts.CommercialPaper
 import net.corda.finance.contracts.Commodity
 import net.corda.finance.contracts.DealState
-import net.corda.finance.workflows.asset.selection.AbstractCashSelection
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.finance.schemas.CashSchemaV1.PersistentCashState
@@ -28,6 +27,7 @@ import net.corda.finance.schemas.CommercialPaperSchemaV1
 import net.corda.finance.test.SampleCashSchemaV2
 import net.corda.finance.test.SampleCashSchemaV3
 import net.corda.finance.workflows.CommercialPaperUtils
+import net.corda.finance.workflows.asset.selection.AbstractCashSelection
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.nodeapi.internal.persistence.DatabaseTransaction
@@ -1669,22 +1669,28 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             // DOCEND VaultQueryExample7
             assertThat(results.states).hasSize(10)
             assertThat(results.totalStatesAvailable).isEqualTo(100)
+            assertThat(results.previousPageAnchor).isNull()
         }
     }
 
     // pagination: last page
     @Test(timeout=300_000)
-	fun `all states with paging specification  - last`() {
+	fun `all states with paging specification - last`() {
         database.transaction {
             vaultFiller.fillWithSomeTestCash(95.DOLLARS, notaryServices, 95, DUMMY_CASH_ISSUER)
+            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+
             // Last page implies we need to perform a row count for the Query first,
             // and then re-query for a given offset defined by (count - pageSize)
-            val pagingSpec = PageSpecification(10, 10)
+            val lastPage = PageSpecification(10, 10)
+            val lastPageResults = vaultService.queryBy<ContractState>(criteria, paging = lastPage)
+            assertThat(lastPageResults.states).hasSize(5) // should retrieve states 90..94
+            assertThat(lastPageResults.totalStatesAvailable).isEqualTo(95)
 
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            val results = vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
-            assertThat(results.states).hasSize(5) // should retrieve states 90..94
-            assertThat(results.totalStatesAvailable).isEqualTo(95)
+            // Make sure the previousPageAnchor points to the previous page's last result
+            val penultimatePage = lastPage.copy(pageNumber = lastPage.pageNumber - 1)
+            val penultimatePageResults = vaultService.queryBy<ContractState>(criteria, paging = penultimatePage)
+            assertThat(lastPageResults.previousPageAnchor).isEqualTo(penultimatePageResults.statesMetadata.last().ref)
         }
     }
 
@@ -1723,7 +1729,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     @Test(timeout=300_000)
 	fun `pagination not specified but more than default results available`() {
         expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("provide a `PageSpecification(pageNumber, pageSize)`")
+        expectedEx.expectMessage("provide a PageSpecification")
 
         database.transaction {
             vaultFiller.fillWithSomeTestCash(201.DOLLARS, notaryServices, 201, DUMMY_CASH_ISSUER)
@@ -1735,16 +1741,23 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     // example of querying states with paging using totalStatesAvailable
     private fun queryStatesWithPaging(vaultService: VaultService, pageSize: Int): List<StateAndRef<ContractState>> {
         // DOCSTART VaultQueryExample24
-        var pageNumber = DEFAULT_PAGE_NUM
-        val states = mutableListOf<StateAndRef<ContractState>>()
-        do {
-            val pageSpec = PageSpecification(pageNumber = pageNumber, pageSize = pageSize)
-            val results = vaultService.queryBy<ContractState>(VaultQueryCriteria(), pageSpec)
-            states.addAll(results.states)
-            pageNumber++
-        } while ((pageSpec.pageSize * (pageNumber - 1)) <= results.totalStatesAvailable)
+        retry@
+        while (true) {
+            var pageNumber = DEFAULT_PAGE_NUM
+            val states = mutableListOf<StateAndRef<ContractState>>()
+            do {
+                val pageSpec = PageSpecification(pageNumber = pageNumber, pageSize = pageSize)
+                val results = vaultService.queryBy<ContractState>(VaultQueryCriteria(), pageSpec)
+                if (results.previousPageAnchor != states.lastOrNull()?.ref) {
+                    // Start querying from the 1st page again if we find the vault has changed from underneath us.
+                    continue@retry
+                }
+                states.addAll(results.states)
+                pageNumber++
+            } while ((pageSpec.pageSize * (pageNumber - 1)) <= results.totalStatesAvailable)
+            return states
+        }
         // DOCEND VaultQueryExample24
-        return states.toList()
     }
 
     // test paging query example works
@@ -1757,6 +1770,51 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             assertThat(queryStatesWithPaging(vaultService, 5).count()).isEqualTo(5)
             vaultFiller.fillWithSomeTestCash(25.DOLLARS, notaryServices, 1, DUMMY_CASH_ISSUER)
             assertThat(queryStatesWithPaging(vaultService, 5).count()).isEqualTo(6)
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `detecting changes to the database whilst pages are loaded`() {
+        val criteria = VaultQueryCriteria()
+        val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Standard(Sort.LinearStateAttribute.EXTERNAL_ID))))
+
+        fun loadPagesAndCheckAnchors(): List<Vault.Page<DealState>> {
+            val pages = (1..3).map {  vaultService.queryBy<DealState>(criteria, PageSpecification(it, 10), sorting) }
+            assertThat(pages[0].previousPageAnchor).isNull()
+            assertThat(pages[1].previousPageAnchor).isEqualTo(pages[0].states.last().ref)
+            assertThat(pages[2].previousPageAnchor).isEqualTo(pages[1].states.last().ref)
+            return pages
+        }
+
+        database.transaction {
+            vaultFiller.fillWithSomeTestDeals(dealIds = (10..30).map(Int::toString))
+            val pagesV1 = loadPagesAndCheckAnchors()
+
+            vaultFiller.fillWithSomeTestDeals(dealIds = listOf("25.5"))  // Insert a state into the middle of the second page
+            val pagesV2 = loadPagesAndCheckAnchors()
+
+            assertThat(pagesV2[2].previousPageAnchor)
+                    .isNotEqualTo(pagesV1[2].previousPageAnchor)  // The previously loaded page is no longer in-sync
+                    .isEqualTo(pagesV1[1].states.let { it[it.lastIndex - 1].ref })  // The anchor now points to the second to last entry
+            assertThat(pagesV2[1].previousPageAnchor).isEqualTo(pagesV1[1].previousPageAnchor)  // The first page is unaffected
+
+            vaultFiller.consumeDeals(pagesV1[0].states.take(1))  // Consume the first state
+            val pagesV3 = loadPagesAndCheckAnchors()
+
+            assertThat(pagesV3[1].previousPageAnchor)
+                    .isNotEqualTo(pagesV1[1].previousPageAnchor)  // Now the first page is no longer in-sync
+                    .isEqualTo(pagesV1[1].states[0].ref)  // The top of the second page has now moved into the first page
+
+            vaultFiller.consumeDeals(pagesV3[2].states)  // Consume the entire third page
+            val pagesV4 = loadPagesAndCheckAnchors()
+            // There are now no states for the third page, but it will still have an anchor
+            assertThat(pagesV4[2].states).isEmpty()
+
+            vaultFiller.consumeDeals(pagesV3[1].states.takeLast(1))  // Consume the third page anchor
+
+            val thirdPageV5 = vaultService.queryBy<DealState>(criteria, PageSpecification(3, 10), sorting)
+            assertThat(thirdPageV5.states).isEmpty()
+            assertThat(thirdPageV5.previousPageAnchor).isNull()
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -10,7 +10,6 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.AbstractParty
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.uncheckedCast
-import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria.SoftLockingCondition
@@ -29,6 +28,7 @@ import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.flows.registerCoreFlowFactory
 import net.corda.coretesting.internal.rigorousMock
+import net.corda.node.internal.NodeServicesForResolution
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startFlow
@@ -86,7 +86,7 @@ class VaultSoftLockManagerTest {
     private val mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(enclosedCordapp()), defaultFactory = { args ->
         object : InternalMockNetwork.MockNode(args) {
             override fun makeVaultService(keyManagementService: KeyManagementService,
-                                          services: ServicesForResolution,
+                                          services: NodeServicesForResolution,
                                           database: CordaPersistence,
                                           cordappLoader: CordappLoader): VaultServiceInternal {
                 val node = this

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -44,6 +44,7 @@ import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.coretesting.internal.DEV_ROOT_CA
 import net.corda.node.VersionInfo
 import net.corda.node.internal.ServicesForResolutionImpl
+import net.corda.node.internal.NodeServicesForResolution
 import net.corda.node.internal.cordapp.JarScanningCordappLoader
 import net.corda.node.services.api.SchemaService
 import net.corda.node.services.api.ServiceHubInternal
@@ -498,7 +499,14 @@ open class MockServices private constructor(
         get() = ServicesForResolutionImpl(identityService, attachments, cordappProvider, networkParametersService, validatedTransactions)
 
     internal fun makeVaultService(schemaService: SchemaService, database: CordaPersistence, cordappLoader: CordappLoader): VaultServiceInternal {
-        return NodeVaultService(clock, keyManagementService, servicesForResolution, database, schemaService, cordappLoader.appClassLoader).apply { start() }
+        return NodeVaultService(
+                clock,
+                keyManagementService,
+                servicesForResolution as NodeServicesForResolution,
+                database,
+                schemaService,
+                cordappLoader.appClassLoader
+        ).apply { start() }
     }
 
     // This needs to be internal as MutableClassToInstanceMap is a guava type and shouldn't be part of our public API


### PR DESCRIPTION
`previousPageAnchor` is a `StateRef` of the last result from the previous page. If the vault has had states added or removed in prior pages then the user can detect this by comparing its most current `Page.previousPageAnchor` with the state ref of the last state in the previous page. If the vault has changed then they may wish to start querying from the first page again. (Note, that if an equal number of states are added and removed at the same time then that may not be detected).

Detekt was complaining about the complexity of `NodeVaultService` but rather than suppressing it, I cleaned it up a bit.