### PR TITLE
ES-839: Disable Internal docker publishing for 4.7 ( only supported post 4.9 pacthes)

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -279,7 +279,7 @@ pipeline {
 
         stage('Publish Release Candidate to Internal Repository') {
             when {
-                expression { isReleaseCandidate }
+                expression { return false} // keeping stage to preserve Jenkins history on release branches, but not supported for patch builds pre 4.9
             }
             steps {
                 withCredentials([

--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM azul/zulu-openjdk:8u192
 
+## Remove Azul Zulu repo, as it is gone by now
+RUN rm /etc/apt/sources.list.d/zulu.list
+
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \
     apt-get -y upgrade && \


### PR DESCRIPTION
- Disable Jenkins stage for internal docker publishing, not required pre 4.9 plus image production is broken on these streams.

Also, remove redundant repo which blocks image building currently should anyone wish to build these locally on this stream.