### PR TITLE
ENT-11261 Re-enabled a number of ignored tests due to class cast exception

### DIFF
--- a/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
@@ -23,7 +23,6 @@ import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.startFlow
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -48,7 +47,6 @@ class IdentitySyncFlowTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: class cast exception")
 	fun `sync confidential identities`() {
         // Set up values we'll need
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)
@@ -77,7 +75,6 @@ class IdentitySyncFlowTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: class cast exception")
 	fun `don't offer other's identities confidential identities`() {
         // Set up values we'll need
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -24,7 +24,6 @@ import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.AfterClass
-import org.junit.Ignore
 import org.junit.Test
 import java.security.PublicKey
 
@@ -48,7 +47,6 @@ class SwapIdentitiesFlowTests {
     private val bob = bobNode.info.singleIdentity()
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Class cast exception")
 	fun `issue key`() {
         assertThat(
             aliceNode.services.startFlow(SwapIdentitiesInitiator(bob)),

--- a/core-tests/src/test/java/net/corda/coretests/flows/FlowsInJavaTest.java
+++ b/core-tests/src/test/java/net/corda/coretests/flows/FlowsInJavaTest.java
@@ -10,7 +10,6 @@ import net.corda.testing.node.MockNetworkParameters;
 import net.corda.testing.node.StartedMockNode;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -22,7 +21,6 @@ import static net.corda.testing.node.internal.InternalTestUtilsKt.enclosedCordap
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.fail;
 
-@Ignore("TODO JDK17: class cast exception")
 public class FlowsInJavaTest {
     private final MockNetwork mockNet = new MockNetwork(
             new MockNetworkParameters().withCordappsForAllNodes(singletonList(enclosedCordapp(this)))

--- a/core-tests/src/test/kotlin/net/corda/coretests/contracts/ContractHierarchyTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/contracts/ContractHierarchyTest.kt
@@ -18,10 +18,8 @@ import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startFlow
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
-@Ignore("TODO JDK17: class cast exception")
 class ContractHierarchyTest {
     private lateinit var mockNet: InternalMockNetwork
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/AttachmentTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/AttachmentTests.kt
@@ -27,10 +27,8 @@ import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.TestStartedNode
 import org.junit.AfterClass
-import org.junit.Ignore
 import org.junit.Test
 
-@Ignore("TODO JDK17: class cast exception")
 class AttachmentTests : WithMockNet {
     companion object {
         val classMockNet = InternalMockNetwork()

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/ContractUpgradeFlowTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/ContractUpgradeFlowTest.kt
@@ -24,11 +24,9 @@ import net.corda.coretesting.internal.matchers.flow.willReturn
 import net.corda.coretesting.internal.matchers.flow.willThrow
 import net.corda.testing.node.internal.*
 import org.junit.AfterClass
-import org.junit.Ignore
 import org.junit.Test
 import java.util.*
 
-@Ignore("TODO JDK17: class cast exception")
 class ContractUpgradeFlowTest : WithContracts, WithFinality {
 
     companion object {

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FinalityFlowTests.kt
@@ -76,7 +76,6 @@ import net.corda.testing.node.internal.findCordapp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Assert.assertNotNull
-import org.junit.Ignore
 import org.junit.Test
 import java.sql.SQLException
 import java.util.Random
@@ -84,7 +83,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.fail
 
-@Ignore("TODO JDK17: class cast exception")
 class FinalityFlowTests : WithFinality {
     companion object {
         private val CHARLIE = TestIdentity(CHARLIE_NAME, 90).party

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/ReceiveAllFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/ReceiveAllFlowTests.kt
@@ -15,12 +15,10 @@ import net.corda.coretesting.internal.matchers.flow.willReturn
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.TestStartedNode
 import org.junit.AfterClass
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
 
-@Ignore("TODO JDK17: class cast exception")
 class ReceiveMultipleFlowTests : WithMockNet {
     companion object {
         private val classMockNet = InternalMockNetwork()

--- a/core-tests/src/test/kotlin/net/corda/coretests/internal/NetworkParametersResolutionTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/internal/NetworkParametersResolutionTest.kt
@@ -30,11 +30,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 
-@Ignore("TODO JDK17: class cast exception")
 class NetworkParametersResolutionTest {
     private lateinit var defaultParams: NetworkParameters
     private lateinit var params2: NetworkParameters

--- a/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt
@@ -45,7 +45,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 // DOCSTART 3
-@Ignore("TODO JDK17: class cast exception")
 class ResolveTransactionsFlowTest {
     private lateinit var mockNet: MockNetwork
     private lateinit var notaryNode: StartedMockNode
@@ -259,7 +258,7 @@ class ResolveTransactionsFlowTest {
 
     // Used for checking larger chains resolve correctly. Note that this takes a long time to run, and so is not suitable for a CI gate.
     @Test(timeout=300_000)
-@Ignore
+    @Ignore
     fun `Can resolve large chain of transactions`() {
         val txToResolve = makeLargeTransactionChain(2500)
         val p = TestFlow(txToResolve, megaCorp)

--- a/core-tests/src/test/kotlin/net/corda/coretests/serialization/AttachmentSerializationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/serialization/AttachmentSerializationTest.kt
@@ -24,7 +24,6 @@ import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.startFlow
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets.UTF_8
@@ -65,7 +64,6 @@ private fun updateAttachment(attachmentId: SecureHash, data: ByteArray) {
     }
 }
 
-@Ignore("TODO JDK17: class cast exception")
 class AttachmentSerializationTest {
     private lateinit var mockNet: InternalMockNetwork
     private lateinit var server: TestStartedNode

--- a/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
@@ -20,7 +20,6 @@ object EmptyWhitelist : ClassWhitelist {
     override fun hasListed(type: Class<*>): Boolean = false
 }
 
-@Ignore("TODO JDK17: class cast exception")
 class KotlinUtilsTest {
     @Rule
     @JvmField
@@ -63,6 +62,7 @@ class KotlinUtilsTest {
     }
 
     @Test(timeout=300_000)
+    @Ignore("TODO JDK17:Fixme serializable lambda issue")
 	fun `checkpointing a transient property with capturing lambda`() {
         val original = CapturingTransientProperty("Hello")
         val originalVal = original.transientVal


### PR DESCRIPTION
The underlying issue that causes these tests to fail is uncheckedCast(..), which sometimes when using generics and a complex type inference generates incorrect code. These tests have now been fixed as the underlying uncheckedCast(..) has been removed.

