### PR TITLE
ENT-11192: Replace usage of @Test.expected annotation parameter

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/contracts/ContractsDSLTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/contracts/ContractsDSLTests.kt
@@ -1,11 +1,16 @@
 package net.corda.coretests.contracts
 
-import net.corda.core.contracts.*
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.CommandWithParties
+import net.corda.core.contracts.TypeOnlyCommandData
+import net.corda.core.contracts.requireSingleCommand
+import net.corda.core.contracts.select
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.testing.core.TestIdentity
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -35,8 +40,8 @@ class RequireSingleCommandTests(private val testFunction: (Collection<CommandWit
         @JvmStatic
         @Parameterized.Parameters(name = "{1}")
         fun data(): Collection<Array<Any>> = listOf(
-                arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>> -> commands.requireSingleCommand<TestCommands>() }, "Inline version"),
-                arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>> -> commands.requireSingleCommand(TestCommands::class.java) }, "Interop version")
+                arrayOf({ commands: Collection<CommandWithParties<CommandData>> -> commands.requireSingleCommand<TestCommands>() }, "Inline version"),
+                arrayOf({ commands: Collection<CommandWithParties<CommandData>> -> commands.requireSingleCommand(TestCommands::class.java) }, "Interop version")
         )
     }
 
@@ -47,16 +52,18 @@ class RequireSingleCommandTests(private val testFunction: (Collection<CommandWit
         assertEquals(returnedCommand, validCommandOne, "they should be the same")
     }
 
-    @Test(expected = IllegalArgumentException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `check error is thrown if more than one valid command`() {
         val commands = listOf(validCommandOne, validCommandTwo)
-        testFunction(commands)
+        assertThatIllegalArgumentException().isThrownBy {
+            testFunction(commands)
+        }
     }
 
     @Test(timeout=300_000)
 	fun `check error is thrown when command is of wrong type`() {
         val commands = listOf(invalidCommand)
-        Assertions.assertThatThrownBy { testFunction(commands) }
+        assertThatThrownBy { testFunction(commands) }
                 .isInstanceOf(IllegalStateException::class.java)
                 .hasMessage("Required net.corda.coretests.contracts.TestCommands command")
     }
@@ -69,8 +76,8 @@ class SelectWithSingleInputsTests(private val testFunction: (Collection<CommandW
         @JvmStatic
         @Parameterized.Parameters(name = "{1}")
         fun data(): Collection<Array<Any>> = listOf(
-                arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signer: PublicKey?, party: AbstractParty? -> commands.select<TestCommands>(signer, party) }, "Inline version"),
-                arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signer: PublicKey?, party: AbstractParty? -> commands.select(TestCommands::class.java, signer, party) }, "Interop version")
+                arrayOf({ commands: Collection<CommandWithParties<CommandData>>, signer: PublicKey?, party: AbstractParty? -> commands.select<TestCommands>(signer, party) }, "Inline version"),
+                arrayOf({ commands: Collection<CommandWithParties<CommandData>>, signer: PublicKey?, party: AbstractParty? -> commands.select(TestCommands::class.java, signer, party) }, "Interop version")
         )
     }
 
@@ -118,8 +125,8 @@ class SelectWithMultipleInputsTests(private val testFunction: (Collection<Comman
         @JvmStatic
         @Parameterized.Parameters(name = "{1}")
         fun data(): Collection<Array<Any>> = listOf(
-                arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signers: Collection<PublicKey>?, party: Collection<Party>? -> commands.select<TestCommands>(signers, party) }, "Inline version"),
-                arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signers: Collection<PublicKey>?, party: Collection<Party>? -> commands.select(TestCommands::class.java, signers, party) }, "Interop version")
+                arrayOf({ commands: Collection<CommandWithParties<CommandData>>, signers: Collection<PublicKey>?, party: Collection<Party>? -> commands.select<TestCommands>(signers, party) }, "Inline version"),
+                arrayOf({ commands: Collection<CommandWithParties<CommandData>>, signers: Collection<PublicKey>?, party: Collection<Party>? -> commands.select(TestCommands::class.java, signers, party) }, "Interop version")
         )
     }
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/PartialMerkleTreeTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/PartialMerkleTreeTest.kt
@@ -1,11 +1,19 @@
 package net.corda.coretests.crypto
 
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import net.corda.core.contracts.*
-import net.corda.core.crypto.*
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.PrivacySalt
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TimeWindow
+import net.corda.core.contracts.TransactionState
+import net.corda.core.crypto.DigestService
+import net.corda.core.crypto.MerkleTree
+import net.corda.core.crypto.MerkleTreeException
+import net.corda.core.crypto.PartialMerkleTree
+import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.internal.DigestAlgorithmFactory
+import net.corda.core.crypto.keys
+import net.corda.core.crypto.randomHash
+import net.corda.core.crypto.sha256
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.BLAKE2s256DigestAlgorithm
@@ -16,9 +24,10 @@ import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.ReferenceStateRef
 import net.corda.core.transactions.WireTransaction
+import net.corda.coretesting.internal.TEST_TX_TIME
 import net.corda.finance.DOLLARS
-import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.`issued by`
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
@@ -26,20 +35,29 @@ import net.corda.testing.core.TestIdentity
 import net.corda.testing.dsl.LedgerDSL
 import net.corda.testing.dsl.TestLedgerDSLInterpreter
 import net.corda.testing.dsl.TestTransactionDSLInterpreter
-import net.corda.coretesting.internal.TEST_TX_TIME
 import net.corda.testing.internal.createWireTransaction
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.ledger
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.util.function.Predicate
 import java.util.stream.IntStream
 import kotlin.streams.toList
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @RunWith(Parameterized::class)
 class PartialMerkleTreeTest(private var digestService: DigestService) {
@@ -204,7 +222,7 @@ class PartialMerkleTreeTest(private var digestService: DigestService) {
 
     @Test(timeout=300_000)
 	fun `nothing filtered`() {
-        val ftxNothing = testTx.buildFilteredTransaction(Predicate { false })
+        val ftxNothing = testTx.buildFilteredTransaction { false }
         assertTrue(ftxNothing.componentGroups.isEmpty())
         assertTrue(ftxNothing.attachments.isEmpty())
         assertTrue(ftxNothing.commands.isEmpty())
@@ -291,10 +309,12 @@ class PartialMerkleTreeTest(private var digestService: DigestService) {
         assertFalse(pmt.verify(wrongRoot, inclHashes))
     }
 
-    @Test(expected = Exception::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `hash map serialization not allowed`() {
         val hm1 = hashMapOf("a" to 1, "b" to 2, "c" to 3, "e" to 4)
-        hm1.serialize()
+        assertThatIllegalArgumentException().isThrownBy {
+            hm1.serialize()
+        }
     }
 
     private fun makeSimpleCashWtx(
@@ -322,11 +342,11 @@ class PartialMerkleTreeTest(private var digestService: DigestService) {
         val merkleTree = MerkleTree.getMerkleTree(sampleLeaves, digestService)
 
         // Provided hashes are not in the tree.
-        assertFailsWith<MerkleTreeException> { PartialMerkleTree.build(merkleTree, listOf<SecureHash>(digestService.hash("20"))) }
+        assertFailsWith<MerkleTreeException> { PartialMerkleTree.build(merkleTree, listOf(digestService.hash("20"))) }
         // One of the provided hashes is not in the tree.
-        assertFailsWith<MerkleTreeException> { PartialMerkleTree.build(merkleTree, listOf<SecureHash>(digestService.hash("20"), digestService.hash("1"), digestService.hash("5"))) }
+        assertFailsWith<MerkleTreeException> { PartialMerkleTree.build(merkleTree, listOf(digestService.hash("20"), digestService.hash("1"), digestService.hash("5"))) }
 
-        val pmt = PartialMerkleTree.build(merkleTree, listOf<SecureHash>(digestService.hash("1"), digestService.hash("5"), digestService.hash("0"), digestService.hash("19")))
+        val pmt = PartialMerkleTree.build(merkleTree, listOf(digestService.hash("1"), digestService.hash("5"), digestService.hash("0"), digestService.hash("19")))
         // First leaf.
         assertEquals(0, pmt.leafIndex(digestService.hash("0")))
         // Second leaf.
@@ -340,17 +360,17 @@ class PartialMerkleTreeTest(private var digestService: DigestService) {
         // The provided hash is not in the tree (using a leaf that didn't exist in the original Merkle tree).
         assertFailsWith<MerkleTreeException> { pmt.leafIndex(digestService.hash("30")) }
 
-        val pmtFirstElementOnly = PartialMerkleTree.build(merkleTree, listOf<SecureHash>(digestService.hash("0")))
+        val pmtFirstElementOnly = PartialMerkleTree.build(merkleTree, listOf(digestService.hash("0")))
         assertEquals(0, pmtFirstElementOnly.leafIndex(digestService.hash("0")))
         // The provided hash is not in the tree.
         assertFailsWith<MerkleTreeException> { pmtFirstElementOnly.leafIndex(digestService.hash("10")) }
 
-        val pmtLastElementOnly = PartialMerkleTree.build(merkleTree, listOf<SecureHash>(digestService.hash("19")))
+        val pmtLastElementOnly = PartialMerkleTree.build(merkleTree, listOf(digestService.hash("19")))
         assertEquals(19, pmtLastElementOnly.leafIndex(digestService.hash("19")))
         // The provided hash is not in the tree.
         assertFailsWith<MerkleTreeException> { pmtLastElementOnly.leafIndex(digestService.hash("10")) }
 
-        val pmtOneElement = PartialMerkleTree.build(merkleTree, listOf<SecureHash>(digestService.hash("5")))
+        val pmtOneElement = PartialMerkleTree.build(merkleTree, listOf(digestService.hash("5")))
         assertEquals(5, pmtOneElement.leafIndex(digestService.hash("5")))
         // The provided hash is not in the tree.
         assertFailsWith<MerkleTreeException> { pmtOneElement.leafIndex(digestService.hash("10")) }

--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/PartialMerkleTreeWithNamedHashMultiAlgTreeTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/PartialMerkleTreeWithNamedHashMultiAlgTreeTest.kt
@@ -1,17 +1,14 @@
 package net.corda.coretests.crypto
 
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.contracts.TransactionState
+import net.corda.core.crypto.DigestService
 import net.corda.core.crypto.MerkleTree
 import net.corda.core.crypto.MerkleTreeException
 import net.corda.core.crypto.PartialMerkleTree
-import net.corda.core.crypto.DigestService
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SecureHash.Companion.SHA2_384
 import net.corda.core.crypto.SecureHash.Companion.hashAs
@@ -26,9 +23,10 @@ import net.corda.core.serialization.serialize
 import net.corda.core.transactions.ReferenceStateRef
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes
+import net.corda.coretesting.internal.TEST_TX_TIME
 import net.corda.finance.DOLLARS
-import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.`issued by`
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
@@ -36,10 +34,10 @@ import net.corda.testing.core.TestIdentity
 import net.corda.testing.dsl.LedgerDSL
 import net.corda.testing.dsl.TestLedgerDSLInterpreter
 import net.corda.testing.dsl.TestTransactionDSLInterpreter
-import net.corda.coretesting.internal.TEST_TX_TIME
 import net.corda.testing.internal.createWireTransaction
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.ledger
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -49,6 +47,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.util.function.Predicate
 import java.util.stream.IntStream
@@ -209,7 +210,7 @@ class PartialMerkleTreeWithNamedHashMultiAlgTreeTest {
 
     @Test(timeout=300_000)
     fun `nothing filtered`() {
-        val ftxNothing = testTx.buildFilteredTransaction(Predicate { false })
+        val ftxNothing = testTx.buildFilteredTransaction { false }
         assertTrue(ftxNothing.componentGroups.isEmpty())
         assertTrue(ftxNothing.attachments.isEmpty())
         assertTrue(ftxNothing.commands.isEmpty())
@@ -296,10 +297,12 @@ class PartialMerkleTreeWithNamedHashMultiAlgTreeTest {
         assertFalse(pmt.verify(wrongRoot, inclHashes))
     }
 
-    @Test(expected = Exception::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `hash map serialization not allowed`() {
         val hm1 = hashMapOf("a" to 1, "b" to 2, "c" to 3, "e" to 4)
-        hm1.serialize()
+        assertThatIllegalArgumentException().isThrownBy {
+            hm1.serialize()
+        }
     }
 
     private fun makeSimpleCashWtx(

--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/SignedDataTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/SignedDataTest.kt
@@ -6,6 +6,7 @@ import net.corda.core.crypto.sign
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
 import net.corda.testing.core.SerializationEnvironmentRule
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -35,12 +36,14 @@ class SignedDataTest {
         assertEquals(data, unwrappedData)
     }
 
-    @Test(expected = SignatureException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `make sure incorrectly signed data raises an exception`() {
         val keyPairA = generateKeyPair()
         val keyPairB = generateKeyPair()
         val sig = keyPairA.private.sign(serialized.bytes, keyPairB.public)
         val wrappedData = SignedData(serialized, sig)
-        wrappedData.verified()
+        assertThatExceptionOfType(SignatureException::class.java).isThrownBy {
+            wrappedData.verified()
+        }
     }
 }

--- a/core-tests/src/test/kotlin/net/corda/coretests/crypto/TransactionSignatureTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/crypto/TransactionSignatureTest.kt
@@ -1,7 +1,17 @@
 package net.corda.coretests.crypto
 
-import net.corda.core.crypto.*
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.MerkleTree
+import net.corda.core.crypto.MerkleTreeException
+import net.corda.core.crypto.PartialMerkleTree
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SignableData
+import net.corda.core.crypto.SignatureMetadata
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.sha256
+import net.corda.core.crypto.sign
 import net.corda.testing.core.SerializationEnvironmentRule
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Rule
 import org.junit.Test
 import java.math.BigInteger
@@ -39,12 +49,14 @@ class TransactionSignatureTest {
     }
 
     /** Verification should fail; corrupted metadata - clearData (Merkle root) has changed. */
-    @Test(expected = SignatureException::class,timeout=300_000)
+    @Test(timeout=300_000)
     fun `Signature metadata full failure clearData has changed`() {
         val keyPair = Crypto.generateKeyPair("ECDSA_SECP256K1_SHA256")
         val signableData = SignableData(testBytes.sha256(), SignatureMetadata(1, Crypto.findSignatureScheme(keyPair.public).schemeNumberID))
         val transactionSignature = keyPair.sign(signableData)
-        Crypto.doVerify((testBytes + testBytes).sha256(), transactionSignature)
+        assertThatExceptionOfType(SignatureException::class.java).isThrownBy {
+            Crypto.doVerify((testBytes + testBytes).sha256(), transactionSignature)
+        }
     }
 
     @Test(timeout=300_000)

--- a/core/src/test/kotlin/net/corda/core/internal/ClassLoadingUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ClassLoadingUtilsTest.kt
@@ -9,6 +9,7 @@ import net.corda.core.node.services.AttachmentId
 import net.corda.core.serialization.internal.AttachmentURLStreamHandlerFactory
 import net.corda.core.serialization.internal.AttachmentsClassLoader
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -76,9 +77,11 @@ class ClassLoadingUtilsTest {
             .doesNotContain(AbstractClass::class.java.name)
     }
 
-    @Test(expected = IllegalArgumentException::class,timeout=300_000)
+    @Test(timeout=300_000)
     fun throwsExceptionWhenClassDoesNotContainProperConstructors() {
-        createInstancesOfClassesImplementing(BaseInterface::class.java.classLoader, BaseInterface2::class.java)
+        assertThatIllegalArgumentException().isThrownBy {
+            createInstancesOfClassesImplementing(BaseInterface::class.java.classLoader, BaseInterface2::class.java)
+        }
     }
 
     @Test(timeout=300_000)

--- a/finance/contracts/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/contracts/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -31,6 +31,9 @@ import net.corda.testing.node.MockServices.Companion.makeTestDatabaseAndMockServ
 import net.corda.testing.node.ledger
 import net.corda.testing.node.makeTestIdentityService
 import net.corda.testing.node.transaction
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -300,7 +303,7 @@ class CashTests {
      * Test that the issuance builder rejects building into a transaction with existing
      * cash inputs.
      */
-    @Test(expected = IllegalStateException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `reject issuance with inputs`() {
         // Issue some cash
         var ptx = TransactionBuilder(dummyNotary.party)
@@ -311,7 +314,9 @@ class CashTests {
         // Include the previously issued cash in a new issuance command
         ptx = TransactionBuilder(dummyNotary.party)
         ptx.addInputState(tx.tx.outRef<Cash.State>(0))
-        Cash().generateIssue(ptx, 100.DOLLARS `issued by` miniCorp.ref(12, 34), owner = miniCorp.party, notary = dummyNotary.party)
+        assertThatIllegalStateException().isThrownBy {
+            Cash().generateIssue(ptx, 100.DOLLARS `issued by` miniCorp.ref(12, 34), owner = miniCorp.party, notary = dummyNotary.party)
+        }
     }
 
     @Test(timeout=300_000)
@@ -762,13 +767,15 @@ class CashTests {
         assertEquals(6000.DOLLARS `issued by` defaultIssuer, states.sumCashBy(megaCorp.party))
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `summing by owner throws`() {
         val states = listOf(
                 Cash.State(2000.DOLLARS `issued by` defaultIssuer, megaCorp.party),
                 Cash.State(4000.DOLLARS `issued by` defaultIssuer, megaCorp.party)
         )
-        states.sumCashBy(miniCorp.party)
+        assertThatExceptionOfType(UnsupportedOperationException::class.java).isThrownBy {
+            states.sumCashBy(miniCorp.party)
+        }
     }
 
     @Test(timeout=300_000)
@@ -778,10 +785,12 @@ class CashTests {
         assertNull(states.sumCashOrNull())
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `summing no currencies throws`() {
         val states = emptyList<Cash.State>()
-        states.sumCash()
+        assertThatExceptionOfType(UnsupportedOperationException::class.java).isThrownBy {
+            states.sumCash()
+        }
     }
 
     @Test(timeout=300_000)
@@ -797,14 +806,16 @@ class CashTests {
         assertEquals(expected, actual)
     }
 
-    @Test(expected = IllegalArgumentException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `summing multiple currencies`() {
         val states = listOf(
                 Cash.State(1000.DOLLARS `issued by` defaultIssuer, megaCorp.party),
                 Cash.State(4000.POUNDS `issued by` defaultIssuer, megaCorp.party)
         )
         // Test that summing everything fails because we're mixing units
-        states.sumCash()
+        assertThatIllegalArgumentException().isThrownBy {
+            states.sumCash()
+        }
     }
 
     // Double spend.

--- a/finance/contracts/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt
+++ b/finance/contracts/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt
@@ -1,9 +1,14 @@
 package net.corda.finance.contracts.asset
 
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import net.corda.core.contracts.*
+import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
+import net.corda.core.contracts.Amount
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.ContractClassName
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.Issued
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.NullKeys.NULL_PARTY
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
@@ -16,25 +21,44 @@ import net.corda.core.utilities.NonEmptySet
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.days
 import net.corda.core.utilities.hours
-import net.corda.finance.*
+import net.corda.coretesting.internal.TEST_TX_TIME
+import net.corda.finance.DOLLARS
+import net.corda.finance.GBP
+import net.corda.finance.POUNDS
+import net.corda.finance.USD
 import net.corda.finance.contracts.Commodity
 import net.corda.finance.contracts.NetType
 import net.corda.finance.contracts.asset.Obligation.Lifecycle
+import net.corda.finance.`issued by`
 import net.corda.finance.workflows.asset.ObligationUtils
 import net.corda.testing.contracts.DummyContract
-import net.corda.testing.core.*
-import net.corda.testing.dsl.*
-import net.corda.coretesting.internal.TEST_TX_TIME
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.CHARLIE_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.DummyCommandData
+import net.corda.testing.core.SerializationEnvironmentRule
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.dsl.EnforceVerifyOrFail
+import net.corda.testing.dsl.LedgerDSL
+import net.corda.testing.dsl.TestLedgerDSLInterpreter
+import net.corda.testing.dsl.TestTransactionDSLInterpreter
+import net.corda.testing.dsl.TransactionDSL
+import net.corda.testing.dsl.TransactionDSLInterpreter
 import net.corda.testing.internal.fakeAttachment
 import net.corda.testing.internal.vault.CommodityState
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.ledger
 import net.corda.testing.node.transaction
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.util.*
+import java.util.Currency
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
@@ -253,7 +277,7 @@ class ObligationTests {
      * Test that the issuance builder rejects building into a transaction with existing
      * cash inputs.
      */
-    @Test(expected = IllegalStateException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `reject issuance with inputs`() {
         // Issue some obligation
         val tx = TransactionBuilder(DUMMY_NOTARY).apply {
@@ -265,8 +289,10 @@ class ObligationTests {
         // Include the previously issued obligation in a new issuance command
         val ptx = TransactionBuilder(DUMMY_NOTARY)
         ptx.addInputState(tx.outRef<Obligation.State<Currency>>(0))
-        ObligationUtils.generateIssue(ptx, MINI_CORP, megaCorpDollarSettlement, 100.DOLLARS.quantity,
-                beneficiary = MINI_CORP, notary = DUMMY_NOTARY)
+        assertThatIllegalStateException().isThrownBy {
+            ObligationUtils.generateIssue(ptx, MINI_CORP, megaCorpDollarSettlement, 100.DOLLARS.quantity,
+                    beneficiary = MINI_CORP, notary = DUMMY_NOTARY)
+        }
     }
 
     /** Test generating a transaction to net two obligations of the same size, and therefore there are no outputs. */
@@ -576,7 +602,7 @@ class ObligationTests {
         val defaultFcoj = Issued(defaultIssuer, Commodity.getInstance("FCOJ")!!)
         val oneUnitFcoj = Amount(1, defaultFcoj)
         val obligationDef = Obligation.Terms(NonEmptySet.of(commodityContractBytes.sha256() as SecureHash), NonEmptySet.of(defaultFcoj), TEST_TX_TIME)
-        val oneUnitFcojObligation = Obligation.State(Obligation.Lifecycle.NORMAL, ALICE,
+        val oneUnitFcojObligation = Obligation.State(Lifecycle.NORMAL, ALICE,
                 obligationDef, oneUnitFcoj.quantity, NULL_PARTY)
         // Try settling a simple commodity obligation
         ledgerServices.ledger(DUMMY_NOTARY) {
@@ -853,9 +879,11 @@ class ObligationTests {
                 fiveKDollarsFromMegaToMega.copy(template = megaCorpDollarSettlement.copy(acceptableIssuedProducts = miniCorpIssuer)).bilateralNetState)
     }
 
-    @Test(expected = IllegalStateException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `states cannot be netted if not in the normal state`() {
-        inState.copy(lifecycle = Lifecycle.DEFAULTED).bilateralNetState
+        assertThatIllegalStateException().isThrownBy {
+            inState.copy(lifecycle = Lifecycle.DEFAULTED).bilateralNetState
+        }
     }
 
     /**
@@ -968,5 +996,5 @@ class ObligationTests {
     private val Issued<Currency>.OBLIGATION_DEF: Obligation.Terms<Currency>
         get() = Obligation.Terms(NonEmptySet.of(cashContractBytes.sha256() as SecureHash), NonEmptySet.of(this), TEST_TX_TIME)
     private val Amount<Issued<Currency>>.OBLIGATION: Obligation.State<Currency>
-        get() = Obligation.State(Obligation.Lifecycle.NORMAL, DUMMY_OBLIGATION_ISSUER, token.OBLIGATION_DEF, quantity, NULL_PARTY)
+        get() = Obligation.State(Lifecycle.NORMAL, DUMMY_OBLIGATION_ISSUER, token.OBLIGATION_DEF, quantity, NULL_PARTY)
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/persistence/RestrictedConnectionTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/persistence/RestrictedConnectionTest.kt
@@ -1,16 +1,24 @@
 package net.corda.nodeapi.internal.persistence
 
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.cordapp.CordappContext
 import net.corda.core.internal.PLATFORM_VERSION
 import net.corda.core.node.ServiceHub
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runners.model.Statement
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.sql.Connection
 import java.sql.Savepoint
 
 class RestrictedConnectionTest {
+    companion object {
+        private const val TEST_STRING: String = "test"
+        private const val TEST_INT: Int = 1
+    }
 
     private val connection: Connection = mock()
     private val savePoint: Savepoint = mock()
@@ -21,212 +29,227 @@ class RestrictedConnectionTest {
     }
     private val restrictedConnection: RestrictedConnection = RestrictedConnection(connection, serviceHub)
 
-    companion object {
-        private const val TEST_STRING: String = "test"
-        private const val TEST_INT: Int = 1
+    @Rule
+    @JvmField
+    val assertUnsupportedExceptionBasedOnTestName = TestRule { base, description ->
+        object : Statement() {
+            override fun evaluate() {
+                val exception = try {
+                    base.evaluate()
+                    null
+                } catch (e: UnsupportedOperationException) {
+                    e
+                }
+                if (description.methodName.endsWith(" throws unsupported exception")) {
+                    assertThat(exception).isNotNull()
+                } else {
+                    assertThat(exception).isNull()
+                }
+            }
+        }
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `abort with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.abort { println("I'm just an executor for this test...") }
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `clearWarnings with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.clearWarnings()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `close with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.close()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `commit with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.commit()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setSavepoint with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.setSavepoint()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setSavepoint with name with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.setSavepoint(TEST_STRING)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `releaseSavepoint with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.releaseSavepoint(savePoint)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `rollback with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.rollback()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `rollbackWithSavepoint with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.rollback(savePoint)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setCatalog with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.catalog = TEST_STRING
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setTransactionIsolation with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.transactionIsolation = TEST_INT
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setTypeMap with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         val map: MutableMap<String, Class<*>> = mutableMapOf()
         restrictedConnection.typeMap = map
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setHoldability with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.holdability = TEST_INT
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setSchema with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.schema = TEST_STRING
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setNetworkTimeout with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.setNetworkTimeout({ println("I'm just an executor for this test...") }, TEST_INT)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setAutoCommit with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.autoCommit = true
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setReadOnly with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedConnection.isReadOnly = true
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `abort with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.abort { println("I'm just an executor for this test...") }
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `clearWarnings with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.clearWarnings()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `close with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.close()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `commit with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.commit()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setSavepoint with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.setSavepoint()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setSavepoint with name with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.setSavepoint(TEST_STRING)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `releaseSavepoint with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.releaseSavepoint(savePoint)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `rollback with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.rollback()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `rollbackWithSavepoint with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.rollback(savePoint)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setCatalog with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.catalog = TEST_STRING
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setTransactionIsolation with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.transactionIsolation = TEST_INT
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setTypeMap with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         val map: MutableMap<String, Class<*>> = mutableMapOf()
         restrictedConnection.typeMap = map
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setHoldability with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.holdability = TEST_INT
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
-    fun `setSchema with target platform version of current 7 unsupported exception`() {
+    @Test(timeout = 300_000)
+    fun `setSchema with target platform version of current 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.schema = TEST_STRING
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setNetworkTimeout with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.setNetworkTimeout({ println("I'm just an executor for this test...") }, TEST_INT)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setAutoCommit with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.autoCommit = true
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setReadOnly with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedConnection.isReadOnly = true

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManagerTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/persistence/RestrictedEntityManagerTest.kt
@@ -1,13 +1,17 @@
 package net.corda.nodeapi.internal.persistence
 
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.cordapp.CordappContext
 import net.corda.core.internal.PLATFORM_VERSION
 import net.corda.core.node.ServiceHub
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runners.model.Statement
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import javax.persistence.EntityManager
 import javax.persistence.EntityTransaction
 import javax.persistence.LockModeType
@@ -23,19 +27,39 @@ class RestrictedEntityManagerTest {
     }
     private val restrictedEntityManager = RestrictedEntityManager(entitymanager, serviceHub)
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Rule
+    @JvmField
+    val assertUnsupportedExceptionBasedOnTestName = TestRule { base, description ->
+        object : Statement() {
+            override fun evaluate() {
+                val exception = try {
+                    base.evaluate()
+                    null
+                } catch (e: UnsupportedOperationException) {
+                    e
+                }
+                if (description.methodName.endsWith(" throws unsupported exception")) {
+                    assertThat(exception).isNotNull()
+                } else {
+                    assertThat(exception).isNull()
+                }
+            }
+        }
+    }
+    
+    @Test(timeout = 300_000)
     fun `close with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedEntityManager.close()
     }
 
     @Test(timeout = 300_000)
-    fun `clear with target platform version of current corda version throws unsupported exception`() {
+    fun `clear with target platform version of current corda version`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedEntityManager.clear()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `getMetaModel with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedEntityManager.metamodel
@@ -48,32 +72,32 @@ class RestrictedEntityManagerTest {
         assertTrue(restrictedEntityManager.transaction is RestrictedEntityTransaction)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `joinTransaction with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedEntityManager.joinTransaction()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `lock with two parameters with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedEntityManager.lock(Object(), LockModeType.OPTIMISTIC)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `lock with three parameters with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         val map: MutableMap<String, Any> = mutableMapOf()
         restrictedEntityManager.lock(Object(), LockModeType.OPTIMISTIC, map)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setProperty with target platform version of current corda version throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(PLATFORM_VERSION)
         restrictedEntityManager.setProperty("number", 12)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `close with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedEntityManager.close()
@@ -85,39 +109,39 @@ class RestrictedEntityManagerTest {
         restrictedEntityManager.clear()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `getMetaModel with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedEntityManager.metamodel
     }
 
     @Test(timeout = 300_000)
-    fun `getTransaction with target platform version of 7 throws unsupported exception`() {
+    fun `getTransaction with target platform version of 7`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         whenever(entitymanager.transaction).doReturn(transaction)
         assertTrue(restrictedEntityManager.transaction is RestrictedEntityTransaction)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `joinTransaction with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedEntityManager.joinTransaction()
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `lock with two parameters with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedEntityManager.lock(Object(), LockModeType.OPTIMISTIC)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `lock with three parameters with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         val map: MutableMap<String, Any> = mutableMapOf()
         restrictedEntityManager.lock(Object(), LockModeType.OPTIMISTIC, map)
     }
 
-    @Test(expected = UnsupportedOperationException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `setProperty with target platform version of 7 throws unsupported exception`() {
         whenever(cordapp.targetPlatformVersion).thenReturn(7)
         restrictedEntityManager.setProperty("number", 12)

--- a/node/src/test/kotlin/net/corda/node/internal/NodeFlowManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeFlowManagerTest.kt
@@ -6,14 +6,10 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.node.services.config.FlowOverride
 import net.corda.node.services.config.FlowOverrideConfig
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.instanceOf
-import org.junit.Assert
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Test
 import org.mockito.Mockito
-import java.lang.IllegalStateException
-
-private val marker = "This is a special marker"
 
 class NodeFlowManagerTest {
 
@@ -57,12 +53,14 @@ class NodeFlowManagerTest {
     }
 
 
-    @Test(expected = IllegalStateException::class, timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `should fail to validate if more than one registration with equal weight`() {
         val nodeFlowManager = NodeFlowManager()
         nodeFlowManager.registerInitiatedFlow(Init::class.java, Resp::class.java)
         nodeFlowManager.registerInitiatedFlow(Init::class.java, Resp2::class.java)
-        nodeFlowManager.validateRegistrations()
+        assertThatIllegalStateException().isThrownBy {
+            nodeFlowManager.validateRegistrations()
+        }
     }
 
     @Test(timeout = 300_000)
@@ -73,7 +71,7 @@ class NodeFlowManagerTest {
         nodeFlowManager.validateRegistrations()
         val factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         val flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
-        Assert.assertThat(flow, `is`(instanceOf(RespSub::class.java)))
+        assertThat(flow).isInstanceOf(RespSub::class.java)
     }
 
     @Test(timeout = 300_000)
@@ -84,14 +82,14 @@ class NodeFlowManagerTest {
         nodeFlowManager.validateRegistrations()
         var factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         var flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
-        Assert.assertThat(flow, `is`(instanceOf(RespSub::class.java)))
+        assertThat(flow).isInstanceOf(RespSub::class.java)
         // update
         nodeFlowManager.registerInitiatedFlow(Init::class.java, RespSubSub::class.java)
         nodeFlowManager.validateRegistrations()
 
         factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
-        Assert.assertThat(flow, `is`(instanceOf(RespSubSub::class.java)))
+        assertThat(flow).isInstanceOf(RespSubSub::class.java)
     }
 
     @Test(timeout=300_000)
@@ -105,6 +103,6 @@ class NodeFlowManagerTest {
         val factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         val flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
 
-        Assert.assertThat(flow, `is`(instanceOf(Resp::class.java)))
+        assertThat(flow).isInstanceOf(Resp::class.java)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappConfigFileProviderTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappConfigFileProviderTests.kt
@@ -7,6 +7,7 @@ import com.typesafe.config.ConfigRenderOptions
 import net.corda.core.internal.div
 import net.corda.core.internal.writeText
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
 import java.nio.file.Paths
 
@@ -45,10 +46,12 @@ class CordappConfigFileProviderTests {
         assertThat(provider.getConfigByName(cordappName)).isEqualTo(alternateValidConfig)
     }
 
-    @Test(expected = ConfigException.Parse::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `an invalid config throws an exception`() {
         cordappConfFile.writeText(invalidConfig)
-        provider.getConfigByName(cordappName)
+        assertThatExceptionOfType(ConfigException::class.java).isThrownBy {
+            provider.getConfigByName(cordappName)
+        }
     }
 
     /**

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfigTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfigTests.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import net.corda.core.cordapp.CordappConfigException
 import org.junit.Test
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 
 class TypesafeCordappConfigTests {
     @Test(timeout=300_000)
@@ -37,11 +38,12 @@ class TypesafeCordappConfigTests {
         assertThat(cordappConf.exists("notexists")).isFalse()
     }
 
-    @Test(expected = CordappConfigException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `test that an exception is thrown when trying to access a non-extant field`() {
         val config = ConfigFactory.empty()
         val cordappConf = TypesafeCordappConfig(config)
-
-        cordappConf.get("anything")
+        assertThatExceptionOfType(CordappConfigException::class.java).isThrownBy {
+            cordappConf.get("anything")
+        }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -26,6 +26,7 @@ import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.rootCause
 import net.corda.core.messaging.DataFeed
@@ -77,6 +78,7 @@ import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.startFlow
 import net.corda.testing.node.ledger
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -84,7 +86,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import rx.Observable
 import java.io.ByteArrayOutputStream
-import java.util.ArrayList
 import java.util.Collections
 import java.util.Currency
 import java.util.Random
@@ -186,7 +187,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
         }
     }
 
-    @Test(expected = InsufficientBalanceException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `trade cash for commercial paper fails using soft locking`() {
         mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP), threadPerNode = true)
         val notaryNode = mockNet.defaultNotaryNode
@@ -226,7 +227,13 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             val (bobStateMachine, aliceResult) = runBuyerAndSeller(notary, bob, aliceNode, bobNode,
                     "alice's paper".outputStateAndRef())
 
-            assertEquals(aliceResult.getOrThrow(), bobStateMachine.getOrThrow().resultFuture.getOrThrow())
+            assertThatExceptionOfType(InsufficientBalanceException::class.java).isThrownBy {
+                bobStateMachine.flatMap { it.resultFuture }.getOrThrow()
+            }
+
+            assertThatExceptionOfType(InsufficientBalanceException::class.java).isThrownBy {
+                aliceResult.getOrThrow()
+            }
 
             aliceNode.dispose()
             bobNode.dispose()
@@ -734,7 +741,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
         }
         val eb3Txns = insertFakeTransactions(listOf(bc2), node, identity, notaryNode, *extraSigningNodes)
 
-        val vault = Vault<ContractState>(listOf("bob cash 1".outputStateAndRef(), "bob cash 2".outputStateAndRef()))
+        val vault = Vault(listOf("bob cash 1".outputStateAndRef(), "bob cash 2".outputStateAndRef()))
         return Triple(vault, listOf(eb1, bc1, bc2), eb1Txns + eb2Txns + eb3Txns)
     }
 
@@ -747,10 +754,10 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             notary: Party): Pair<Vault<ContractState>, List<WireTransaction>> {
         val ap = transaction(transactionBuilder = TransactionBuilder(notary = notary)) {
             output(CommercialPaper.CP_PROGRAM_ID, "alice's paper", notary = notary,
-                    contractState = CommercialPaper.State(issuer, owner, amount, net.corda.coretesting.internal.TEST_TX_TIME + 7.days))
+                    contractState = CommercialPaper.State(issuer, owner, amount, TEST_TX_TIME + 7.days))
             command(issuer.party.owningKey, CommercialPaper.Commands.Issue())
             if (!withError)
-                timeWindow(time = net.corda.coretesting.internal.TEST_TX_TIME)
+                timeWindow(time = TEST_TX_TIME)
             if (attachmentID != null)
                 attachment(attachmentID)
             if (withError) {
@@ -760,7 +767,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             }
         }
 
-        val vault = Vault<ContractState>(listOf("alice's paper".outputStateAndRef()))
+        val vault = Vault(listOf("alice's paper".outputStateAndRef()))
         return Pair(vault, listOf(ap))
     }
 
@@ -786,7 +793,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             }
         }
 
-        val records: MutableList<TxRecord> = Collections.synchronizedList(ArrayList<TxRecord>())
+        val records: MutableList<TxRecord> = Collections.synchronizedList(ArrayList())
         override val updates: Observable<SignedTransaction>
             get() = delegate.updates
 

--- a/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
@@ -1,18 +1,19 @@
 package net.corda.node.services.config
 
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.verify
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import net.corda.core.internal.delete
 import net.corda.core.internal.div
 import net.corda.node.internal.Node
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.mockito.ArgumentMatchers.contains
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
 import org.slf4j.Logger
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
@@ -60,11 +61,13 @@ class ConfigHelperTests {
         Assert.assertEquals(sshPort, config?.getLong("sshd.port"))
     }
 
-    @Test(timeout = 300_000, expected = ShadowingException::class)
+    @Test(timeout = 300_000)
     fun `shadowing is forbidden`() {
         val sshPort: Long = 12000
-        loadConfig("CORDA_sshd_port" to sshPort.toString(),
-                "corda.sshd.port" to sshPort.toString())
+        assertThatExceptionOfType(ShadowingException::class.java).isThrownBy {
+            loadConfig("CORDA_sshd_port" to sshPort.toString(),
+                    "corda.sshd.port" to sshPort.toString())
+        }
     }
 
     @Test(timeout = 300_000)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.statemachine
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.IllegalFlowLogicException
 import net.corda.core.flows.SchedulableFlow
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
 import java.time.Duration
 import kotlin.reflect.jvm.jvmName
@@ -77,8 +78,10 @@ class FlowLogicRefFactoryImplTest {
         flowLogicRefFactory.createKotlin(KotlinFlowLogic::class.java, args)
     }
 
-    @Test(expected = IllegalFlowLogicException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `create for non-schedulable flow logic`() {
-        flowLogicRefFactory.create(NonSchedulableFlow::class.jvmName)
+        assertThatExceptionOfType(IllegalFlowLogicException::class.java).isThrownBy {
+            flowLogicRefFactory.create(NonSchedulableFlow::class.jvmName)
+        }
     }
 }

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
@@ -1,35 +1,40 @@
 package net.corda.serialization.internal
 
-import com.esotericsoftware.kryo.*
+import com.esotericsoftware.kryo.DefaultSerializer
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.KryoException
+import com.esotericsoftware.kryo.KryoSerializable
+import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.util.DefaultClassResolver
 import com.esotericsoftware.kryo.util.MapReferenceResolver
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
-import net.corda.core.contracts.TransactionVerificationException
+import net.corda.core.contracts.TransactionVerificationException.UntrustedAttachmentsException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.internal.AttachmentsClassLoader
 import net.corda.core.serialization.internal.CheckpointSerializationContext
+import net.corda.coretesting.internal.rigorousMock
+import net.corda.node.services.attachments.NodeAttachmentTrustCalculator
 import net.corda.nodeapi.internal.serialization.kryo.CordaClassResolver
 import net.corda.nodeapi.internal.serialization.kryo.CordaKryo
-import net.corda.node.services.attachments.NodeAttachmentTrustCalculator
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.internal.TestingNamedCacheFactory
-import net.corda.coretesting.internal.rigorousMock
 import net.corda.testing.internal.services.InternalMockAttachmentStorage
 import net.corda.testing.services.MockAttachmentStorage
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.net.URL
 import java.sql.Connection
-import java.util.*
+import java.util.Collections
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -114,7 +119,7 @@ class CordaClassResolverTests {
         val emptyListClass = listOf<Any>().javaClass
         val emptySetClass = setOf<Any>().javaClass
         val emptyMapClass = mapOf<Any, Any>().javaClass
-        val ISOLATED_CONTRACTS_JAR_PATH: URL = CordaClassResolverTests::class.java.getResource("/isolated.jar")
+        val ISOLATED_CONTRACTS_JAR_PATH: URL = CordaClassResolverTests::class.java.getResource("/isolated.jar")!!
     }
 
     private val emptyWhitelistContext: CheckpointSerializationContext = CheckpointSerializationContextImpl(this.javaClass.classLoader, EmptyWhitelist, emptyMap(), true, null)
@@ -125,9 +130,11 @@ class CordaClassResolverTests {
         CordaClassResolver(emptyWhitelistContext).getRegistration(Foo.Bar::class.java)
     }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Unannotated specialised enum does not work`() {
-        CordaClassResolver(emptyWhitelistContext).getRegistration(BadFood.Mud::class.java)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            CordaClassResolver(emptyWhitelistContext).getRegistration(BadFood.Mud::class.java)
+        }
     }
 
     @Test(timeout=300_000)
@@ -135,9 +142,11 @@ class CordaClassResolverTests {
         CordaClassResolver(emptyWhitelistContext).getRegistration(Simple.Easy::class.java)
     }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Unannotated simple enum does not work`() {
-        CordaClassResolver(emptyWhitelistContext).getRegistration(BadSimple.Nasty::class.java)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            CordaClassResolver(emptyWhitelistContext).getRegistration(BadSimple.Nasty::class.java)
+        }
     }
 
     @Test(timeout=300_000)
@@ -146,10 +155,12 @@ class CordaClassResolverTests {
         CordaClassResolver(emptyWhitelistContext).getRegistration(values.javaClass)
     }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Unannotated array elements do not work`() {
         val values = arrayOf(NotSerializable())
-        CordaClassResolver(emptyWhitelistContext).getRegistration(values.javaClass)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            CordaClassResolver(emptyWhitelistContext).getRegistration(values.javaClass)
+        }
     }
 
     @Test(timeout=300_000)
@@ -168,15 +179,19 @@ class CordaClassResolverTests {
         kryo.register(NotSerializable::class.java)
     }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Calling register method on unmodified Kryo does consult the whitelist`() {
         val kryo = Kryo(CordaClassResolver(emptyWhitelistContext), MapReferenceResolver())
-        kryo.register(NotSerializable::class.java)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            kryo.register(NotSerializable::class.java)
+        }
     }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Annotation is needed without whitelisting`() {
-        CordaClassResolver(emptyWhitelistContext).getRegistration(NotSerializable::class.java)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            CordaClassResolver(emptyWhitelistContext).getRegistration(NotSerializable::class.java)
+        }
     }
 
     @Test(timeout=300_000)
@@ -195,36 +210,47 @@ class CordaClassResolverTests {
         CordaClassResolver(emptyWhitelistContext).getRegistration(Integer.TYPE)
     }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Annotation does not work for custom serializable`() {
-        CordaClassResolver(emptyWhitelistContext).getRegistration(CustomSerializable::class.java)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            CordaClassResolver(emptyWhitelistContext).getRegistration(CustomSerializable::class.java)
+        }
     }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Annotation does not work in conjunction with Kryo annotation`() {
-        CordaClassResolver(emptyWhitelistContext).getRegistration(DefaultSerializable::class.java)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            CordaClassResolver(emptyWhitelistContext).getRegistration(DefaultSerializable::class.java)
+        }
     }
 
     private fun importJar(storage: AttachmentStorage, uploader: String = DEPLOYED_CORDAPP_UPLOADER) = ISOLATED_CONTRACTS_JAR_PATH.openStream().use { storage.importAttachment(it, uploader, "") }
 
-    @Test(expected = KryoException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Annotation does not work in conjunction with AttachmentClassLoader annotation`() {
         val storage = InternalMockAttachmentStorage(MockAttachmentStorage())
         val attachmentTrustCalculator = NodeAttachmentTrustCalculator(storage, TestingNamedCacheFactory())
         val attachmentHash = importJar(storage)
         val classLoader = AttachmentsClassLoader(arrayOf(attachmentHash).map { storage.openAttachment(it)!! }, testNetworkParameters(), SecureHash.zeroHash, { attachmentTrustCalculator.calculate(it) })
         val attachedClass = Class.forName("net.corda.isolated.contracts.AnotherDummyContract", true, classLoader)
-        CordaClassResolver(emptyWhitelistContext).getRegistration(attachedClass)
+        assertThatExceptionOfType(KryoException::class.java).isThrownBy {
+            CordaClassResolver(emptyWhitelistContext).getRegistration(attachedClass)
+        }
     }
 
-    @Test(expected = TransactionVerificationException.UntrustedAttachmentsException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun `Attempt to load contract attachment with untrusted uploader should fail with UntrustedAttachmentsException`() {
         val storage = InternalMockAttachmentStorage(MockAttachmentStorage())
         val attachmentTrustCalculator = NodeAttachmentTrustCalculator(storage, TestingNamedCacheFactory())
         val attachmentHash = importJar(storage, "some_uploader")
-        val classLoader = AttachmentsClassLoader(arrayOf(attachmentHash).map { storage.openAttachment(it)!! }, testNetworkParameters(), SecureHash.zeroHash, { attachmentTrustCalculator.calculate(it) })
-        val attachedClass = Class.forName("net.corda.isolated.contracts.AnotherDummyContract", true, classLoader)
-        CordaClassResolver(emptyWhitelistContext).getRegistration(attachedClass)
+        assertThatExceptionOfType(UntrustedAttachmentsException::class.java).isThrownBy {
+            AttachmentsClassLoader(
+                    arrayOf(attachmentHash).map { storage.openAttachment(it)!! },
+                    testNetworkParameters(),
+                    SecureHash.zeroHash,
+                    { attachmentTrustCalculator.calculate(it) }
+            )
+        }
     }
 
     @Test(timeout=300_000)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt
@@ -4,8 +4,16 @@ import net.corda.serialization.internal.amqp.testutils.TestSerializationOutput
 import net.corda.serialization.internal.amqp.testutils.deserialize
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
-import java.util.*
+import java.io.NotSerializableException
+import java.util.AbstractMap
+import java.util.Dictionary
+import java.util.Hashtable
+import java.util.NavigableMap
+import java.util.SortedMap
+import java.util.TreeMap
+import java.util.WeakHashMap
 
 class DeserializeMapTests {
     companion object {
@@ -27,24 +35,26 @@ class DeserializeMapTests {
         DeserializationInput(sf).deserialize(serialisedBytes)
     }
 
-    @Test(expected = java.io.NotSerializableException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun abstractMapFromMapOf() {
         data class C(val c: AbstractMap<String, Int>)
 
         val c = C(mapOf("A" to 1, "B" to 2) as AbstractMap)
 
-        val serialisedBytes = TestSerializationOutput(VERBOSE, sf).serialize(c)
-        DeserializationInput(sf).deserialize(serialisedBytes)
+        assertThatExceptionOfType(NotSerializableException::class.java).isThrownBy {
+            TestSerializationOutput(VERBOSE, sf).serialize(c)
+        }
     }
 
-    @Test(expected = java.io.NotSerializableException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun abstractMapFromTreeMap() {
         data class C(val c: AbstractMap<String, Int>)
 
         val c = C(TreeMap(mapOf("A" to 1, "B" to 2)))
 
-        val serialisedBytes = TestSerializationOutput(VERBOSE, sf).serialize(c)
-        DeserializationInput(sf).deserialize(serialisedBytes)
+        assertThatExceptionOfType(NotSerializableException::class.java).isThrownBy {
+            TestSerializationOutput(VERBOSE, sf).serialize(c)
+        }
     }
 
     @Test(timeout=300_000)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt
@@ -12,6 +12,7 @@ import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolu
 import net.corda.serialization.internal.amqp.testutils.testName
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Assert.assertNotSame
 import org.junit.Test
 import java.io.NotSerializableException
@@ -157,7 +158,7 @@ class EnumTests {
         assertEquals(c.c, obj.c)
     }
 
-    @Test(expected = NotSerializableException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun changedEnum1() {
         val url = EnumTests::class.java.getResource("EnumTests.changedEnum1")
 
@@ -173,10 +174,12 @@ class EnumTests {
         val sc2 = url.readBytes()
 
         // we expect this to throw
-        DeserializationInput(sf1).deserialize(SerializedBytes<C>(sc2))
+        assertThatExceptionOfType(NotSerializableException::class.java).isThrownBy {
+            DeserializationInput(sf1).deserialize(SerializedBytes<C>(sc2))
+        }
     }
 
-    @Test(expected = NotSerializableException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun changedEnum2() {
         val url = EnumTests::class.java.getResource("EnumTests.changedEnum2")
 
@@ -195,7 +198,9 @@ class EnumTests {
         val sc2 = url.readBytes()
 
         // we expect this to throw
-        DeserializationInput(sf1).deserialize(SerializedBytes<C>(sc2))
+        assertThatExceptionOfType(NotSerializableException::class.java).isThrownBy {
+            DeserializationInput(sf1).deserialize(SerializedBytes<C>(sc2))
+        }
     }
 
     @Test(timeout=300_000)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt
@@ -15,6 +15,7 @@ import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.serialization.SerializableCalculatedProperty
 import net.corda.core.serialization.SerializedBytes
 import net.corda.serialization.internal.amqp.custom.InstantSerializer
+import net.corda.serialization.internal.amqp.custom.PublicKeySerializer
 import net.corda.serialization.internal.amqp.testutils.ProjectStructure.projectRootDir
 import net.corda.serialization.internal.amqp.testutils.TestSerializationOutput
 import net.corda.serialization.internal.amqp.testutils.deserialize
@@ -23,6 +24,7 @@ import net.corda.serialization.internal.amqp.testutils.serializeAndReturnSchema
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactory
 import net.corda.serialization.internal.amqp.testutils.testName
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertNotSame
@@ -68,7 +70,7 @@ class EvolvabilityTests {
         // new version of the class, in this case the order of the parameters has been swapped
         data class C(val b: Int, val a: Int)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedC = DeserializationInput(sf).deserialize(SerializedBytes<C>(sc2))
 
@@ -90,7 +92,7 @@ class EvolvabilityTests {
         // new version of the class, in this case the order of the parameters has been swapped
         data class C(val b: String, val a: Int)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedC = DeserializationInput(sf).deserialize(SerializedBytes<C>(sc2))
 
@@ -110,7 +112,7 @@ class EvolvabilityTests {
 
         data class C(val a: Int, val b: Int?)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedC = DeserializationInput(sf).deserialize(SerializedBytes<C>(sc2))
 
@@ -118,10 +120,10 @@ class EvolvabilityTests {
         assertEquals(null, deserializedC.b)
     }
 
-    @Test(expected = NotSerializableException::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun addAdditionalParam() {
         val sf = testDefaultFactory()
-        val url = EvolvabilityTests::class.java.getResource("EvolvabilityTests.addAdditionalParam")
+        val url = EvolvabilityTests::class.java.getResource("EvolvabilityTests.addAdditionalParam")!!
         @Suppress("UNUSED_VARIABLE")
         val A = 1
 
@@ -140,7 +142,9 @@ class EvolvabilityTests {
         // Expected to throw as we can't construct the new type as it contains a newly
         // added parameter that isn't optional, i.e. not nullable and there isn't
         // a constructor that takes the old parameters
-        DeserializationInput(sf).deserialize(SerializedBytes<C>(sc2))
+        assertThatExceptionOfType(NotSerializableException::class.java).isThrownBy {
+            DeserializationInput(sf).deserialize(SerializedBytes<C>(sc2))
+        }
     }
 
     @Suppress("UNUSED_VARIABLE")
@@ -159,7 +163,7 @@ class EvolvabilityTests {
 
         data class CC(val b: String, val d: Int)
 
-        val url = EvolvabilityTests::class.java.getResource("EvolvabilityTests.removeParameters")
+        val url = EvolvabilityTests::class.java.getResource("EvolvabilityTests.removeParameters")!!
         val sc2 = url.readBytes()
         val deserializedCC = DeserializationInput(sf).deserialize(SerializedBytes<CC>(sc2))
 
@@ -167,7 +171,6 @@ class EvolvabilityTests {
         assertEquals(D, deserializedCC.d)
     }
 
-    @Suppress("UNUSED_VARIABLE")
     @Test(timeout=300_000)
 	fun removeParameterWithCalculatedParameter() {
         val sf = testDefaultFactory()
@@ -186,7 +189,7 @@ class EvolvabilityTests {
             val e: String get() = "$b sailor"
         }
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedCC = DeserializationInput(sf).deserialize(SerializedBytes<CC>(sc2))
 
@@ -213,7 +216,7 @@ class EvolvabilityTests {
 
         data class CC(val a: Int, val e: Boolean?, val d: Int)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedCC = DeserializationInput(sf).deserialize(SerializedBytes<CC>(sc2))
 
@@ -238,7 +241,7 @@ class EvolvabilityTests {
             constructor (a: Int) : this(a, "hello")
         }
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedCC = DeserializationInput(sf).deserialize(SerializedBytes<CC>(sc2))
 
@@ -263,7 +266,7 @@ class EvolvabilityTests {
             constructor (z: Int, y: Int) : this(z, y, "10")
         }
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val deserializedCC = DeserializationInput(sf).deserialize(SerializedBytes<CC>(url.readBytes()))
 
         assertEquals("10", deserializedCC.a)
@@ -322,16 +325,16 @@ class EvolvabilityTests {
         //                 9,
         //                 mapOf("A" to listOf(1, 2, 3), "B" to listOf (4, 5, 6)))).bytes)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         DeserializationInput(factory).deserialize(SerializedBytes<NetworkParametersExample>(url.readBytes()))
     }
 
-    @Test(expected = NotSerializableException::class, timeout=300_000)
+    @Test(timeout=300_000)
     @Suppress("UNUSED")
     fun addMandatoryFieldWithAltConstructorUnAnnotated() {
         val sf = testDefaultFactory()
         val url = EvolvabilityTests::class.java.getResource(
-                "EvolvabilityTests.addMandatoryFieldWithAltConstructorUnAnnotated")
+                "EvolvabilityTests.addMandatoryFieldWithAltConstructorUnAnnotated")!!
         @Suppress("UNUSED_VARIABLE")
         val A = 1
 
@@ -349,7 +352,9 @@ class EvolvabilityTests {
 
         // we expect this to throw as we should not find any constructors
         // capable of dealing with this
-        DeserializationInput(sf).deserialize(SerializedBytes<CC>(url.readBytes()))
+        assertThatExceptionOfType(NotSerializableException::class.java).isThrownBy {
+            DeserializationInput(sf).deserialize(SerializedBytes<CC>(url.readBytes()))
+        }
     }
 
     @Test(timeout=300_000)
@@ -372,7 +377,7 @@ class EvolvabilityTests {
             constructor (c: String, a: Int, b: Int) : this(a, b, c, "wibble")
         }
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedCC = DeserializationInput(sf).deserialize(SerializedBytes<CC>(sc2))
 
@@ -404,7 +409,7 @@ class EvolvabilityTests {
             constructor (c: String, a: Int) : this(a, c, "wibble")
         }
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedCC = DeserializationInput(sf).deserialize(SerializedBytes<CC>(sc2))
 
@@ -451,9 +456,9 @@ class EvolvabilityTests {
             constructor (a: Int, b: Int, c: Int, d: Int) : this(-1, c, b, a, d)
         }
 
-        val url1 = EvolvabilityTests::class.java.getResource(resource1)
-        val url2 = EvolvabilityTests::class.java.getResource(resource2)
-        val url3 = EvolvabilityTests::class.java.getResource(resource3)
+        val url1 = EvolvabilityTests::class.java.getResource(resource1)!!
+        val url2 = EvolvabilityTests::class.java.getResource(resource2)!!
+        val url3 = EvolvabilityTests::class.java.getResource(resource3)!!
 
         val sb1 = url1.readBytes()
         val db1 = DeserializationInput(sf).deserialize(SerializedBytes<C>(sb1))
@@ -500,7 +505,7 @@ class EvolvabilityTests {
 
         data class Outer(val a: Int, val b: Inner)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val outer = DeserializationInput(sf).deserialize(SerializedBytes<Outer>(sc2))
 
@@ -565,9 +570,9 @@ class EvolvabilityTests {
             constructor (b: Int, c: Int, d: Int, e: Int, f: Int) : this(b, c, d, e, f, -1)
         }
 
-        val url1 = EvolvabilityTests::class.java.getResource(resource1)
-        val url2 = EvolvabilityTests::class.java.getResource(resource2)
-        val url3 = EvolvabilityTests::class.java.getResource(resource3)
+        val url1 = EvolvabilityTests::class.java.getResource(resource1)!!
+        val url2 = EvolvabilityTests::class.java.getResource(resource2)!!
+        val url3 = EvolvabilityTests::class.java.getResource(resource3)!!
 
         val sb1 = url1.readBytes()
         val db1 = DeserializationInput(sf).deserialize(SerializedBytes<C>(sb1))
@@ -616,8 +621,8 @@ class EvolvabilityTests {
 @Ignore("Test fails after moving NetworkParameters and NotaryInfo into core from node-api")
     fun readBrokenNetworkParameters() {
         val sf = testDefaultFactory()
-        sf.register(net.corda.serialization.internal.amqp.custom.InstantSerializer(sf))
-        sf.register(net.corda.serialization.internal.amqp.custom.PublicKeySerializer)
+        sf.register(InstantSerializer(sf))
+        sf.register(PublicKeySerializer)
 
         //
         // filename breakdown
@@ -627,7 +632,7 @@ class EvolvabilityTests {
         //
         val resource = "networkParams.r3corda.6a6b6f256"
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedC = DeserializationInput(sf).deserialize(SerializedBytes<SignedData<NetworkParameters>>(sc2))
         val networkParams = DeserializationInput(sf).deserialize(deserializedC.raw)
@@ -654,8 +659,8 @@ class EvolvabilityTests {
     @Test(timeout=300_000)
     fun `read corda 4-11 network parameters`() {
         val sf = testDefaultFactory()
-        sf.register(net.corda.serialization.internal.amqp.custom.InstantSerializer(sf))
-        sf.register(net.corda.serialization.internal.amqp.custom.PublicKeySerializer)
+        sf.register(InstantSerializer(sf))
+        sf.register(PublicKeySerializer)
         sf.register(net.corda.serialization.internal.amqp.custom.DurationSerializer(sf))
 
         //
@@ -666,7 +671,7 @@ class EvolvabilityTests {
         //
         val resource = "networkParams.4.11.58ecce1"
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedC = DeserializationInput(sf).deserialize(SerializedBytes<SignedData<NetworkParameters>>(sc2))
         val networkParams = DeserializationInput(sf).deserialize(deserializedC.raw)
@@ -691,8 +696,8 @@ class EvolvabilityTests {
                 3, listOf(NotaryInfo(DUMMY_NOTARY_PARTY, false)), 1000, 1000, Instant.EPOCH, 1, emptyMap())
 
         val sf = testDefaultFactory()
-        sf.register(net.corda.serialization.internal.amqp.custom.InstantSerializer(sf))
-        sf.register(net.corda.serialization.internal.amqp.custom.PublicKeySerializer)
+        sf.register(InstantSerializer(sf))
+        sf.register(PublicKeySerializer)
 
         val testOutput = TestSerializationOutput(true, sf)
         val serialized = testOutput.serialize(networkParameters)
@@ -704,7 +709,6 @@ class EvolvabilityTests {
         File(URI("$localPath/$resource")).writeBytes(signedAndSerialized.bytes)
     }
 
-    @Suppress("UNCHECKED_CAST")
     @Test(timeout=300_000)
 	fun getterSetterEvolver1() {
         val resource = "EvolvabilityTests.getterSetterEvolver1"
@@ -734,7 +738,7 @@ class EvolvabilityTests {
             constructor() : this(0, 0, 0, 0)
         }
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
 
         val sc2 = url.readBytes()
         val deserializedC = DeserializationInput(sf).deserialize(SerializedBytes<C>(sc2))
@@ -759,7 +763,7 @@ class EvolvabilityTests {
         // Uncomment to recreate
         // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(Evolved("dronf", NewEnum.BUCKLE_MY_SHOE)).bytes)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
 
         val sc2 = url.readBytes()
         val deserialized = DeserializationInput(sf).deserialize(SerializedBytes<Evolved>(sc2))
@@ -786,7 +790,7 @@ class EvolvabilityTests {
         // Uncomment to recreate
         // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(ParameterizedContainer(Parameterized(10, setOf(20)))).bytes)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
 
         val sc2 = url.readBytes()
         val deserialized = DeserializationInput(sf).deserialize(SerializedBytes<ParameterizedContainer>(sc2))
@@ -900,7 +904,7 @@ class EvolvabilityTests {
         File(URI("$localPath/$resource")).writeBytes(currentForm.bytes)
          */
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val previousForm = SerializedBytes<NotarisationRequest>(sc2)
         val deserialized = DeserializationInput(sf).deserialize(previousForm)
@@ -932,7 +936,7 @@ class EvolvabilityTests {
         //val A = MaybeSerializedSignedTransaction(SecureHash.randomSHA256(), null, null)
         //File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(A).bytes)
 
-        val url = EvolvabilityTests::class.java.getResource(resource)
+        val url = EvolvabilityTests::class.java.getResource(resource)!!
         val sc2 = url.readBytes()
         val deserializedA = DeserializationInput(sf).deserialize(SerializedBytes<MaybeSerializedSignedTransaction>(sc2))
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StaticInitialisationOfSerializedObjectTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StaticInitialisationOfSerializedObjectTest.kt
@@ -5,6 +5,7 @@ import net.corda.core.serialization.SerializedBytes
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.testutils.deserialize
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Ignore
 import org.junit.Test
@@ -40,9 +41,11 @@ class C2(var b: Int) {
 }
 
 class StaticInitialisationOfSerializedObjectTest {
-    @Test(expected = java.lang.ExceptionInInitializerError::class, timeout=300_000)
+    @Test(timeout=300_000)
     fun itBlowsUp() {
-        C()
+        assertThatExceptionOfType(ExceptionInInitializerError::class.java).isThrownBy {
+            C()
+        }
     }
 
     @Ignore("Suppressing this, as it depends on obtaining internal access to serialiser cache")

--- a/tools/error-tool/build.gradle
+++ b/tools/error-tool/build.gradle
@@ -8,15 +8,16 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
 
     testImplementation "junit:junit:$junit_version"
+    testImplementation "org.assertj:assertj-core:$assertj_version"
 }
 
 jar {
     enabled = false
-    classifier = 'ignore'
+    archiveClassifier = 'ignore'
 }
 
 shadowJar {
-    baseName = "corda-tools-error-utils"
+    archiveBaseName = "corda-tools-error-utils"
     manifest {
         attributes(
                 'Main-Class': "net.corda.errorUtilities.ErrorToolKt"

--- a/tools/error-tool/src/test/kotlin/net/corda/errorUtilities/docsTable/DocsTableGeneratorTest.kt
+++ b/tools/error-tool/src/test/kotlin/net/corda/errorUtilities/docsTable/DocsTableGeneratorTest.kt
@@ -1,10 +1,10 @@
 package net.corda.errorUtilities.docsTable
 
 import junit.framework.TestCase.assertEquals
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.Test
-import java.lang.IllegalArgumentException
 import java.nio.file.Paths
-import java.util.*
+import java.util.Locale
 
 class DocsTableGeneratorTest {
 
@@ -37,9 +37,11 @@ class DocsTableGeneratorTest {
         assertEquals(irishTable.split("\n").joinToString(System.lineSeparator()), table)
     }
 
-    @Test(expected = IllegalArgumentException::class, timeout = 1000)
+    @Test(timeout = 1000)
     fun `error thrown if unknown directory passed to generator`() {
         val generator = DocsTableGenerator(Paths.get("not/a/directory"), Locale.getDefault())
-        generator.generateMarkdown()
+        assertThatIllegalArgumentException().isThrownBy {
+            generator.generateMarkdown()
+        }
     }
 }


### PR DESCRIPTION
Replaced usage of `@Test.expected` annotation parameter with more specific exception assertions.

This is also needed to migrate away from the explicit timeouts in every tests.

