### PR TITLE
ES-562: Updating modules to scan on Snyk nightly

### DIFF
--- a/.ci/dev/nightly-regression/JenkinsfileSnykScan
+++ b/.ci/dev/nightly-regression/JenkinsfileSnykScan
@@ -3,5 +3,5 @@
 cordaSnykScanPipeline (
     snykTokenId: 'c4-os-snyk-api-token-secret',
     // specify the Gradle submodules to scan and monitor on snyk Server
-    modulesToScan: ['node', 'capsule', 'bridge', 'bridgecapsule']
+    modulesToScan: ['node', 'capsule']
 )

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
             steps {
                 script {
                     // Invoke Snyk for each Gradle sub project we wish to scan
-                    def modulesToScan = ['node', 'capsule', 'bridge', 'bridgecapsule']
+                    def modulesToScan = ['node', 'capsule']
                     modulesToScan.each { module ->
                         snykSecurityScan("${env.SNYK_API_KEY}", "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
                     }

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|AG|EG|ENT|INFRA|NAAS|ES)-\d+)(.*)'
+          title-regex: '^((CORDA|AG|EG|ENT|INFRA|ES)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Updating .snyk expiry & updating modules to scan on Snyk nightly.

Both 'bridge', 'bridgecapsule' are ENT submodules, so the pipeline fails when it tries to scan those.

Updating to only include the 'node', 'capsule' submodules.