### PR TITLE
ES-1131: Re-add authenticateGradleWrapper

### DIFF
--- a/.ci/dev/compatibility/JenkinsfileJDK11Compile
+++ b/.ci/dev/compatibility/JenkinsfileJDK11Compile
@@ -36,6 +36,7 @@ pipeline {
     stages {
         stage('JDK 11 Compile') {
             steps {
+                authenticateGradleWrapper()
                 sh "./gradlew --no-daemon --parallel --build-cache -Pcompilation.allWarningsAsErrors=true -Ptests.failFast=false " +
                 "-Ptests.ignoreFailures=true clean compileAll --stacktrace"
             }


### PR DESCRIPTION
authenticateGradleWrapper was mistakenly removed in previous forward merge commit. 