### PR TITLE
ES-758: add corda remotes env vars to Jenkins logic

### DIFF
--- a/.ci/dev/compatibility/JenkinsfileJDK11Compile
+++ b/.ci/dev/compatibility/JenkinsfileJDK11Compile
@@ -22,6 +22,13 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
     }
 
+    environment {
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_USE_CACHE = "corda-remotes"
+    }
+
     stages {
         stage('JDK 11 Compile') {
             steps {

--- a/.ci/dev/nightly-regression/Jenkinsfile
+++ b/.ci/dev/nightly-regression/Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_USE_CACHE = "corda-remotes"
     }
 
     stages {

--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -17,6 +17,10 @@ pipeline {
     environment {
         SNYK_API_TOKEN = credentials('c4-os-snyk-api-token-secret')
         C4_OS_SNYK_ORG_ID = credentials('c4-os-snyk-org-id')
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_USE_CACHE = "corda-remotes"
     }
 
     stages {

--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -54,6 +54,7 @@ pipeline {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_USE_CACHE = "corda-remotes"
         DOCKER_URL = "https://index.docker.io/v1/"
         EMAIL_RECIPIENTS = credentials('corda4-email-recipient')
         SNYK_API_KEY = "c4-os-snyk" //Jenkins credential type: Snyk Api token

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_USE_CACHE = "corda-remotes"
     }
 
     stages {


### PR DESCRIPTION
- add Corda remotes logic to ensure CI uses cached artifacts , thus ensuring we are not susceptible to outages from Gradle / Jcentre etc. 