### PR TITLE
ENT-11245 Serialization evolution: catch and transform new TRANSACTION_RECOVERY enum type value.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
@@ -80,7 +80,8 @@ sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
     // against not having unknown by using the platform version as a guard.
     @CordaSerializationTransformEnumDefaults(
             CordaSerializationTransformEnumDefault("BATCH_TRANSACTION", "TRANSACTION"),
-            CordaSerializationTransformEnumDefault("UNKNOWN", "TRANSACTION")
+            CordaSerializationTransformEnumDefault("UNKNOWN", "TRANSACTION"),
+            CordaSerializationTransformEnumDefault("TRANSACTION_RECOVERY", "TRANSACTION")
     )
     @CordaSerializable
     enum class DataType {


### PR DESCRIPTION
Fix enum value serialization error:

```
java.lang.IllegalArgumentException: Payload invalid
	at net.corda.core.internal.InternalUtils.checkPayloadIs(InternalUtils.kt:570) ~[corda-core-4.10.3.jar:?]
	at net.corda.core.flows.FlowLogic.receiveAllMap(FlowLogic.kt:321) ~[corda-core-4.10.3.jar:?]
	at net.corda.core.flows.FlowLogic.receiveAllMap$default(FlowLogic.kt:315) ~[corda-core-4.10.3.jar:?]
	at net.corda.node.internal.aliasing.flows.EnterpriseDataVendingFlow.call(EnterpriseSendTransactionFlow.kt:60) ~[corda-node-4.10.3.jar:?]
	at net.corda.node.internal.aliasing.flows.EnterpriseDataVendingFlow.call(EnterpriseSendTransactionFlow.kt:45) ~[corda-node-4.10.3.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.subFlow(FlowStateMachineImpl.kt:443) ~[corda-node-4.10.3.jar:?]
	at net.corda.core.flows.FlowLogic.subFlow(FlowLogic.kt:412) ~[corda-core-4.10.3.jar:?]
	at net.corda.node.internal.aliasing.flows.EnterpriseFinalityFlow.call(EnterpriseFinalityFlow.kt:87) ~[corda-node-4.10.3.jar:?]
	at net.corda.node.internal.aliasing.flows.EnterpriseFinalityFlow.call(EnterpriseFinalityFlow.kt:30) ~[corda-node-4.10.3.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.subFlow(FlowStateMachineImpl.kt:443) ~[corda-node-4.10.3.jar:?]
	at net.corda.core.flows.FlowLogic.subFlow(FlowLogic.kt:412) ~[corda-core-4.10.3.jar:?]
	at net.corda.finance.flows.AbstractCashFlow.finaliseTx(AbstractCashFlow.kt:28) ~[?:?]
	at net.corda.finance.flows.CashPaymentFlow.call(CashPaymentFlow.kt:85) ~[?:?]
	at net.corda.finance.flows.CashPaymentFlow.call(CashPaymentFlow.kt:33) ~[?:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:366) ~[corda-node-4.10.3.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:79) ~[corda-node-4.10.3.jar:?]
	at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1108) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:804) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:103) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:94) ~[quasar-core-0.7.15_r3.jar:0.7.15_r3]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_382]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_382]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_382]
Caused by: net.corda.serialization.internal.amqp.EvolutionSerializationException: Cannot construct evolution serializer for remote type net.corda.core.internal.FetchDataFlow$DataType: Cannot resolve local enum member TRANSACTION_RECOVERY to a member of [TRANSACTION, ATTACHMENT, PARAMETERS, BATCH_TRANSACTION, UNKNOWN] using rules {BATCH_TRANSACTION=TRANSACTION, UNKNOWN=TRANSACTION}
```

