### PR TITLE
ENT-9927 Ledger Recovery: fix incorrect recording of StatesToRecord.

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2543,18 +2543,14 @@ public interface net.corda.core.flows.Destination
 ##
 @CordaSerializable
 public final class net.corda.core.flows.DistributionList extends java.lang.Object
-  public <init>(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
+  public <init>(java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
   @NotNull
-  public final net.corda.core.node.StatesToRecord component1()
+  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> component1()
   @NotNull
-  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> component2()
-  @NotNull
-  public final net.corda.core.flows.DistributionList copy(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
+  public final net.corda.core.flows.DistributionList copy(java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
   public boolean equals(Object)
   @NotNull
   public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> getPeersToStatesToRecord()
-  @NotNull
-  public final net.corda.core.node.StatesToRecord getSenderStatesToRecord()
   public int hashCode()
   @NotNull
   public String toString()
@@ -3293,6 +3289,15 @@ public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flo
 ##
 public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<? extends net.corda.core.flows.FlowSession>, java.util.Set<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord)
+  @NotNull
+  public final java.util.Set<net.corda.core.flows.FlowSession> getObserverSessions()
+  @NotNull
+  public final java.util.Set<net.corda.core.flows.FlowSession> getParticipantSessions()
+  @NotNull
+  public final net.corda.core.node.StatesToRecord getSenderStatesToRecord()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getStx()
   public static final net.corda.core.flows.SendTransactionFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.SendTransactionFlow$Companion extends java.lang.Object
@@ -3336,16 +3341,20 @@ public static final class net.corda.core.flows.SignTransactionFlow$Companion$VER
 ##
 @CordaSerializable
 public final class net.corda.core.flows.SignedTransactionWithDistributionList extends java.lang.Object
-  public <init>(net.corda.core.transactions.SignedTransaction, byte[])
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.node.StatesToRecord, byte[])
   @NotNull
   public final net.corda.core.transactions.SignedTransaction component1()
   @NotNull
-  public final byte[] component2()
+  public final net.corda.core.node.StatesToRecord component2()
   @NotNull
-  public final net.corda.core.flows.SignedTransactionWithDistributionList copy(net.corda.core.transactions.SignedTransaction, byte[])
+  public final byte[] component3()
+  @NotNull
+  public final net.corda.core.flows.SignedTransactionWithDistributionList copy(net.corda.core.transactions.SignedTransaction, net.corda.core.node.StatesToRecord, byte[])
   public boolean equals(Object)
   @NotNull
   public final byte[] getDistributionList()
+  @NotNull
+  public final net.corda.core.node.StatesToRecord getSenderStatesToRecord()
   @NotNull
   public final net.corda.core.transactions.SignedTransaction getStx()
   public int hashCode()
@@ -3425,18 +3434,22 @@ public class net.corda.core.flows.StateReplacementException extends net.corda.co
 ##
 @CordaSerializable
 public final class net.corda.core.flows.TransactionMetadata extends java.lang.Object
-  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord, net.corda.core.flows.DistributionList)
   @NotNull
   public final net.corda.core.identity.CordaX500Name component1()
   @NotNull
-  public final net.corda.core.flows.DistributionList component2()
+  public final net.corda.core.node.StatesToRecord component2()
   @NotNull
-  public final net.corda.core.flows.TransactionMetadata copy(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
+  public final net.corda.core.flows.DistributionList component3()
+  @NotNull
+  public final net.corda.core.flows.TransactionMetadata copy(net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord, net.corda.core.flows.DistributionList)
   public boolean equals(Object)
   @NotNull
   public final net.corda.core.flows.DistributionList getDistributionList()
   @NotNull
   public final net.corda.core.identity.CordaX500Name getInitiator()
+  @NotNull
+  public final net.corda.core.node.StatesToRecord getSenderStatesToRecord()
   public int hashCode()
   @NotNull
   public String toString()

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -354,11 +354,10 @@ class FinalityFlowTests : WithFinality {
 
         getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(1, this.size)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[0].receiverStatesToRecord)
             assertEquals(BOB_NAME.hashCode().toLong(), this[0].peerPartyId)
         }
         getReceiverRecoveryData(stx.id, bobNode.database).apply {
-            assertEquals(StatesToRecord.ALL_VISIBLE, this?.statesToRecord)
             assertEquals(StatesToRecord.ONLY_RELEVANT, this?.senderStatesToRecord)
             assertEquals(aliceNode.info.singleIdentity().name.hashCode().toLong(), this?.initiatorPartyId)
             assertEquals(mapOf(BOB_NAME.hashCode().toLong() to StatesToRecord.ALL_VISIBLE), this?.peersToStatesToRecord)
@@ -385,13 +384,12 @@ class FinalityFlowTests : WithFinality {
 
         getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(2, this.size)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].receiverStatesToRecord)
             assertEquals(BOB_NAME.hashCode().toLong(), this[0].peerPartyId)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[1].statesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[1].receiverStatesToRecord)
             assertEquals(CHARLIE_NAME.hashCode().toLong(), this[1].peerPartyId)
         }
         getReceiverRecoveryData(stx.id, bobNode.database).apply {
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.statesToRecord)
             assertEquals(StatesToRecord.ONLY_RELEVANT, this?.senderStatesToRecord)
             assertEquals(aliceNode.info.singleIdentity().name.hashCode().toLong(), this?.initiatorPartyId)
             // note: Charlie assertion here is using the hinted StatesToRecord value passed to it from Alice
@@ -430,11 +428,10 @@ class FinalityFlowTests : WithFinality {
 
         getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(1, this.size)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].receiverStatesToRecord)
             assertEquals(BOB_NAME.hashCode().toLong(), this[0].peerPartyId)
         }
         getReceiverRecoveryData(stx.id, bobNode.database).apply {
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.statesToRecord)
             assertEquals(StatesToRecord.ONLY_RELEVANT, this?.senderStatesToRecord)
             assertEquals(aliceNode.info.singleIdentity().name.hashCode().toLong(), this?.initiatorPartyId)
             assertEquals(mapOf(BOB_NAME.hashCode().toLong() to StatesToRecord.ONLY_RELEVANT), this?.peersToStatesToRecord)

--- a/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
@@ -24,12 +24,12 @@ data class FlowTransactionInfo(
 @CordaSerializable
 data class TransactionMetadata(
     val initiator: CordaX500Name,
+    val senderStatesToRecord: StatesToRecord,
     val distributionList: DistributionList
 )
 
 @CordaSerializable
 data class DistributionList(
-    val senderStatesToRecord: StatesToRecord,
     val peersToStatesToRecord: Map<CordaX500Name, StatesToRecord>
 )
 

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -62,7 +62,12 @@ open class ReceiveTransactionFlow constructor(private val otherSideSession: Flow
         val payload = otherSideSession.receive<Any>().unwrap { it }
         val stx =
             if (payload is SignedTransactionWithDistributionList) {
-                (serviceHub as ServiceHubCoreInternal).recordReceiverTransactionRecoveryMetadata(payload.stx.id, otherSideSession.counterparty.name, ourIdentity.name, statesToRecord, payload.distributionList)
+                (serviceHub as ServiceHubCoreInternal).recordReceiverTransactionRecoveryMetadata(
+                        payload.stx.id,
+                        otherSideSession.counterparty.name,
+                        ourIdentity.name,
+                        payload.senderStatesToRecord,
+                        payload.distributionList)
                 payload.stx
             } else payload as SignedTransaction
         stx.pushToLoggingContext()

--- a/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ServiceHubCoreInternal.kt
@@ -79,10 +79,10 @@ interface ServiceHubCoreInternal : ServiceHub {
      * @param txnId The SecureHash of a transaction.
      * @param sender The sender of the transaction.
      * @param receiver The receiver of the transaction.
-     * @param receiverStatesToRecord The StatesToRecord value of the receiver.
+     * @param senderStatesToRecord The StatesToRecord value of the sender.
      * @param encryptedDistributionList encrypted distribution list (hashed peers -> StatesToRecord values)
      */
-    fun recordReceiverTransactionRecoveryMetadata(txnId: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, receiverStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray)
+    fun recordReceiverTransactionRecoveryMetadata(txnId: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, senderStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray)
 }
 
 interface TransactionsResolver {

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -384,10 +384,10 @@ interface WritableTransactionStorage : TransactionStorage {
      * @param id The SecureHash of a transaction.
      * @param sender The sender of the transaction.
      * @param receiver The receiver of the transaction.
-     * @param receiverStatesToRecord The StatesToRecord value of the receiver.
+     * @param senderStatesToRecord The StatesToRecord value of the receiver.
      * @param encryptedDistributionList encrypted distribution list (hashed peers -> StatesToRecord values)
      */
-    fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, receiverStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray)
+    fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, senderStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray)
 
     /**
      * Removes an un-notarised transaction (with a status of *MISSING_TRANSACTION_SIG*) from the data store.

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -198,8 +198,8 @@ interface ServiceHubInternal : ServiceHubCoreInternal {
     override fun recordSenderTransactionRecoveryMetadata(txnId: SecureHash, txnMetadata: TransactionMetadata) =
         validatedTransactions.addSenderTransactionRecoveryMetadata(txnId, txnMetadata)
 
-    override fun recordReceiverTransactionRecoveryMetadata(txnId: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, receiverStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) =
-            validatedTransactions.addReceiverTransactionRecoveryMetadata(txnId, sender, receiver, receiverStatesToRecord, encryptedDistributionList)
+    override fun recordReceiverTransactionRecoveryMetadata(txnId: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, senderStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) =
+            validatedTransactions.addReceiverTransactionRecoveryMetadata(txnId, sender, receiver, senderStatesToRecord, encryptedDistributionList)
 
     @Suppress("NestedBlockDepth")
     @VisibleForTesting

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -217,7 +217,7 @@ open class DBTransactionStorage(private val database: CordaPersistence, cacheFac
 
     override fun addSenderTransactionRecoveryMetadata(id: SecureHash, metadata: TransactionMetadata): ByteArray? { return null }
 
-    override fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, receiverStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) { }
+    override fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, senderStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) { }
 
     override fun finalizeTransaction(transaction: SignedTransaction) =
             addTransaction(transaction) {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
@@ -61,7 +61,7 @@ class DBTransactionStorageLedgerRecovery(private val database: CordaPersistence,
             val receiverPartyId: Long,
 
             /** states to record: NONE, ALL_VISIBLE, ONLY_RELEVANT */
-            @Column(name = "states_to_record", nullable = false)
+            @Column(name = "receiver_states_to_record", nullable = false)
             var receiverStatesToRecord: StatesToRecord
 
     ) {
@@ -87,14 +87,15 @@ class DBTransactionStorageLedgerRecovery(private val database: CordaPersistence,
             @Column(name = "sender_party_id", nullable = true)
             val senderPartyId: Long,
 
+            /** states to record: NONE, ALL_VISIBLE, ONLY_RELEVANT */
+            @Column(name = "sender_states_to_record", nullable = false)
+            val senderStatesToRecord: StatesToRecord,
+
             /** Encrypted recovery information for sole use by Sender **/
             @Lob
             @Column(name = "distribution_list", nullable = false)
-            val distributionList: ByteArray,
+            val distributionList: ByteArray
 
-            /** states to record: NONE, ALL_VISIBLE, ONLY_RELEVANT */
-            @Column(name = "receiver_states_to_record", nullable = false)
-            val senderStatesToRecord: StatesToRecord
 ) {
         constructor(key: Key, txId: SecureHash, initiatorPartyId: Long, encryptedDistributionList: ByteArray, senderStatesToRecord: StatesToRecord) :
             this(PersistentKey(key),

--- a/node/src/main/resources/migration/node-core.changelog-v25.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v25.xml
@@ -24,7 +24,7 @@
             <column name="receiver_party_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="states_to_record" type="INT">
+            <column name="receiver_states_to_record" type="INT">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -57,10 +57,10 @@
             <column name="sender_party_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="distribution_list" type="BLOB">
+            <column name="sender_states_to_record" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="receiver_states_to_record" type="INT">
+            <column name="distribution_list" type="BLOB">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -816,9 +816,9 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             }
         }
 
-        override fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, receiverStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) {
+        override fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, senderStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) {
             database.transaction {
-                delegate.addReceiverTransactionRecoveryMetadata(id, sender, receiver, receiverStatesToRecord, encryptedDistributionList)
+                delegate.addReceiverTransactionRecoveryMetadata(id, sender, receiver, senderStatesToRecord, encryptedDistributionList)
             }
         }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -84,7 +84,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         val beforeFirstTxn = now()
         val txn = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(txn.id, TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(BOB_NAME to ONLY_RELEVANT))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(txn.id, TransactionMetadata(ALICE_NAME, ALL_VISIBLE, DistributionList(mapOf(BOB_NAME to ONLY_RELEVANT))))
         val timeWindow = RecoveryTimeWindow(fromTime = beforeFirstTxn,
                                             untilTime = beforeFirstTxn.plus(1, ChronoUnit.MINUTES))
         val results = transactionRecovery.querySenderDistributionRecords(timeWindow)
@@ -93,7 +93,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         val afterFirstTxn = now()
         val txn2 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn2)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(txn2.id, TransactionMetadata(ALICE_NAME, DistributionList(ONLY_RELEVANT, mapOf(CHARLIE_NAME to ONLY_RELEVANT))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(txn2.id, TransactionMetadata(ALICE_NAME, ONLY_RELEVANT, DistributionList(mapOf(CHARLIE_NAME to ONLY_RELEVANT))))
         assertEquals(2, transactionRecovery.querySenderDistributionRecords(timeWindow).size)
         assertEquals(1, transactionRecovery.querySenderDistributionRecords(RecoveryTimeWindow(fromTime = afterFirstTxn)).size)
     }
@@ -102,10 +102,10 @@ class DBTransactionStorageLedgerRecoveryTests {
     fun `query local ledger for transactions within timeWindow and excluding remoteTransactionIds`() {
         val transaction1 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(transaction1)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction1.id, TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(BOB_NAME to ONLY_RELEVANT))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction1.id, TransactionMetadata(ALICE_NAME, ALL_VISIBLE, DistributionList(mapOf(BOB_NAME to ONLY_RELEVANT))))
         val transaction2 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(transaction2)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction2.id, TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(BOB_NAME to ONLY_RELEVANT))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction2.id, TransactionMetadata(ALICE_NAME, ALL_VISIBLE, DistributionList(mapOf(BOB_NAME to ONLY_RELEVANT))))
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         val results = transactionRecovery.querySenderDistributionRecords(timeWindow, excludingTxnIds = setOf(transaction1.id))
         assertEquals(1, results.size)
@@ -116,22 +116,22 @@ class DBTransactionStorageLedgerRecoveryTests {
         val transaction1 = newTransaction()
         // sender txn
         transactionRecovery.addUnnotarisedTransaction(transaction1)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction1.id, TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(BOB_NAME to ALL_VISIBLE))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction1.id, TransactionMetadata(ALICE_NAME, ALL_VISIBLE, DistributionList(mapOf(BOB_NAME to ALL_VISIBLE))))
         val transaction2 = newTransaction()
         // receiver txn
         transactionRecovery.addUnnotarisedTransaction(transaction2)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(transaction2.id, BOB_NAME, ALICE_NAME, ALL_VISIBLE,
-                DistributionList(ONLY_RELEVANT, mapOf(ALICE_NAME to ALL_VISIBLE)).toWire())
+                DistributionList(mapOf(ALICE_NAME to ALL_VISIBLE)).toWire())
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.SENDER).let {
             assertEquals(1, it.size)
             assertEquals(BOB_NAME.hashCode().toLong(), (it[0] as SenderDistributionRecord).peerPartyId)
-            assertEquals(ALL_VISIBLE, (it[0] as SenderDistributionRecord).statesToRecord)
+            assertEquals(ALL_VISIBLE, (it[0] as SenderDistributionRecord).receiverStatesToRecord)
         }
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.RECEIVER).let {
             assertEquals(1, it.size)
             assertEquals(BOB_NAME.hashCode().toLong(), (it[0] as ReceiverDistributionRecord).initiatorPartyId)
-            assertEquals(ALL_VISIBLE, (it[0] as ReceiverDistributionRecord).statesToRecord)
+            assertEquals(ALL_VISIBLE, (it[0] as ReceiverDistributionRecord).senderStatesToRecord)
         }
         val resultsAll = transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.ALL)
         assertEquals(2, resultsAll.size)
@@ -141,26 +141,26 @@ class DBTransactionStorageLedgerRecoveryTests {
     fun `query for sender distribution records by peers`() {
         val txn1 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn1)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(txn1.id, TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(BOB_NAME to ALL_VISIBLE))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(txn1.id, TransactionMetadata(ALICE_NAME, ALL_VISIBLE, DistributionList(mapOf(BOB_NAME to ALL_VISIBLE))))
         val txn2 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn2)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(txn2.id, TransactionMetadata(ALICE_NAME, DistributionList(ONLY_RELEVANT, mapOf(CHARLIE_NAME to ONLY_RELEVANT))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(txn2.id, TransactionMetadata(ALICE_NAME, ONLY_RELEVANT, DistributionList(mapOf(CHARLIE_NAME to ONLY_RELEVANT))))
         val txn3 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn3)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(txn3.id, TransactionMetadata(ALICE_NAME, DistributionList(ONLY_RELEVANT, mapOf(BOB_NAME to ONLY_RELEVANT, CHARLIE_NAME to ALL_VISIBLE))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(txn3.id, TransactionMetadata(ALICE_NAME, ONLY_RELEVANT, DistributionList(mapOf(BOB_NAME to ONLY_RELEVANT, CHARLIE_NAME to ALL_VISIBLE))))
         val txn4 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn4)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(txn4.id, TransactionMetadata(BOB_NAME, DistributionList(ONLY_RELEVANT, mapOf(ALICE_NAME to ONLY_RELEVANT))))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(txn4.id, TransactionMetadata(BOB_NAME, ONLY_RELEVANT, DistributionList(mapOf(ALICE_NAME to ONLY_RELEVANT))))
         val txn5 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn5)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(txn5.id, TransactionMetadata(CHARLIE_NAME, DistributionList(ONLY_RELEVANT, emptyMap())))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(txn5.id, TransactionMetadata(CHARLIE_NAME, ONLY_RELEVANT, DistributionList(emptyMap())))
         assertEquals(5, readSenderDistributionRecordFromDB().size)
 
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(BOB_NAME)).let {
             assertEquals(2, it.size)
-            assertEquals(it[0].statesToRecord, ALL_VISIBLE)
-            assertEquals(it[1].statesToRecord, ONLY_RELEVANT)
+            assertEquals(it[0].receiverStatesToRecord, ALL_VISIBLE)
+            assertEquals(it[1].receiverStatesToRecord, ONLY_RELEVANT)
         }
         assertEquals(1, transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(ALICE_NAME)).size)
         assertEquals(2, transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(CHARLIE_NAME)).size)
@@ -171,30 +171,30 @@ class DBTransactionStorageLedgerRecoveryTests {
         val txn1 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn1)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(txn1.id, ALICE_NAME, BOB_NAME, ALL_VISIBLE,
-                DistributionList(ONLY_RELEVANT, mapOf(BOB_NAME to ALL_VISIBLE, CHARLIE_NAME to ALL_VISIBLE)).toWire())
+                DistributionList(mapOf(BOB_NAME to ALL_VISIBLE, CHARLIE_NAME to ALL_VISIBLE)).toWire())
         val txn2 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn2)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(txn2.id, ALICE_NAME, BOB_NAME, ONLY_RELEVANT,
-                DistributionList(ONLY_RELEVANT, mapOf(BOB_NAME to ONLY_RELEVANT)).toWire())
+                DistributionList(mapOf(BOB_NAME to ONLY_RELEVANT)).toWire())
         val txn3 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn3)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(txn3.id, ALICE_NAME, CHARLIE_NAME, NONE,
-                DistributionList(ONLY_RELEVANT, mapOf(CHARLIE_NAME to NONE)).toWire())
+                DistributionList(mapOf(CHARLIE_NAME to NONE)).toWire())
         val txn4 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn4)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(txn4.id, BOB_NAME, ALICE_NAME, ONLY_RELEVANT,
-                DistributionList(ONLY_RELEVANT, mapOf(ALICE_NAME to ALL_VISIBLE)).toWire())
+                DistributionList(mapOf(ALICE_NAME to ALL_VISIBLE)).toWire())
         val txn5 = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(txn5)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(txn5.id, CHARLIE_NAME, BOB_NAME, ONLY_RELEVANT,
-                DistributionList(ONLY_RELEVANT, mapOf(BOB_NAME to ONLY_RELEVANT)).toWire())
+                DistributionList(mapOf(BOB_NAME to ONLY_RELEVANT)).toWire())
 
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.queryReceiverDistributionRecords(timeWindow, initiators = setOf(ALICE_NAME)).let {
             assertEquals(3, it.size)
-            assertEquals(it[0].statesToRecord, ALL_VISIBLE)
-            assertEquals(it[1].statesToRecord, ONLY_RELEVANT)
-            assertEquals(it[2].statesToRecord, NONE)
+            assertEquals(it[0].senderStatesToRecord, ALL_VISIBLE)
+            assertEquals(it[1].senderStatesToRecord, ONLY_RELEVANT)
+            assertEquals(it[2].senderStatesToRecord, NONE)
         }
         assertEquals(1, transactionRecovery.queryReceiverDistributionRecords(timeWindow, initiators = setOf(BOB_NAME)).size)
         assertEquals(1, transactionRecovery.queryReceiverDistributionRecords(timeWindow, initiators = setOf(CHARLIE_NAME)).size)
@@ -205,7 +205,7 @@ class DBTransactionStorageLedgerRecoveryTests {
     fun `transaction without peers does not store recovery metadata in database`() {
         val senderTransaction = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(senderTransaction)
-        transactionRecovery.addSenderTransactionRecoveryMetadata(senderTransaction.id, TransactionMetadata(ALICE_NAME, DistributionList(ONLY_RELEVANT, emptyMap())))
+        transactionRecovery.addSenderTransactionRecoveryMetadata(senderTransaction.id, TransactionMetadata(ALICE_NAME, ONLY_RELEVANT, DistributionList(emptyMap())))
         assertEquals(IN_FLIGHT, readTransactionFromDB(senderTransaction.id).status)
         assertEquals(0, readSenderDistributionRecordFromDB(senderTransaction.id).size)
     }
@@ -215,22 +215,21 @@ class DBTransactionStorageLedgerRecoveryTests {
         val senderTransaction = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(senderTransaction)
         transactionRecovery.addSenderTransactionRecoveryMetadata(senderTransaction.id,
-                TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(BOB_NAME to ALL_VISIBLE))))
+                TransactionMetadata(ALICE_NAME, ALL_VISIBLE, DistributionList(mapOf(BOB_NAME to ALL_VISIBLE))))
         assertEquals(IN_FLIGHT, readTransactionFromDB(senderTransaction.id).status)
         readSenderDistributionRecordFromDB(senderTransaction.id).let {
             assertEquals(1, it.size)
-            assertEquals(ALL_VISIBLE, it[0].statesToRecord)
+            assertEquals(ALL_VISIBLE, it[0].receiverStatesToRecord)
             assertEquals(BOB_NAME, partyInfoCache.getCordaX500NameByPartyId(it[0].peerPartyId))
         }
 
         val receiverTransaction = newTransaction()
         transactionRecovery.addUnnotarisedTransaction(receiverTransaction)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(receiverTransaction.id, ALICE_NAME, BOB_NAME, ALL_VISIBLE,
-                DistributionList(ONLY_RELEVANT, mapOf(BOB_NAME to ALL_VISIBLE)).toWire())
+                DistributionList(mapOf(BOB_NAME to ALL_VISIBLE)).toWire())
         assertEquals(IN_FLIGHT, readTransactionFromDB(receiverTransaction.id).status)
         readReceiverDistributionRecordFromDB(receiverTransaction.id).let {
-            assertEquals(ALL_VISIBLE, it.statesToRecord)
-            assertEquals(ONLY_RELEVANT, it.senderStatesToRecord)
+            assertEquals(ALL_VISIBLE, it.senderStatesToRecord)
             assertEquals(ALICE_NAME, partyInfoCache.getCordaX500NameByPartyId(it.initiatorPartyId))
             assertEquals(setOf(BOB_NAME), it.peersToStatesToRecord.map { (peer, _) -> partyInfoCache.getCordaX500NameByPartyId(peer) }.toSet() )
         }
@@ -241,11 +240,11 @@ class DBTransactionStorageLedgerRecoveryTests {
         val transaction = newTransaction(notarySig = false)
         transactionRecovery.finalizeTransaction(transaction)
         transactionRecovery.addSenderTransactionRecoveryMetadata(transaction.id,
-                TransactionMetadata(ALICE_NAME, DistributionList(ONLY_RELEVANT, mapOf(CHARLIE_NAME to ALL_VISIBLE))))
+                TransactionMetadata(ALICE_NAME, ONLY_RELEVANT, DistributionList(mapOf(CHARLIE_NAME to ALL_VISIBLE))))
         assertEquals(VERIFIED, readTransactionFromDB(transaction.id).status)
         readSenderDistributionRecordFromDB(transaction.id).apply {
             assertEquals(1, this.size)
-            assertEquals(ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(ALL_VISIBLE, this[0].receiverStatesToRecord)
         }
     }
 
@@ -254,7 +253,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         val senderTransaction = newTransaction(notarySig = false)
         transactionRecovery.addUnnotarisedTransaction(senderTransaction)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(senderTransaction.id, ALICE.name, BOB.name, ONLY_RELEVANT,
-                DistributionList(ONLY_RELEVANT, mapOf(BOB.name to ONLY_RELEVANT, CHARLIE_NAME to ONLY_RELEVANT)).toWire())
+                DistributionList(mapOf(BOB.name to ONLY_RELEVANT, CHARLIE_NAME to ONLY_RELEVANT)).toWire())
         assertNull(transactionRecovery.getTransaction(senderTransaction.id))
         assertEquals(IN_FLIGHT, readTransactionFromDB(senderTransaction.id).status)
 
@@ -266,7 +265,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         val receiverTransaction = newTransaction(notarySig = false)
         transactionRecovery.addUnnotarisedTransaction(receiverTransaction)
         transactionRecovery.addReceiverTransactionRecoveryMetadata(receiverTransaction.id, ALICE.name, BOB.name, ONLY_RELEVANT,
-                DistributionList(ONLY_RELEVANT, mapOf(BOB.name to ONLY_RELEVANT)).toWire())
+                DistributionList(mapOf(BOB.name to ONLY_RELEVANT)).toWire())
         assertNull(transactionRecovery.getTransaction(receiverTransaction.id))
         assertEquals(IN_FLIGHT, readTransactionFromDB(receiverTransaction.id).status)
 
@@ -278,8 +277,7 @@ class DBTransactionStorageLedgerRecoveryTests {
 
     @Test(timeout = 300_000)
     fun `test lightweight serialization and deserialization of hashed distribution list payload`() {
-        val dl = HashedDistributionList(ALL_VISIBLE,
-                mapOf(BOB.name.hashCode().toLong() to NONE, CHARLIE_NAME.hashCode().toLong() to ONLY_RELEVANT))
+        val dl = HashedDistributionList(mapOf(BOB.name.hashCode().toLong() to NONE, CHARLIE_NAME.hashCode().toLong() to ONLY_RELEVANT))
         assertEquals(dl, dl.serialize().let { HashedDistributionList.deserialize(it) })
     }
 
@@ -373,7 +371,7 @@ class DBTransactionStorageLedgerRecoveryTests {
     private fun DistributionList.toWire(cryptoService: CryptoService = MockCryptoService(emptyMap())): ByteArray {
         val hashedPeersToStatesToRecord = this.peersToStatesToRecord.map { (peer, statesToRecord) ->
             partyInfoCache.getPartyIdByCordaX500Name(peer) to statesToRecord }.toMap()
-        val hashedDistributionList = HashedDistributionList(this.senderStatesToRecord, hashedPeersToStatesToRecord)
+        val hashedDistributionList = HashedDistributionList(hashedPeersToStatesToRecord)
         return cryptoService.encrypt(hashedDistributionList.serialize())
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt
@@ -63,7 +63,7 @@ open class MockTransactionStorage : WritableTransactionStorage, SingletonSeriali
 
     override fun addSenderTransactionRecoveryMetadata(id: SecureHash, metadata: TransactionMetadata): ByteArray? { return null }
 
-    override fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, receiverStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) { }
+    override fun addReceiverTransactionRecoveryMetadata(id: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, senderStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) { }
 
     override fun removeUnnotarisedTransaction(id: SecureHash): Boolean {
         return txns.remove(id) != null

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -150,7 +150,7 @@ data class TestTransactionDSLInterpreter private constructor(
 
         override fun recordSenderTransactionRecoveryMetadata(txnId: SecureHash, txnMetadata: TransactionMetadata): ByteArray? { return null }
 
-        override fun recordReceiverTransactionRecoveryMetadata(txnId: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, receiverStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) {}
+        override fun recordReceiverTransactionRecoveryMetadata(txnId: SecureHash, sender: CordaX500Name, receiver: CordaX500Name, senderStatesToRecord: StatesToRecord, encryptedDistributionList: ByteArray) {}
     }
 
     private fun copy(): TestTransactionDSLInterpreter =


### PR DESCRIPTION
Plus small clean-up of Distribution List: move `SenderStatesToRecord` outside of DL.