### PR TITLE
ENT-9927 Ledger Recovery tweaks

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -283,7 +283,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
             try {
                 logger.debug { "Sending transaction to party sessions: $sessions." }
                 val (participantSessions, observerSessions) = deriveSessions(sessions)
-                subFlow(SendTransactionFlow(tx, participantSessions, observerSessions, statesToRecord))
+                subFlow(SendTransactionFlow(tx, participantSessions, observerSessions, statesToRecord, true))
             } catch (e: UnexpectedFlowEndException) {
                 throw UnexpectedFlowEndException(
                         "One of the sessions ${sessions.map { it.counterparty }} has finished prematurely and we're trying to send them a transaction." +
@@ -367,7 +367,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
                 oldV3Broadcast(tx, oldParticipants.toSet())
                 try {
                     logger.debug { "Sending transaction to party sessions $sessions." }
-                    subFlow(SendTransactionFlow(tx, sessions.toSet(), emptySet(), statesToRecord))
+                    subFlow(SendTransactionFlow(tx, sessions.toSet(), emptySet(), statesToRecord, true))
                 } catch (e: UnexpectedFlowEndException) {
                     throw UnexpectedFlowEndException(
                             "One of the sessions ${sessions.map { it.counterparty }} has finished prematurely and we're trying to send them the finalised transaction. " +

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -83,32 +83,38 @@ class MaybeSerializedSignedTransaction(override val id: SecureHash, val serializ
 open class SendTransactionFlow(val stx: SignedTransaction,
                                val participantSessions: Set<FlowSession>,
                                val observerSessions: Set<FlowSession>,
-                               val senderStatesToRecord: StatesToRecord,
-                               recordMetaDataEvenIfNotFullySigned: Boolean = false) : DataVendingFlow(participantSessions + observerSessions, stx,
-                                   TransactionMetadata(DUMMY_PARTICIPANT_NAME,
-                                       DistributionList(senderStatesToRecord,
-                                       (participantSessions.map { it.counterparty.name to StatesToRecord.ONLY_RELEVANT}).toMap() +
-                                                           (observerSessions.map { it.counterparty.name to StatesToRecord.ALL_VISIBLE}).toMap()
-                                   )), recordMetaDataEvenIfNotFullySigned(stx)) {
+                               val senderStatesToRecord: StatesToRecord)
+    : DataVendingFlow(participantSessions + observerSessions, stx,
+        makeMetaData(senderStatesToRecord, participantSessions, observerSessions),
+        recordMetaDataEvenIfNotFullySigned(stx)) {
+
     constructor(otherSide: FlowSession, stx: SignedTransaction) : this(stx, setOf(otherSide), emptySet(), StatesToRecord.NONE)
+
     // Note: DUMMY_PARTICIPANT_NAME to be substituted with actual "ourIdentity.name" in flow call()
     companion object {
         val DUMMY_PARTICIPANT_NAME = CordaX500Name("Transaction Participant", "London", "GB")
-    }
-}
 
-private operator fun Boolean.invoke(stx: SignedTransaction): Boolean {
-    return try {
-        val notary = stx.tx.notary
-        // The notary signature(s) are allowed to be missing but no others.
-        if (notary != null) stx.verifySignaturesExcept(notary.owningKey) else stx.verifyRequiredSignatures()
-        true
-    }
-    catch (e: SignedTransaction.SignaturesMissingException) {
-        false
-    }
-    catch (e: SignatureException) {
-        false
+        fun makeMetaData(senderStatesToRecord: StatesToRecord, participantSessions: Set<FlowSession>, observerSessions: Set<FlowSession>): TransactionMetadata {
+            return TransactionMetadata(DUMMY_PARTICIPANT_NAME,
+                    DistributionList(senderStatesToRecord,
+                            (participantSessions.map { it.counterparty.name to StatesToRecord.ONLY_RELEVANT}).toMap() +
+                                    (observerSessions.map { it.counterparty.name to StatesToRecord.ALL_VISIBLE}).toMap()))
+        }
+
+        fun recordMetaDataEvenIfNotFullySigned(stx: SignedTransaction): Boolean {
+            return try {
+                val notary = stx.tx.notary
+                // The notary signature(s) are allowed to be missing but no others.
+                if (notary != null) stx.verifySignaturesExcept(notary.owningKey) else stx.verifyRequiredSignatures()
+                true
+            }
+            catch (e: SignedTransaction.SignaturesMissingException) {
+                false
+            }
+            catch (e: SignatureException) {
+                false
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Tweak `SendTransactionFlow` to prevent recording recovery metadata for a transaction that is not fully signed (eg. in `CollectSignaturesFlow`)