### PR TITLE
ENT-10756: Use normal select count query for totalStatesAvailable

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -771,7 +771,7 @@ class NodeVaultService(
 
     private fun <T : ContractState> queryTotalStateCount(criteria: QueryCriteria, contractStateType: Class<out T>): Long {
         val (criteriaQuery, criteriaParser) = buildCriteriaQuery<Long>(criteria, contractStateType, null)
-        criteriaQuery.select(criteriaBuilder.countDistinct(criteriaParser.vaultStates))
+        criteriaQuery.select(criteriaBuilder.count(criteriaParser.vaultStates))
         val query = getSession().createQuery(criteriaQuery)
         return query.singleResult
     }


### PR DESCRIPTION
Some DBs do not like the use of `distinct` in the count query for the `Page.totalStatesAvailable` result. It turns out it's not needed anyway and a non-distinct select count works as well.

