### PR TITLE
ENT-9943: Missed test that had assumed party id was still a long, now…

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FinalityFlowErrorHandlingTest.kt
@@ -74,7 +74,7 @@ class FinalityFlowErrorHandlingTest : StateMachineErrorHandlingTest() {
 
                 alice.rpc.startFlow(::GetFlowTransaction, txId).returnValue.getOrThrow().apply {
                     assertEquals("V", this.first)              // "V" -> VERIFIED
-                    assertEquals(CHARLIE_NAME.hashCode().toLong(), this.second)   // peer
+                    assertEquals(SecureHash.sha256(CHARLIE_NAME.toString()).toString(), this.second)   // peer
                 }
             }
         }
@@ -83,9 +83,9 @@ class FinalityFlowErrorHandlingTest : StateMachineErrorHandlingTest() {
 
 // Internal use for testing only!!
 @StartableByRPC
-class GetFlowTransaction(private val txId: SecureHash) : FlowLogic<Pair<String, Long>>() {
+class GetFlowTransaction(private val txId: SecureHash) : FlowLogic<Pair<String, String>>() {
     @Suspendable
-    override fun call(): Pair<String, Long> {
+    override fun call(): Pair<String, String> {
         val transactionStatus = serviceHub.jdbcSession().prepareStatement("select * from node_transactions where tx_id = ?")
                 .apply { setString(1, txId.toString()) }
                 .use { ps ->
@@ -99,7 +99,7 @@ class GetFlowTransaction(private val txId: SecureHash) : FlowLogic<Pair<String, 
                 .use { ps ->
                     ps.executeQuery().use { rs ->
                         rs.next()
-                        rs.getLong(4)     // receiverPartyId
+                        rs.getString(4)     // receiverPartyId
                     }
                 }
         return Pair(transactionStatus, receiverPartyId)


### PR DESCRIPTION
ENT-9943: Missed test that had assumed party id was still a long, now updated to string.

