### PR TITLE
ES-1313: changes for better future forward merges

### DIFF
--- a/.ci/dev/forward-merge/Jenkinsfile
+++ b/.ci/dev/forward-merge/Jenkinsfile
@@ -1,8 +1,31 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
-forwardMerger(
-    targetBranch: 'release/os/4.7',
-    originBranch: 'release/os/4.6',
-    slackChannel: '#c4-forward-merge-bot-notifications'
-)
+/*
+ * Forward merge any changes in current branch to the branch with following version.
+ *
+ * Please note, the branches names are intentionally separated as variables, to minimised conflicts
+ * during automated merges for this file.
+ *
+ * These variables should be updated when a new version is cut
+ */
 
+/**
+ * the branch name of origin branch, it should match the current branch
+ * and it acts as a fail-safe inside {@code forwardMerger} pipeline
+ */
+String originBranch = 'release/os/4.6'
+
+/**
+ * the branch name of target branch, it should be the branch with the next version
+ * after the one in current branch.
+ */
+String targetBranch = 'release/os/4.7'
+
+/**
+ * Forward merge any changes between #originBranch and #targetBranch
+ */
+forwardMerger(
+    targetBranch: targetBranch,
+    originBranch: originBranch,
+    slackChannel: '#c4-forward-merge-bot-notifications',
+)


### PR DESCRIPTION
* add more comments as a form of documentation
* move variable names away from calling pipeline for better experience of future forward merges if pipeline parameters were to change
* tested with https://ci02.dev.r3.com/blue/organizations/jenkins/Infrastructure%2Fforward-merging-automation%2Fcorda/detail/release%2Fos%2F4.6/3/pipeline - it fails, due to merge conflicts this change is aiming to help with