### PR TITLE
ENT-11036 Add "forceRecoverFlowIds" parameter to FinalityRecoveryFlow

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityRecoveryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityRecoveryFlow.kt
@@ -57,10 +57,9 @@ class FlowRecoveryException(message: String, cause: Throwable? = null) : FlowExc
 data class FlowRecoveryQuery(
         val timeframe: FlowTimeWindow? = null,
         val initiatedBy: CordaX500Name? = null,
-        val counterParties: List<CordaX500Name>?  = null,
-        val excludeFlowIds: List<StateMachineRunId>? = null) {
+        val counterParties: List<CordaX500Name>?  = null) {
     init {
-        require(timeframe != null || initiatedBy != null || counterParties != null || excludeFlowIds != null) {
+        require(timeframe != null || initiatedBy != null || counterParties != null) {
             "Must specify at least one recovery criteria"
         }
     }

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityRecoveryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityRecoveryFlow.kt
@@ -21,6 +21,7 @@ class FinalityRecoveryFlow(
         private val matchingCriteria: FlowRecoveryQuery? = null,
         private val forceRecover: Boolean = false,
         private val recoverAll: Boolean = false,
+        private val forceRecoverFlowIds: Collection<StateMachineRunId> = emptySet(),
         override val progressTracker: ProgressTracker = ProgressTracker()) : FlowLogic<Map<FlowTransactionInfo, Boolean>>() {
 
     @CordaInternal
@@ -28,16 +29,17 @@ class FinalityRecoveryFlow(
                                     val flowIds: Collection<StateMachineRunId>,
                                     val matchingCriteria: FlowRecoveryQuery?,
                                     val forceRecover: Boolean,
-                                    val recoverAll: Boolean)
+                                    val recoverAll: Boolean,
+                                    val forceRecoverFlowIds: Collection<StateMachineRunId>)
     @CordaInternal
-    fun getExtraConstructorArgs() = ExtraConstructorArgs(txIds, flowIds, matchingCriteria, forceRecover, recoverAll)
+    fun getExtraConstructorArgs() = ExtraConstructorArgs(txIds, flowIds, matchingCriteria, forceRecover, recoverAll, forceRecoverFlowIds)
 
     constructor(txId: SecureHash, forceRecover: Boolean = false) : this(setOf(txId), forceRecover)
-    constructor(txIds: Collection<SecureHash>, forceRecover: Boolean = false, recoverAll: Boolean = false) : this(txIds, emptySet(), null, forceRecover, recoverAll, tracker())
+    constructor(txIds: Collection<SecureHash>, forceRecover: Boolean = false, recoverAll: Boolean = false) : this(txIds, emptySet(), null, forceRecover, recoverAll,  emptySet(), tracker())
     constructor(flowId: StateMachineRunId, forceRecover: Boolean = false) : this(emptySet(), setOf(flowId), null, forceRecover)
-    constructor(flowIds: Collection<StateMachineRunId>, forceRecover: Boolean = false) : this(emptySet(), flowIds, null, forceRecover, false, tracker())
-    constructor(recoverAll: Boolean, forceRecover: Boolean = false) : this(emptySet(), emptySet(), null, forceRecover, recoverAll, tracker())
-    constructor(matchingCriteria: FlowRecoveryQuery, forceRecover: Boolean = false) : this(emptySet(), emptySet(), matchingCriteria, forceRecover, false, tracker())
+    constructor(flowIds: Collection<StateMachineRunId>, forceRecover: Boolean = false) : this(emptySet(), flowIds, null, forceRecover, false,  emptySet(), tracker())
+    constructor(recoverAll: Boolean, forceRecover: Boolean = false) : this(emptySet(), emptySet(), null, forceRecover, recoverAll,  emptySet(), tracker())
+    constructor(matchingCriteria: FlowRecoveryQuery, forceRecover: Boolean = false) : this(emptySet(), emptySet(), matchingCriteria, forceRecover, false,  emptySet(), tracker())
 
     @Suspendable
     @Throws(FlowRecoveryException::class)
@@ -55,9 +57,10 @@ class FlowRecoveryException(message: String, cause: Throwable? = null) : FlowExc
 data class FlowRecoveryQuery(
         val timeframe: FlowTimeWindow? = null,
         val initiatedBy: CordaX500Name? = null,
-        val counterParties: List<CordaX500Name>?  = null) {
+        val counterParties: List<CordaX500Name>?  = null,
+        val excludeFlowIds: List<StateMachineRunId>? = null) {
     init {
-        require(timeframe != null || initiatedBy != null || counterParties != null) {
+        require(timeframe != null || initiatedBy != null || counterParties != null || excludeFlowIds != null) {
             "Must specify at least one recovery criteria"
         }
     }


### PR DESCRIPTION
Required by Ledger Recovery to force recovery of recovered IN_FLIGHT transactions which are associated with RUNNABLE ids whilst the Ledger Recovery flow is executing.