### PR TITLE
ENT-10371: Fix unit test failure in CordaServiceLifecycleTests.

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/CordaServiceLifecycleTests.kt
@@ -156,6 +156,6 @@ class CordaServiceLifecycleTests {
         /**
          * Given an event, was the SMM started when the event was received?
          */
-        fun getSmmStartedForEvent(event: ServiceLifecycleEvent) : Int = smmStateAtEvent.getOrDefault(event, STATE_MACHINE_MANAGER_UNKNOWN_STATUS)
+        fun getSmmStartedForEvent(event: ServiceLifecycleEvent) : Int  = smmStateAtEvent[event] ?: checkSmmStarted()
     }
 }


### PR DESCRIPTION
Fixing up unit test failure, the STATE_MACHINE_STARTED event is dispatched in a separate thread, and may not have been dispatched by the time the check for it is done in the main thread.
