### PR TITLE
ES-757: ensure correct method is called with extra paramater

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
         always {
             script {
                 if (gitUtils.isReleaseTag()) {
-                    gitUtils.getGitLog(env.TAG_NAME, env.GIT_URL.replace('https://github.com/corda/', ''))
+                    gitUtils.getGitLog(env.TAG_NAME, env.GIT_URL.replace('https://github.com/corda/', ''), scm.userRemoteConfigs[0].credentialsId)
                 }
                 try {
                     if (params.DO_TEST) {


### PR DESCRIPTION
While C4 stays on the 5.0 version of the shared library we must pass all 3 parameters to `gitUtils.getGitLog`

Later versions of the shared library have refactored this method to remove the third property, this change was previously applied to 4.6, but pulling this out for now and reverting to 5.0 as the default version for C4 builds