### PR TITLE
ENT-10416: Rename ledger recovery tx_id columns to transaction_id

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -239,7 +239,7 @@ class FinalityFlowTests : WithFinality {
     private fun assertTxnRemovedFromDatabase(node: TestStartedNode, stxId: SecureHash) {
         val fromDb = node.database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where tx_id = :transactionId",
+                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where txId = :transactionId",
                     DBTransactionStorage.DBTransaction::class.java
             ).setParameter("transactionId", stxId.toString()).resultList.map { it }
         }
@@ -444,7 +444,7 @@ class FinalityFlowTests : WithFinality {
     private fun getSenderRecoveryData(id: SecureHash, database: CordaPersistence): List<SenderDistributionRecord> {
         val fromDb = database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorageLedgerRecovery.DBSenderDistributionRecord::class.java.name} where tx_id = :transactionId",
+                    "from ${DBTransactionStorageLedgerRecovery.DBSenderDistributionRecord::class.java.name} where txId = :transactionId",
                     DBTransactionStorageLedgerRecovery.DBSenderDistributionRecord::class.java
             ).setParameter("transactionId", id.toString()).resultList.map { it }
         }
@@ -454,7 +454,7 @@ class FinalityFlowTests : WithFinality {
     private fun getReceiverRecoveryData(id: SecureHash, database: CordaPersistence): ReceiverDistributionRecord? {
         val fromDb = database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorageLedgerRecovery.DBReceiverDistributionRecord::class.java.name} where tx_id = :transactionId",
+                    "from ${DBTransactionStorageLedgerRecovery.DBReceiverDistributionRecord::class.java.name} where txId = :transactionId",
                     DBTransactionStorageLedgerRecovery.DBReceiverDistributionRecord::class.java
             ).setParameter("transactionId", id.toString()).resultList.map { it }
         }

--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -94,7 +94,7 @@ class GetFlowTransaction(private val txId: SecureHash) : FlowLogic<Pair<String, 
                         rs.getString(4)   // TransactionStatus
                     }
                 }
-        val receiverPartyId = serviceHub.jdbcSession().prepareStatement("select * from node_sender_distribution_records where tx_id = ?")
+        val receiverPartyId = serviceHub.jdbcSession().prepareStatement("select * from node_sender_distribution_records where transaction_id = ?")
                 .apply { setString(1, txId.toString()) }
                 .use { ps ->
                     ps.executeQuery().use { rs ->

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
@@ -53,7 +53,7 @@ class DBTransactionStorageLedgerRecovery(private val database: CordaPersistence,
             @EmbeddedId
             var compositeKey: PersistentKey,
 
-            @Column(name = "tx_id", length = 144, nullable = false)
+            @Column(name = "transaction_id", length = 144, nullable = false)
             var txId: String,
 
             /** PartyId of flow peer **/
@@ -80,7 +80,7 @@ class DBTransactionStorageLedgerRecovery(private val database: CordaPersistence,
             @EmbeddedId
             var compositeKey: PersistentKey,
 
-            @Column(name = "tx_id", length = 144, nullable = false)
+            @Column(name = "transaction_id", length = 144, nullable = false)
             var txId: String,
 
             /** PartyId of flow initiator **/

--- a/node/src/main/resources/migration/node-core.changelog-v25.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v25.xml
@@ -18,7 +18,7 @@
             <column name="timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="tx_id" type="NVARCHAR(144)">
+            <column name="transaction_id" type="NVARCHAR(144)">
                 <constraints nullable="false"/>
             </column>
             <column name="receiver_party_id" type="BIGINT">
@@ -51,7 +51,7 @@
             <column name="timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="tx_id" type="NVARCHAR(144)">
+            <column name="transaction_id" type="NVARCHAR(144)">
                 <constraints nullable="false"/>
             </column>
             <column name="sender_party_id" type="BIGINT">

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -286,7 +286,7 @@ class DBTransactionStorageLedgerRecoveryTests {
     private fun readTransactionFromDB(id: SecureHash): DBTransactionStorage.DBTransaction {
         val fromDb = database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where tx_id = :transactionId",
+                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where txId = :transactionId",
                     DBTransactionStorage.DBTransaction::class.java
             ).setParameter("transactionId", id.toString()).resultList.map { it }
         }
@@ -298,7 +298,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         return database.transaction {
             if (id != null)
                 session.createQuery(
-                        "from ${DBTransactionStorageLedgerRecovery.DBSenderDistributionRecord::class.java.name} where tx_id = :transactionId",
+                        "from ${DBTransactionStorageLedgerRecovery.DBSenderDistributionRecord::class.java.name} where txId = :transactionId",
                         DBTransactionStorageLedgerRecovery.DBSenderDistributionRecord::class.java
                 ).setParameter("transactionId", id.toString()).resultList.map { it.toSenderDistributionRecord() }
             else
@@ -312,7 +312,7 @@ class DBTransactionStorageLedgerRecoveryTests {
     private fun readReceiverDistributionRecordFromDB(id: SecureHash): ReceiverDistributionRecord {
         val fromDb = database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorageLedgerRecovery.DBReceiverDistributionRecord::class.java.name} where tx_id = :transactionId",
+                    "from ${DBTransactionStorageLedgerRecovery.DBReceiverDistributionRecord::class.java.name} where txId = :transactionId",
                     DBTransactionStorageLedgerRecovery.DBReceiverDistributionRecord::class.java
             ).setParameter("transactionId", id.toString()).resultList.map { it }
         }


### PR DESCRIPTION
This is so that the node archiving service, which scans for tables containing "transaction_id" column, can automatically archive the sender and receiver distribution record information with the transaction.
