### PR TITLE
ENT-11270: fix structure tests

### DIFF
--- a/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt
@@ -14,13 +14,13 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class AttachmentTest {
 
     @Test(timeout=300_000)
     @Suppress("ThrowsCount")
-    @Ignore("TODO JDK17: Line too long no longer thrown?")
 	fun `openAsJAR does not leak file handle if attachment has corrupted manifest`() {
         var closeCalls = 0
         val inputStream = spy(ByteArrayOutputStream().apply {
@@ -42,7 +42,7 @@ class AttachmentTest {
             attachment.openAsJAR()
             fail("Expected line too long.")
         } catch (e: IOException) {
-            assertEquals("line too long", e.message)
+            assertTrue { e.message!!.contains("line too long") }
         }
         assertEquals(1, closeCalls)
     }

--- a/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt
@@ -1,14 +1,13 @@
 package net.corda.core.contracts
 
+import net.corda.core.identity.Party
+import org.junit.Test
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
-import net.corda.core.identity.Party
-import org.junit.Ignore
-import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.io.IOException
-import java.util.*
+import java.util.UUID
 import java.util.jar.JarFile.MANIFEST_NAME
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! [ENT-11270](https://r3-cev.atlassian.net/browse/ENT-11270): Fix structure tests !!!! 👮🏻👮🏻👮🏻

Newer JDK adds the line position as well along exception message string, this makes the actual as:
line too long (line 1)
instead of: line too long
So, error is still thrown but the message contains a little more detail in the newer JDK.

Hence, changing equals to contains.

# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs/kdocs?
- [x] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)


[ENT-11270]: https://r3-cev.atlassian.net/browse/ENT-11270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ