### PR TITLE
ENT-10009 Enhance SendTransactionFlow to allow sending a txn to multiple sessions.

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3292,9 +3292,7 @@ public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flo
   public <init>(net.corda.core.flows.FlowSession, java.util.List<? extends net.corda.core.contracts.StateAndRef<?>>)
 ##
 public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
-  public <init>(java.util.Set<? extends net.corda.core.flows.FlowSession>, net.corda.core.transactions.SignedTransaction, net.corda.core.flows.TransactionMetadata)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
-  public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction, net.corda.core.flows.TransactionMetadata)
   public static final net.corda.core.flows.SendTransactionFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.SendTransactionFlow$Companion extends java.lang.Object

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1798,6 +1798,8 @@ public final class net.corda.core.crypto.Crypto extends java.lang.Object
   public static final boolean doVerify(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
   public static final boolean doVerify(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
   @NotNull
+  public static final byte[] encodePublicKey(java.security.PublicKey)
+  @NotNull
   public static final java.security.Provider findProvider(String)
   @NotNull
   public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(int)
@@ -2518,14 +2520,20 @@ public static final class net.corda.core.flows.ContractUpgradeFlow$Initiate exte
   protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
 ##
 public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.FlowLogic
+  public <init>(java.util.Set<? extends net.corda.core.flows.FlowSession>, Object, net.corda.core.flows.TransactionMetadata)
+  public <init>(java.util.Set, Object, net.corda.core.flows.TransactionMetadata, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.flows.FlowSession, Object)
+  public <init>(net.corda.core.flows.FlowSession, Object, net.corda.core.flows.TransactionMetadata)
+  public <init>(net.corda.core.flows.FlowSession, Object, net.corda.core.flows.TransactionMetadata, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @Nullable
   public Void call()
   @NotNull
-  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  public final java.util.Set<net.corda.core.flows.FlowSession> getOtherSessions()
   @NotNull
   public final Object getPayload()
+  @Nullable
+  public final net.corda.core.flows.TransactionMetadata getTxnMetadata()
   @Suspendable
   @NotNull
   protected net.corda.core.utilities.UntrustworthyData<net.corda.core.internal.FetchDataFlow$Request> sendPayloadAndReceiveDataRequest(net.corda.core.flows.FlowSession, Object)
@@ -2535,10 +2543,29 @@ public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.F
 @DoNotImplement
 public interface net.corda.core.flows.Destination
 ##
+@CordaSerializable
+public final class net.corda.core.flows.DistributionList extends java.lang.Object
+  public <init>(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
+  @NotNull
+  public final net.corda.core.node.StatesToRecord component1()
+  @NotNull
+  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> component2()
+  @NotNull
+  public final net.corda.core.flows.DistributionList copy(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> getPeersToStatesToRecord()
+  @NotNull
+  public final net.corda.core.node.StatesToRecord getSenderStatesToRecord()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
 @InitiatingFlow
 public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord, net.corda.core.utilities.ProgressTracker)
@@ -2570,10 +2597,30 @@ public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTI
   public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING INSTANCE
 ##
 @CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_NOTARY_ERROR extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_NOTARY_ERROR INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_POST_NOTARISATION extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_POST_NOTARISATION INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_PRE_NOTARISATION extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_PRE_NOTARISATION INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$FINALISING_TRANSACTION extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$FINALISING_TRANSACTION INSTANCE
+##
+@CordaSerializable
 public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING extends net.corda.core.utilities.ProgressTracker$Step
   @NotNull
   public net.corda.core.utilities.ProgressTracker childProgressTracker()
   public static final net.corda.core.flows.FinalityFlow$Companion$NOTARISING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$RECORD_UNNOTARISED extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$RECORD_UNNOTARISED INSTANCE
 ##
 @CordaSerializable
 public class net.corda.core.flows.FlowException extends net.corda.core.CordaException implements net.corda.core.flows.IdentifiableException
@@ -2877,6 +2924,37 @@ public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends j
   public String toString()
 ##
 @CordaSerializable
+public final class net.corda.core.flows.FlowTransactionInfo extends java.lang.Object
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.TransactionStatus, java.time.Instant, net.corda.core.flows.TransactionMetadata)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.TransactionStatus component3()
+  @NotNull
+  public final java.time.Instant component4()
+  @Nullable
+  public final net.corda.core.flows.TransactionMetadata component5()
+  @NotNull
+  public final net.corda.core.flows.FlowTransactionInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.TransactionStatus, java.time.Instant, net.corda.core.flows.TransactionMetadata)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.core.flows.TransactionMetadata getMetadata()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getStateMachineRunId()
+  @NotNull
+  public final net.corda.core.flows.TransactionStatus getStatus()
+  @NotNull
+  public final java.time.Instant getTimestamp()
+  @NotNull
+  public final String getTxId()
+  public int hashCode()
+  public final boolean isInitiator(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
 public class net.corda.core.flows.HospitalizeFlowException extends net.corda.core.CordaRuntimeException
   public <init>()
   public <init>(String)
@@ -3138,10 +3216,16 @@ public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUE
 public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
 ##
+public final class net.corda.core.flows.NotarySigCheck extends java.lang.Object
+  public final boolean needsNotarySignature(net.corda.core.transactions.SignedTransaction)
+  public static final net.corda.core.flows.NotarySigCheck INSTANCE
+##
 public final class net.corda.core.flows.ReceiveFinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
@@ -3157,11 +3241,48 @@ public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.
   public <init>(net.corda.core.flows.FlowSession, boolean)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
   @Suspendable
   protected void checkBeforeRecording(net.corda.core.transactions.SignedTransaction)
+##
+@CordaSerializable
+public final class net.corda.core.flows.RecoveryTimeWindow extends java.lang.Object
+  public <init>(java.time.Instant, java.time.Instant)
+  public <init>(java.time.Instant, java.time.Instant, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public static final net.corda.core.flows.RecoveryTimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow copy(java.time.Instant, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.flows.RecoveryTimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public final java.time.Instant getFromTime()
+  @NotNull
+  public final java.time.Instant getUntilTime()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.flows.RecoveryTimeWindow untilOnly(java.time.Instant)
+  public static final net.corda.core.flows.RecoveryTimeWindow$Companion Companion
+##
+public static final class net.corda.core.flows.RecoveryTimeWindow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow untilOnly(java.time.Instant)
 ##
 @CordaSerializable
 public final class net.corda.core.flows.ResultSerializationException extends net.corda.core.CordaRuntimeException
@@ -3173,7 +3294,15 @@ public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flo
   public <init>(net.corda.core.flows.FlowSession, java.util.List<? extends net.corda.core.contracts.StateAndRef<?>>)
 ##
 public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
+  public <init>(java.util.Set<? extends net.corda.core.flows.FlowSession>, net.corda.core.transactions.SignedTransaction, net.corda.core.flows.TransactionMetadata)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction, net.corda.core.flows.TransactionMetadata)
+  public static final net.corda.core.flows.SendTransactionFlow$Companion Companion
+##
+public static final class net.corda.core.flows.SendTransactionFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getDUMMY_PARTICIPANT_NAME()
 ##
 public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
@@ -3208,6 +3337,24 @@ public static final class net.corda.core.flows.SignTransactionFlow$Companion$SIG
 @CordaSerializable
 public static final class net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.flows.SignedTransactionWithDistributionList extends java.lang.Object
+  public <init>(net.corda.core.transactions.SignedTransaction, byte[])
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction component1()
+  @NotNull
+  public final byte[] component2()
+  @NotNull
+  public final net.corda.core.flows.SignedTransactionWithDistributionList copy(net.corda.core.transactions.SignedTransaction, byte[])
+  public boolean equals(Object)
+  @NotNull
+  public final byte[] getDistributionList()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getStx()
+  public int hashCode()
+  @NotNull
+  public String toString()
 ##
 public final class net.corda.core.flows.StackFrameDataToken extends java.lang.Object
   public <init>(String)
@@ -3279,6 +3426,29 @@ public class net.corda.core.flows.StateReplacementException extends net.corda.co
   public <init>(String)
   public <init>(String, Throwable)
   public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public final class net.corda.core.flows.TransactionMetadata extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final net.corda.core.flows.DistributionList component2()
+  @NotNull
+  public final net.corda.core.flows.TransactionMetadata copy(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.flows.DistributionList getDistributionList()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getInitiator()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.TransactionStatus extends java.lang.Enum
+  public static net.corda.core.flows.TransactionStatus valueOf(String)
+  public static net.corda.core.flows.TransactionStatus[] values()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
@@ -4140,6 +4310,7 @@ public interface net.corda.core.node.ServicesForResolution
   @NotNull
   public net.corda.core.transactions.LedgerTransaction specialise(net.corda.core.transactions.LedgerTransaction)
 ##
+@CordaSerializable
 public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
   public static net.corda.core.node.StatesToRecord valueOf(String)
   public static net.corda.core.node.StatesToRecord[] values()
@@ -4473,6 +4644,8 @@ public static final class net.corda.core.node.services.Vault$ConstraintInfo$Type
 @CordaSerializable
 public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>, net.corda.core.contracts.StateRef)
+  public <init>(java.util.List, java.util.List, long, net.corda.core.node.services.Vault$StateStatus, java.util.List, net.corda.core.contracts.StateRef, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<T>> component1()
   @NotNull
@@ -4482,11 +4655,17 @@ public static final class net.corda.core.node.services.Vault$Page extends java.l
   public final net.corda.core.node.services.Vault$StateStatus component4()
   @NotNull
   public final java.util.List<Object> component5()
+  @Nullable
+  public final net.corda.core.contracts.StateRef component6()
   @NotNull
   public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>, net.corda.core.contracts.StateRef)
   public boolean equals(Object)
   @NotNull
   public final java.util.List<Object> getOtherResults()
+  @Nullable
+  public final net.corda.core.contracts.StateRef getPreviousPageAnchor()
   @NotNull
   public final net.corda.core.node.services.Vault$StateStatus getStateTypes()
   @NotNull
@@ -8383,6 +8562,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean, java.time.Duration)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, boolean, java.time.Duration, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
   public final boolean component1()
   @NotNull
@@ -8407,6 +8588,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final java.nio.file.Path component2()
   public final boolean component20()
   @NotNull
+  public final java.time.Duration component21()
+  @NotNull
   public final net.corda.testing.driver.PortAllocation component3()
   @NotNull
   public final net.corda.testing.driver.PortAllocation component4()
@@ -8425,6 +8608,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean)
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean, java.time.Duration)
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
   public boolean equals(Object)
@@ -8450,6 +8635,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
   public final java.util.Map<String, Object> getNotaryCustomOverrides()
+  @NotNull
+  public final java.time.Duration getNotaryHandleTimeout()
   @NotNull
   public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
   @NotNull
@@ -8490,6 +8677,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNotaryCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotaryHandleTimeout(java.time.Duration)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
   @NotNull
@@ -8723,6 +8912,7 @@ public final class net.corda.testing.flows.FlowTestsUtilsKt extends java.lang.Ob
   public static final java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAll(net.corda.core.flows.FlowLogic<?>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>...)
   @NotNull
   public static final rx.Observable<T> registerCoreFlowFactory(net.corda.testing.node.internal.TestStartedNode, Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<T>, kotlin.jvm.functions.Function1<? super net.corda.core.flows.FlowSession, ? extends T>, boolean)
+  public static final void waitForAllFlowsToComplete(net.corda.testing.driver.NodeHandle, int, long)
 ##
 @DoNotImplement
 public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
@@ -9144,7 +9334,9 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @NotNull
   public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>, net.corda.testing.internal.TestingNamedCacheFactory)
   public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public final void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>, boolean)
   public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public final void recordTransactions(net.corda.core.transactions.SignedTransaction, boolean)
   public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
   public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2532,8 +2532,6 @@ public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.F
   public final java.util.Set<net.corda.core.flows.FlowSession> getOtherSessions()
   @NotNull
   public final Object getPayload()
-  @Nullable
-  public final net.corda.core.flows.TransactionMetadata getTxnMetadata()
   @Suspendable
   @NotNull
   protected net.corda.core.utilities.UntrustworthyData<net.corda.core.internal.FetchDataFlow$Request> sendPayloadAndReceiveDataRequest(net.corda.core.flows.FlowSession, Object)

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -10,7 +10,6 @@ import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
-import net.corda.core.flows.DistributionList
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
@@ -24,7 +23,6 @@ import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.flows.ReceiveTransactionFlow
 import net.corda.core.flows.SendTransactionFlow
 import net.corda.core.flows.StartableByRPC
-import net.corda.core.flows.TransactionMetadata
 import net.corda.core.flows.TransactionStatus
 import net.corda.core.flows.UnexpectedFlowEndException
 import net.corda.core.identity.CordaX500Name
@@ -581,8 +579,7 @@ class FinalityFlowTests : WithFinality {
             val txBuilder = DummyContract.move(stateAndRef, newOwner)
             val stxn = serviceHub.signInitialTransaction(txBuilder, ourIdentity.owningKey)
             val sessionWithCounterParty = initiateFlow(newOwner)
-            subFlow(SendTransactionFlow(sessionWithCounterParty, stxn,
-                    TransactionMetadata(ourIdentity.name, DistributionList(StatesToRecord.ONLY_RELEVANT, mapOf(BOB_NAME to StatesToRecord.ONLY_RELEVANT)))))
+            subFlow(SendTransactionFlow(stxn, setOf(sessionWithCounterParty), emptySet(), StatesToRecord.ONLY_RELEVANT))
             throw UnexpectedFlowEndException("${stxn.id}")
         }
     }

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/TestNoSecurityDataVendingFlow.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/TestNoSecurityDataVendingFlow.kt
@@ -15,7 +15,7 @@ class TestNoSecurityDataVendingFlow(otherSideSession: FlowSession) : DataVending
             // Hack to not send the first message.
             otherSideSession.receive()
         } else {
-            super.sendPayloadAndReceiveDataRequest(this.otherSideSession, payload)
+            super.sendPayloadAndReceiveDataRequest(this.otherSessions.first(), payload)
         }
     }
 }

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -286,7 +286,6 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
             try {
                 logger.debug { "Sending transaction to party sessions: $sessions." }
                 subFlow(SendTransactionFlow(sessions, tx, txnMetadata))
-                txnMetadata = txnMetadata.copy(persist = false)
             } catch (e: UnexpectedFlowEndException) {
                 throw UnexpectedFlowEndException(
                         "One of the sessions ${sessions.map { it.counterparty }} has finished prematurely and we're trying to send them a transaction." +
@@ -374,7 +373,6 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
                 try {
                     logger.debug { "Sending transaction to party sessions $sessions." }
                     subFlow(SendTransactionFlow(sessions, tx, txnMetadata))
-                    txnMetadata = txnMetadata.copy(persist = false)
                 } catch (e: UnexpectedFlowEndException) {
                     throw UnexpectedFlowEndException(
                             "One of the sessions ${sessions.map { it.counterparty }} has finished prematurely and we're trying to send them the finalised transaction. " +
@@ -396,7 +394,6 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
         logger.debug { "Sending transaction to parties $remoteRecipients." }
         val sessions = remoteRecipients.map { initiateFlow(it) }.toSet()
         subFlow(SendTransactionFlow(sessions, notarised, txnMetadata))
-        txnMetadata = txnMetadata.copy(persist = false)
         logger.info("Parties $remoteRecipients received the transaction.")
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -249,7 +249,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
                     recordTransactionLocally(transaction)
                 transaction
             }
-            broadcastToOtherParticipants(externalTxParticipants, oldPlatformSessions.toSet(), stxn)
+            broadcastToOtherParticipants(externalTxParticipants, oldPlatformSessions, stxn)
             return stxn
         }
         else {
@@ -257,7 +257,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
                 notarise().first
             } else transaction
             recordTransactionLocally(stxn)
-            broadcastToOtherParticipants(externalTxParticipants, (newPlatformSessions + oldPlatformSessions).toSet(), stxn)
+            broadcastToOtherParticipants(externalTxParticipants, newPlatformSessions + oldPlatformSessions, stxn)
             return stxn
         }
     }

--- a/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
@@ -23,9 +23,8 @@ data class FlowTransactionInfo(
 
 @CordaSerializable
 data class TransactionMetadata(
-        val initiator: CordaX500Name,
-        val distributionList: DistributionList,
-        val persist: Boolean = true     // hint to persist to transactional store
+    val initiator: CordaX500Name,
+    val distributionList: DistributionList
 )
 
 @CordaSerializable

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -74,13 +74,14 @@ class MaybeSerializedSignedTransaction(override val id: SecureHash, val serializ
  * the right point in the conversation to receive the sent transaction and perform the resolution back-and-forth required
  * to check the dependencies and download any missing attachments.
  *
- * @param otherSide the target party.
- * @param stx the [SignedTransaction] being sent to the [otherSideSession].
- * @property txnMetadata transaction recovery metadata (eg. used by Two Phase Finality).
+ * @param otherSessions the target parties.
+ * @param stx the [SignedTransaction] being sent to the [otherSessions].
+ * @param txnMetadata transaction recovery metadata (eg. used by Two Phase Finality).
  */
-open class SendTransactionFlow(otherSide: FlowSession, stx: SignedTransaction, txnMetadata: TransactionMetadata) : DataVendingFlow(otherSide, stx, txnMetadata) {
+open class SendTransactionFlow(otherSessions: Set<FlowSession>, stx: SignedTransaction, txnMetadata: TransactionMetadata) : DataVendingFlow(otherSessions, stx, txnMetadata) {
     constructor(otherSide: FlowSession, stx: SignedTransaction) : this(otherSide, stx,
         TransactionMetadata(DUMMY_PARTICIPANT_NAME, DistributionList(StatesToRecord.NONE, mapOf(otherSide.counterparty.name to StatesToRecord.ALL_VISIBLE))))
+    constructor(otherSide: FlowSession, stx: SignedTransaction, txnMetadata: TransactionMetadata) : this(setOf(otherSide), stx, txnMetadata)
         // Note: DUMMY_PARTICIPANT_NAME to be substituted with actual "ourIdentity.name" in flow call()
     companion object {
         val DUMMY_PARTICIPANT_NAME = CordaX500Name("Transaction Participant", "London", "GB")
@@ -98,7 +99,8 @@ open class SendTransactionFlow(otherSide: FlowSession, stx: SignedTransaction, t
  */
 open class SendStateAndRefFlow(otherSideSession: FlowSession, stateAndRefs: List<StateAndRef<*>>) : DataVendingFlow(otherSideSession, stateAndRefs)
 
-open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any, val txnMetadata: TransactionMetadata? = null) : FlowLogic<Void?>() {
+open class DataVendingFlow(val otherSessions: Set<FlowSession>, val payload: Any, private val txnMetadata: TransactionMetadata? = null) : FlowLogic<Void?>() {
+    constructor(otherSideSession: FlowSession, payload: Any, txnMetadata: TransactionMetadata? = null) : this(setOf(otherSideSession), payload, txnMetadata)
     constructor(otherSideSession: FlowSession, payload: Any) : this(otherSideSession, payload, null)
 
     @Suspendable
@@ -109,7 +111,7 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any, 
         // User can override this method to perform custom request verification.
     }
 
-    @Suppress("ComplexCondition", "ComplexMethod")
+    @Suppress("ComplexCondition", "ComplexMethod", "LongMethod")
     @Suspendable
     override fun call(): Void? {
         val networkMaxMessageSize = serviceHub.networkParameters.maxMessageSize
@@ -140,115 +142,126 @@ open class DataVendingFlow(val otherSideSession: FlowSession, val payload: Any, 
 
         // store and share transaction recovery metadata if required
         val useTwoPhaseFinality = serviceHub.myInfo.platformVersion >= PlatformVersionSwitches.TWO_PHASE_FINALITY
-        val toTwoPhaseFinalityNode = serviceHub.networkMapCache.getNodeByLegalIdentity(otherSideSession.counterparty)?.platformVersion!! >= PlatformVersionSwitches.TWO_PHASE_FINALITY
-        if (txnMetadata != null && toTwoPhaseFinalityNode && useTwoPhaseFinality && payload is SignedTransaction) {
-            val encryptedDistributionList = (serviceHub as ServiceHubCoreInternal).recordSenderTransactionRecoveryMetadata(payload.id, txnMetadata.copy(initiator = ourIdentity.name))
-            payload = SignedTransactionWithDistributionList(payload, encryptedDistributionList!!)
+        val toTwoPhaseFinalityNode = otherSessions.any { otherSideSession ->
+            serviceHub.networkMapCache.getNodeByLegalIdentity(otherSideSession.counterparty)?.platformVersion!! >= PlatformVersionSwitches.TWO_PHASE_FINALITY
         }
+        // record transaction recovery metadata once
+        val payloadWithMetadata =
+            if (txnMetadata != null && toTwoPhaseFinalityNode && useTwoPhaseFinality && payload is SignedTransaction) {
+                val encryptedDistributionList = (serviceHub as ServiceHubCoreInternal).recordSenderTransactionRecoveryMetadata(payload.id, txnMetadata.copy(initiator = ourIdentity.name))
+                SignedTransactionWithDistributionList(payload, encryptedDistributionList!!)
+            } else null
 
-        // This loop will receive [FetchDataFlow.Request] continuously until the `otherSideSession` has all the data they need
-        // to resolve the transaction, a [FetchDataFlow.EndRequest] will be sent from the `otherSideSession` to indicate end of
-        // data request.
-        var loopCount = 0
-        while (true) {
-            val loopCnt = loopCount++
-            logger.trace { "DataVendingFlow: Main While [$loopCnt]..." }
-            val dataRequest = sendPayloadAndReceiveDataRequest(otherSideSession, payload).unwrap { request ->
-                logger.trace { "sendPayloadAndReceiveDataRequest(): ${request.javaClass.name}" }
-                when (request) {
-                    is FetchDataFlow.Request.Data -> {
-                        // Security TODO: Check for abnormally large or malformed data requests
-                        verifyDataRequest(request)
-                        request
-                    }
-                    FetchDataFlow.Request.End -> {
-                        logger.trace { "DataVendingFlow: END" }
-                        return null
+        otherSessions.forEachIndexed { idx, otherSideSession ->
+            if (payloadWithMetadata != null)
+                payload = payloadWithMetadata
+            // This loop will receive [FetchDataFlow.Request] continuously until the `otherSideSession` has all the data they need
+            // to resolve the transaction, a [FetchDataFlow.EndRequest] will be sent from the `otherSideSession` to indicate end of
+            // data request.
+            var loopCount = 0
+            while (true) {
+                val loopCnt = loopCount++
+                logger.trace { "DataVendingFlow: Main While [$loopCnt]..." }
+                val dataRequest = sendPayloadAndReceiveDataRequest(otherSideSession, payload).unwrap { request ->
+                    logger.trace { "sendPayloadAndReceiveDataRequest(): ${request.javaClass.name}" }
+                    when (request) {
+                        is FetchDataFlow.Request.Data -> {
+                            // Security TODO: Check for abnormally large or malformed data requests
+                            verifyDataRequest(request)
+                            request
+                        }
+                        FetchDataFlow.Request.End -> {
+                            logger.trace { "DataVendingFlow: END" }
+                            return@forEachIndexed
+                        }
                     }
                 }
-            }
 
-            logger.trace { "Sending data (Type = ${dataRequest.dataType.name})" }
-            var totalByteCount = 0
-            var firstItem = true
-            var batchFetchCountExceeded = false
-            var numSent = 0
-            payload = when (dataRequest.dataType) {
-                FetchDataFlow.DataType.TRANSACTION -> dataRequest.hashes.map { txId ->
-                    logger.trace { "Sending: TRANSACTION (dataRequest.hashes.size=${dataRequest.hashes.size})" }
-                    if (!authorisedTransactions.isAuthorised(txId)) {
-                        throw FetchDataFlow.IllegalTransactionRequest(txId)
-                    }
-                    val tx = serviceHub.validatedTransactions.getTransaction(txId)
-                            ?: throw FetchDataFlow.HashNotFound(txId)
-                    authorisedTransactions.removeAuthorised(tx.id)
-                    authorisedTransactions.addAuthorised(getInputTransactions(tx))
-                    totalByteCount += tx.txBits.size
-                    numSent++
-                    tx
-                }
-                // Loop on all items returned using dataRequest.hashes.map:
-                FetchDataFlow.DataType.BATCH_TRANSACTION -> dataRequest.hashes.map { txId ->
-                    if (!authorisedTransactions.isAuthorised(txId)) {
-                        throw FetchDataFlow.IllegalTransactionRequest(txId)
-                    }
-                    // Maybe we should not just throw here as it's not recoverable on the client side. Might be better to send a reason code or
-                    // remove the restriction on sending once.
-                    logger.trace { "Transaction authorised OK: '$txId'" }
-                    var serialized: SerializedBytes<SignedTransaction>? = null
-                    if (!batchFetchCountExceeded) {
-                        // Only fetch and serialize if we have not already exceeded the maximum byte count. Once we have, no more fetching
-                        // is required, just reject all additional items.
+                logger.trace { "Sending data (Type = ${dataRequest.dataType.name})" }
+                var totalByteCount = 0
+                var firstItem = true
+                var batchFetchCountExceeded = false
+                var numSent = 0
+                payload = when (dataRequest.dataType) {
+                    FetchDataFlow.DataType.TRANSACTION -> dataRequest.hashes.map { txId ->
+                        logger.trace { "Sending: TRANSACTION (dataRequest.hashes.size=${dataRequest.hashes.size})" }
+                        if (!authorisedTransactions.isAuthorised(txId)) {
+                            throw FetchDataFlow.IllegalTransactionRequest(txId)
+                        }
                         val tx = serviceHub.validatedTransactions.getTransaction(txId)
                                 ?: throw FetchDataFlow.HashNotFound(txId)
-                        logger.trace { "Transaction get OK: '$txId'" }
-                        serialized = tx.serialize()
-
-                        val itemByteCount = serialized.size
-                        logger.trace { "Batch-Send '$txId': first = $firstItem, Total bytes = $totalByteCount, Item byte count = $itemByteCount, Maximum = $maxPayloadSize" }
-                        if (firstItem || (totalByteCount + itemByteCount) < maxPayloadSize) {
-                            totalByteCount += itemByteCount
-                            numSent++
-                            // Always include at least one item else if the max is set too low nothing will ever get returned.
-                            // Splitting items will be a separate Jira if need be
+                        if (idx == otherSessions.size - 1)
                             authorisedTransactions.removeAuthorised(tx.id)
-                            authorisedTransactions.addAuthorised(getInputTransactions(tx))
-                            logger.trace { "Adding item to return set: '$txId'" }
-                        } else {
-                            logger.trace { "Fetch block size EXCEEDED at '$txId'." }
-                            batchFetchCountExceeded = true
-                        }
-                    } // end
-
-                    if (batchFetchCountExceeded) {
-                        logger.trace { "Excluding '$txId' from return set due to exceeded count." }
+                        authorisedTransactions.addAuthorised(getInputTransactions(tx))
+                        totalByteCount += tx.txBits.size
+                        numSent++
+                        tx
                     }
+                    // Loop on all items returned using dataRequest.hashes.map:
+                    FetchDataFlow.DataType.BATCH_TRANSACTION -> dataRequest.hashes.map { txId ->
+                        if (!authorisedTransactions.isAuthorised(txId)) {
+                            throw FetchDataFlow.IllegalTransactionRequest(txId)
+                        }
+                        // Maybe we should not just throw here as it's not recoverable on the client side. Might be better to send a reason code or
+                        // remove the restriction on sending once.
+                        logger.trace { "Transaction authorised OK: '$txId'" }
+                        var serialized: SerializedBytes<SignedTransaction>? = null
+                        if (!batchFetchCountExceeded) {
+                            // Only fetch and serialize if we have not already exceeded the maximum byte count. Once we have, no more fetching
+                            // is required, just reject all additional items.
+                            val tx = serviceHub.validatedTransactions.getTransaction(txId)
+                                    ?: throw FetchDataFlow.HashNotFound(txId)
+                            logger.trace { "Transaction get OK: '$txId'" }
+                            serialized = tx.serialize()
 
-                    // Send null if limit is exceeded
-                    val maybeserialized = MaybeSerializedSignedTransaction(txId, if (batchFetchCountExceeded) {
-                        null
-                    } else {
-                        serialized
-                    }, null)
-                    firstItem = false
-                    maybeserialized
-                } // Batch response loop end
-                FetchDataFlow.DataType.ATTACHMENT -> dataRequest.hashes.map {
-                    logger.trace { "Sending: Attachments for '$it'" }
-                    serviceHub.attachments.openAttachment(it)?.open()?.readFully()
-                            ?: throw FetchDataFlow.HashNotFound(it)
+                            val itemByteCount = serialized.size
+                            logger.trace { "Batch-Send '$txId': first = $firstItem, Total bytes = $totalByteCount, Item byte count = $itemByteCount, Maximum = $maxPayloadSize" }
+                            if (firstItem || (totalByteCount + itemByteCount) < maxPayloadSize) {
+                                totalByteCount += itemByteCount
+                                numSent++
+                                // Always include at least one item else if the max is set too low nothing will ever get returned.
+                                // Splitting items will be a separate Jira if need be
+                                if (idx == otherSessions.size - 1)
+                                    authorisedTransactions.removeAuthorised(tx.id)
+                                authorisedTransactions.addAuthorised(getInputTransactions(tx))
+                                logger.trace { "Adding item to return set: '$txId'" }
+                            } else {
+                                logger.trace { "Fetch block size EXCEEDED at '$txId'." }
+                                batchFetchCountExceeded = true
+                            }
+                        } // end
+
+                        if (batchFetchCountExceeded) {
+                            logger.trace { "Excluding '$txId' from return set due to exceeded count." }
+                        }
+
+                        // Send null if limit is exceeded
+                        val maybeserialized = MaybeSerializedSignedTransaction(txId, if (batchFetchCountExceeded) {
+                            null
+                        } else {
+                            serialized
+                        }, null)
+                        firstItem = false
+                        maybeserialized
+                    } // Batch response loop end
+                    FetchDataFlow.DataType.ATTACHMENT -> dataRequest.hashes.map {
+                        logger.trace { "Sending: Attachments for '$it'" }
+                        serviceHub.attachments.openAttachment(it)?.open()?.readFully()
+                                ?: throw FetchDataFlow.HashNotFound(it)
+                    }
+                    FetchDataFlow.DataType.PARAMETERS -> dataRequest.hashes.map {
+                        logger.trace { "Sending: Parameters for '$it'" }
+                        (serviceHub.networkParametersService as NetworkParametersStorage).lookupSigned(it)
+                                ?: throw FetchDataFlow.MissingNetworkParameters(it)
+                    }
+                    FetchDataFlow.DataType.UNKNOWN -> dataRequest.hashes.map {
+                        logger.warn("Message from from a future version of Corda with UNKNOWN enum value for FetchDataFlow.DataType: ID='$it'")
+                    }
                 }
-                FetchDataFlow.DataType.PARAMETERS -> dataRequest.hashes.map {
-                    logger.trace { "Sending: Parameters for '$it'" }
-                    (serviceHub.networkParametersService as NetworkParametersStorage).lookupSigned(it)
-                            ?: throw FetchDataFlow.MissingNetworkParameters(it)
-                }
-                FetchDataFlow.DataType.UNKNOWN -> dataRequest.hashes.map {
-                    logger.warn("Message from from a future version of Corda with UNKNOWN enum value for FetchDataFlow.DataType: ID='$it'")
-                }
+                logger.trace { "Block total size = $totalByteCount: Num Items = ($numSent of ${dataRequest.hashes.size} total)" }
             }
-            logger.trace { "Block total size = $totalByteCount: Num Items = ($numSent of ${dataRequest.hashes.size} total)" }
         }
+        return null
     }
 
     @Suspendable

--- a/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithCustomSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DeterministicContractWithCustomSerializerTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
 @Suppress("FunctionName")
+@Ignore("flaky tests in CI")
 class DeterministicContractWithCustomSerializerTest {
     companion object {
         val logger = loggerFor<DeterministicContractWithCustomSerializerTest>()
@@ -61,7 +62,6 @@ class DeterministicContractWithCustomSerializerTest {
     }
 
     @Test(timeout=300_000)
-    @Ignore("Flaky test in CI: org.opentest4j.AssertionFailedError: Unexpected exception thrown: net.corda.client.rpc.RPCException: Class \"class net.corda.contracts.serialization.custom.Currantsy\" is not on the whitelist or annotated with @CordaSerializable.")
     fun `test DJVM can verify using custom serializer`() {
         driver(parametersFor(djvmSources, listOf(flowCordapp, contractCordapp))) {
             val alice = startNode(providedName = ALICE_NAME).getOrThrow()

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -38,11 +38,14 @@ import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.internal.div
 import net.corda.core.internal.messaging.AttachmentTrustInfoRPCOps
 import net.corda.core.internal.notary.NotaryService
 import net.corda.core.internal.rootMessage
+import net.corda.core.internal.telemetry.OpenTelemetryComponent
+import net.corda.core.internal.telemetry.SimpleLogTelemetryComponent
+import net.corda.core.internal.telemetry.TelemetryComponent
+import net.corda.core.internal.telemetry.TelemetryServiceImpl
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.ClientRpcSslOptions
 import net.corda.core.messaging.CordaRPCOps
@@ -57,10 +60,6 @@ import net.corda.core.node.services.ContractUpgradeService
 import net.corda.core.node.services.CordaService
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
-import net.corda.core.internal.telemetry.SimpleLogTelemetryComponent
-import net.corda.core.internal.telemetry.TelemetryComponent
-import net.corda.core.internal.telemetry.OpenTelemetryComponent
-import net.corda.core.internal.telemetry.TelemetryServiceImpl
 import net.corda.core.node.services.TelemetryService
 import net.corda.core.node.services.TransactionVerifierService
 import net.corda.core.node.services.diagnostics.DiagnosticsService

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -659,6 +659,8 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             tokenizableServices = null
 
             verifyCheckpointsCompatible(frozenTokenizableServices)
+            partyInfoCache.start()
+
             /* Note the .get() at the end of the distributeEvent call, below.
                This will block until all Corda Services have returned from processing the event, allowing a service to prevent the
                state machine manager from starting (just below this) until the service is ready.
@@ -697,9 +699,6 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 log.warn("Not distributing events as NetworkMap is not ready")
             }
         }
-        nodeReadyFuture.thenMatch({
-            partyInfoCache.start()
-        }, { th -> log.error("Unexpected exception during cache initialisation", th) })
 
         setNodeStatus(NodeStatus.STARTED)
         return resultingNodeInfo

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
@@ -141,14 +141,13 @@ class DBTransactionStorageLedgerRecovery(private val database: CordaPersistence,
 
     override fun addSenderTransactionRecoveryMetadata(id: SecureHash, metadata: TransactionMetadata): ByteArray {
         return database.transaction {
-            if (metadata.persist)
-                metadata.distributionList.peersToStatesToRecord.map { (peer, _) ->
-                    val senderDistributionRecord = DBSenderDistributionRecord(PersistentKey(Key(clock.instant())),
-                            id.toString(),
-                            partyInfoCache.getPartyIdByCordaX500Name(peer),
-                            metadata.distributionList.senderStatesToRecord)
-                    session.save(senderDistributionRecord)
-                }
+            metadata.distributionList.peersToStatesToRecord.map { (peer, _) ->
+                val senderDistributionRecord = DBSenderDistributionRecord(PersistentKey(Key(clock.instant())),
+                        id.toString(),
+                        partyInfoCache.getPartyIdByCordaX500Name(peer),
+                        metadata.distributionList.senderStatesToRecord)
+                session.save(senderDistributionRecord)
+            }
             val hashedPeersToStatesToRecord = metadata.distributionList.peersToStatesToRecord.map { (peer, statesToRecord) ->
                 partyInfoCache.getPartyIdByCordaX500Name(peer) to statesToRecord }.toMap()
             val hashedDistributionList = HashedDistributionList(metadata.distributionList.senderStatesToRecord, hashedPeersToStatesToRecord)


### PR DESCRIPTION
- Update FinalityFlow to use above.
- Remove redundant "persist" flag from `TransactionMetadata`

**Additional**
- address [PR review comment](https://github.com/corda/enterprise/pull/4805#discussion_r1222651369): start `partyInfoCache` before state machine is started.
- update outdated `api-current.txt`


