### PR TITLE
ES-839: fix for dropping Zulu repository

### DIFF
--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM azul/zulu-openjdk:8u192
 
 ## Remove Azul Zulu repo, as it is gone by now
-RUN rm /etc/apt/sources.list.d/zulu.list
+RUN rm -rf /etc/apt/sources.list.d/zulu.list
 
 ## Add packages, clean cache, create dirs, create corda user and change ownership
 RUN apt-get update && \


### PR DESCRIPTION
* make sure `rm` doesn't fail if the file is not present
* it makes it easier for forward merge to a branch with newer base image without that file
