### PR TITLE
ES-1622: Switch corda/corda Github Actions to use Github App for authentication

### DIFF
--- a/.github/workflows/jira_assign_issue.yml
+++ b/.github/workflows/jira_assign_issue.yml
@@ -2,7 +2,7 @@ name: Sync assigned jira issues
 
 on:
   schedule:
-    - cron: '15 * * * *' 
+    - cron: '15 * * * *'
 
 jobs:
   sync_assigned:

--- a/.github/workflows/jira_assign_issue.yml
+++ b/.github/workflows/jira_assign_issue.yml
@@ -2,18 +2,24 @@ name: Sync assigned jira issues
 
 on:
   schedule:
-    - cron: '15 * * * *'
+    - cron: '15 * * * *'  
 
 jobs:
   sync_assigned:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PK }}
       - name: Assign
         uses: corda/jira-sync-assigned-action@master
         with:
           jiraBaseUrl: ${{ secrets.JIRA_BASE_URL }}
           jiraEmail: ${{ secrets.JIRA_USER_EMAIL }}
           jiraToken: ${{ secrets.JIRA_API_TOKEN }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           owner: corda
           repository: corda

--- a/.github/workflows/jira_assign_issue.yml
+++ b/.github/workflows/jira_assign_issue.yml
@@ -2,7 +2,7 @@ name: Sync assigned jira issues
 
 on:
   schedule:
-    - cron: '15 * * * *'  
+    - cron: '15 * * * *' 
 
 jobs:
   sync_assigned:

--- a/.github/workflows/jira_close_issue.yml
+++ b/.github/workflows/jira_close_issue.yml
@@ -8,12 +8,18 @@ jobs:
   sync_closed:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PK }}
       - name: Close
         uses: corda/jira-sync-closed-action@master
         with:
           jiraBaseUrl: https://r3-cev.atlassian.net
           jiraEmail: ${{ secrets.JIRA_USER_EMAIL }}
           jiraToken: ${{ secrets.JIRA_API_TOKEN }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           owner: corda
           repository: corda

--- a/.github/workflows/jira_create_issue.yml
+++ b/.github/workflows/jira_create_issue.yml
@@ -10,6 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PK }}
+
       - name: Jira Create issue
         id: create
         uses: corda/jira-create-issue-action@master
@@ -30,7 +37,7 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             Automatically created Jira issue: ${{ steps.create.outputs.issue }}


### PR DESCRIPTION
After IT enforced SSO in Github, and removed legacy `r3tc` Github user, the jira assign, close, and create Github Actions in Corda 4 OS repositories will no longer work.

This PR will switch them over to use a GitHub App for authentication as per: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow 