### PR TITLE
ENT-11168 - reduce database index name.

### DIFF
--- a/node/src/main/resources/migration/node-core.changelog-v25.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v25.xml
@@ -75,7 +75,7 @@
     </changeSet>
 
     <changeSet author="R3.Corda" id="node_receiver_distr_recs_add_indexes">
-        <createIndex indexName="node_receiver_distr_recs_keyinfo_idx" tableName="node_receiver_distr_recs">
+        <createIndex indexName="node_receiver_distr_recs_idx1" tableName="node_receiver_distr_recs">
             <column name="transaction_id"/>
             <column name="timestamp"/>
             <column name="timestamp_discriminator"/>


### PR DESCRIPTION
Renamed the index _node_receiver_distr_recs_keyinfo_idx_ as it was too long for Oracle.
The new name is _node_receiver_distr_recs_idx1_.