### PR TITLE
ENT-6875 Deserialisation exception on output state can cause ledger inconsistency

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version1/AttachmentContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version1/AttachmentContract.kt
@@ -2,12 +2,17 @@ package net.corda.contracts.incompatible.version1
 
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.transactions.LedgerTransaction
+
 class AttachmentContract : Contract {
+
+    private val FAIL_CONTRACT_VERIFY = java.lang.Boolean.getBoolean("net.corda.contracts.incompatible.AttachmentContract.fail.verify")
     override fun verify(tx: LedgerTransaction) {
+        if (FAIL_CONTRACT_VERIFY) throw object:TransactionVerificationException(tx.id, "AttachmentContract verify failed.", null) {}
         val state = tx.outputsOfType<State>().single()
         // we check that at least one has the matching hash, the other will be the contract
         require(tx.attachments.any { it.id == state.hash }) {"At least one attachment in transaction must match hash ${state.hash}"}
@@ -16,6 +21,10 @@ class AttachmentContract : Contract {
     object Command : TypeOnlyCommandData()
 
     data class State(val hash: SecureHash.SHA256) : ContractState {
+        private val FAIL_CONTRACT_STATE = java.lang.Boolean.getBoolean("net.corda.contracts.incompatible.AttachmentContract.fail.state")
+        init {
+            if (FAIL_CONTRACT_STATE) throw TransactionVerificationException.TransactionRequiredContractUnspecifiedException(hash,"AttachmentContract state initialisation failed.")
+        }
         override val participants: List<AbstractParty> = emptyList()
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version1/AttachmentContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version1/AttachmentContract.kt
@@ -6,6 +6,7 @@ import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
+import net.corda.core.serialization.internal.AttachmentsClassLoader
 import net.corda.core.transactions.LedgerTransaction
 
 class AttachmentContract : Contract {
@@ -21,7 +22,7 @@ class AttachmentContract : Contract {
     object Command : TypeOnlyCommandData()
 
     data class State(val hash: SecureHash.SHA256) : ContractState {
-        private val FAIL_CONTRACT_STATE = java.lang.Boolean.getBoolean("net.corda.contracts.incompatible.AttachmentContract.fail.state")
+        private val FAIL_CONTRACT_STATE = java.lang.Boolean.getBoolean("net.corda.contracts.incompatible.AttachmentContract.fail.state") && (this.javaClass.classLoader !is AttachmentsClassLoader)
         init {
             if (FAIL_CONTRACT_STATE) throw TransactionVerificationException.TransactionRequiredContractUnspecifiedException(hash,"AttachmentContract state initialisation failed.")
         }

--- a/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version1/AttachmentContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version1/AttachmentContract.kt
@@ -1,0 +1,23 @@
+package net.corda.contracts.incompatible.version1
+
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.TypeOnlyCommandData
+import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.AbstractParty
+import net.corda.core.transactions.LedgerTransaction
+class AttachmentContract : Contract {
+    override fun verify(tx: LedgerTransaction) {
+        val state = tx.outputsOfType<State>().single()
+        // we check that at least one has the matching hash, the other will be the contract
+        require(tx.attachments.any { it.id == state.hash }) {"At least one attachment in transaction must match hash ${state.hash}"}
+    }
+
+    object Command : TypeOnlyCommandData()
+
+    data class State(val hash: SecureHash.SHA256) : ContractState {
+        override val participants: List<AbstractParty> = emptyList()
+    }
+}
+
+const val ATTACHMENT_PROGRAM_ID = "net.corda.contracts.incompatible.version1.AttachmentContract"

--- a/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version2/AttachmentContract.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/incompatible/version2/AttachmentContract.kt
@@ -1,0 +1,25 @@
+package net.corda.contracts.incompatible.version2
+
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.TypeOnlyCommandData
+import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.AbstractParty
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.utilities.OpaqueBytes
+
+class AttachmentContract : Contract {
+    override fun verify(tx: LedgerTransaction) {
+        val state = tx.outputsOfType<State>().single()
+        // we check that at least one has the matching hash, the other will be the contract
+        require(tx.attachments.any { it.id == SecureHash.SHA256(state.opaqueBytes.bytes) }) {"At least one attachment in transaction must match hash ${state.opaqueBytes}"}
+    }
+
+    object Command : TypeOnlyCommandData()
+
+    data class State(val opaqueBytes: OpaqueBytes) : ContractState {
+        override val participants: List<AbstractParty> = emptyList()
+    }
+}
+
+const val ATTACHMENT_PROGRAM_ID = "net.corda.contracts.incompatible.version2.AttachmentContract"

--- a/node/src/integration-test/kotlin/net/corda/flows/incompatible/version1/AttachmentFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/incompatible/version1/AttachmentFlow.kt
@@ -1,0 +1,48 @@
+package net.corda.flows.incompatible.version1
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.contracts.incompatible.version1.ATTACHMENT_PROGRAM_ID
+import net.corda.contracts.incompatible.version1.AttachmentContract
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+@InitiatingFlow
+@StartableByRPC
+class AttachmentFlow(private val otherSide: Party,
+                     private val notary: Party,
+                     private val attachId: SecureHash.SHA256) : FlowLogic<SignedTransaction>() {
+
+    object SIGNING : ProgressTracker.Step("Signing transaction")
+
+    override val progressTracker: ProgressTracker = ProgressTracker(SIGNING)
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        // Create a trivial transaction with an output that describes the attachment, and the attachment itself
+        val ptx = TransactionBuilder(notary)
+                .addOutputState(AttachmentContract.State(attachId), ATTACHMENT_PROGRAM_ID)
+                .addCommand(AttachmentContract.Command, ourIdentity.owningKey)
+                .addAttachment(attachId)
+
+        progressTracker.currentStep = SIGNING
+
+        val stx = serviceHub.signInitialTransaction(ptx)
+
+        // Send the transaction to the other recipient
+        return subFlow(FinalityFlow(stx, initiateFlow(otherSide)))
+    }
+}
+
+@InitiatedBy(AttachmentFlow::class)
+class StoreAttachmentFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        // As a non-participant to the transaction we need to record all states
+        subFlow(ReceiveFinalityFlow(otherSide, statesToRecord = StatesToRecord.ALL_VISIBLE))
+    }
+}
+

--- a/node/src/integration-test/kotlin/net/corda/flows/incompatible/version1/AttachmentFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/incompatible/version1/AttachmentFlow.kt
@@ -4,12 +4,19 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.incompatible.version1.ATTACHMENT_PROGRAM_ID
 import net.corda.contracts.incompatible.version1.AttachmentContract
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.*
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveFinalityFlow
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
+
 @InitiatingFlow
 @StartableByRPC
 class AttachmentFlow(private val otherSide: Party,

--- a/node/src/integration-test/kotlin/net/corda/flows/incompatible/version1/AttachmentFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/incompatible/version1/AttachmentFlow.kt
@@ -3,25 +3,32 @@ package net.corda.flows.incompatible.version1
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.incompatible.version1.ATTACHMENT_PROGRAM_ID
 import net.corda.contracts.incompatible.version1.AttachmentContract
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.CollectSignaturesFlow
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.ReceiveFinalityFlow
+import net.corda.core.flows.SignTransactionFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.unwrap
 
 @InitiatingFlow
 @StartableByRPC
 class AttachmentFlow(private val otherSide: Party,
                      private val notary: Party,
-                     private val attachId: SecureHash.SHA256) : FlowLogic<SignedTransaction>() {
+                     private val attachId: SecureHash.SHA256,
+                     private val notariseInputState: StateAndRef<AttachmentContract.State>? = null) : FlowLogic<SignedTransaction>() {
 
     object SIGNING : ProgressTracker.Step("Signing transaction")
 
@@ -29,18 +36,29 @@ class AttachmentFlow(private val otherSide: Party,
 
     @Suspendable
     override fun call(): SignedTransaction {
+        val session = initiateFlow(otherSide)
+        val notarise = notariseInputState != null
+        session.send(notarise)  // inform peer whether to sign for notarisation
+
         // Create a trivial transaction with an output that describes the attachment, and the attachment itself
         val ptx = TransactionBuilder(notary)
                 .addOutputState(AttachmentContract.State(attachId), ATTACHMENT_PROGRAM_ID)
-                .addCommand(AttachmentContract.Command, ourIdentity.owningKey)
                 .addAttachment(attachId)
+        if (notarise) {
+            ptx.addInputState(notariseInputState!!)
+            ptx.addCommand(AttachmentContract.Command, ourIdentity.owningKey, otherSide.owningKey)
+        }
+        else
+            ptx.addCommand(AttachmentContract.Command, ourIdentity.owningKey)
 
         progressTracker.currentStep = SIGNING
 
         val stx = serviceHub.signInitialTransaction(ptx)
+        val ftx = if (notarise) {
+            subFlow(CollectSignaturesFlow(stx, listOf(session)))
+        } else stx
 
-        // Send the transaction to the other recipient
-        return subFlow(FinalityFlow(stx, initiateFlow(otherSide)))
+        return subFlow(FinalityFlow(ftx, setOf(session), statesToRecord = StatesToRecord.ALL_VISIBLE))
     }
 }
 
@@ -48,8 +66,29 @@ class AttachmentFlow(private val otherSide: Party,
 class StoreAttachmentFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
-        // As a non-participant to the transaction we need to record all states
-        subFlow(ReceiveFinalityFlow(otherSide, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        val notarise = otherSide.receive<Boolean>().unwrap { it }
+        if (notarise) {
+            val stx = subFlow(object : SignTransactionFlow(otherSide) {
+                override fun checkTransaction(stx: SignedTransaction) {
+                }
+            })
+            subFlow(ReceiveFinalityFlow(otherSide, stx.id, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        } else {
+            subFlow(ReceiveFinalityFlow(otherSide, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        }
     }
 }
 
+@StartableByRPC
+class AttachmentIssueFlow(private val attachId: SecureHash.SHA256,
+                          private val notary: Party): FlowLogic<SignedTransaction>() {
+    @Suspendable
+    override fun call(): SignedTransaction {
+        val builder = TransactionBuilder(notary)
+        builder.addAttachment(attachId)
+        builder.addOutputState(TransactionState(AttachmentContract.State(attachId), ATTACHMENT_PROGRAM_ID, notary))
+        builder.addCommand(Command(AttachmentContract.Command, listOf(ourIdentity.owningKey)))
+        val tx = serviceHub.signInitialTransaction(builder, ourIdentity.owningKey)
+        return subFlow(FinalityFlow(tx, emptySet<FlowSession>(), statesToRecord = StatesToRecord.ALL_VISIBLE))
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/flows/incompatible/version2/AttachmentFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/incompatible/version2/AttachmentFlow.kt
@@ -1,0 +1,49 @@
+package net.corda.flows.incompatible.version2
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.contracts.incompatible.version2.ATTACHMENT_PROGRAM_ID
+import net.corda.contracts.incompatible.version2.AttachmentContract
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.ProgressTracker
+@InitiatingFlow
+@StartableByRPC
+class AttachmentFlow(private val otherSide: Party,
+                     private val notary: Party,
+                     private val attachId: SecureHash.SHA256) : FlowLogic<SignedTransaction>() {
+
+    object SIGNING : ProgressTracker.Step("Signing transaction")
+
+    override val progressTracker: ProgressTracker = ProgressTracker(SIGNING)
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        // Create a trivial transaction with an output that describes the attachment, and the attachment itself
+        val ptx = TransactionBuilder(notary)
+                .addOutputState(AttachmentContract.State(OpaqueBytes(attachId.bytes)), ATTACHMENT_PROGRAM_ID)
+                .addCommand(AttachmentContract.Command, ourIdentity.owningKey)
+                .addAttachment(attachId)
+
+        progressTracker.currentStep = SIGNING
+
+        val stx = serviceHub.signInitialTransaction(ptx)
+
+        // Send the transaction to the other recipient
+        return subFlow(FinalityFlow(stx, initiateFlow(otherSide)))
+    }
+}
+
+@InitiatedBy(AttachmentFlow::class)
+class StoreAttachmentFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        // As a non-participant to the transaction we need to record all states
+        subFlow(ReceiveFinalityFlow(otherSide, statesToRecord = StatesToRecord.ALL_VISIBLE))
+    }
+}
+

--- a/node/src/integration-test/kotlin/net/corda/flows/incompatible/version2/AttachmentFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/incompatible/version2/AttachmentFlow.kt
@@ -4,13 +4,20 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.incompatible.version2.ATTACHMENT_PROGRAM_ID
 import net.corda.contracts.incompatible.version2.AttachmentContract
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.*
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveFinalityFlow
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.ProgressTracker
+
 @InitiatingFlow
 @StartableByRPC
 class AttachmentFlow(private val otherSide: Party,

--- a/node/src/integration-test/kotlin/net/corda/flows/incompatible/version3/AttachmentFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/incompatible/version3/AttachmentFlow.kt
@@ -48,12 +48,9 @@ class AttachmentFlow(private val otherSide: Party,
 class StoreAttachmentFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
-        // purposely prevent transaction verification and recording in ReceiveTransactionFlow
-        val stx = subFlow(ReceiveTransactionFlow(otherSide, checkSufficientSignatures = true, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        // purposely enable transaction verification and recording in ReceiveTransactionFlow
+        subFlow(ReceiveTransactionFlow(otherSide, checkSufficientSignatures = true, statesToRecord = StatesToRecord.ALL_VISIBLE))
         logger.info("StoreAttachmentFlow: successfully received fully signed tx. Sending it to the vault for processing.")
-
-        serviceHub.recordTransactions(StatesToRecord.ALL_VISIBLE, setOf(stx))
-        logger.info("StoreAttachmentFlow: successfully recorded received transaction locally.")
     }
 }
 

--- a/node/src/integration-test/kotlin/net/corda/flows/incompatible/version3/AttachmentFlow.kt
+++ b/node/src/integration-test/kotlin/net/corda/flows/incompatible/version3/AttachmentFlow.kt
@@ -1,0 +1,59 @@
+package net.corda.flows.incompatible.version3
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.contracts.incompatible.version1.ATTACHMENT_PROGRAM_ID
+import net.corda.contracts.incompatible.version1.AttachmentContract
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveTransactionFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+
+@InitiatingFlow
+@StartableByRPC
+class AttachmentFlow(private val otherSide: Party,
+                     private val notary: Party,
+                     private val attachId: SecureHash.SHA256) : FlowLogic<SignedTransaction>() {
+
+    object SIGNING : ProgressTracker.Step("Signing transaction")
+
+    override val progressTracker: ProgressTracker = ProgressTracker(SIGNING)
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        // Create a trivial transaction with an output that describes the attachment, and the attachment itself
+        val ptx = TransactionBuilder(notary)
+                .addOutputState(AttachmentContract.State(attachId), ATTACHMENT_PROGRAM_ID)
+                .addCommand(AttachmentContract.Command, ourIdentity.owningKey)
+                .addAttachment(attachId)
+
+        progressTracker.currentStep = SIGNING
+
+        val stx = serviceHub.signInitialTransaction(ptx)
+
+        // Send the transaction to the other recipient
+        return subFlow(FinalityFlow(stx, initiateFlow(otherSide)))
+    }
+}
+
+@InitiatedBy(AttachmentFlow::class)
+class StoreAttachmentFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        // purposely prevent transaction verification and recording in ReceiveTransactionFlow
+        val stx = subFlow(ReceiveTransactionFlow(otherSide, checkSufficientSignatures = true, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        logger.info("StoreAttachmentFlow: successfully received fully signed tx. Sending it to the vault for processing.")
+
+        serviceHub.recordTransactions(StatesToRecord.ALL_VISIBLE, setOf(stx))
+        logger.info("StoreAttachmentFlow: successfully recorded received transaction locally.")
+    }
+}
+

--- a/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
@@ -1,8 +1,7 @@
 package net.corda.node
 
+import co.paralleluniverse.strands.Strand
 import junit.framework.TestCase.assertEquals
-import net.corda.contracts.incompatible.version1.AttachmentContract as AttachmentContractV1
-import net.corda.contracts.incompatible.version2.AttachmentContract as AttachmentContractV2
 import net.corda.core.internal.InputStreamAndHash
 import net.corda.core.internal.deleteRecursively
 import net.corda.core.internal.div
@@ -10,23 +9,28 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.messaging.vaultQueryBy
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
-import net.corda.flows.incompatible.version1.AttachmentFlow
 import net.corda.node.services.Permissions
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.OutOfProcess
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.flows.waitForAllFlowsToComplete
 import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.cordappWithPackages
 import org.junit.Test
 import java.util.concurrent.TimeoutException
+import net.corda.contracts.incompatible.version1.AttachmentContract as AttachmentContractV1
+import net.corda.contracts.incompatible.version2.AttachmentContract as AttachmentContractV2
+import net.corda.flows.incompatible.version1.AttachmentFlow as AttachmentFlowV1
+import net.corda.flows.incompatible.version2.AttachmentFlow as AttachmentFlowV2
 
 class VaultUpdateDeserializationTest {
     companion object {
@@ -36,14 +40,15 @@ class VaultUpdateDeserializationTest {
         val contractVersion1 = cordappWithPackages("net.corda.contracts.incompatible.version1")
         val contractVersion2 = cordappWithPackages("net.corda.contracts.incompatible.version2")
 
-        fun driverParameters(ignoreTransactionDeserializationErrors: Boolean = false,
+        fun driverParameters(cordapps: List<TestCordapp>,
+                             ignoreTransactionDeserializationErrors: Boolean = false,
                              disableSignatureVerification: Boolean = false): DriverParameters {
             return DriverParameters(
                 portAllocation = incrementalPortAllocation(),
                 inMemoryDB = false,
                 startNodesInProcess = false,
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME)),
-                cordappsForAllNodes = emptyList(),
+                cordappsForAllNodes = cordapps,
                 systemProperties = mapOf(
                         "net.corda.vaultupdate.ignore.transaction.deserialization.errors" to ignoreTransactionDeserializationErrors.toString(),
                         "net.corda.recordtransaction.signature.verification.disabled" to disableSignatureVerification.toString())
@@ -57,7 +62,7 @@ class VaultUpdateDeserializationTest {
      */
     @Test(timeout=300_000)
 	fun `receiver flow throws deserialization error when using incompatible contract jar`() {
-        driver(driverParameters()) {
+        driver(driverParameters(emptyList())) {
             val alice = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion1)),
                     providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
             val bob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion2)),
@@ -68,7 +73,7 @@ class VaultUpdateDeserializationTest {
 
             // ISSUE: exception is not propagating from Receiver
             try {
-                alice.rpc.startFlow(::AttachmentFlow, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash).returnValue.getOrThrow(30.seconds)
+                alice.rpc.startFlow(::AttachmentFlowV1, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash).returnValue.getOrThrow(30.seconds)
             }
             catch(e: TimeoutException) {
                 println("Alice: Timeout awaiting flow completion.")
@@ -84,7 +89,7 @@ class VaultUpdateDeserializationTest {
             val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion1)),
                     providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
             // original hospitalized transaction should now have been re-processed with correct contract jar
-            assertEquals(1, restartedBob.rpc.vaultQueryBy<AttachmentContractV1.State>().states.size)
+            assertEquals(1, waitForVaultUpdate(restartedBob))
         }
     }
 
@@ -94,35 +99,47 @@ class VaultUpdateDeserializationTest {
      */
     @Test(timeout = 300_000)
     fun `receiver flow ignores deserialization failure when using override system property`() {
-        driver(driverParameters(ignoreTransactionDeserializationErrors = true,
-                                disableSignatureVerification = true)) {
-            val alice = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion1)),
+        driver(driverParameters(emptyList(),
+                ignoreTransactionDeserializationErrors = true,
+                disableSignatureVerification = true)) {
+            val alice = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion2)),
                     providedName = ALICE_NAME).getOrThrow()
-            val bob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion2)),
+            val bob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion1)),
                     providedName = BOB_NAME).getOrThrow()
 
             val (inputStream, hash) = InputStreamAndHash.createInMemoryTestZip(1024, 0)
             alice.rpc.uploadAttachment(inputStream)
 
             // Note: TransactionDeserialisationException is swallowed on the receiver node (without updating the vault).
-            val stx = alice.rpc.startFlow(::AttachmentFlow, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash).returnValue.getOrThrow(30.seconds)
+            val stx = alice.rpc.startFlow(::AttachmentFlowV2, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash).returnValue.getOrThrow(30.seconds)
             println("Alice txId: ${stx.id}")
 
             waitForAllFlowsToComplete(bob)
-            val txId = alice.rpc.stateMachineRecordedTransactionMappingSnapshot().single().transactionId
+            val txId = bob.rpc.stateMachineRecordedTransactionMappingSnapshot().single().transactionId
             println("Bob txId: $txId")
 
-            assertEquals(0, bob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
+//            assertEquals(0, bob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
 
             // restart Bob with correct contract jar version
             (bob as OutOfProcess).process.destroyForcibly()
             bob.stop()
             (baseDirectory(BOB_NAME) / "cordapps").deleteRecursively()
 
-            val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion1)),
+            val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion2)),
                     providedName = BOB_NAME).getOrThrow()
             // NOTE: flow is not re-tried as it was never sent to flow hospital.
-            assertEquals(0, restartedBob.rpc.vaultQueryBy<AttachmentContractV1.State>().states.size)
+            assertEquals(0, restartedBob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
         }
     }
+    private fun waitForVaultUpdate(nodeHandle: NodeHandle, maxIterations: Int = 5, iterationDelay: Long = 500): Int {
+        repeat((0..maxIterations).count()) {
+            val count = nodeHandle.rpc.vaultQueryBy<AttachmentContractV1.State>().states
+            if (count.isNotEmpty()) {
+                return count.size
+            }
+            Strand.sleep(iterationDelay)
+        }
+        return 0
+    }
 }
+

--- a/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
@@ -75,7 +75,7 @@ class VaultUpdateDeserializationTest {
             val stx = alice.rpc.startFlow(::AttachmentIssueFlow, hash, defaultNotaryIdentity).returnValue.getOrThrow(30.seconds)
             val spendableState = stx.coreTransaction.outRef<AttachmentContractV1.State>(0)
 
-            // ISSUE: exception is not propagating from Receiver
+            // ISSUE: exception is propagated from Receiver
             try {
                 alice.rpc.startFlow(::AttachmentFlowV1, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash, spendableState).returnValue.getOrThrow(30.seconds)
             }

--- a/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
@@ -75,7 +75,7 @@ class VaultUpdateDeserializationTest {
             val stx = alice.rpc.startFlow(::AttachmentIssueFlow, hash, defaultNotaryIdentity).returnValue.getOrThrow(30.seconds)
             val spendableState = stx.coreTransaction.outRef<AttachmentContractV1.State>(0)
 
-            // ISSUE: exception is propagated from Receiver
+            // NOTE: exception is propagated from Receiver
             try {
                 alice.rpc.startFlow(::AttachmentFlowV1, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash, spendableState).returnValue.getOrThrow(30.seconds)
             }

--- a/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
@@ -1,0 +1,98 @@
+package net.corda.node
+
+import net.corda.contracts.incompatible.version1.AttachmentContract
+import net.corda.contracts.incompatible.version2.AttachmentContract as AttachmentContractV2
+import net.corda.core.internal.InputStreamAndHash
+import net.corda.core.internal.deleteRecursively
+import net.corda.core.internal.div
+import net.corda.core.messaging.startFlow
+import net.corda.core.messaging.vaultQueryBy
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.flows.incompatible.version1.AttachmentFlow
+import net.corda.node.services.Permissions
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeParameters
+import net.corda.testing.driver.OutOfProcess
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.incrementalPortAllocation
+import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.User
+import net.corda.testing.node.internal.cordappWithPackages
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.concurrent.TimeoutException
+
+@Suppress("FunctionName")
+class VaultUpdateDeserializationTest {
+    companion object {
+        val user = User("u", "p", setOf(Permissions.all()))
+        val flowVersion1 = cordappWithPackages("net.corda.flows.incompatible.version1")
+        val flowVersion2 = cordappWithPackages("net.corda.flows.incompatible.version2")
+        val contractVersion1 = cordappWithPackages("net.corda.contracts.incompatible.version1")
+        val contractVersion2 = cordappWithPackages("net.corda.contracts.incompatible.version2")
+
+        fun driverParameters(cordapps: List<TestCordapp>, runInProcess: Boolean = false,
+                             ignoreTransactionDeserializationErrors: Boolean = false): DriverParameters {
+            return DriverParameters(
+                portAllocation = incrementalPortAllocation(),
+                startNodesInProcess = runInProcess,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME)),
+                cordappsForAllNodes = cordapps,
+                systemProperties = mapOf("net.corda.vaultupdate.ignore.transaction.deserialization.errors" to ignoreTransactionDeserializationErrors.toString())
+            )
+        }
+    }
+
+    /*
+     * Test that a deserialization error is raised where the receiver node of a finality flow has an incompatible contract jar.
+     * The ledger will be temporarily inconsistent until the correct contract jar version is installed and the receiver node is re-started.
+     */
+    @Test(timeout=300_000)
+	fun `receiver flow throws deserialization error when using incompatible contract jar`() {
+        driver(driverParameters(emptyList(), false)) {
+            val alice = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion1)),
+                    providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+            val bob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion2)),
+                    providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+
+            val (inputStream, hash) = InputStreamAndHash.createInMemoryTestZip(1024, 0)
+            alice.rpc.uploadAttachment(inputStream)
+
+            // ISSUE: exception is not propagating from Receiver
+//            val ex = assertFailsWith<TransactionDeserialisationException> {
+//            val ex = assertFailsWith<FlowException> {
+            println("Alice: Start AttachmentFlow")
+            try {
+                alice.rpc.startFlow(::AttachmentFlow, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash).returnValue.getOrThrow(30.seconds)
+            }
+            catch(e: TimeoutException) {
+                println("Alice: Timeout awaiting flow completion.")
+            }
+//            }
+//            println(ex.message)
+//            assertThat(ex).hasMessageContaining("Invalid data: $data")
+
+            println("Bob: Check vault")
+            assertThat(bob.rpc.vaultQueryBy<AttachmentContractV2.State>().states).hasSize(0)
+
+            // restart Bob with correct contract jar version
+            println("Bob: stop and remove cordapps")
+            (bob as OutOfProcess).process.destroyForcibly()
+            bob.stop()
+            (baseDirectory(BOB_NAME) / "cordapps").deleteRecursively()
+
+            println("Bob: re-start")
+            val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion1)),
+                    providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+            // ISSUE: receiver is not re-processing hospitalized flow
+            println("Bob: Re-check vault")
+            assertThat(restartedBob.rpc.vaultQueryBy<AttachmentContract.State>().states).hasSize(1)
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
@@ -88,7 +88,9 @@ class VaultUpdateDeserializationTest {
             }
             assertEquals(0, bob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
             // check transaction records
+            @Suppress("DEPRECATION")
             assertTrue(alice.rpc.internalVerifiedTransactionsSnapshot().isNotEmpty())
+            @Suppress("DEPRECATION")
             assertTrue(bob.rpc.internalVerifiedTransactionsSnapshot().isEmpty())
 
             // restart Bob with correct contract jar version
@@ -100,6 +102,7 @@ class VaultUpdateDeserializationTest {
                     providedName = BOB_NAME).getOrThrow()
             // original hospitalized transaction should now have been re-processed with correct contract jar
             assertEquals(1, waitForVaultUpdate(restartedBob))
+            @Suppress("DEPRECATION")
             assertTrue(restartedBob.rpc.internalVerifiedTransactionsSnapshot().isNotEmpty())
         }
     }
@@ -140,6 +143,7 @@ class VaultUpdateDeserializationTest {
             val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion2)),
                     providedName = BOB_NAME).getOrThrow()
             // transaction recorded
+            @Suppress("DEPRECATION")
             assertNotNull(restartedBob.rpc.internalFindVerifiedTransaction(txId))
             // but vault states not updated
             assertEquals(0, restartedBob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
@@ -166,7 +170,9 @@ class VaultUpdateDeserializationTest {
                 println("Alice: Caught flow propagation error from peer.")
             }
             // check transaction records
+            @Suppress("DEPRECATION")
             assertTrue(alice.rpc.internalVerifiedTransactionsSnapshot().isNotEmpty())
+            @Suppress("DEPRECATION")
             assertTrue(bob.rpc.internalVerifiedTransactionsSnapshot().isEmpty())
 
             // restart Bob with correct contract jar version
@@ -179,6 +185,7 @@ class VaultUpdateDeserializationTest {
             // NOTE: flow is not re-tried as it was never sent to flow hospital.
             assertEquals(0, restartedBob.rpc.vaultQueryBy<AttachmentContractV1.State>().states.size)
             // no transaction recorded
+            @Suppress("DEPRECATION")
             assertTrue(restartedBob.rpc.internalVerifiedTransactionsSnapshot().isEmpty())
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/VaultUpdateDeserializationTest.kt
@@ -2,6 +2,9 @@ package net.corda.node
 
 import co.paralleluniverse.strands.Strand
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import net.corda.core.flows.UnexpectedFlowEndException
 import net.corda.core.internal.InputStreamAndHash
 import net.corda.core.internal.deleteRecursively
 import net.corda.core.internal.div
@@ -9,7 +12,6 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.messaging.vaultQueryBy
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
-import net.corda.node.services.Permissions
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
@@ -23,21 +25,27 @@ import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.flows.waitForAllFlowsToComplete
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.TestCordapp
-import net.corda.testing.node.User
 import net.corda.testing.node.internal.cordappWithPackages
+import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.TimeoutException
 import net.corda.contracts.incompatible.version1.AttachmentContract as AttachmentContractV1
 import net.corda.contracts.incompatible.version2.AttachmentContract as AttachmentContractV2
 import net.corda.flows.incompatible.version1.AttachmentFlow as AttachmentFlowV1
 import net.corda.flows.incompatible.version2.AttachmentFlow as AttachmentFlowV2
+import net.corda.flows.incompatible.version3.AttachmentFlow as AttachmentFlowV3
 
 class VaultUpdateDeserializationTest {
     companion object {
-        val user = User("u", "p", setOf(Permissions.all()))
+        // uses ReceiveFinalityFlow
         val flowVersion1 = cordappWithPackages("net.corda.flows.incompatible.version1")
+        // uses ReceiveTransactionFlow with signature checking disabled
         val flowVersion2 = cordappWithPackages("net.corda.flows.incompatible.version2")
+        // uses ReceiveTransactionFlow with signature checking enabled
+        val flowVersion3 = cordappWithPackages("net.corda.flows.incompatible.version3")
+        // single state field of type SecureHash.SHA256
         val contractVersion1 = cordappWithPackages("net.corda.contracts.incompatible.version1")
+        // single state field of type OpaqueBytes
         val contractVersion2 = cordappWithPackages("net.corda.contracts.incompatible.version2")
 
         fun driverParameters(cordapps: List<TestCordapp>,
@@ -61,12 +69,12 @@ class VaultUpdateDeserializationTest {
      * The ledger will be temporarily inconsistent until the correct contract jar version is installed and the receiver node is re-started.
      */
     @Test(timeout=300_000)
-	fun `receiver flow throws deserialization error when using incompatible contract jar`() {
+	fun `receiver flow is hospitalized upon deserialization failure when using incompatible contract jar`() {
         driver(driverParameters(emptyList())) {
             val alice = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion1)),
-                    providedName = ALICE_NAME, rpcUsers = listOf(user)).getOrThrow()
+                    providedName = ALICE_NAME).getOrThrow()
             val bob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion2)),
-                    providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+                    providedName = BOB_NAME).getOrThrow()
 
             val (inputStream, hash) = InputStreamAndHash.createInMemoryTestZip(1024, 0)
             alice.rpc.uploadAttachment(inputStream)
@@ -78,8 +86,10 @@ class VaultUpdateDeserializationTest {
             catch(e: TimeoutException) {
                 println("Alice: Timeout awaiting flow completion.")
             }
-
             assertEquals(0, bob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
+            // check transaction records
+            assertTrue(alice.rpc.internalVerifiedTransactionsSnapshot().isNotEmpty())
+            assertTrue(bob.rpc.internalVerifiedTransactionsSnapshot().isEmpty())
 
             // restart Bob with correct contract jar version
             (bob as OutOfProcess).process.destroyForcibly()
@@ -87,9 +97,10 @@ class VaultUpdateDeserializationTest {
             (baseDirectory(BOB_NAME) / "cordapps").deleteRecursively()
 
             val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion1, contractVersion1)),
-                    providedName = BOB_NAME, rpcUsers = listOf(user)).getOrThrow()
+                    providedName = BOB_NAME).getOrThrow()
             // original hospitalized transaction should now have been re-processed with correct contract jar
             assertEquals(1, waitForVaultUpdate(restartedBob))
+            assertTrue(restartedBob.rpc.internalVerifiedTransactionsSnapshot().isNotEmpty())
         }
     }
 
@@ -97,8 +108,9 @@ class VaultUpdateDeserializationTest {
      * Test original deserialization failure behaviour by setting a new configurable java system property.
      * The ledger will enter an inconsistent state from which is cannot auto-recover.
      */
+    @Ignore("This test will only succeed if transaction verification is removed from ReceiveFinalityFlow. Otherwise it will throw an UntrustedAttachmentsException error.")
     @Test(timeout = 300_000)
-    fun `receiver flow ignores deserialization failure when using override system property`() {
+    fun `receiver flow ignores deserialization failure when using incompatible contract jar and overriden system property`() {
         driver(driverParameters(emptyList(),
                 ignoreTransactionDeserializationErrors = true,
                 disableSignatureVerification = true)) {
@@ -118,7 +130,7 @@ class VaultUpdateDeserializationTest {
             val txId = bob.rpc.stateMachineRecordedTransactionMappingSnapshot().single().transactionId
             println("Bob txId: $txId")
 
-//            assertEquals(0, bob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
+            assertEquals(0, bob.rpc.vaultQueryBy<AttachmentContractV1.State>().states.size)
 
             // restart Bob with correct contract jar version
             (bob as OutOfProcess).process.destroyForcibly()
@@ -127,10 +139,50 @@ class VaultUpdateDeserializationTest {
 
             val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion2, contractVersion2)),
                     providedName = BOB_NAME).getOrThrow()
-            // NOTE: flow is not re-tried as it was never sent to flow hospital.
+            // transaction recorded
+            assertNotNull(restartedBob.rpc.internalFindVerifiedTransaction(txId))
+            // but vault states not updated
             assertEquals(0, restartedBob.rpc.vaultQueryBy<AttachmentContractV2.State>().states.size)
         }
     }
+
+    @Test(timeout = 300_000)
+    fun `receiver flow propagates error upon deserialization failure using incompatible contract jar`() {
+        driver(driverParameters(emptyList(),
+                ignoreTransactionDeserializationErrors = true,
+                disableSignatureVerification = true)) {
+            val alice = startNode(NodeParameters(additionalCordapps = listOf(flowVersion3, contractVersion1)),
+                    providedName = ALICE_NAME).getOrThrow()
+            val bob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion3, contractVersion2)),
+                    providedName = BOB_NAME).getOrThrow()
+
+            val (inputStream, hash) = InputStreamAndHash.createInMemoryTestZip(1024, 0)
+            alice.rpc.uploadAttachment(inputStream)
+
+            try {
+                alice.rpc.startFlow(::AttachmentFlowV3, bob.nodeInfo.singleIdentity(), defaultNotaryIdentity, hash).returnValue.getOrThrow(30.seconds)
+            }
+            catch (e: UnexpectedFlowEndException) {
+                println("Alice: Caught flow propagation error from peer.")
+            }
+            // check transaction records
+            assertTrue(alice.rpc.internalVerifiedTransactionsSnapshot().isNotEmpty())
+            assertTrue(bob.rpc.internalVerifiedTransactionsSnapshot().isEmpty())
+
+            // restart Bob with correct contract jar version
+            (bob as OutOfProcess).process.destroyForcibly()
+            bob.stop()
+            (baseDirectory(BOB_NAME) / "cordapps").deleteRecursively()
+
+            val restartedBob = startNode(NodeParameters(additionalCordapps = listOf(flowVersion3, contractVersion1)),
+                    providedName = BOB_NAME).getOrThrow()
+            // NOTE: flow is not re-tried as it was never sent to flow hospital.
+            assertEquals(0, restartedBob.rpc.vaultQueryBy<AttachmentContractV1.State>().states.size)
+            // no transaction recorded
+            assertTrue(restartedBob.rpc.internalVerifiedTransactionsSnapshot().isEmpty())
+        }
+    }
+
     private fun waitForVaultUpdate(nodeHandle: NodeHandle, maxIterations: Int = 5, iterationDelay: Long = 500): Int {
         repeat((0..maxIterations).count()) {
             val count = nodeHandle.rpc.vaultQueryBy<AttachmentContractV1.State>().states

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -21,6 +21,7 @@ import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.tee
 import net.corda.core.internal.uncheckedCast
+import net.corda.core.internal.warnOnce
 import net.corda.core.messaging.DataFeed
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.KeyManagementService
@@ -106,6 +107,8 @@ class NodeVaultService(
         private val log = contextLogger()
 
         const val DEFAULT_SOFT_LOCKING_SQL_IN_CLAUSE_SIZE = 16
+
+        private val IGNORE_TRANSACTION_DESERIALIZATION_ERRORS = java.lang.Boolean.getBoolean("net.corda.vaultupdate.ignore.transaction.deserialization.errors")
 
         /**
          * Establish whether a given state is relevant to a node, given the node's public keys.
@@ -307,18 +310,29 @@ class NodeVaultService(
 
     private fun makeUpdates(batch: Iterable<CoreTransaction>, statesToRecord: StatesToRecord, previouslySeen: Boolean): List<Vault.Update<ContractState>> {
 
-        fun <T> withValidDeserialization(list: List<T>, txId: SecureHash): Map<Int, T> = (0 until list.size).mapNotNull { idx ->
-            try {
-                idx to list[idx]
-            } catch (e: TransactionDeserialisationException) {
-                // When resolving transaction dependencies we might encounter contracts we haven't installed locally.
-                // This will cause a failure as we can't deserialize such states in the context of the `appClassloader`.
-                // For now we ignore these states.
-                // In the future we will use the AttachmentsClassloader to correctly deserialize and asses the relevancy.
-                log.warn("Could not deserialize state $idx from transaction $txId. Cause: $e")
-                null
-            }
-        }.toMap()
+        fun <T> withValidDeserialization(list: List<T>, txId: SecureHash): Map<Int, T> {
+            var error: TransactionDeserialisationException? = null
+            val map = (0 until list.size).mapNotNull { idx ->
+                try {
+                    idx to list[idx]
+                } catch (e: TransactionDeserialisationException) {
+                    // When resolving transaction dependencies we might encounter contracts we haven't installed locally.
+                    // This will cause a failure as we can't deserialize such states in the context of the `appClassloader`.
+                    // For now we ignore these states.
+                    // In the future we will use the AttachmentsClassloader to correctly deserialize and asses the relevancy.
+                    if (IGNORE_TRANSACTION_DESERIALIZATION_ERRORS) {
+                        log.warnOnce("The current usage of transaction deserialization for the vault is unsafe." +
+                                "Ignoring vault updates due to failed deserialized states may lead to severe problems with ledger consistency. ")
+                        log.warn("Could not deserialize state $idx from transaction $txId. Cause: $e")
+                    } else {
+                        log.error("Could not deserialize state $idx from transaction $txId. Cause: $e")
+                        if(error == null) error = e
+                    }
+                    null
+                }
+            }.toMap()
+            return error?.let { throw it } ?: map
+        }
 
         // Returns only output states that can be deserialised successfully.
         fun WireTransaction.deserializableOutputStates(): Map<Int, TransactionState<ContractState>> = withValidDeserialization(this.outputs, this.id)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
@@ -128,4 +128,95 @@ data class NodeParameters(
             flowOverrides = flowOverrides,
             logLevelOverride = logLevelOverride)
 
+    constructor(
+            providedName: CordaX500Name?,
+            rpcUsers: List<User>,
+            verifierType: VerifierType,
+            customOverrides: Map<String, Any?>,
+            startInSameProcess: Boolean?,
+            maximumHeapSize: String,
+            additionalCordapps: Collection<TestCordapp> = emptySet(),
+            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>,
+            logLevelOverride: String? = null
+    ) : this(
+            providedName,
+            rpcUsers,
+            verifierType,
+            customOverrides,
+            startInSameProcess,
+            maximumHeapSize,
+            additionalCordapps,
+            flowOverrides,
+            logLevelOverride,
+            rpcAddress = null)
+
+    fun copy(
+            providedName: CordaX500Name?,
+            rpcUsers: List<User>,
+            verifierType: VerifierType,
+            customOverrides: Map<String, Any?>,
+            startInSameProcess: Boolean?,
+            maximumHeapSize: String,
+            additionalCordapps: Collection<TestCordapp> = emptySet(),
+            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>,
+            logLevelOverride: String? = null
+    ) = this.copy(
+            providedName = providedName,
+            rpcUsers = rpcUsers,
+            verifierType = verifierType,
+            customOverrides = customOverrides,
+            startInSameProcess = startInSameProcess,
+            maximumHeapSize = maximumHeapSize,
+            additionalCordapps = additionalCordapps,
+            flowOverrides = flowOverrides,
+            logLevelOverride = logLevelOverride,
+            rpcAddress = rpcAddress)
+
+    constructor(
+            providedName: CordaX500Name?,
+            rpcUsers: List<User>,
+            verifierType: VerifierType,
+            customOverrides: Map<String, Any?>,
+            startInSameProcess: Boolean?,
+            maximumHeapSize: String,
+            additionalCordapps: Collection<TestCordapp> = emptySet(),
+            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>,
+            logLevelOverride: String? = null,
+            rpcAddress: NetworkHostAndPort? = null
+    ) : this(
+            providedName,
+            rpcUsers,
+            verifierType,
+            customOverrides,
+            startInSameProcess,
+            maximumHeapSize,
+            additionalCordapps,
+            flowOverrides,
+            logLevelOverride,
+            rpcAddress,
+            systemProperties = emptyMap())
+
+    fun copy(
+            providedName: CordaX500Name?,
+            rpcUsers: List<User>,
+            verifierType: VerifierType,
+            customOverrides: Map<String, Any?>,
+            startInSameProcess: Boolean?,
+            maximumHeapSize: String,
+            additionalCordapps: Collection<TestCordapp> = emptySet(),
+            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>,
+            logLevelOverride: String? = null,
+            rpcAddress: NetworkHostAndPort? = null
+    ) = this.copy(
+            providedName = providedName,
+            rpcUsers = rpcUsers,
+            verifierType = verifierType,
+            customOverrides = customOverrides,
+            startInSameProcess = startInSameProcess,
+            maximumHeapSize = maximumHeapSize,
+            additionalCordapps = additionalCordapps,
+            flowOverrides = flowOverrides,
+            logLevelOverride = logLevelOverride,
+            rpcAddress = rpcAddress,
+            systemProperties = systemProperties)
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
@@ -36,7 +36,8 @@ data class NodeParameters(
         val additionalCordapps: Collection<TestCordapp> = emptySet(),
         val flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap(),
         val logLevelOverride: String? = null,
-        val rpcAddress: NetworkHostAndPort? = null
+        val rpcAddress: NetworkHostAndPort? = null,
+        val systemProperties: Map<String, String> = emptyMap()
 ) {
     /**
      * Create a new node parameters object with default values. Each parameter can be specified with its wither method which returns a copy

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
@@ -150,6 +150,7 @@ data class NodeParameters(
             logLevelOverride,
             rpcAddress = null)
 
+    @Suppress("LongParameterList")
     fun copy(
             providedName: CordaX500Name?,
             rpcUsers: List<User>,
@@ -196,6 +197,7 @@ data class NodeParameters(
             rpcAddress,
             systemProperties = emptyMap())
 
+    @Suppress("LongParameterList")
     fun copy(
             providedName: CordaX500Name?,
             rpcUsers: List<User>,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -755,7 +755,7 @@ class DriverDSLImpl(
                     debugPort,
                     bytemanJarPath,
                     bytemanPort,
-                    systemProperties,
+                    systemProperties + parameters.systemProperties,
                     parameters.maximumHeapSize,
                     parameters.logLevelOverride,
                     identifier,


### PR DESCRIPTION
Until now, deserialisation exceptions upon updating the vault were being ignored - leading to ledger inconsistency (a transaction would silently complete but without the vault contents being updated).

This PR changes the default behaviour of vault updates by explicitly logging Deserialisation exceptions and re-throwing them  to the caller. 

In addition, we introduce a new run-time property: `IGNORE_TRANSACTION_DESERIALIZATION_ERRORS`, which can be used to revert back to the original run-time behaviour.

**Testing**
Use variations of Send / Receive Attachment flow with and without notarisation.
We set a system property at run-time to force the AttachmentContract to fail on the receiver node.

