### PR TITLE
ENT-10806 - Security issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ buildscript {
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
     ext.jackson_version = '2.13.5'
     ext.jackson_kotlin_version = '2.9.7'
-    ext.jetty_version = '9.4.19.v20190610'
+    ext.jetty_version = '9.4.52.v20230823'
     ext.jersey_version = '2.25'
     ext.servlet_version = '4.0.1'
     ext.assertj_version = '3.12.2'


### PR DESCRIPTION
Bumped jetty version to get past CVE-2023-40167.
