### PR TITLE
Add Recovery Flows to be ENT aliased (with NO_OP implementations).

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityRecoveryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityRecoveryFlow.kt
@@ -1,0 +1,87 @@
+package net.corda.core.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FinalityFlow.Companion.tracker
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.ProgressTracker
+import java.time.Instant
+
+/**
+ * TWO_PHASE_FINALITY Recovery Flow (available in Enterprise only)
+ */
+@StartableByRPC
+@InitiatingFlow
+class FinalityRecoveryFlow(
+        private val txIds: Collection<SecureHash> = emptySet(),
+        private val flowIds: Collection<StateMachineRunId> = emptySet(),
+        private val matchingCriteria: FlowRecoveryQuery? = null,
+        private val forceRecover: Boolean = false,
+        private val recoverAll: Boolean = false,
+        override val progressTracker: ProgressTracker = ProgressTracker()) : FlowLogic<Map<FlowTransactionInfo, Boolean>>() {
+
+    constructor(txId: SecureHash, forceRecover: Boolean = false) : this(setOf(txId), forceRecover)
+    constructor(txIds: Collection<SecureHash>, forceRecover: Boolean = false, recoverAll: Boolean = false) : this(txIds, emptySet(), null, forceRecover, recoverAll, tracker())
+    constructor(flowId: StateMachineRunId, forceRecover: Boolean = false) : this(emptySet(), setOf(flowId), null, forceRecover)
+    constructor(flowIds: Collection<StateMachineRunId>, forceRecover: Boolean = false) : this(emptySet(), flowIds, null, forceRecover, false, tracker())
+    constructor(recoverAll: Boolean, forceRecover: Boolean = false) : this(emptySet(), emptySet(), null, forceRecover, recoverAll, tracker())
+    constructor(matchingCriteria: FlowRecoveryQuery, forceRecover: Boolean = false) : this(emptySet(), emptySet(), matchingCriteria, forceRecover, false, tracker())
+
+    @Suspendable
+    @Suppress("ComplexMethod")
+    @Throws(FlowRecoveryException::class)
+    override fun call(): Map<FlowTransactionInfo, Boolean> {
+        throw NotImplementedError("Enterprise only feature")
+    }
+}
+
+@CordaSerializable
+class FlowRecoveryException(message: String, cause: Throwable? = null) : FlowException(message, cause) {
+    constructor(txnId: SecureHash, message: String, cause: Throwable? = null) : this("Flow recovery failed for transaction $txnId: $message", cause)
+}
+
+@CordaSerializable
+data class FlowRecoveryQuery(
+        val timeframe: FlowTimeWindow? = null,
+        val initiatedBy: CordaX500Name? = null,
+        val counterParties: List<CordaX500Name>?  = null) {
+    init {
+        require(timeframe != null || initiatedBy != null || counterParties != null) {
+            "Must specify at least one recovery criteria"
+        }
+    }
+}
+
+@CordaSerializable
+data class FlowTimeWindow(val fromTime: Instant? = null, val untilTime: Instant? = null) {
+
+    init {
+        if (fromTime == null && untilTime == null)
+            throw IllegalArgumentException("Must specify one or both of fromTime or/and untilTime")
+        fromTime?.let { startTime ->
+            untilTime?.let { endTime ->
+                if (endTime < startTime) {
+                    throw IllegalArgumentException(FlowTimeWindow::fromTime.name + " must be before or equal to " + FlowTimeWindow::untilTime.name)
+                }
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun between(fromTime: Instant, untilTime: Instant): FlowTimeWindow {
+            return FlowTimeWindow(fromTime, untilTime)
+        }
+
+        @JvmStatic
+        fun fromOnly(fromTime: Instant): FlowTimeWindow {
+            return FlowTimeWindow(fromTime = fromTime)
+        }
+
+        @JvmStatic
+        fun untilOnly(untilTime: Instant): FlowTimeWindow {
+            return FlowTimeWindow(untilTime = untilTime)
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/LedgerRecoverFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/LedgerRecoverFlow.kt
@@ -1,0 +1,79 @@
+package net.corda.core.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.ProgressTracker
+
+/**
+ * Ledger Recovery Flow (available in Enterprise only).
+ */
+@StartableByRPC
+@InitiatingFlow
+class LedgerRecoveryFlow(
+        private val recoveryPeers: Collection<Party>,
+        private val timeWindow: RecoveryTimeWindow,
+        private val useAllNetworkNodes: Boolean = false,
+        private val transactionRole: TransactionRole = TransactionRole.ALL,
+        private val dryRun: Boolean = false,
+        private val optimisticInitiatorRecovery: Boolean = false,
+        override val progressTracker: ProgressTracker = tracker()) : FlowLogic<Map<SecureHash, RecoveryResult>>() {
+
+    // unused constructors added to facilitate Node Shell command invocation
+    constructor(recoveryPeer: Party, timeWindow: RecoveryTimeWindow) : this(setOf(recoveryPeer), timeWindow, false, TransactionRole.ALL, false, false, tracker())
+    constructor(recoveryPeer: Party, timeWindow: RecoveryTimeWindow, dryRun: Boolean) : this(setOf(recoveryPeer), timeWindow, false, TransactionRole.ALL, dryRun, false, tracker())
+
+    constructor(timeWindow: RecoveryTimeWindow, dryRun: Boolean) : this(emptySet(), timeWindow, false, TransactionRole.ALL, dryRun, false, tracker())
+    constructor(timeWindow: RecoveryTimeWindow, dryRun: Boolean, optimisticInitiatorRecovery: Boolean) : this(emptySet(), timeWindow, false, TransactionRole.ALL, dryRun, optimisticInitiatorRecovery, tracker())
+    constructor(recoveryPeers: Collection<Party>, timeWindow: RecoveryTimeWindow, dryRun: Boolean) : this(recoveryPeers, timeWindow, false, TransactionRole.ALL, dryRun, false, tracker())
+    constructor(recoveryPeers: Collection<Party>, timeWindow: RecoveryTimeWindow, dryRun: Boolean, optimisticInitiatorRecovery: Boolean) : this(recoveryPeers, timeWindow, false, TransactionRole.ALL, dryRun, optimisticInitiatorRecovery, tracker())
+
+    companion object {
+        @JvmStatic
+        fun tracker() = ProgressTracker()
+    }
+
+    @Suspendable
+    @Throws(LedgerRecoveryException::class)
+    override fun call(): Map<SecureHash, RecoveryResult> {
+        throw NotImplementedError("Enterprise only feature")
+    }
+}
+
+@InitiatedBy(LedgerRecoveryFlow::class)
+class ReceiveLedgerRecoveryFlow constructor(private val otherSideSession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        throw NotImplementedError("Enterprise only feature")
+    }
+}
+
+@CordaSerializable
+class LedgerRecoveryException(message: String) : FlowException("Ledger recovery failed: $message")
+
+/**
+ * This specifies which type of transactions to recover based on the transaction role of the recovering node
+ */
+@CordaSerializable
+enum class TransactionRole {
+    ALL,
+    INITIATOR,  // only recover transactions that I initiated
+    PEER,       // only recover transactions where I am a participant on a transaction
+    OBSERVER,   // only recover transactions where I am an observer (but not participant) to a transaction
+    PEER_AND_OBSERVER   // recovery transactions where I am either participant or observer
+}
+
+@CordaSerializable
+data class RecoveryResult(
+        val transactionId: SecureHash,
+        val recoveryPeer: CordaX500Name,
+        val transactionRole: TransactionRole,  // what role did I play in this transaction
+        val synchronised: Boolean,   // whether the transaction was successfully synchronised (will always be false when dryRun option specified)
+        val synchronisedInitiated: Boolean = false,    // only attempted if [optimisticInitiatorRecovery] option set to true and [TransactionRecoveryType.INITIATOR]
+        val failureCause: String? = null    // reason why a transaction failed to synchronise
+)
+
+
+


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
