### PR TITLE
ENT-9927 Ledger Recovery: synchronise changes from ENT -> OS.

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -354,12 +354,11 @@ class FinalityFlowTests : WithFinality {
 
         getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(1, this.size)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[0].statesToRecord)
             assertEquals(BOB_NAME.hashCode().toLong(), this[0].peerPartyId)
         }
         getReceiverRecoveryData(stx.id, bobNode.database).apply {
-            assertEquals(StatesToRecord.ALL_VISIBLE, this?.statesToRecord)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.senderStatesToRecord)
+            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.statesToRecord)
             assertEquals(aliceNode.info.singleIdentity().name.hashCode().toLong(), this?.initiatorPartyId)
             assertEquals(mapOf(BOB_NAME.hashCode().toLong() to StatesToRecord.ALL_VISIBLE), this?.peersToStatesToRecord)
         }
@@ -387,12 +386,10 @@ class FinalityFlowTests : WithFinality {
             assertEquals(2, this.size)
             assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].statesToRecord)
             assertEquals(BOB_NAME.hashCode().toLong(), this[0].peerPartyId)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[1].statesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[1].statesToRecord)
             assertEquals(CHARLIE_NAME.hashCode().toLong(), this[1].peerPartyId)
         }
         getReceiverRecoveryData(stx.id, bobNode.database).apply {
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.statesToRecord)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.senderStatesToRecord)
             assertEquals(aliceNode.info.singleIdentity().name.hashCode().toLong(), this?.initiatorPartyId)
             // note: Charlie assertion here is using the hinted StatesToRecord value passed to it from Alice
             assertEquals(mapOf(BOB_NAME.hashCode().toLong() to StatesToRecord.ONLY_RELEVANT,
@@ -434,8 +431,6 @@ class FinalityFlowTests : WithFinality {
             assertEquals(BOB_NAME.hashCode().toLong(), this[0].peerPartyId)
         }
         getReceiverRecoveryData(stx.id, bobNode.database).apply {
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.statesToRecord)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this?.senderStatesToRecord)
             assertEquals(aliceNode.info.singleIdentity().name.hashCode().toLong(), this?.initiatorPartyId)
             assertEquals(mapOf(BOB_NAME.hashCode().toLong() to StatesToRecord.ONLY_RELEVANT), this?.peersToStatesToRecord)
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecovery.kt
@@ -22,7 +22,6 @@ import java.io.DataOutputStream
 import java.io.Serializable
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
 import javax.persistence.Column
 import javax.persistence.Embeddable
 import javax.persistence.EmbeddedId

--- a/node/src/main/resources/migration/node-core.changelog-v25.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v25.xml
@@ -12,9 +12,6 @@
 
     <changeSet author="R3.Corda" id="create_sender_distribution_records_table">
         <createTable tableName="node_sender_distribution_records">
-            <column name="sequence_number" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
             <column name="timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
@@ -34,24 +31,12 @@
     </changeSet>
 
     <changeSet author="R3.Corda" id="node_sender_distribution_records_pkey">
-        <addPrimaryKey columnNames="timestamp, sequence_number, timestamp_discriminator" constraintName="node_sender_distribution_records_pkey"
+        <addPrimaryKey columnNames="receiver_party_id, timestamp, timestamp_discriminator" constraintName="node_sender_distribution_records_pkey"
                        tableName="node_sender_distribution_records"/>
-    </changeSet>
-
-    <changeSet author="R3.Corda" id="node_sender_distribution_records_idx">
-        <createIndex indexName="node_sender_distribution_records_idx" tableName="node_sender_distribution_records">
-            <column name="timestamp"/>
-            <column name="sequence_number"/>
-            <column name="timestamp_discriminator"/>
-            <column name="receiver_party_id"/>
-        </createIndex>
     </changeSet>
 
     <changeSet author="R3.Corda" id="create_receiver_distribution_records_table">
         <createTable tableName="node_receiver_distribution_records">
-            <column name="sequence_number" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
             <column name="timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
@@ -71,17 +56,8 @@
     </changeSet>
 
     <changeSet author="R3.Corda" id="node_receiver_distribution_records_pkey">
-        <addPrimaryKey columnNames="timestamp, sequence_number, timestamp_discriminator" constraintName="node_receiver_distribution_records_pkey"
+        <addPrimaryKey columnNames="sender_party_id, timestamp, timestamp_discriminator" constraintName="node_receiver_distribution_records_pkey"
                        tableName="node_receiver_distribution_records"/>
-    </changeSet>
-
-    <changeSet author="R3.Corda" id="node_receiver_distribution_records_idx">
-        <createIndex indexName="node_receiver_distribution_records_idx" tableName="node_receiver_distribution_records">
-            <column name="timestamp"/>
-            <column name="sequence_number"/>
-            <column name="timestamp_discriminator"/>
-            <column name="sender_party_id"/>
-        </createIndex>
     </changeSet>
 
     <changeSet author="R3.Corda" id="create_recovery_party_info_table">

--- a/node/src/main/resources/migration/node-core.changelog-v25.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v25.xml
@@ -18,6 +18,9 @@
             <column name="timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
+            <column name="timestamp_discriminator" type="INT">
+                <constraints nullable="false"/>
+            </column>
             <column name="transaction_id" type="NVARCHAR(144)">
                 <constraints nullable="false"/>
             </column>
@@ -31,7 +34,7 @@
     </changeSet>
 
     <changeSet author="R3.Corda" id="node_sender_distribution_records_pkey">
-        <addPrimaryKey columnNames="timestamp, sequence_number" constraintName="node_sender_distribution_records_pkey"
+        <addPrimaryKey columnNames="timestamp, sequence_number, timestamp_discriminator" constraintName="node_sender_distribution_records_pkey"
                        tableName="node_sender_distribution_records"/>
     </changeSet>
 
@@ -39,6 +42,7 @@
         <createIndex indexName="node_sender_distribution_records_idx" tableName="node_sender_distribution_records">
             <column name="timestamp"/>
             <column name="sequence_number"/>
+            <column name="timestamp_discriminator"/>
             <column name="receiver_party_id"/>
         </createIndex>
     </changeSet>
@@ -51,6 +55,9 @@
             <column name="timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
+            <column name="timestamp_discriminator" type="INT">
+                <constraints nullable="false"/>
+            </column>
             <column name="transaction_id" type="NVARCHAR(144)">
                 <constraints nullable="false"/>
             </column>
@@ -60,14 +67,11 @@
             <column name="distribution_list" type="BLOB">
                 <constraints nullable="false"/>
             </column>
-            <column name="receiver_states_to_record" type="INT">
-                <constraints nullable="false"/>
-            </column>
         </createTable>
     </changeSet>
 
     <changeSet author="R3.Corda" id="node_receiver_distribution_records_pkey">
-        <addPrimaryKey columnNames="timestamp, sequence_number" constraintName="node_receiver_distribution_records_pkey"
+        <addPrimaryKey columnNames="timestamp, sequence_number, timestamp_discriminator" constraintName="node_receiver_distribution_records_pkey"
                        tableName="node_receiver_distribution_records"/>
     </changeSet>
 
@@ -75,6 +79,7 @@
         <createIndex indexName="node_receiver_distribution_records_idx" tableName="node_receiver_distribution_records">
             <column name="timestamp"/>
             <column name="sequence_number"/>
+            <column name="timestamp_discriminator"/>
             <column name="sender_party_id"/>
         </createIndex>
     </changeSet>

--- a/node/src/main/resources/migration/node-core.changelog-v25.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v25.xml
@@ -21,7 +21,7 @@
             <column name="transaction_id" type="NVARCHAR(144)">
                 <constraints nullable="false"/>
             </column>
-            <column name="receiver_party_id" type="BIGINT">
+            <column name="peer_party_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
             <column name="states_to_record" type="INT">
@@ -31,7 +31,7 @@
     </changeSet>
 
     <changeSet author="R3.Corda" id="node_sender_distribution_records_pkey">
-        <addPrimaryKey columnNames="receiver_party_id, timestamp, timestamp_discriminator" constraintName="node_sender_distribution_records_pkey"
+        <addPrimaryKey columnNames="peer_party_id, timestamp, timestamp_discriminator" constraintName="node_sender_distribution_records_pkey"
                        tableName="node_sender_distribution_records"/>
     </changeSet>
 
@@ -46,7 +46,7 @@
             <column name="transaction_id" type="NVARCHAR(144)">
                 <constraints nullable="false"/>
             </column>
-            <column name="sender_party_id" type="BIGINT">
+            <column name="peer_party_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
             <column name="distribution_list" type="BLOB">
@@ -56,7 +56,7 @@
     </changeSet>
 
     <changeSet author="R3.Corda" id="node_receiver_distribution_records_pkey">
-        <addPrimaryKey columnNames="sender_party_id, timestamp, timestamp_discriminator" constraintName="node_receiver_distribution_records_pkey"
+        <addPrimaryKey columnNames="peer_party_id, timestamp, timestamp_discriminator" constraintName="node_receiver_distribution_records_pkey"
                        tableName="node_receiver_distribution_records"/>
     </changeSet>
 
@@ -75,15 +75,15 @@
         <addPrimaryKey columnNames="party_id" constraintName="node_recovery_party_info_pkey" tableName="node_recovery_party_info"/>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="FK__sender_distribution_records__receiver_party_id">
-        <addForeignKeyConstraint baseColumnNames="receiver_party_id" baseTableName="node_sender_distribution_records"
-                                 constraintName="FK__sender_distribution_records__receiver_party_id"
+    <changeSet author="R3.Corda" id="FK__sender_distribution_records__peer_party_id">
+        <addForeignKeyConstraint baseColumnNames="peer_party_id" baseTableName="node_sender_distribution_records"
+                                 constraintName="FK__sender_distribution_records__peer_party_id"
                                  referencedColumnNames="party_id" referencedTableName="node_recovery_party_info"/>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="FK__receiver_distribution_records__initiator_party_id">
-        <addForeignKeyConstraint baseColumnNames="sender_party_id" baseTableName="node_receiver_distribution_records"
-                                 constraintName="FK__receiver_distribution_records__initiator_party_id"
+    <changeSet author="R3.Corda" id="FK__receiver_distribution_records__peer_party_id">
+        <addForeignKeyConstraint baseColumnNames="peer_party_id" baseTableName="node_receiver_distribution_records"
+                                 constraintName="FK__receiver_distribution_records__peer_party_id"
                                  referencedColumnNames="party_id" referencedTableName="node_recovery_party_info"/>
     </changeSet>
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -140,12 +140,12 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.SENDER).let {
             assertEquals(1, it.size)
-            assertEquals(BOB_NAME.hashCode().toLong(), it.senderRecords[0].receiverPartyId)
+            assertEquals(BOB_NAME.hashCode().toLong(), it.senderRecords[0].compositeKey.receiverPartyId)
             assertEquals(ALL_VISIBLE, it.senderRecords[0].statesToRecord)
         }
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.RECEIVER).let {
             assertEquals(1, it.size)
-            assertEquals(BOB_NAME.hashCode().toLong(), it.receiverRecords[0].senderPartyId)
+            assertEquals(BOB_NAME.hashCode().toLong(), it.receiverRecords[0].compositeKey.senderPartyId)
             assertEquals(ALL_VISIBLE, (transactionRecovery.decrypt(it.receiverRecords[0].distributionList).peerHashToStatesToRecord.map { it.value }[0]))
         }
         val resultsAll = transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.ALL)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -109,6 +109,21 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         val results = transactionRecovery.querySenderDistributionRecords(timeWindow, excludingTxnIds = setOf(transaction1.id))
         assertEquals(1, results.size)
+        assertEquals(transaction2.id.toString(), results[0].txId)
+    }
+
+    @Test(timeout = 300_000)
+    fun `query local ledger for transactions within timeWindow and for given peers`() {
+        val transaction1 = newTransaction()
+        transactionRecovery.addUnnotarisedTransaction(transaction1)
+        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction1.id, TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(BOB_NAME to ONLY_RELEVANT))))
+        val transaction2 = newTransaction()
+        transactionRecovery.addUnnotarisedTransaction(transaction2)
+        transactionRecovery.addSenderTransactionRecoveryMetadata(transaction2.id, TransactionMetadata(ALICE_NAME, DistributionList(ALL_VISIBLE, mapOf(CHARLIE_NAME to ONLY_RELEVANT))))
+        val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
+        val results = transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(CHARLIE_NAME))
+        assertEquals(1, results.size)
+        assertEquals(transaction2.id.toString(), results[0].txId)
     }
 
     @Test(timeout = 300_000)
@@ -125,13 +140,13 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.SENDER).let {
             assertEquals(1, it.size)
-            assertEquals(BOB_NAME.hashCode().toLong(), (it[0] as SenderDistributionRecord).peerPartyId)
-            assertEquals(ALL_VISIBLE, (it[0] as SenderDistributionRecord).statesToRecord)
+            assertEquals(BOB_NAME.hashCode().toLong(), it.senderRecords[0].receiverPartyId)
+            assertEquals(ALL_VISIBLE, it.senderRecords[0].statesToRecord)
         }
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.RECEIVER).let {
             assertEquals(1, it.size)
-            assertEquals(BOB_NAME.hashCode().toLong(), (it[0] as ReceiverDistributionRecord).initiatorPartyId)
-            assertEquals(ALL_VISIBLE, (it[0] as ReceiverDistributionRecord).statesToRecord)
+            assertEquals(BOB_NAME.hashCode().toLong(), it.receiverRecords[0].senderPartyId)
+            assertEquals(ALL_VISIBLE, (transactionRecovery.decrypt(it.receiverRecords[0].distributionList).peerHashToStatesToRecord.map { it.value }[0]))
         }
         val resultsAll = transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.ALL)
         assertEquals(2, resultsAll.size)
@@ -192,9 +207,9 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.queryReceiverDistributionRecords(timeWindow, initiators = setOf(ALICE_NAME)).let {
             assertEquals(3, it.size)
-            assertEquals(it[0].statesToRecord, ALL_VISIBLE)
-            assertEquals(it[1].statesToRecord, ONLY_RELEVANT)
-            assertEquals(it[2].statesToRecord, NONE)
+            assertEquals(transactionRecovery.decrypt(it[0].distributionList).peerHashToStatesToRecord.map { it.value }[0], ALL_VISIBLE)
+            assertEquals(transactionRecovery.decrypt(it[1].distributionList).peerHashToStatesToRecord.map { it.value }[0], ONLY_RELEVANT)
+            assertEquals(transactionRecovery.decrypt(it[2].distributionList).peerHashToStatesToRecord.map { it.value }[0], NONE)
         }
         assertEquals(1, transactionRecovery.queryReceiverDistributionRecords(timeWindow, initiators = setOf(BOB_NAME)).size)
         assertEquals(1, transactionRecovery.queryReceiverDistributionRecords(timeWindow, initiators = setOf(CHARLIE_NAME)).size)
@@ -229,8 +244,8 @@ class DBTransactionStorageLedgerRecoveryTests {
                 DistributionList(ONLY_RELEVANT, mapOf(BOB_NAME to ALL_VISIBLE)).toWire())
         assertEquals(IN_FLIGHT, readTransactionFromDB(receiverTransaction.id).status)
         readReceiverDistributionRecordFromDB(receiverTransaction.id).let {
-            assertEquals(ALL_VISIBLE, it.statesToRecord)
-            assertEquals(ONLY_RELEVANT, it.senderStatesToRecord)
+            assertEquals(ONLY_RELEVANT, it.statesToRecord)
+            assertEquals(ALL_VISIBLE, it.peersToStatesToRecord.map { it.value }[0])
             assertEquals(ALICE_NAME, partyInfoCache.getCordaX500NameByPartyId(it.initiatorPartyId))
             assertEquals(setOf(BOB_NAME), it.peersToStatesToRecord.map { (peer, _) -> partyInfoCache.getCordaX500NameByPartyId(peer) }.toSet() )
         }
@@ -245,7 +260,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         assertEquals(VERIFIED, readTransactionFromDB(transaction.id).status)
         readSenderDistributionRecordFromDB(transaction.id).apply {
             assertEquals(1, this.size)
-            assertEquals(ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(ALL_VISIBLE, this[0].statesToRecord)
         }
     }
 
@@ -376,4 +391,8 @@ class DBTransactionStorageLedgerRecoveryTests {
         val hashedDistributionList = HashedDistributionList(this.senderStatesToRecord, hashedPeersToStatesToRecord, now())
         return cryptoService.encrypt(hashedDistributionList.serialize())
     }
+}
+
+internal fun DBTransactionStorageLedgerRecovery.decrypt(distributionList: ByteArray): HashedDistributionList {
+    return HashedDistributionList.deserialize(this.cryptoService.decrypt(distributionList))
 }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -140,12 +140,12 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.SENDER).let {
             assertEquals(1, it.size)
-            assertEquals(BOB_NAME.hashCode().toLong(), it.senderRecords[0].compositeKey.receiverPartyId)
+            assertEquals(BOB_NAME.hashCode().toLong(), it.senderRecords[0].compositeKey.peerPartyId)
             assertEquals(ALL_VISIBLE, it.senderRecords[0].statesToRecord)
         }
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.RECEIVER).let {
             assertEquals(1, it.size)
-            assertEquals(BOB_NAME.hashCode().toLong(), it.receiverRecords[0].compositeKey.senderPartyId)
+            assertEquals(BOB_NAME.hashCode().toLong(), it.receiverRecords[0].compositeKey.peerPartyId)
             assertEquals(ALL_VISIBLE, (transactionRecovery.decrypt(it.receiverRecords[0].distributionList).peerHashToStatesToRecord.map { it.value }[0]))
         }
         val resultsAll = transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.ALL)


### PR DESCRIPTION
Removed `sequenceNumber` from composite PK. 
Added `receiverPartyId` to PK for SenderDistribution records.
Added `senderPartyId` to PK for ReceiverDistribution records.