### PR TITLE
ENT-10803 - Security issues

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -54,7 +54,7 @@ artemisVersion=2.19.1
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.13.5
 jacksonKotlinVersion=2.9.7
-jettyVersion=9.4.19.v20190610
+jettyVersion=9.4.52.v20230823
 jerseyVersion=2.25
 servletVersion=4.0.1
 assertjVersion=3.12.2


### PR DESCRIPTION
Bumped jetty version to get past [CVE-2023-40167](https://nvd.nist.gov/vuln/detail/CVE-2023-40167).