### PR TITLE
ENT-10110 Back-port changes from ENT + additional clean-up

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2580,6 +2580,16 @@ public static final class net.corda.core.flows.DistributionList$SenderDistributi
   public int hashCode()
   @NotNull
   public String toString()
+@CordaSerializable
+public abstract class net.corda.core.flows.DistributionRecord extends java.lang.Object implements net.corda.core.contracts.NamedByHash
+  public <init>()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getPeerPartyId()
+  @NotNull
+  public abstract java.time.Instant getTimestamp()
+  public abstract int getTimestampDiscriminator()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getTxId()
 ##
 @InitiatingFlow
 public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -21,7 +21,9 @@ import net.corda.core.flows.NotaryException
 import net.corda.core.flows.NotarySigCheck
 import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.flows.ReceiveTransactionFlow
+import net.corda.core.flows.ReceiverDistributionRecord
 import net.corda.core.flows.SendTransactionFlow
+import net.corda.core.flows.SenderDistributionRecord
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.flows.TransactionStatus
 import net.corda.core.flows.UnexpectedFlowEndException
@@ -53,8 +55,6 @@ import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.persistence.DBTransactionStorageLedgerRecovery.DBReceiverDistributionRecord
 import net.corda.node.services.persistence.DBTransactionStorageLedgerRecovery.DBSenderDistributionRecord
 import net.corda.node.services.persistence.HashedDistributionList
-import net.corda.node.services.persistence.ReceiverDistributionRecord
-import net.corda.node.services.persistence.SenderDistributionRecord
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
@@ -361,7 +361,7 @@ class FinalityFlowTests : WithFinality {
             assertNotNull(this)
             val hashedDL = HashedDistributionList.decrypt(this!!.encryptedDistributionList.bytes, aliceNode.internals.encryptionService)
             assertEquals(StatesToRecord.ONLY_RELEVANT, hashedDL.senderStatesToRecord)
-            assertEquals(SecureHash.sha256(aliceNode.info.singleIdentity().name.toString()), this.initiatorPartyId)
+            assertEquals(SecureHash.sha256(aliceNode.info.singleIdentity().name.toString()), this.peerPartyId)
             assertEquals(mapOf<SecureHash, StatesToRecord>(SecureHash.sha256(BOB_NAME.toString()) to StatesToRecord.ALL_VISIBLE), hashedDL.peerHashToStatesToRecord)
         }
         validateSenderAndReceiverTimestamps(sdrs, rdr!!)
@@ -396,7 +396,7 @@ class FinalityFlowTests : WithFinality {
             assertNotNull(this)
             val hashedDL = HashedDistributionList.decrypt(this!!.encryptedDistributionList.bytes, aliceNode.internals.encryptionService)
             assertEquals(StatesToRecord.ONLY_RELEVANT, hashedDL.senderStatesToRecord)
-            assertEquals(SecureHash.sha256(aliceNode.info.singleIdentity().name.toString()), this.initiatorPartyId)
+            assertEquals(SecureHash.sha256(aliceNode.info.singleIdentity().name.toString()), this.peerPartyId)
             // note: Charlie assertion here is using the hinted StatesToRecord value passed to it from Alice
             assertEquals(mapOf<SecureHash, StatesToRecord>(
                     SecureHash.sha256(BOB_NAME.toString()) to StatesToRecord.ONLY_RELEVANT,
@@ -458,7 +458,7 @@ class FinalityFlowTests : WithFinality {
             assertNotNull(this)
             val hashedDL = HashedDistributionList.decrypt(this!!.encryptedDistributionList.bytes, aliceNode.internals.encryptionService)
             assertEquals(StatesToRecord.ONLY_RELEVANT, hashedDL.senderStatesToRecord)
-            assertEquals(SecureHash.sha256(aliceNode.info.singleIdentity().name.toString()), this.initiatorPartyId)
+            assertEquals(SecureHash.sha256(aliceNode.info.singleIdentity().name.toString()), this.peerPartyId)
             assertEquals(mapOf<SecureHash, StatesToRecord>(SecureHash.sha256(BOB_NAME.toString()) to StatesToRecord.ONLY_RELEVANT), hashedDL.peerHashToStatesToRecord)
         }
         validateSenderAndReceiverTimestamps(sdr, rdr!!)

--- a/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowTransaction.kt
@@ -1,8 +1,11 @@
 package net.corda.core.flows
 
+import net.corda.core.contracts.NamedByHash
+import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.node.StatesToRecord
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.OpaqueBytes
 import java.time.Instant
 
 /**
@@ -42,6 +45,59 @@ sealed class DistributionList {
             val receiverStatesToRecord: StatesToRecord  // inferred or actual
     ) : DistributionList()
 }
+
+@CordaSerializable
+class DistributionRecords(
+        val senderRecords: List<SenderDistributionRecord> = emptyList(),
+        val receiverRecords: List<ReceiverDistributionRecord> = emptyList()
+) {
+    val size = senderRecords.size + receiverRecords.size
+}
+
+@CordaSerializable
+abstract class DistributionRecord : NamedByHash {
+    abstract val txId: SecureHash
+    abstract val peerPartyId: SecureHash
+    abstract val timestamp: Instant
+    abstract val timestampDiscriminator: Int
+}
+
+@CordaSerializable
+data class SenderDistributionRecord(
+        override val txId: SecureHash,
+        override val peerPartyId: SecureHash,
+        override val timestamp: Instant,
+        override val timestampDiscriminator: Int,
+        val senderStatesToRecord: StatesToRecord,
+        val receiverStatesToRecord: StatesToRecord
+) : DistributionRecord() {
+    override val id: SecureHash
+        get() = this.txId
+}
+
+@CordaSerializable
+data class ReceiverDistributionRecord(
+        override val txId: SecureHash,
+        override val peerPartyId: SecureHash,
+        override val timestamp: Instant,
+        override val timestampDiscriminator: Int,
+        val encryptedDistributionList: OpaqueBytes,
+        val receiverStatesToRecord: StatesToRecord
+) : DistributionRecord() {
+    override val id: SecureHash
+        get() = this.txId
+}
+
+@CordaSerializable
+enum class DistributionRecordType {
+    SENDER, RECEIVER, ALL
+}
+@CordaSerializable
+data class DistributionRecordKey(
+        val txnId: SecureHash,
+        val timestamp: Instant,
+        val timestampDiscriminator: Int
+)
 
 @CordaSerializable
 enum class TransactionStatus {


### PR DESCRIPTION

Clean-up to include not passing Entity classes around as @CordaSerializable. 
Move general Distribution Record data classes to core package for re-use in ENT.
