### PR TITLE
ES-562: Updating .snyk YAML expiry & updating modules to scan on Snyk nightly

### DIFF
--- a/.ci/dev/nightly-regression/JenkinsfileSnykScan
+++ b/.ci/dev/nightly-regression/JenkinsfileSnykScan
@@ -3,5 +3,5 @@
 cordaSnykScanPipeline (
     snykTokenId: 'c4-os-snyk-api-token-secret',
     // specify the Gradle submodules to scan and monitor on snyk Server
-    modulesToScan: ['node', 'capsule', 'bridge', 'bridgecapsule']
+    modulesToScan: ['node', 'capsule']
 )

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
             steps {
                 script {
                     // Invoke Snyk for each Gradle sub project we wish to scan
-                    def modulesToScan = ['node', 'capsule', 'bridge', 'bridgecapsule']
+                    def modulesToScan = ['node', 'capsule']
                     modulesToScan.each { module ->
                         snykSecurityScan("${env.SNYK_API_KEY}", "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
                     }

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS)-\d+|NOTICK)(.*)'
+          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS|ES)-\d+|NOTICK)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.snyk
+++ b/.snyk
@@ -8,7 +8,7 @@ ignore:
           Guava’s Files.createTempDir() is used during integration tests only.
           Users of Corda are advised not to use Guava’s Files.createTempDir()
           when building applications on Corda.
-        expires: 2023-03-21T11:38:11.478Z
+        expires: 2023-07-21T11:38:11.478Z
         created: 2022-12-29T11:38:11.489Z
   SNYK-JAVA-COMH2DATABASE-31685:
     - '*':
@@ -17,7 +17,7 @@ ignore:
 
           When it comes to DB connectivity parameters, we do not allow changing 
           them as they are supplied by Corda Node configuration file.
-        expires: 2023-03-21T11:39:26.763Z
+        expires: 2023-07-21T11:39:26.763Z
         created: 2022-12-29T11:39:26.775Z
   SNYK-JAVA-COMH2DATABASE-2331071:
     - '*':
@@ -26,7 +26,7 @@ ignore:
 
           When it comes to DB connectivity parameters, we do not allow changing 
           them as they are supplied by Corda Node configuration file.
-        expires: 2023-03-21T11:41:05.707Z
+        expires: 2023-07-21T11:41:05.707Z
         created: 2022-12-29T11:41:05.723Z
   SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044:
     - '*':
@@ -34,7 +34,7 @@ ignore:
           The vulnerability in okhttp’s error handling is only exploitable in
           services that receive and parse HTTP requests. Corda does not receive
           HTTP requests and thus is not exposed to this issue.
-        expires: 2023-03-21T11:42:55.546Z
+        expires: 2023-07-21T11:42:55.546Z
         created: 2022-12-29T11:42:55.556Z
   SNYK-JAVA-IONETTY-1042268:
     - '*':
@@ -47,7 +47,7 @@ ignore:
           RPC SSL client connections Artemis is used which calls into netty. The
           default value for verifyHost is true for Artemis client connectors so
           verification of the host name in netty does occur.
-        expires: 2023-03-21T11:45:42.976Z
+        expires: 2023-07-21T11:45:42.976Z
         created: 2022-12-29T11:45:42.981Z
   SNYK-JAVA-ORGJETBRAINSKOTLIN-2628385:
     - '*':
@@ -57,7 +57,7 @@ ignore:
           time for Corda we do not use Multiplatform Gradle Projects so are not
           affected by this vulnerability. In addition as it is a build time
           vulnerability released artifacts are not affected.
-        expires: 2023-03-21T11:52:35.855Z
+        expires: 2023-07-21T11:52:35.855Z
         created: 2022-12-29T11:52:35.870Z
   SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
     - '*':
@@ -66,7 +66,7 @@ ignore:
           temporary files (via Kotlin functions) with insecure permissions.
           Corda does not use any of the vulnerable functions so it not
           susceptible to this vulnerability.
-        expires: 2023-03-21T13:39:03.244Z
+        expires: 2023-07-21T13:39:03.244Z
         created: 2022-12-29T13:39:03.262Z
   SNYK-JAVA-ORGYAML-3016888:
     - '*':
@@ -80,7 +80,7 @@ ignore:
           XML files are used here to define the changes not YAML and therefore
           the Corda node itself is not exposed to this deserialisation
           vulnerability.
-        expires: 2023-03-21T13:39:49.450Z
+        expires: 2023-07-21T13:39:49.450Z
         created: 2022-12-29T13:39:49.470Z
   SNYK-JAVA-ORGYAML-2806360:
     - '*':
@@ -93,7 +93,7 @@ ignore:
           used to apply the database migration changes. XML files are used here
           to define the changes not YAML and therefore the Corda node itself is
           not exposed to this DOS vulnerability.
-        expires: 2023-03-21T13:40:55.262Z
+        expires: 2023-07-21T13:40:55.262Z
         created: 2022-12-29T13:40:55.279Z
   SNYK-JAVA-ORGLIQUIBASE-2419059:
     - '*':
@@ -108,7 +108,7 @@ ignore:
           exploit this vulnerability would need access to the server with the
           XML input files, and specifically the access and ability to change JAR
           files on the file system that make up the Corda installation.
-        expires: 2023-03-21T13:42:11.552Z
+        expires: 2023-07-21T13:42:11.552Z
         created: 2022-12-29T13:42:11.570Z
   SNYK-JAVA-ORGYAML-3113851:
     - '*':
@@ -134,7 +134,7 @@ ignore:
           their own assessment. This vulnerability relates to deeply nested
           untyped Object or Array values (3000 levels deep). Only CorDapps with
           these types at this level of nesting are potentially susceptible.
-        expires: 2023-03-12T16:50:57.921Z
+        expires: 2023-07-12T16:50:57.921Z
         created: 2022-12-29T16:50:57.943Z
   SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424:
     - '*':
@@ -146,7 +146,7 @@ ignore:
           their own assessment. This vulnerability relates to deeply nested
           untyped Object or Array values (3000 levels deep). Only CorDapps with
           these types at this level of nesting are potentially susceptible.
-        expires: 2023-03-12T16:52:30.722Z
+        expires: 2023-07-12T16:52:30.722Z
         created: 2022-12-29T16:52:30.747Z
   SNYK-JAVA-ORGYAML-3016891:
     - '*':
@@ -160,7 +160,7 @@ ignore:
           XML files are used here to define the changes not YAML and therefore
           the Corda node itself is not exposed to this deserialisation
           vulnerability. 
-        expires: 2023-03-12T17:00:51.957Z
+        expires: 2023-07-12T17:00:51.957Z
         created: 2022-12-29T17:00:51.970Z
   SNYK-JAVA-ORGYAML-3016889:
     - '*':
@@ -174,7 +174,7 @@ ignore:
           XML files are used here to define the changes not YAML and therefore
           the Corda node itself is not exposed to this deserialisation
           vulnerability.
-        expires: 2023-03-12T17:02:02.538Z
+        expires: 2023-07-12T17:02:02.538Z
         created: 2022-12-29T17:02:02.564Z
   SNYK-JAVA-COMH2DATABASE-2348247:
     - '*':
@@ -182,7 +182,7 @@ ignore:
           H2 console is not enabled for any of the applications we are running.
           When it comes to DB connectivity parameters, we do not allow changing 
           them as they are supplied by Corda Node configuration file.
-        expires: 2023-03-28T11:36:39.068Z
+        expires: 2023-07-28T11:36:39.068Z
         created: 2022-12-29T11:36:39.089Z
   SNYK-JAVA-COMH2DATABASE-1769238:
     - '*':
@@ -194,7 +194,7 @@ ignore:
           Corda is not susceptible to this vulnerability. If CorDapp developers
           store XML data to the database they need to ascertain themselves that
           they are not susceptible.
-        expires: 2023-03-28T11:40:29.871Z
+        expires: 2023-07-28T11:40:29.871Z
         created: 2022-12-29T11:40:29.896Z
   SNYK-JAVA-ORGYAML-3152153:
     - '*':
@@ -206,7 +206,7 @@ ignore:
           not yaml. So given this Corda is not susceptible to this
           vulnerability.Cordapp authors should exercise their own judgment if
           using this library directly in their cordapp.
-        expires: 2023-03-03T11:35:04.385Z
+        expires: 2023-07-03T11:35:04.385Z
         created: 2023-01-04T11:35:04.414Z
   SNYK-JAVA-IONETTY-3167773:
     - '*':
@@ -216,13 +216,13 @@ ignore:
           but it is not used in Corda, which uses a custom binary protocol
           secured by mutually authenticated TLS. The vulnerability relating to
           HTTP Response splitting is not exposed.
-        expires: 2023-03-03T11:40:51.456Z
+        expires: 2023-07-03T11:40:51.456Z
         created: 2023-01-04T11:40:51.467Z
   SNYK-JAVA-COMH2DATABASE-3146851:
     - '*':
         reason: >-
           Corda does not make use of the H2 web admin console, so it not
           susceptible to this reported vulnerability
-        expires: 2023-03-03T11:45:11.295Z
+        expires: 2023-07-03T11:45:11.295Z
         created: 2023-01-04T11:45:11.322Z
 patch: {}


### PR DESCRIPTION
Updating .snyk expiry & updating modules to scan on Snyk nightly.

Both 'bridge', 'bridgecapsule' are ENT submodules, so the pipeline fails when it tries to scan those.

Updating to only include the 'node', 'capsule' submodules.