### PR TITLE
ENT-10606: Update artifact resolution for corda shell 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -432,7 +432,7 @@ allprojects {
                 }
             }
             maven {
-                url "${artifactory_contextUrl}/corda-releases"
+                url "${publicArtifactURL}/corda-releases"
                 content {
                     includeModule('net.corda', 'corda-shell')
                 }


### PR DESCRIPTION
Fix issue with samples unable to resolve `corda-shell`. This is due to a misconfiguration on the repository declarations post Artifactory migration, Rather than pointing to Artifactory here, we should use the public mirror. 