### PR TITLE
ES-562: Correct modules to scan for C4 OS Snyk scan nightly

### DIFF
--- a/.ci/dev/nightly-regression/JenkinsfileSnykScan
+++ b/.ci/dev/nightly-regression/JenkinsfileSnykScan
@@ -3,5 +3,5 @@
 cordaSnykScanPipeline (
     snykTokenId: 'c4-os-snyk-api-token-secret',
     // specify the Gradle submodules to scan and monitor on snyk Server
-    modulesToScan: ['node', 'capsule', 'bridge', 'bridgecapsule']
+    modulesToScan: ['node', 'capsule']
 )


### PR DESCRIPTION
Snyk pipeline [here](https://github.com/corda/corda/blob/release/os/4.5/.ci/dev/nightly-regression/JenkinsfileSnykScan) which references the modules to scan - 
`modulesToScan: ['node', 'capsule', 'bridge', 'bridgecapsule']`
Both  `'bridge', 'bridgecapsule'`  are ENT submodules, so the pipeline fails when it tries to scan those.

Updating to only include the ` 'node', 'capsule'` submodules.

Tested here: https://ci01.dev.r3.com/job/Corda-Open-Source/job/Nightly%20Snyk%20Scans/job/release%252Fos%252F4.5/69 