### PR TITLE
ENT-10306 Swap logic from receive finality to receive transaction flows

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3222,8 +3222,7 @@ public final class net.corda.core.flows.ReceiveFinalityFlow extends net.corda.co
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord)
-  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean)
-  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
@@ -3239,8 +3238,6 @@ public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.
   public <init>(net.corda.core.flows.FlowSession, boolean)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean)
-  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3334,24 +3334,6 @@ public static final class net.corda.core.flows.SignTransactionFlow$Companion$SIG
 public static final class net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING INSTANCE
 ##
-@CordaSerializable
-public final class net.corda.core.flows.SignedTransactionWithDistributionList extends java.lang.Object
-  public <init>(net.corda.core.transactions.SignedTransaction, byte[])
-  @NotNull
-  public final net.corda.core.transactions.SignedTransaction component1()
-  @NotNull
-  public final byte[] component2()
-  @NotNull
-  public final net.corda.core.flows.SignedTransactionWithDistributionList copy(net.corda.core.transactions.SignedTransaction, byte[])
-  public boolean equals(Object)
-  @NotNull
-  public final byte[] getDistributionList()
-  @NotNull
-  public final net.corda.core.transactions.SignedTransaction getStx()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
 public final class net.corda.core.flows.StackFrameDataToken extends java.lang.Object
   public <init>(String)
   @NotNull

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1798,6 +1798,8 @@ public final class net.corda.core.crypto.Crypto extends java.lang.Object
   public static final boolean doVerify(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
   public static final boolean doVerify(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
   @NotNull
+  public static final byte[] encodePublicKey(java.security.PublicKey)
+  @NotNull
   public static final java.security.Provider findProvider(String)
   @NotNull
   public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(int)
@@ -2518,12 +2520,16 @@ public static final class net.corda.core.flows.ContractUpgradeFlow$Initiate exte
   protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
 ##
 public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.FlowLogic
+  public <init>(java.util.Set<? extends net.corda.core.flows.FlowSession>, Object, net.corda.core.flows.TransactionMetadata)
+  public <init>(java.util.Set, Object, net.corda.core.flows.TransactionMetadata, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.flows.FlowSession, Object)
+  public <init>(net.corda.core.flows.FlowSession, Object, net.corda.core.flows.TransactionMetadata)
+  public <init>(net.corda.core.flows.FlowSession, Object, net.corda.core.flows.TransactionMetadata, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @Nullable
   public Void call()
   @NotNull
-  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  public final java.util.Set<net.corda.core.flows.FlowSession> getOtherSessions()
   @NotNull
   public final Object getPayload()
   @Suspendable
@@ -2535,10 +2541,29 @@ public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.F
 @DoNotImplement
 public interface net.corda.core.flows.Destination
 ##
+@CordaSerializable
+public final class net.corda.core.flows.DistributionList extends java.lang.Object
+  public <init>(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
+  @NotNull
+  public final net.corda.core.node.StatesToRecord component1()
+  @NotNull
+  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> component2()
+  @NotNull
+  public final net.corda.core.flows.DistributionList copy(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> getPeersToStatesToRecord()
+  @NotNull
+  public final net.corda.core.node.StatesToRecord getSenderStatesToRecord()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
 @InitiatingFlow
 public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord, net.corda.core.utilities.ProgressTracker)
@@ -2570,10 +2595,30 @@ public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTI
   public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING INSTANCE
 ##
 @CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_NOTARY_ERROR extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_NOTARY_ERROR INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_POST_NOTARISATION extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_POST_NOTARISATION INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_PRE_NOTARISATION extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_PRE_NOTARISATION INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$FINALISING_TRANSACTION extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$FINALISING_TRANSACTION INSTANCE
+##
+@CordaSerializable
 public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING extends net.corda.core.utilities.ProgressTracker$Step
   @NotNull
   public net.corda.core.utilities.ProgressTracker childProgressTracker()
   public static final net.corda.core.flows.FinalityFlow$Companion$NOTARISING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$RECORD_UNNOTARISED extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$RECORD_UNNOTARISED INSTANCE
 ##
 @CordaSerializable
 public class net.corda.core.flows.FlowException extends net.corda.core.CordaException implements net.corda.core.flows.IdentifiableException
@@ -2877,6 +2922,37 @@ public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends j
   public String toString()
 ##
 @CordaSerializable
+public final class net.corda.core.flows.FlowTransactionInfo extends java.lang.Object
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.TransactionStatus, java.time.Instant, net.corda.core.flows.TransactionMetadata)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.TransactionStatus component3()
+  @NotNull
+  public final java.time.Instant component4()
+  @Nullable
+  public final net.corda.core.flows.TransactionMetadata component5()
+  @NotNull
+  public final net.corda.core.flows.FlowTransactionInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.TransactionStatus, java.time.Instant, net.corda.core.flows.TransactionMetadata)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.core.flows.TransactionMetadata getMetadata()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getStateMachineRunId()
+  @NotNull
+  public final net.corda.core.flows.TransactionStatus getStatus()
+  @NotNull
+  public final java.time.Instant getTimestamp()
+  @NotNull
+  public final String getTxId()
+  public int hashCode()
+  public final boolean isInitiator(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
 public class net.corda.core.flows.HospitalizeFlowException extends net.corda.core.CordaRuntimeException
   public <init>()
   public <init>(String)
@@ -3138,11 +3214,16 @@ public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUE
 public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
 ##
+public final class net.corda.core.flows.NotarySigCheck extends java.lang.Object
+  public final boolean needsNotarySignature(net.corda.core.transactions.SignedTransaction)
+  public static final net.corda.core.flows.NotarySigCheck INSTANCE
+##
 public final class net.corda.core.flows.ReceiveFinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord)
-  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
@@ -3158,11 +3239,48 @@ public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.
   public <init>(net.corda.core.flows.FlowSession, boolean)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
   @Suspendable
   protected void checkBeforeRecording(net.corda.core.transactions.SignedTransaction)
+##
+@CordaSerializable
+public final class net.corda.core.flows.RecoveryTimeWindow extends java.lang.Object
+  public <init>(java.time.Instant, java.time.Instant)
+  public <init>(java.time.Instant, java.time.Instant, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public static final net.corda.core.flows.RecoveryTimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow copy(java.time.Instant, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.flows.RecoveryTimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public final java.time.Instant getFromTime()
+  @NotNull
+  public final java.time.Instant getUntilTime()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.flows.RecoveryTimeWindow untilOnly(java.time.Instant)
+  public static final net.corda.core.flows.RecoveryTimeWindow$Companion Companion
+##
+public static final class net.corda.core.flows.RecoveryTimeWindow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.flows.RecoveryTimeWindow untilOnly(java.time.Instant)
 ##
 @CordaSerializable
 public final class net.corda.core.flows.ResultSerializationException extends net.corda.core.CordaRuntimeException
@@ -3175,6 +3293,12 @@ public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flo
 ##
 public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
+  public static final net.corda.core.flows.SendTransactionFlow$Companion Companion
+##
+public static final class net.corda.core.flows.SendTransactionFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getDUMMY_PARTICIPANT_NAME()
 ##
 public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
@@ -3280,6 +3404,29 @@ public class net.corda.core.flows.StateReplacementException extends net.corda.co
   public <init>(String)
   public <init>(String, Throwable)
   public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public final class net.corda.core.flows.TransactionMetadata extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final net.corda.core.flows.DistributionList component2()
+  @NotNull
+  public final net.corda.core.flows.TransactionMetadata copy(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.flows.DistributionList getDistributionList()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getInitiator()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.TransactionStatus extends java.lang.Enum
+  public static net.corda.core.flows.TransactionStatus valueOf(String)
+  public static net.corda.core.flows.TransactionStatus[] values()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
@@ -4141,6 +4288,7 @@ public interface net.corda.core.node.ServicesForResolution
   @NotNull
   public net.corda.core.transactions.LedgerTransaction specialise(net.corda.core.transactions.LedgerTransaction)
 ##
+@CordaSerializable
 public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
   public static net.corda.core.node.StatesToRecord valueOf(String)
   public static net.corda.core.node.StatesToRecord[] values()
@@ -4474,6 +4622,8 @@ public static final class net.corda.core.node.services.Vault$ConstraintInfo$Type
 @CordaSerializable
 public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>, net.corda.core.contracts.StateRef)
+  public <init>(java.util.List, java.util.List, long, net.corda.core.node.services.Vault$StateStatus, java.util.List, net.corda.core.contracts.StateRef, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<T>> component1()
   @NotNull
@@ -4483,11 +4633,17 @@ public static final class net.corda.core.node.services.Vault$Page extends java.l
   public final net.corda.core.node.services.Vault$StateStatus component4()
   @NotNull
   public final java.util.List<Object> component5()
+  @Nullable
+  public final net.corda.core.contracts.StateRef component6()
   @NotNull
   public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>, net.corda.core.contracts.StateRef)
   public boolean equals(Object)
   @NotNull
   public final java.util.List<Object> getOtherResults()
+  @Nullable
+  public final net.corda.core.contracts.StateRef getPreviousPageAnchor()
   @NotNull
   public final net.corda.core.node.services.Vault$StateStatus getStateTypes()
   @NotNull
@@ -8380,10 +8536,12 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.util.Map, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean, java.time.Duration)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.util.Map, boolean, boolean, java.time.Duration, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
   public final boolean component1()
   @NotNull
@@ -8397,16 +8555,14 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final boolean component14()
   @Nullable
   public final java.util.Collection<net.corda.testing.node.TestCordapp> component15()
-  @Nullable
-  public final java.nio.file.Path component16()
   @NotNull
-  public final java.util.List<java.nio.file.Path> component17()
+  public final java.util.Map<String, String> component16()
+  public final boolean component17()
+  public final boolean component18()
   @NotNull
-  public final java.util.Map<String, String> component18()
-  public final boolean component19()
+  public final java.time.Duration component19()
   @NotNull
   public final java.nio.file.Path component2()
-  public final boolean component20()
   @NotNull
   public final net.corda.testing.driver.PortAllocation component3()
   @NotNull
@@ -8423,9 +8579,11 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean)
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean)
   @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean)
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean, java.time.Duration)
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
   public boolean equals(Object)
@@ -8434,10 +8592,6 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
   @NotNull
   public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
-  @Nullable
-  public final java.nio.file.Path getDjvmBootstrapSource()
-  @NotNull
-  public final java.util.List<java.nio.file.Path> getDjvmCordaSource()
   @NotNull
   public final java.nio.file.Path getDriverDirectory()
   @NotNull
@@ -8451,6 +8605,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
   public final java.util.Map<String, Object> getNotaryCustomOverrides()
+  @NotNull
+  public final java.time.Duration getNotaryHandleTimeout()
   @NotNull
   public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
   @NotNull
@@ -8472,10 +8628,6 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   @NotNull
   public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
   @NotNull
-  public final net.corda.testing.driver.DriverParameters withDjvmBootstrapSource(java.nio.file.Path)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withDjvmCordaSource(java.util.List<? extends java.nio.file.Path>)
-  @NotNull
   public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withEnvironmentVariables(java.util.Map<String, String>)
@@ -8491,6 +8643,8 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNotaryCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotaryHandleTimeout(java.time.Duration)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
   @NotNull
@@ -8724,6 +8878,7 @@ public final class net.corda.testing.flows.FlowTestsUtilsKt extends java.lang.Ob
   public static final java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAll(net.corda.core.flows.FlowLogic<?>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>...)
   @NotNull
   public static final rx.Observable<T> registerCoreFlowFactory(net.corda.testing.node.internal.TestStartedNode, Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<T>, kotlin.jvm.functions.Function1<? super net.corda.core.flows.FlowSession, ? extends T>, boolean)
+  public static final void waitForAllFlowsToComplete(net.corda.testing.driver.NodeHandle, int, long)
 ##
 @DoNotImplement
 public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
@@ -9145,7 +9300,9 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @NotNull
   public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>, net.corda.testing.internal.TestingNamedCacheFactory)
   public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public final void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>, boolean)
   public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public final void recordTransactions(net.corda.core.transactions.SignedTransaction, boolean)
   public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
   public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1798,8 +1798,6 @@ public final class net.corda.core.crypto.Crypto extends java.lang.Object
   public static final boolean doVerify(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
   public static final boolean doVerify(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
   @NotNull
-  public static final byte[] encodePublicKey(java.security.PublicKey)
-  @NotNull
   public static final java.security.Provider findProvider(String)
   @NotNull
   public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(int)
@@ -2520,16 +2518,12 @@ public static final class net.corda.core.flows.ContractUpgradeFlow$Initiate exte
   protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
 ##
 public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.FlowLogic
-  public <init>(java.util.Set<? extends net.corda.core.flows.FlowSession>, Object, net.corda.core.flows.TransactionMetadata)
-  public <init>(java.util.Set, Object, net.corda.core.flows.TransactionMetadata, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.flows.FlowSession, Object)
-  public <init>(net.corda.core.flows.FlowSession, Object, net.corda.core.flows.TransactionMetadata)
-  public <init>(net.corda.core.flows.FlowSession, Object, net.corda.core.flows.TransactionMetadata, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @Nullable
   public Void call()
   @NotNull
-  public final java.util.Set<net.corda.core.flows.FlowSession> getOtherSessions()
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
   @NotNull
   public final Object getPayload()
   @Suspendable
@@ -2541,29 +2535,10 @@ public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.F
 @DoNotImplement
 public interface net.corda.core.flows.Destination
 ##
-@CordaSerializable
-public final class net.corda.core.flows.DistributionList extends java.lang.Object
-  public <init>(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
-  @NotNull
-  public final net.corda.core.node.StatesToRecord component1()
-  @NotNull
-  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> component2()
-  @NotNull
-  public final net.corda.core.flows.DistributionList copy(net.corda.core.node.StatesToRecord, java.util.Map<net.corda.core.identity.CordaX500Name, ? extends net.corda.core.node.StatesToRecord>)
-  public boolean equals(Object)
-  @NotNull
-  public final java.util.Map<net.corda.core.identity.CordaX500Name, net.corda.core.node.StatesToRecord> getPeersToStatesToRecord()
-  @NotNull
-  public final net.corda.core.node.StatesToRecord getSenderStatesToRecord()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
 @InitiatingFlow
 public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
-  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.node.StatesToRecord, net.corda.core.utilities.ProgressTracker)
@@ -2595,30 +2570,10 @@ public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTI
   public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING INSTANCE
 ##
 @CordaSerializable
-public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_NOTARY_ERROR extends net.corda.core.utilities.ProgressTracker$Step
-  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_NOTARY_ERROR INSTANCE
-##
-@CordaSerializable
-public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_POST_NOTARISATION extends net.corda.core.utilities.ProgressTracker$Step
-  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_POST_NOTARISATION INSTANCE
-##
-@CordaSerializable
-public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_PRE_NOTARISATION extends net.corda.core.utilities.ProgressTracker$Step
-  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING_PRE_NOTARISATION INSTANCE
-##
-@CordaSerializable
-public static final class net.corda.core.flows.FinalityFlow$Companion$FINALISING_TRANSACTION extends net.corda.core.utilities.ProgressTracker$Step
-  public static final net.corda.core.flows.FinalityFlow$Companion$FINALISING_TRANSACTION INSTANCE
-##
-@CordaSerializable
 public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING extends net.corda.core.utilities.ProgressTracker$Step
   @NotNull
   public net.corda.core.utilities.ProgressTracker childProgressTracker()
   public static final net.corda.core.flows.FinalityFlow$Companion$NOTARISING INSTANCE
-##
-@CordaSerializable
-public static final class net.corda.core.flows.FinalityFlow$Companion$RECORD_UNNOTARISED extends net.corda.core.utilities.ProgressTracker$Step
-  public static final net.corda.core.flows.FinalityFlow$Companion$RECORD_UNNOTARISED INSTANCE
 ##
 @CordaSerializable
 public class net.corda.core.flows.FlowException extends net.corda.core.CordaException implements net.corda.core.flows.IdentifiableException
@@ -2922,37 +2877,6 @@ public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends j
   public String toString()
 ##
 @CordaSerializable
-public final class net.corda.core.flows.FlowTransactionInfo extends java.lang.Object
-  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.TransactionStatus, java.time.Instant, net.corda.core.flows.TransactionMetadata)
-  @NotNull
-  public final net.corda.core.flows.StateMachineRunId component1()
-  @NotNull
-  public final String component2()
-  @NotNull
-  public final net.corda.core.flows.TransactionStatus component3()
-  @NotNull
-  public final java.time.Instant component4()
-  @Nullable
-  public final net.corda.core.flows.TransactionMetadata component5()
-  @NotNull
-  public final net.corda.core.flows.FlowTransactionInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.TransactionStatus, java.time.Instant, net.corda.core.flows.TransactionMetadata)
-  public boolean equals(Object)
-  @Nullable
-  public final net.corda.core.flows.TransactionMetadata getMetadata()
-  @NotNull
-  public final net.corda.core.flows.StateMachineRunId getStateMachineRunId()
-  @NotNull
-  public final net.corda.core.flows.TransactionStatus getStatus()
-  @NotNull
-  public final java.time.Instant getTimestamp()
-  @NotNull
-  public final String getTxId()
-  public int hashCode()
-  public final boolean isInitiator(net.corda.core.identity.CordaX500Name)
-  @NotNull
-  public String toString()
-##
-@CordaSerializable
 public class net.corda.core.flows.HospitalizeFlowException extends net.corda.core.CordaRuntimeException
   public <init>()
   public <init>(String)
@@ -3214,16 +3138,11 @@ public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUE
 public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
 ##
-public final class net.corda.core.flows.NotarySigCheck extends java.lang.Object
-  public final boolean needsNotarySignature(net.corda.core.transactions.SignedTransaction)
-  public static final net.corda.core.flows.NotarySigCheck INSTANCE
-##
 public final class net.corda.core.flows.ReceiveFinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord)
-  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean)
-  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, Boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
@@ -3239,48 +3158,11 @@ public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.
   public <init>(net.corda.core.flows.FlowSession, boolean)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean)
-  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
   @Suspendable
   protected void checkBeforeRecording(net.corda.core.transactions.SignedTransaction)
-##
-@CordaSerializable
-public final class net.corda.core.flows.RecoveryTimeWindow extends java.lang.Object
-  public <init>(java.time.Instant, java.time.Instant)
-  public <init>(java.time.Instant, java.time.Instant, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public static final net.corda.core.flows.RecoveryTimeWindow between(java.time.Instant, java.time.Instant)
-  @NotNull
-  public final java.time.Instant component1()
-  @NotNull
-  public final java.time.Instant component2()
-  @NotNull
-  public final net.corda.core.flows.RecoveryTimeWindow copy(java.time.Instant, java.time.Instant)
-  public boolean equals(Object)
-  @NotNull
-  public static final net.corda.core.flows.RecoveryTimeWindow fromOnly(java.time.Instant)
-  @NotNull
-  public final java.time.Instant getFromTime()
-  @NotNull
-  public final java.time.Instant getUntilTime()
-  public int hashCode()
-  @NotNull
-  public String toString()
-  @NotNull
-  public static final net.corda.core.flows.RecoveryTimeWindow untilOnly(java.time.Instant)
-  public static final net.corda.core.flows.RecoveryTimeWindow$Companion Companion
-##
-public static final class net.corda.core.flows.RecoveryTimeWindow$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.core.flows.RecoveryTimeWindow between(java.time.Instant, java.time.Instant)
-  @NotNull
-  public final net.corda.core.flows.RecoveryTimeWindow fromOnly(java.time.Instant)
-  @NotNull
-  public final net.corda.core.flows.RecoveryTimeWindow untilOnly(java.time.Instant)
 ##
 @CordaSerializable
 public final class net.corda.core.flows.ResultSerializationException extends net.corda.core.CordaRuntimeException
@@ -3293,12 +3175,6 @@ public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flo
 ##
 public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
-  public static final net.corda.core.flows.SendTransactionFlow$Companion Companion
-##
-public static final class net.corda.core.flows.SendTransactionFlow$Companion extends java.lang.Object
-  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name getDUMMY_PARTICIPANT_NAME()
 ##
 public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
@@ -3404,29 +3280,6 @@ public class net.corda.core.flows.StateReplacementException extends net.corda.co
   public <init>(String)
   public <init>(String, Throwable)
   public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
-##
-@CordaSerializable
-public final class net.corda.core.flows.TransactionMetadata extends java.lang.Object
-  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name component1()
-  @NotNull
-  public final net.corda.core.flows.DistributionList component2()
-  @NotNull
-  public final net.corda.core.flows.TransactionMetadata copy(net.corda.core.identity.CordaX500Name, net.corda.core.flows.DistributionList)
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.core.flows.DistributionList getDistributionList()
-  @NotNull
-  public final net.corda.core.identity.CordaX500Name getInitiator()
-  public int hashCode()
-  @NotNull
-  public String toString()
-##
-@CordaSerializable
-public final class net.corda.core.flows.TransactionStatus extends java.lang.Enum
-  public static net.corda.core.flows.TransactionStatus valueOf(String)
-  public static net.corda.core.flows.TransactionStatus[] values()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
@@ -4288,7 +4141,6 @@ public interface net.corda.core.node.ServicesForResolution
   @NotNull
   public net.corda.core.transactions.LedgerTransaction specialise(net.corda.core.transactions.LedgerTransaction)
 ##
-@CordaSerializable
 public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
   public static net.corda.core.node.StatesToRecord valueOf(String)
   public static net.corda.core.node.StatesToRecord[] values()
@@ -4622,8 +4474,6 @@ public static final class net.corda.core.node.services.Vault$ConstraintInfo$Type
 @CordaSerializable
 public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
-  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>, net.corda.core.contracts.StateRef)
-  public <init>(java.util.List, java.util.List, long, net.corda.core.node.services.Vault$StateStatus, java.util.List, net.corda.core.contracts.StateRef, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<T>> component1()
   @NotNull
@@ -4633,17 +4483,11 @@ public static final class net.corda.core.node.services.Vault$Page extends java.l
   public final net.corda.core.node.services.Vault$StateStatus component4()
   @NotNull
   public final java.util.List<Object> component5()
-  @Nullable
-  public final net.corda.core.contracts.StateRef component6()
   @NotNull
   public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
-  @NotNull
-  public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>, net.corda.core.contracts.StateRef)
   public boolean equals(Object)
   @NotNull
   public final java.util.List<Object> getOtherResults()
-  @Nullable
-  public final net.corda.core.contracts.StateRef getPreviousPageAnchor()
   @NotNull
   public final net.corda.core.node.services.Vault$StateStatus getStateTypes()
   @NotNull
@@ -8536,12 +8380,10 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.util.Map, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean, java.time.Duration)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.util.Map, boolean, boolean, java.time.Duration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, java.nio.file.Path, java.util.List, java.util.Map, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
   public final boolean component1()
   @NotNull
@@ -8555,14 +8397,16 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final boolean component14()
   @Nullable
   public final java.util.Collection<net.corda.testing.node.TestCordapp> component15()
+  @Nullable
+  public final java.nio.file.Path component16()
   @NotNull
-  public final java.util.Map<String, String> component16()
-  public final boolean component17()
-  public final boolean component18()
+  public final java.util.List<java.nio.file.Path> component17()
   @NotNull
-  public final java.time.Duration component19()
+  public final java.util.Map<String, String> component18()
+  public final boolean component19()
   @NotNull
   public final java.nio.file.Path component2()
+  public final boolean component20()
   @NotNull
   public final net.corda.testing.driver.PortAllocation component3()
   @NotNull
@@ -8579,11 +8423,9 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean)
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean)
   @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<String, String>, boolean, boolean, java.time.Duration)
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.nio.file.Path, java.util.List<? extends java.nio.file.Path>, java.util.Map<String, String>, boolean, boolean)
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
   public boolean equals(Object)
@@ -8592,6 +8434,10 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
   @NotNull
   public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
+  @Nullable
+  public final java.nio.file.Path getDjvmBootstrapSource()
+  @NotNull
+  public final java.util.List<java.nio.file.Path> getDjvmCordaSource()
   @NotNull
   public final java.nio.file.Path getDriverDirectory()
   @NotNull
@@ -8605,8 +8451,6 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
   public final java.util.Map<String, Object> getNotaryCustomOverrides()
-  @NotNull
-  public final java.time.Duration getNotaryHandleTimeout()
   @NotNull
   public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
   @NotNull
@@ -8628,6 +8472,10 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   @NotNull
   public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
   @NotNull
+  public final net.corda.testing.driver.DriverParameters withDjvmBootstrapSource(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDjvmCordaSource(java.util.List<? extends java.nio.file.Path>)
+  @NotNull
   public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withEnvironmentVariables(java.util.Map<String, String>)
@@ -8643,8 +8491,6 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNotaryCustomOverrides(java.util.Map<String, ?>)
-  @NotNull
-  public final net.corda.testing.driver.DriverParameters withNotaryHandleTimeout(java.time.Duration)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
   @NotNull
@@ -8878,7 +8724,6 @@ public final class net.corda.testing.flows.FlowTestsUtilsKt extends java.lang.Ob
   public static final java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAll(net.corda.core.flows.FlowLogic<?>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>, kotlin.Pair<? extends net.corda.core.flows.FlowSession, ? extends Class<?>>...)
   @NotNull
   public static final rx.Observable<T> registerCoreFlowFactory(net.corda.testing.node.internal.TestStartedNode, Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<T>, kotlin.jvm.functions.Function1<? super net.corda.core.flows.FlowSession, ? extends T>, boolean)
-  public static final void waitForAllFlowsToComplete(net.corda.testing.driver.NodeHandle, int, long)
 ##
 @DoNotImplement
 public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
@@ -9300,9 +9145,7 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @NotNull
   public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndPersistentServices(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.util.Set<java.security.KeyPair>, java.util.Set<net.corda.core.identity.PartyAndCertificate>, net.corda.testing.internal.TestingNamedCacheFactory)
   public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
-  public final void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>, boolean)
   public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
-  public final void recordTransactions(net.corda.core.transactions.SignedTransaction, boolean)
   public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
   public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -572,7 +572,9 @@ class FinalityFlowTests : WithFinality {
             val txBuilder = DummyContract.move(stateAndRef, newOwner)
             val stxn = serviceHub.signInitialTransaction(txBuilder, ourIdentity.owningKey)
             val sessionWithCounterParty = initiateFlow(newOwner)
-            subFlow(SendTransactionFlow(stxn, setOf(sessionWithCounterParty), emptySet(), StatesToRecord.ONLY_RELEVANT))
+            subFlow(object : SendTransactionFlow(stxn, setOf(sessionWithCounterParty), emptySet(), StatesToRecord.ONLY_RELEVANT, true) {
+                override fun isFinality(): Boolean = true
+            })
             throw UnexpectedFlowEndException("${stxn.id}")
         }
     }

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -216,8 +216,6 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
 
         val requiresNotarisation = needsNotarySignature(transaction)
         val useTwoPhaseFinality = serviceHub.myInfo.platformVersion >= PlatformVersionSwitches.TWO_PHASE_FINALITY
-                && serviceHub.getAppContext().cordapp.targetPlatformVersion >= PlatformVersionSwitches.TWO_PHASE_FINALITY
-
         if (useTwoPhaseFinality) {
             val stxn = if (requiresNotarisation) {
                 recordLocallyAndBroadcast(newPlatformSessions, transaction)

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -280,7 +280,9 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
             try {
                 logger.debug { "Sending transaction to party sessions: $sessions." }
                 val (participantSessions, observerSessions) = deriveSessions(sessions)
-                subFlow(SendTransactionFlow(tx, participantSessions, observerSessions, statesToRecord, true))
+                subFlow(object : SendTransactionFlow(tx, participantSessions, observerSessions, statesToRecord, true) {
+                    override fun isFinality(): Boolean = true
+                })
             } catch (e: UnexpectedFlowEndException) {
                 throw UnexpectedFlowEndException(
                         "One of the sessions ${sessions.map { it.counterparty }} has finished prematurely and we're trying to send them a transaction." +

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -95,6 +95,7 @@ open class ReceiveTransactionFlow constructor(private val otherSideSession: Flow
         }
     }
 
+    @Suspendable
     private fun doReceiveFinality(payload: Any): SignedTransaction {
         val stx = resolvePayload(payload)
         stx.pushToLoggingContext()
@@ -132,7 +133,7 @@ open class ReceiveTransactionFlow constructor(private val otherSideSession: Flow
     }
 
     open fun isReallyReceiveFinality(payload: Any): Boolean {
-        return payload is SignedTransactionWithDistributionList && checkSufficientSignatures && NotarySigCheck.needsNotarySignature(payload.stx)
+        return payload is SignedTransactionWithDistributionList && checkSufficientSignatures && payload.isFinality && NotarySigCheck.needsNotarySignature(payload.stx)
     }
 
     open fun resolvePayload(payload: Any): SignedTransaction {

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -6,15 +6,22 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.TransactionResolutionException
 import net.corda.core.contracts.TransactionVerificationException
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.internal.FetchDataFlow
+import net.corda.core.internal.PlatformVersionSwitches
 import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.internal.ServiceHubCoreInternal
 import net.corda.core.internal.checkParameterHash
 import net.corda.core.internal.pushToLoggingContext
+import net.corda.core.internal.telemetry.telemetryServiceInternal
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.Try
+import net.corda.core.utilities.debug
 import net.corda.core.utilities.trace
 import net.corda.core.utilities.unwrap
 import java.security.SignatureException
+import java.time.Duration
 
 /**
  * The [ReceiveTransactionFlow] should be called in response to the [SendTransactionFlow].
@@ -39,12 +46,13 @@ import java.security.SignatureException
 open class ReceiveTransactionFlow constructor(private val otherSideSession: FlowSession,
                                               private val checkSufficientSignatures: Boolean = true,
                                               private val statesToRecord: StatesToRecord = StatesToRecord.NONE,
-                                              private val deferredAck: Boolean = false) : FlowLogic<SignedTransaction>() {
-    @JvmOverloads constructor(
+                                              private val handlePropagatedNotaryError: Boolean? = null) : FlowLogic<SignedTransaction>() {
+    @JvmOverloads
+    constructor(
             otherSideSession: FlowSession,
             checkSufficientSignatures: Boolean = true,
             statesToRecord: StatesToRecord = StatesToRecord.NONE
-    ) : this(otherSideSession, checkSufficientSignatures, statesToRecord, false)
+    ) : this(otherSideSession, checkSufficientSignatures, statesToRecord, null)
 
     @Suppress("KDocMissingDocumentation")
     @Suspendable
@@ -60,32 +68,76 @@ open class ReceiveTransactionFlow constructor(private val otherSideSession: Flow
         }
 
         val payload = otherSideSession.receive<Any>().unwrap { it }
+        return if (isReallyReceiveFinality(payload)) {
+            doReceiveFinality(payload)
+        } else {
+            val stx = resolvePayload(payload)
+            stx.pushToLoggingContext()
+            logger.info("Received transaction acknowledgement request from party ${otherSideSession.counterparty}.")
+            checkParameterHash(stx.networkParametersHash)
+            subFlow(ResolveTransactionsFlow(stx, otherSideSession, statesToRecord, false))
+            logger.info("Transaction dependencies resolution completed.")
+            try {
+                stx.verify(serviceHub, checkSufficientSignatures)
+            } catch (e: Exception) {
+                logger.warn("Transaction verification failed.")
+                throw e
+            }
+            if (checkSufficientSignatures) {
+                // We should only send a transaction to the vault for processing if we did in fact fully verify it, and
+                // there are no missing signatures. We don't want partly signed stuff in the vault.
+                checkBeforeRecording(stx)
+                logger.info("Successfully received fully signed tx. Sending it to the vault for processing.")
+                serviceHub.recordTransactions(statesToRecord, setOf(stx))
+                logger.info("Successfully recorded received transaction locally.")
+            }
+            stx
+        }
+    }
+
+    private fun doReceiveFinality(payload: Any): SignedTransaction {
         val stx = resolvePayload(payload)
         stx.pushToLoggingContext()
         logger.info("Received transaction acknowledgement request from party ${otherSideSession.counterparty}.")
         checkParameterHash(stx.networkParametersHash)
-        subFlow(ResolveTransactionsFlow(stx, otherSideSession, statesToRecord, deferredAck))
+        subFlow(ResolveTransactionsFlow(stx, otherSideSession, statesToRecord, true))
         logger.info("Transaction dependencies resolution completed.")
-        try {
-            stx.verify(serviceHub, checkSufficientSignatures)
-        } catch (e: Exception) {
-            logger.warn("Transaction verification failed.")
-            throw e
+
+        serviceHub.telemetryServiceInternal.span("${this::class.java.name}#recordUnnotarisedTransaction", flowLogic = this) {
+            logger.debug { "Peer recording transaction without notary signature." }
+            (serviceHub as ServiceHubCoreInternal).recordUnnotarisedTransaction(stx)
         }
-        if (checkSufficientSignatures) {
-            // We should only send a transaction to the vault for processing if we did in fact fully verify it, and
-            // there are no missing signatures. We don't want partly signed stuff in the vault.
-            checkBeforeRecording(stx)
-            logger.info("Successfully received fully signed tx. Sending it to the vault for processing.")
-            serviceHub.recordTransactions(statesToRecord, setOf(stx))
-            logger.info("Successfully recorded received transaction locally.")
+        otherSideSession.send(FetchDataFlow.Request.End) // Finish fetching data (deferredAck)
+        logger.info("Peer recorded transaction without notary signature. Waiting to receive notary signature.")
+        try {
+            val notarySignatures = otherSideSession.receive<Try<List<TransactionSignature>>>().unwrap { it.getOrThrow() }
+            serviceHub.telemetryServiceInternal.span("${this::class.java.name}#finalizeTransactionWithExtraSignatures", flowLogic = this) {
+                logger.debug { "Peer received notarised signature." }
+                (serviceHub as ServiceHubCoreInternal).finalizeTransactionWithExtraSignatures(stx, notarySignatures, statesToRecord)
+                logger.info("Peer finalised transaction with notary signature.")
+            }
+        } catch (e: NotaryException) {
+            logger.info("Peer received notary error.")
+            val overrideHandlePropagatedNotaryError = handlePropagatedNotaryError
+                    ?: (serviceHub.cordappProvider.getAppContext().cordapp.targetPlatformVersion >= PlatformVersionSwitches.TWO_PHASE_FINALITY)
+            if (overrideHandlePropagatedNotaryError) {
+                (serviceHub as ServiceHubCoreInternal).removeUnnotarisedTransaction(stx.id)
+                sleep(Duration.ZERO) // force checkpoint to persist db update.
+                throw e
+            } else {
+                otherSideSession.receive<Any>() // simulate unexpected flow end
+            }
         }
         return stx
     }
 
+    open fun isReallyReceiveFinality(payload: Any): Boolean {
+        return payload is SignedTransactionWithDistributionList && checkSufficientSignatures && NotarySigCheck.needsNotarySignature(payload.stx)
+    }
+
     open fun resolvePayload(payload: Any): SignedTransaction {
         return if (payload is SignedTransactionWithDistributionList) {
-            if (checkSufficientSignatures || deferredAck) {
+            if (checkSufficientSignatures) {
                 (serviceHub as ServiceHubCoreInternal).recordReceiverTransactionRecoveryMetadata(payload.stx.id, otherSideSession.counterparty.name, ourIdentity.name, statesToRecord, payload.distributionList)
                 payload.stx
             } else payload.stx

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -138,7 +138,7 @@ open class ReceiveTransactionFlow constructor(private val otherSideSession: Flow
         return stx
     }
 
-    open fun isReallyReceiveFinality(payload: Any): Boolean {
+    private fun isReallyReceiveFinality(payload: Any): Boolean {
         return payload is SignedTransactionWithDistributionList && checkSufficientSignatures && payload.isFinality && NotarySigCheck.needsNotarySignature(payload.stx)
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -15,13 +15,6 @@ import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.trace
 import net.corda.core.utilities.unwrap
-import kotlin.collections.List
-import kotlin.collections.MutableSet
-import kotlin.collections.Set
-import kotlin.collections.flatMap
-import kotlin.collections.map
-import kotlin.collections.mutableSetOf
-import kotlin.collections.plus
 import kotlin.collections.toSet
 
 /**
@@ -136,6 +129,8 @@ open class DataVendingFlow(val otherSessions: Set<FlowSession>, val payload: Any
         // User can override this method to perform custom request verification.
     }
 
+    protected open fun isFinality(): Boolean = false
+
     @Suppress("ComplexCondition", "ComplexMethod", "LongMethod")
     @Suspendable
     override fun call(): Void? {
@@ -174,7 +169,7 @@ open class DataVendingFlow(val otherSessions: Set<FlowSession>, val payload: Any
         val payloadWithMetadata =
             if (txnMetadata != null && toTwoPhaseFinalityNode && useTwoPhaseFinality && payload is SignedTransaction) {
                 val encryptedDistributionList = (serviceHub as ServiceHubCoreInternal).recordSenderTransactionRecoveryMetadata(payload.id, txnMetadata.copy(initiator = ourIdentity.name))
-                SignedTransactionWithDistributionList(payload, encryptedDistributionList!!)
+                SignedTransactionWithDistributionList(payload, encryptedDistributionList!!, isFinality())
             } else null
 
         otherSessions.forEachIndexed { idx, otherSideSession ->
@@ -311,5 +306,6 @@ open class DataVendingFlow(val otherSessions: Set<FlowSession>, val payload: Any
 @CordaSerializable
 data class SignedTransactionWithDistributionList(
         val stx: SignedTransaction,
-        val distributionList: ByteArray
+        val distributionList: ByteArray,
+        val isFinality: Boolean
 )


### PR DESCRIPTION
We have discovered that CorDapps may have written their own `ReceiveFinalityFlow` based on `ReceiveTransactionFlow`.  It seems our own TokensSDK has done this.  4.11 thus breaks those.  We looked to address by using Target Platform Version and releasing an updated TokensSDK but there is one upgrade scenario that no longer works using this solution.

This alternative pushes the `ReceiveFinalityFlow` logic into `ReceiveTransactionFlow` and introduces a way for `FinalityFlow` to signal to `ReceiveTransactionFlow` that it is participating in two-phase finality, rather than just receiving a previously finalised transaction.

We will have to describe in the release notes that if `ReceiveTransactionFlow` has been re-implemented as part of pairing with `FinalityFlow`, then the CorDapp will have to make changes to be compatible with 4.11.  This is expected to be unlikely, but we should warn about this scenario just in case.