### PR TITLE
ENT-10811: Removed index on primary key in node_aes_encryption_keys table

### DIFF
--- a/node/src/main/resources/migration/node-core.changelog-v26.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v26.xml
@@ -19,10 +19,4 @@
         <addPrimaryKey constraintName="node_aes_encryption_keys_pkey" tableName="node_aes_encryption_keys" columnNames="key_id"/>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="node_aes_encryption_keys_idx">
-        <createIndex indexName="node_aes_encryption_keys_idx" tableName="node_aes_encryption_keys">
-            <column name="key_id"/>
-        </createIndex>
-    </changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
The index is redundant on the primary key, and causes an issue in the schema migration for some databases, such as Oracle.