### PR TITLE
ES-1313: Update merge bot for slack channel

### DIFF
--- a/.ci/dev/forward-merge/Jenkinsfile
+++ b/.ci/dev/forward-merge/Jenkinsfile
@@ -3,6 +3,6 @@
 forwardMerger(
     targetBranch: 'release/os/4.7',
     originBranch: 'release/os/4.6',
-    slackChannel: '#build-team-automated-notifications'
+    slackChannel: '#c4-forward-merge-bot-notifications'
 )
 


### PR DESCRIPTION
Use a specific slack channel for C4 OS forward merge notifications rather than the existing build team channel.

This bot will post to Slack and signal that the merge has passed and is ready for review or that it has failed and needs human intervention for the merge 