### PR TITLE
ENT-11130 - OS vs Enterprise changeset checksums

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -37,6 +37,7 @@ import net.corda.nodeapi.internal.persistence.contextTransactionOrNull
 import net.corda.nodeapi.internal.persistence.currentDBSession
 import net.corda.nodeapi.internal.persistence.wrapWithDatabaseTransaction
 import net.corda.serialization.internal.CordaSerializationEncoding.SNAPPY
+import org.hibernate.annotations.Type
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.time.Instant
@@ -78,6 +79,7 @@ open class DBTransactionStorage(private val database: CordaPersistence, cacheFac
             val timestamp: Instant,
 
             @Column(name = "signatures")
+            @Type(type = "corda-blob")
             val signatures: ByteArray?
     )
 

--- a/node/src/main/resources/migration/node-core.changelog-v23.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v23.xml
@@ -4,9 +4,16 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
                    logicalFilePath="migration/node-services.changelog-init.xml">
 
-    <changeSet author="R3.Corda" id="add_signatures_column">
+    <changeSet author="R3.Corda" id="add_signatures_column" dbms="postgresql">
         <addColumn tableName="node_transactions">
-            <column name="signatures" type="VARBINARY(33554432)"/>
+            <column name="signatures" type="varbinary(33554432)"/>
         </addColumn>
     </changeSet>
+
+    <changeSet author="R3.Corda" id="add_signatures_column" dbms="!postgresql">
+        <addColumn tableName="node_transactions">
+            <column name="signatures" type="blob"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Previously, upgrading from OS to |Enterprise caused a changeset checksum error when running the Enterprise migration scripts.

The _add_signatures_column_ changeset has been updated to match Enterprise, so the checksums match up.
