### PR TITLE
ES-562: Updating .snyk YAML indentation & updating modules to scan on Snyk nightly 

### DIFF
--- a/.ci/dev/nightly-regression/JenkinsfileSnykScan
+++ b/.ci/dev/nightly-regression/JenkinsfileSnykScan
@@ -3,5 +3,5 @@
 cordaSnykScanPipeline (
     snykTokenId: 'c4-os-snyk-api-token-secret',
     // specify the Gradle submodules to scan and monitor on snyk Server
-    modulesToScan: ['node', 'capsule', 'bridge', 'bridgecapsule']
+    modulesToScan: ['node', 'capsule']
 )

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
             steps {
                 script {
                     // Invoke Snyk for each Gradle sub project we wish to scan
-                    def modulesToScan = ['node', 'capsule', 'bridge', 'bridgecapsule']
+                    def modulesToScan = ['node', 'capsule']
                     modulesToScan.each { module ->
                         snykSecurityScan("${env.SNYK_API_KEY}", "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
                     }

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.4.1
         with:
-          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS)-\d+|NOTICK)(.*)'
+          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS|ES)-\d+|NOTICK)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.snyk
+++ b/.snyk
@@ -131,7 +131,7 @@ ignore:
           this vulnerability.
         expires: 2023-09-01T11:32:38.120Z
         created: 2022-09-21T11:32:38.125Z
- SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424:
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424:
     - '*':
         reason: >-
           Corda does not set the non-default UNWRAP_SINGLE_VALUE_ARRAYS required
@@ -145,7 +145,7 @@ ignore:
           nesting are potentially susceptible.
         expires: 2023-09-01T12:04:40.180Z
         created: 2023-02-09T12:04:40.209Z
- SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426:
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426:
     - '*':
         reason: >-
           Corda does not set the non-default UNWRAP_SINGLE_VALUE_ARRAYS required
@@ -159,7 +159,7 @@ ignore:
           nesting are potentially susceptible.
         expires: 2023-09-01T12:05:03.931Z
         created: 2023-02-09T12:05:03.962Z
- SNYK-JAVA-ORGYAML-2806360:
+  SNYK-JAVA-ORGYAML-2806360:
     - '*':
         reason: >-
           Snakeyaml is being used by Jackson and liquidbase. Corda does not use
@@ -172,7 +172,7 @@ ignore:
           not exposed to this DOS vulnerability.
         expires: 2023-09-01T13:40:55.262Z
         created: 2022-09-21T13:40:55.279Z
- SNYK-JAVA-ORGYAML-3016891:
+  SNYK-JAVA-ORGYAML-3016891:
     - '*':
         reason: >-
           Snakeyaml is being used by Jackson and liquidbase. Corda does not use
@@ -186,7 +186,7 @@ ignore:
           vulnerability.
         expires: 2023-09-01T16:37:28.911Z
         created: 2023-02-06T16:37:28.933Z
- SNYK-JAVA-ORGYAML-3016888:
+  SNYK-JAVA-ORGYAML-3016888:
     - '*':
         reason: >-
           Snakeyaml is being used by Jackson and liquidbase. Corda does not use
@@ -200,7 +200,7 @@ ignore:
           vulnerability.
         expires: 2023-09-01T13:39:49.450Z
         created: 2022-09-21T13:39:49.470Z
- SNYK-JAVA-ORGYAML-3016889:
+  SNYK-JAVA-ORGYAML-3016889:
     - '*':
         reason: >-
           Snakeyaml is being used by Jackson and liquidbase. Corda does not use
@@ -214,7 +214,7 @@ ignore:
           vulnerability.
         expires: 2023-09-01T16:35:13.840Z
         created: 2023-02-06T16:35:13.875Z
- SNYK-JAVA-ORGYAML-3113851:
+  SNYK-JAVA-ORGYAML-3113851:
     - '*':
         reason: >-
           Snakeyaml is being used by Jackson and liquidbase. Corda does not use

--- a/.snyk
+++ b/.snyk
@@ -131,7 +131,7 @@ ignore:
           this vulnerability.
         expires: 2023-09-01T11:32:38.120Z
         created: 2022-09-21T11:32:38.125Z
-SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424:
+ SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424:
     - '*':
         reason: >-
           Corda does not set the non-default UNWRAP_SINGLE_VALUE_ARRAYS required


### PR DESCRIPTION
Updating .snyk YAML indentation & updating modules to scan on Snyk nightly.

Both 'bridge', 'bridgecapsule' are ENT submodules, so the pipeline fails when it tries to scan those.

Updating to only include the  'node', 'capsule' submodules.