### PR TITLE
ENT-11294  Fix failing tests in - FlowCheckpointVersionNodeStartupCheckTest

### DIFF
--- a/node/src/integration-test-slow/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheckTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheckTest.kt
@@ -22,13 +22,11 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.assertUncompletedCheckpoints
 import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 // TraderDemoTest already has a test which checks the node can resume a flow from a checkpoint
-@Ignore("TODO JDK17: Fixme")
 class FlowCheckpointVersionNodeStartupCheckTest {
     companion object {
         val defaultCordapp = enclosedCordapp()

--- a/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplicateSerializerLogTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplicateSerializerLogTest.kt
@@ -9,11 +9,9 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.logFile
 import org.assertj.core.api.Assertions
-import org.junit.Ignore
 import org.junit.Test
 import java.time.Duration
 
-@Ignore("TODO JDK17: Fixme")
 class DuplicateSerializerLogTest{
     @Test(timeout=300_000)
     fun `check duplicate serialisers are logged`() {

--- a/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplicateSerializerLogWithSameSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplicateSerializerLogWithSameSerializerTest.kt
@@ -12,11 +12,9 @@ import net.corda.testing.driver.driver
 import net.corda.testing.driver.logFile
 import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions
-import org.junit.Ignore
 import org.junit.Test
 import java.time.Duration
 
-@Ignore("TODO JDK17: Fixme")
 class DuplicateSerializerLogWithSameSerializerTest {
     @Test(timeout=300_000)
     fun `check duplicate serialisers are logged not logged for the same class`() {


### PR DESCRIPTION
These tests were failing because kryo exception are now wrapped in KryoException


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
