### PR TITLE
ES-562: Correct modules to scan for C4 OS Snyk scan nightly 

### DIFF
--- a/.ci/dev/nightly-regression/JenkinsfileSnykScan
+++ b/.ci/dev/nightly-regression/JenkinsfileSnykScan
@@ -3,5 +3,5 @@
 cordaSnykScanPipeline (
     snykTokenId: 'c4-os-snyk-api-token-secret',
     // specify the Gradle submodules to scan and monitor on snyk Server
-    modulesToScan: ['node', 'capsule', 'bridge', 'bridgecapsule']
+    modulesToScan: ['node', 'capsule']
 )

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.4.1
         with:
-          title-regex: '^((CORDA|AG|EG|ENT|INFRA)-\d+|NOTICK)(.*)'
+          title-regex: '^((CORDA|AG|EG|ENT|INFRA|ES)-\d+|NOTICK)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Cherry-picked from 4.5 

Snyk pipeline [here](https://github.com/corda/corda/blob/release/os/4.5/.ci/dev/nightly-regression/JenkinsfileSnykScan) which references the modules to scan -
modulesToScan: ['node', 'capsule', 'bridge', 'bridgecapsule']
Both 'bridge', 'bridgecapsule' are ENT submodules, so the pipeline fails when it tries to scan those.

Updating to only include the  'node', 'capsule' submodules.

Tested here: https://ci01.dev.r3.com/job/Corda-Open-Source/job/Nightly%20Snyk%20Scans/job/release%252Fos%252F4.5/69