### PR TITLE
ENT-10100 Ledger Recovery: set verboseLogging to false by default.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/LedgerRecoverFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/LedgerRecoverFlow.kt
@@ -36,7 +36,7 @@ data class LedgerRecoveryParameters(
     val useAllNetworkNodes: Boolean = false,
     val dryRun: Boolean = false,
     val useTimeWindowNarrowing: Boolean = true,
-    val verboseLogging: Boolean = true,
+    val verboseLogging: Boolean = false,
     val recoveryBatchSize: Int = 1000
 )
 

--- a/core/src/main/kotlin/net/corda/core/flows/RecoveryTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/RecoveryTypes.kt
@@ -94,6 +94,10 @@ data class ReceiverDistributionRecord(
 ) : DistributionRecord() {
     override val id: SecureHash
         get() = this.txId
+
+    override fun toString(): String {
+        return "txId: $txId, peerPartyId: $peerPartyId, timestamp: $timestamp, timestampDiscriminator: $timestampDiscriminator, receiverStatesToRecord: $receiverStatesToRecord"
+    }
 }
 
 @CordaSerializable


### PR DESCRIPTION
Override toString() for ReceiverDistributionRecord

