### PR TITLE
ENT-10110 Ledger Recovery database table tweaks

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -354,7 +354,7 @@ class FinalityFlowTests : WithFinality {
 
         val sdrs = getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(1, this.size)
-            assertEquals(StatesToRecord.ALL_VISIBLE, this[0].statesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[0].senderStatesToRecord)
             assertEquals(SecureHash.sha256(BOB_NAME.toString()), this[0].peerPartyId)
         }
         val rdr = getReceiverRecoveryData(stx.id, bobNode).apply {
@@ -387,9 +387,9 @@ class FinalityFlowTests : WithFinality {
 
         val sdrs = getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(2, this.size)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].senderStatesToRecord)
             assertEquals(SecureHash.sha256(BOB_NAME.toString()), this[0].peerPartyId)
-            assertEquals(StatesToRecord.ALL_VISIBLE, this[1].statesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[1].senderStatesToRecord)
             assertEquals(SecureHash.sha256(CHARLIE_NAME.toString()), this[1].peerPartyId)
         }
         val rdr = getReceiverRecoveryData(stx.id, bobNode).apply {
@@ -451,7 +451,7 @@ class FinalityFlowTests : WithFinality {
 
         val sdr = getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(1, this.size)
-            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].statesToRecord)
+            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].senderStatesToRecord)
             assertEquals(SecureHash.sha256(BOB_NAME.toString()), this[0].peerPartyId)
         }
         val rdr = getReceiverRecoveryData(stx.id, bobNode).apply {

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -123,7 +123,6 @@ class FinalityFlowTests : WithFinality {
 	fun `allow use of the old API if the CorDapp target version is 3`() {
         val oldBob = createBob(cordapps = listOf(tokenOldCordapp()))
         val stx = aliceNode.issuesCashTo(oldBob)
-        @Suppress("DEPRECATION")
         aliceNode.startFlowAndRunNetwork(OldFinalityInvoker(stx)).resultFuture.getOrThrow()
         assertThat(oldBob.services.validatedTransactions.getTransaction(stx.id)).isNotNull
     }
@@ -239,7 +238,7 @@ class FinalityFlowTests : WithFinality {
     private fun assertTxnRemovedFromDatabase(node: TestStartedNode, stxId: SecureHash) {
         val fromDb = node.database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where txId = :transactionId",
+                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where transaction_id = :transactionId",
                     DBTransactionStorage.DBTransaction::class.java
             ).setParameter("transactionId", stxId.toString()).resultList
         }
@@ -354,7 +353,8 @@ class FinalityFlowTests : WithFinality {
 
         val sdrs = getSenderRecoveryData(stx.id, aliceNode.database).apply {
             assertEquals(1, this.size)
-            assertEquals(StatesToRecord.ALL_VISIBLE, this[0].senderStatesToRecord)
+            assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].senderStatesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[0].receiverStatesToRecord)
             assertEquals(SecureHash.sha256(BOB_NAME.toString()), this[0].peerPartyId)
         }
         val rdr = getReceiverRecoveryData(stx.id, bobNode).apply {
@@ -467,7 +467,7 @@ class FinalityFlowTests : WithFinality {
     private fun getSenderRecoveryData(id: SecureHash, database: CordaPersistence): List<SenderDistributionRecord> {
         val fromDb = database.transaction {
             session.createQuery(
-                    "from ${DBSenderDistributionRecord::class.java.name} where txId = :transactionId",
+                    "from ${DBSenderDistributionRecord::class.java.name} where transaction_id = :transactionId",
                     DBSenderDistributionRecord::class.java
             ).setParameter("transactionId", id.toString()).resultList
         }
@@ -477,7 +477,7 @@ class FinalityFlowTests : WithFinality {
     private fun getReceiverRecoveryData(txId: SecureHash, receiver: TestStartedNode): ReceiverDistributionRecord? {
         return receiver.database.transaction {
             session.createQuery(
-                    "from ${DBReceiverDistributionRecord::class.java.name} where txId = :transactionId",
+                    "from ${DBReceiverDistributionRecord::class.java.name} where transaction_id = :transactionId",
                     DBReceiverDistributionRecord::class.java
             ).setParameter("transactionId", txId.toString()).resultList
         }.singleOrNull()?.toReceiverDistributionRecord()

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -238,7 +238,7 @@ class FinalityFlowTests : WithFinality {
     private fun assertTxnRemovedFromDatabase(node: TestStartedNode, stxId: SecureHash) {
         val fromDb = node.database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where transaction_id = :transactionId",
+                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where tx_id = :transactionId",
                     DBTransactionStorage.DBTransaction::class.java
             ).setParameter("transactionId", stxId.toString()).resultList
         }
@@ -389,7 +389,7 @@ class FinalityFlowTests : WithFinality {
             assertEquals(2, this.size)
             assertEquals(StatesToRecord.ONLY_RELEVANT, this[0].senderStatesToRecord)
             assertEquals(SecureHash.sha256(BOB_NAME.toString()), this[0].peerPartyId)
-            assertEquals(StatesToRecord.ALL_VISIBLE, this[1].senderStatesToRecord)
+            assertEquals(StatesToRecord.ALL_VISIBLE, this[1].receiverStatesToRecord)
             assertEquals(SecureHash.sha256(CHARLIE_NAME.toString()), this[1].peerPartyId)
         }
         val rdr = getReceiverRecoveryData(stx.id, bobNode).apply {

--- a/node/src/main/resources/migration/node-core.changelog-v25.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v25.xml
@@ -24,7 +24,10 @@
             <column name="peer_party_id" type="NVARCHAR(144)">
                 <constraints nullable="false"/>
             </column>
-            <column name="states_to_record" type="INT">
+            <column name="sender_states_to_record" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="receiver_states_to_record" type="INT">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -148,7 +148,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.SENDER).let {
             assertEquals(2, it.size)
             assertEquals(SecureHash.sha256(BOB_NAME.toString()).toString(), it.senderRecords[0].compositeKey.peerPartyId)
-            assertEquals(ALL_VISIBLE, it.senderRecords[0].statesToRecord)
+            assertEquals(ALL_VISIBLE, it.senderRecords[0].senderStatesToRecord)
         }
         transactionRecovery.queryDistributionRecords(timeWindow, recordType = DistributionRecordType.RECEIVER).let {
             assertEquals(1, it.size)
@@ -181,8 +181,8 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(BOB_NAME)).let {
             assertEquals(2, it.size)
-            assertEquals(it[0].statesToRecord, ALL_VISIBLE)
-            assertEquals(it[1].statesToRecord, ONLY_RELEVANT)
+            assertEquals(it[0].senderStatesToRecord, ALL_VISIBLE)
+            assertEquals(it[1].senderStatesToRecord, ONLY_RELEVANT)
         }
         assertEquals(1, transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(ALICE_NAME)).size)
         assertEquals(2, transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(CHARLIE_NAME)).size)
@@ -251,7 +251,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         assertEquals(IN_FLIGHT, readTransactionFromDB(senderTransaction.id).status)
         readSenderDistributionRecordFromDB(senderTransaction.id).let {
             assertEquals(1, it.size)
-            assertEquals(ALL_VISIBLE, it[0].statesToRecord)
+            assertEquals(ALL_VISIBLE, it[0].senderStatesToRecord)
             assertEquals(BOB_NAME, partyInfoCache.getCordaX500NameByPartyId(it[0].peerPartyId))
         }
 
@@ -280,7 +280,8 @@ class DBTransactionStorageLedgerRecoveryTests {
         assertEquals(VERIFIED, readTransactionFromDB(transaction.id).status)
         readSenderDistributionRecordFromDB(transaction.id).apply {
             assertEquals(1, this.size)
-            assertEquals(ALL_VISIBLE, this[0].statesToRecord)
+            assertEquals(ONLY_RELEVANT, this[0].senderStatesToRecord)
+            assertEquals(ALL_VISIBLE, this[0].receiverStatesToRecord)
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -114,7 +114,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         val results = transactionRecovery.querySenderDistributionRecords(timeWindow, excludingTxnIds = setOf(transaction1.id))
         assertEquals(1, results.size)
-        assertEquals(transaction2.id.toString(), results[0].txId)
+        assertEquals(transaction2.id.toString(), results[0].compositeKey.txId)
     }
 
     @Test(timeout = 300_000)
@@ -128,7 +128,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         val timeWindow = RecoveryTimeWindow(fromTime = now().minus(1, ChronoUnit.DAYS))
         val results = transactionRecovery.querySenderDistributionRecords(timeWindow, peers = setOf(CHARLIE_NAME))
         assertEquals(1, results.size)
-        assertEquals(transaction2.id.toString(), results[0].txId)
+        assertEquals(transaction2.id.toString(), results[0].compositeKey.txId)
     }
 
     @Test(timeout = 300_000)
@@ -330,7 +330,7 @@ class DBTransactionStorageLedgerRecoveryTests {
     private fun readTransactionFromDB(txId: SecureHash): DBTransactionStorage.DBTransaction {
         val fromDb = database.transaction {
             session.createQuery(
-                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where txId = :transactionId",
+                    "from ${DBTransactionStorage.DBTransaction::class.java.name} where tx_id = :transactionId",
                     DBTransactionStorage.DBTransaction::class.java
             ).setParameter("transactionId", txId.toString()).resultList
         }
@@ -342,7 +342,7 @@ class DBTransactionStorageLedgerRecoveryTests {
         return database.transaction {
             if (txId != null)
                 session.createQuery(
-                        "from ${DBSenderDistributionRecord::class.java.name} where txId = :transactionId",
+                        "from ${DBSenderDistributionRecord::class.java.name} where transaction_id = :transactionId",
                         DBSenderDistributionRecord::class.java
                 ).setParameter("transactionId", txId.toString()).resultList.map { it.toSenderDistributionRecord() }
             else
@@ -356,7 +356,7 @@ class DBTransactionStorageLedgerRecoveryTests {
     private fun readReceiverDistributionRecordFromDB(txId: SecureHash): ReceiverDistributionRecord {
         val fromDb = database.transaction {
             session.createQuery(
-                    "from ${DBReceiverDistributionRecord::class.java.name} where txId = :transactionId",
+                    "from ${DBReceiverDistributionRecord::class.java.name} where transaction_id = :transactionId",
                     DBReceiverDistributionRecord::class.java
             ).setParameter("transactionId", txId.toString()).resultList
         }


### PR DESCRIPTION
- Capture "sender_states_to_record" in DBSenderDistributionRecord table.
- Incorporate txId into composite PK for distribution record tables