### PR TITLE
ENT-9940: Updated quasar dependency to 0.7.16_r3

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -17,7 +17,7 @@ openTelemetryVersion=1.20.1
 openTelemetrySemConvVersion=1.20.1-alpha
 guavaVersion=28.0-jre
 # Quasar version to use with Java 8:
-quasarVersion=0.7.15_r3
+quasarVersion=0.7.16_r3
 # Quasar version to use with Java 11:
 quasarVersion11=0.8.1_r3
 jdkClassifier11=jdk11


### PR DESCRIPTION
Updated quasar to 0.7.16_r3 to include change done in ENT-9940.
