### PR TITLE
ES-757: remove extra paramater from the calling side of get git log

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
         always {
             script {
                 if (gitUtils.isReleaseTag()) {
-                    gitUtils.getGitLog(env.TAG_NAME, env.GIT_URL.replace('https://github.com/corda/', ''), scm.userRemoteConfigs[0].credentialsId)
+                    gitUtils.getGitLog(env.TAG_NAME, env.GIT_URL.replace('https://github.com/corda/', ''))
                 }
                 try {
                     if (params.DO_TEST) {


### PR DESCRIPTION
Recent refactoring work to `getGitLog` has removed the need for the third parameter here, and as such, implementing code needs to be updated 