### PR TITLE
ENT-11125  Fix publish preview releases

### DIFF
--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -46,3 +46,12 @@ jar {
         attributes 'Automatic-Module-Name': 'net.corda.client.jackson'
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -90,3 +90,12 @@ jar {
         attributes 'Automatic-Module-Name': 'net.corda.client.jfx'
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -37,3 +37,12 @@ jar {
         )
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -85,3 +85,12 @@ jar {
         attributes 'Automatic-Module-Name': 'net.corda.client.rpc'
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/common/configuration-parsing/build.gradle
+++ b/common/configuration-parsing/build.gradle
@@ -23,3 +23,12 @@ jar {
     baseName 'corda-common-configuration-parsing'
 }
 
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}
+

--- a/common/logging/build.gradle
+++ b/common/logging/build.gradle
@@ -36,3 +36,12 @@ jar {
     baseName 'corda-common-logging'
 }
 
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}
+

--- a/common/validation/build.gradle
+++ b/common/validation/build.gradle
@@ -8,3 +8,12 @@ dependencies {
 jar {
     baseName 'corda-common-validation'
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,7 +1,6 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'corda.common-publishing'
 
 dependencies {
     implementation rootProject
@@ -22,6 +21,10 @@ def internalPackagePrefixes(sourceDirs) {
 
 ext {
     archivedApiDocsBaseFilename = 'api-docs'
+}
+
+jar {
+    enabled = false
 }
 
 dokkaHtml {
@@ -94,6 +97,8 @@ task archiveApiDocs(type: Tar) {
 publishing {
     publications {
         if (System.getProperty('publishApiDocs') != null) {
+            apply plugin: 'corda.common-publishing'
+
             archivedApiDocs(MavenPublication) {
                 artifact archiveApiDocs {
                     artifactId archivedApiDocsBaseFilename

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -106,3 +106,12 @@ jar {
         attributes('Add-Opens': 'java.base/java.io java.base/java.time java.base/java.util java.base/java.lang.invoke java.base/java.security')
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -338,3 +338,12 @@ tasks.named('test', Test) {
     maxHeapSize = "3g"
     maxParallelForks = (System.env.CORDA_NODE_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_TESTING_FORKS".toInteger()
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/testing/core-test-utils/build.gradle
+++ b/testing/core-test-utils/build.gradle
@@ -44,3 +44,12 @@ jar {
         attributes('Corda-Testing': true)
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -139,3 +139,12 @@ scanApi {
         ]
     ]
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -29,3 +29,12 @@ jar {
         attributes('Corda-Testing': true)
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/testing/test-db/build.gradle
+++ b/testing/test-db/build.gradle
@@ -20,3 +20,12 @@ jar {
         attributes('Corda-Testing': true)
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/testing/test-utils/build.gradle
+++ b/testing/test-utils/build.gradle
@@ -55,3 +55,12 @@ jar {
         attributes('Corda-Testing': true)
     }
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/testing/testserver/build.gradle
+++ b/testing/testserver/build.gradle
@@ -89,3 +89,12 @@ task integrationTest(type: Test) {
 jar {
     baseName 'corda-testserver-impl'
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}

--- a/tools/cliutils/build.gradle
+++ b/tools/cliutils/build.gradle
@@ -23,3 +23,11 @@ jar {
     archiveBaseName = "corda-tools-cliutils"
 }
 
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId jar.baseName
+            from components.java
+        }
+    }
+}


### PR DESCRIPTION
The upgrade to Kotlin 1.9.0 across the whole project via gradle.properties has broken the publication of jar artifacts where the publishing section was not explicitly added. 

In previous versions it appears a default maven publication from components.java was added. This PR explicitly adds the publishing configuration to those projects missing it.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
