### PR TITLE
ENT-4973 Introduce explicit constructors to evolve ReceiveFinalityFlow for binary backwards compatibility

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -484,25 +484,19 @@ object NotarySigCheck {
  * @param statesToRecord Which states to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
  * @param handlePropagatedNotaryError Whether to catch and propagate Double Spend exception to peers.
  */
-class ReceiveFinalityFlow constructor(private val otherSideSession: FlowSession,
-                                      private val expectedTxId: SecureHash? = null,
-                                      private val statesToRecord: StatesToRecord = ONLY_RELEVANT,
-                                      private val handlePropagatedNotaryError: Boolean? = null) : FlowLogic<SignedTransaction>() {
+class ReceiveFinalityFlow(private val otherSideSession: FlowSession,
+                          private val expectedTxId: SecureHash? = null,
+                          private val statesToRecord: StatesToRecord = ONLY_RELEVANT,
+                          private val handlePropagatedNotaryError: Boolean? = null) : FlowLogic<SignedTransaction>() {
+
     @DeprecatedConstructorForDeserialization(version = 1)
-    constructor(otherSideSession: FlowSession,
+    @JvmOverloads constructor(otherSideSession: FlowSession,
                 expectedTxId: SecureHash? = null,
                 statesToRecord: StatesToRecord = ONLY_RELEVANT) : this(otherSideSession, expectedTxId, statesToRecord, null)
 
     @DeprecatedConstructorForDeserialization(version = 1)
     constructor(otherSideSession: FlowSession,
                 statesToRecord: StatesToRecord = ONLY_RELEVANT) : this(otherSideSession, null, statesToRecord, null)
-
-    @DeprecatedConstructorForDeserialization(version = 1)
-    constructor(otherSideSession: FlowSession,
-                expectedTxId: SecureHash) : this(otherSideSession, expectedTxId, ONLY_RELEVANT, null)
-
-    @DeprecatedConstructorForDeserialization(version = 1)
-    constructor(otherSideSession: FlowSession) : this(otherSideSession, null, ONLY_RELEVANT, null)
 
     @Suppress("ComplexMethod", "NestedBlockDepth")
     @Suspendable

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -494,10 +494,6 @@ class ReceiveFinalityFlow(private val otherSideSession: FlowSession,
                 expectedTxId: SecureHash? = null,
                 statesToRecord: StatesToRecord = ONLY_RELEVANT) : this(otherSideSession, expectedTxId, statesToRecord, null)
 
-    @DeprecatedConstructorForDeserialization(version = 1)
-    constructor(otherSideSession: FlowSession,
-                statesToRecord: StatesToRecord = ONLY_RELEVANT) : this(otherSideSession, null, statesToRecord, null)
-
     @Suppress("ComplexMethod", "NestedBlockDepth")
     @Suspendable
     override fun call(): SignedTransaction {

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -16,6 +16,7 @@ import net.corda.core.internal.telemetry.telemetryServiceInternal
 import net.corda.core.internal.warnOnce
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.StatesToRecord.ONLY_RELEVANT
+import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
@@ -483,10 +484,26 @@ object NotarySigCheck {
  * @param statesToRecord Which states to commit to the vault. Defaults to [StatesToRecord.ONLY_RELEVANT].
  * @param handlePropagatedNotaryError Whether to catch and propagate Double Spend exception to peers.
  */
-class ReceiveFinalityFlow @JvmOverloads constructor(private val otherSideSession: FlowSession,
-                                                    private val expectedTxId: SecureHash? = null,
-                                                    private val statesToRecord: StatesToRecord = ONLY_RELEVANT,
-                                                    private val handlePropagatedNotaryError: Boolean? = null) : FlowLogic<SignedTransaction>() {
+class ReceiveFinalityFlow constructor(private val otherSideSession: FlowSession,
+                                      private val expectedTxId: SecureHash? = null,
+                                      private val statesToRecord: StatesToRecord = ONLY_RELEVANT,
+                                      private val handlePropagatedNotaryError: Boolean? = null) : FlowLogic<SignedTransaction>() {
+    @DeprecatedConstructorForDeserialization(version = 1)
+    constructor(otherSideSession: FlowSession,
+                expectedTxId: SecureHash? = null,
+                statesToRecord: StatesToRecord = ONLY_RELEVANT) : this(otherSideSession, expectedTxId, statesToRecord, null)
+
+    @DeprecatedConstructorForDeserialization(version = 1)
+    constructor(otherSideSession: FlowSession,
+                statesToRecord: StatesToRecord = ONLY_RELEVANT) : this(otherSideSession, null, statesToRecord, null)
+
+    @DeprecatedConstructorForDeserialization(version = 1)
+    constructor(otherSideSession: FlowSession,
+                expectedTxId: SecureHash) : this(otherSideSession, expectedTxId, ONLY_RELEVANT, null)
+
+    @DeprecatedConstructorForDeserialization(version = 1)
+    constructor(otherSideSession: FlowSession) : this(otherSideSession, null, ONLY_RELEVANT, null)
+
     @Suppress("ComplexMethod", "NestedBlockDepth")
     @Suspendable
     override fun call(): SignedTransaction {


### PR DESCRIPTION
QA team reported issue with backwards compatibility in HC01.

Specifically, a CorDapp that has not been re-compiled with HC01 throws a constructor initialisation error:

```
java.lang.NoSuchMethodError: net.corda.core.flows.ReceiveFinalityFlow.<init>(Lnet/corda/core/flows/FlowSession;Lnet/corda/core/crypto/SecureHash;Lnet/corda/core/node/StatesToRecord;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
	at net.craft.cordapp.attachment.flows.SendAttachmentResponder.call(SendAttachment.kt:92) ~[?:?]
	at net.craft.cordapp.attachment.flows.SendAttachmentResponder.call(SendAttachment.kt:79) ~[?:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:366) ~[corda-node-4.11-HC01.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:79) ~[corda-node-4.11-HC01.jar:?]
	at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1108) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:804) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:103) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:94) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_352]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_352]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_352]
[INFO ] 2023-06-22T09:39:15,072Z [flow-worker] statemachine.StaffedFlowHospital. - Flow error allowed to propagate {fiber-id=10000001, flow-id=7bffd19a-3c64-4781-af57-98e6fbbc35fb, invocation_id=4bcbcc75-8303-4fa7-a3d5-d97fd192ba65, invocation_timestamp=2023-06-22T09:39:13.944Z, origin=OU=CRAFT-craft-hcpu-spot447a10, O=PartyA-58ded4c3-96d3-4477-ab30-1d84226baf87, L=London, C=GB, session_id=4bcbcc75-8303-4fa7-a3d5-d97fd192ba65, session_timestamp=2023-06-22T09:39:13.944Z, thread-id=208, tx_id=12470A30993BBDA7A5F4D8F424858C004F1E250EF4EB5758950D07B41D2C59D5}
java.lang.NoSuchMethodError: net.corda.core.flows.ReceiveFinalityFlow.<init>(Lnet/corda/core/flows/FlowSession;Lnet/corda/core/crypto/SecureHash;Lnet/corda/core/node/StatesToRecord;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
	at net.craft.cordapp.attachment.flows.SendAttachmentResponder.call(SendAttachment.kt:92) ~[?:?]
	at net.craft.cordapp.attachment.flows.SendAttachmentResponder.call(SendAttachment.kt:79) ~[?:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:366) ~[corda-node-4.11-HC01.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:79) ~[corda-node-4.11-HC01.jar:?]
	at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1108) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:804) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:103) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:94) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_352]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_352]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_352]
```