### PR TITLE
ENT-11113 JDK17 Test Fixing: Crypto related failures

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
@@ -46,23 +46,6 @@ val cordaBouncyCastleProvider = BouncyCastleProvider().apply {
     // This registration is needed for reading back EdDSA key from java keystore.
     // TODO: Find a way to make JKS work with bouncy castle provider or implement our own provide so we don't have to register bouncy castle provider.
     Security.addProvider(it)
-
-    // Remove providers that class with bouncy castle
-    val bcProviders = it.keys
-
-    // JDK 17: Add SunEC provider as lowest priority, as we use Bouncycastle for EDDSA
-    // and remove amy algorithms that conflict with Bouncycastle
-    val sunEC = Security.getProvider("SunEC")
-    if (sunEC != null) {
-        Security.removeProvider("SunEC")
-        Security.addProvider(sunEC)
-
-        for(alg in sunEC.keys) {
-            if (bcProviders.contains(alg)) {
-                sunEC.remove(alg)
-            }
-        }
-    }
 }
 
 val bouncyCastlePQCProvider = BouncyCastlePQCProvider().apply {

--- a/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
@@ -27,7 +27,6 @@ import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PrivateKey
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PublicKey
 import org.junit.Assert.assertNotEquals
-import org.junit.Ignore
 import org.junit.Test
 import java.math.BigInteger
 import java.security.KeyPairGenerator
@@ -670,7 +669,6 @@ class CryptoUtilsTest {
     }
 
     @Test(timeout = 300_000)
-    @Ignore("TODO JDK17: Fixme")
     fun `Unsupported EC public key type on curve`() {
         val keyGen = KeyPairGenerator.getInstance("EC") // sun.security.ec.ECPublicKeyImpl
         keyGen.initialize(256, newSecureRandom())

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoServiceTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoServiceTests.kt
@@ -110,7 +110,6 @@ class BCCryptoServiceTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme")
 	fun `BCCryptoService generate key pair and sign with passed signing algorithm`() {
 
         assertTrue{signAndVerify(signAlgo = "NONEwithRSA", alias = "myKeyAlias", keyTypeAlgo = "RSA")}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoServiceTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoServiceTests.kt
@@ -61,7 +61,7 @@ class BCCryptoServiceTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme")
+    @Ignore("Caused by: org.bouncycastle.operator.RuntimeOperatorException: exception obtaining signature: Curve not supported: org.bouncycastle.jce.spec.ECNamedCurveSpec@305932e4")
 	fun `BCCryptoService generate key pair and sign both data and cert`() {
         val cryptoService = BCCryptoService(ALICE_NAME.x500Principal, signingCertificateStore, wrappingKeyStorePath)
         // Testing every supported scheme.
@@ -95,7 +95,7 @@ class BCCryptoServiceTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme")
+    @Ignore("Caused by: org.bouncycastle.operator.RuntimeOperatorException: exception obtaining signature: Curve not supported: org.bouncycastle.jce.spec.ECNamedCurveSpec@305932e4")
 	fun `BCCryptoService generate key pair and sign with existing schemes`() {
         val cryptoService = BCCryptoService(ALICE_NAME.x500Principal, signingCertificateStore, wrappingKeyStorePath)
         // Testing every supported scheme.


### PR DESCRIPTION
**BCCryptoServiceTests** 
- fun `BCCryptoService generate key pair and sign with passed signing algorithm`() 
Fixed by re-instating SunEC provider algorithms.

- fun `BCCryptoService generate key pair and sign with existing schemes`()
- fun `BCCryptoService generate key pair and sign both data and cert`()
Implementation of `ECDSASignature.java` function `engineVerify` in JDK17 causes a `SignatureException: Curve not supported`

**CryptoUtilsTest**
- fun `Unsupported EC public key type on curve`()
Fixed by re-instating SunEC provider algorithms.