### PR TITLE
ENT-9924  Fix failing slow test.

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -99,7 +99,7 @@ class GetFlowTransaction(private val txId: SecureHash) : FlowLogic<Pair<String, 
                 .use { ps ->
                     ps.executeQuery().use { rs ->
                         rs.next()
-                        rs.getLong(2)     // receiverPartyId
+                        rs.getLong(4)     // receiverPartyId
                     }
                 }
         return Pair(transactionStatus, receiverPartyId)


### PR DESCRIPTION
Fix [error after recording an issuance transaction inside of FinalityFlow generates recovery metadata – net.corda.node.flows.FinalityFlowErrorHandlingTest](https://ci01.dev.r3.com/blue/organizations/jenkins/Corda-Open-Source%2FCorda-OS-Release-Branch-Tests%2Fcorda/detail/release%2Fos%2F4.11/30/tests/)