### PR TITLE
ES-1351: Bump platform version to 14, in line with creation of 4.12 branch

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -12,7 +12,7 @@ java8MinUpdateVersion=171
 # When incrementing platformVersion make sure to update          #
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #
 # ***************************************************************#
-platformVersion=13
+platformVersion=14
 openTelemetryVersion=1.20.1
 openTelemetrySemConvVersion=1.20.1-alpha
 guavaVersion=28.0-jre

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -29,7 +29,7 @@ import java.util.jar.JarInputStream
 
 
 // When incrementing platformVersion make sure to update PLATFORM_VERSION in constants.properties as well.
-const val PLATFORM_VERSION = 13
+const val PLATFORM_VERSION = 14
 
 fun ServicesForResolution.ensureMinimumPlatformVersion(requiredMinPlatformVersion: Int, feature: String) {
     checkMinimumPlatformVersion(networkParameters.minimumPlatformVersion, requiredMinPlatformVersion, feature)


### PR DESCRIPTION
With the creation of the `release/os/4.12` corda branch, the platform version should also be bumped to 14