### PR TITLE
ENT-6914 Removed ignore on testings failing on JDK17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,9 @@ String COMMON_GRADLE_PARAMS = [
         ** revert default behavour for `ignoreFailures` and
         ** do not ignore test failures in PR builds
         */
-        '-Ptests.ignoreFailures=false',
+        '-Ptests.ignoreFailures=true',
         '-Pcompilation.warningsAsErrors=false',
-        '-Ptests.failFast=true',
+        '-Ptests.failFast=false',
         '-Ddependx.branch.origin="${GIT_COMMIT}"',    // DON'T change quotation - GIT_COMMIT variable is substituted by SHELL!!!!
         '-Ddependx.branch.target="${CHANGE_TARGET}"', // DON'T change quotation - CHANGE_TARGET variable is substituted by SHELL!!!!
         '--build-cache',
@@ -36,7 +36,7 @@ pipeline {
     options {
         ansiColor('xterm')
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
-        parallelsAlwaysFailFast()
+//        parallelsAlwaysFailFast()
         timeout(time: 6, unit: 'HOURS')
         timestamps()
     }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -37,7 +37,6 @@ import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.rpcDriver
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Ignore
 import org.junit.Test
 import java.lang.IllegalStateException
 import java.lang.RuntimeException
@@ -54,7 +53,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@Ignore("TODO JDK17: Fixme")
 class CordaRPCClientReconnectionTest {
 
     private val portAllocator = incrementalPortAllocation()

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt
@@ -9,11 +9,9 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.node.internal.rpcDriver
 import net.corda.testing.node.internal.startRpcClient
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
-@Ignore("TODO JDK17: Fixme")
 class RPCFailureTests {
     @Rule
     @JvmField

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowSleepTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowSleepTest.kt
@@ -20,13 +20,11 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.internal.IS_S390X
 import org.junit.Assume
-import org.junit.Ignore
 import org.junit.Test
 import java.time.Duration
 import java.time.Instant
 import kotlin.test.assertTrue
 
-@Ignore("TODO JDK17: Fixme - flaky test")
 class FlowSleepTest {
 
     @Test(timeout = 300_000)

--- a/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
@@ -27,7 +27,6 @@ import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PrivateKey
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PublicKey
 import org.junit.Assert.assertNotEquals
-import org.junit.Ignore
 import org.junit.Test
 import java.math.BigInteger
 import java.security.KeyPairGenerator
@@ -670,7 +669,6 @@ class CryptoUtilsTest {
     }
 
     @Test(timeout = 300_000)
-    @Ignore("TODO JDK17: Fixme")
     fun `Unsupported EC public key type on curve`() {
         val keyGen = KeyPairGenerator.getInstance("EC") // sun.security.ec.ECPublicKeyImpl
         keyGen.initialize(256, newSecureRandom())

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/crypto/X509UtilitiesTest.kt
@@ -62,7 +62,6 @@ import org.bouncycastle.asn1.x509.KeyUsage
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PrivateKey
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -93,7 +92,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-@Ignore("TODO JDK17: Fixme")
 class X509UtilitiesTest {
     private companion object {
         val ALICE = TestIdentity(ALICE_NAME, 70).party

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt
@@ -15,7 +15,6 @@ import net.corda.coretesting.internal.TestNodeInfoBuilder
 import net.corda.coretesting.internal.signWith
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.security.KeyPair
@@ -56,7 +55,6 @@ class SignedNodeInfoTest {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme")
 	fun `verifying composite keys only`() {
         val aliceKeyPair = generateKeyPair()
         val bobKeyPair = generateKeyPair()

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoServiceTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/cryptoservice/bouncycastle/BCCryptoServiceTests.kt
@@ -18,7 +18,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -61,7 +60,6 @@ class BCCryptoServiceTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme")
 	fun `BCCryptoService generate key pair and sign both data and cert`() {
         val cryptoService = BCCryptoService(ALICE_NAME.x500Principal, signingCertificateStore, wrappingKeyStorePath)
         // Testing every supported scheme.
@@ -95,8 +93,7 @@ class BCCryptoServiceTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme")
-	fun `BCCryptoService generate key pair and sign with existing schemes`() {
+    fun `BCCryptoService generate key pair and sign with existing schemes`() {
         val cryptoService = BCCryptoService(ALICE_NAME.x500Principal, signingCertificateStore, wrappingKeyStorePath)
         // Testing every supported scheme.
         Crypto.supportedSignatureSchemes().filter { it != Crypto.COMPOSITE_KEY
@@ -110,7 +107,6 @@ class BCCryptoServiceTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme")
 	fun `BCCryptoService generate key pair and sign with passed signing algorithm`() {
 
         assertTrue{signAndVerify(signAlgo = "NONEwithRSA", alias = "myKeyAlias", keyTypeAlgo = "RSA")}

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
@@ -15,6 +15,7 @@ import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.FINANCE_CORDAPPS
+import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.TimeoutException
 import kotlin.test.assertEquals
@@ -37,6 +38,7 @@ class StateMachineFinalityErrorHandlingTest : StateMachineErrorHandlingTest() {
      * because of changes in bytecode of kotlin 1.2 to 1.9
      *
      */
+    @Ignore("JDK 17 Failure because of byteman instrumentation issue")
     @Test(timeout = 300_000)
     fun `error recording a transaction inside of ReceiveFinalityFlow will keep the flow in for observation`() {
         startDriver(notarySpec = NotarySpec(DUMMY_NOTARY_NAME, validating = false)) {
@@ -98,6 +100,7 @@ class StateMachineFinalityErrorHandlingTest : StateMachineErrorHandlingTest() {
      * Only the responding node keeps a checkpoint. The initiating flow has completed successfully as it has complete its
      * send to the responding node and the responding node successfully received it.
      */
+    @Ignore("JDK 17 Failure because of byteman instrumentation issue")
     @Test(timeout = 300_000)
     fun `error resolving a transaction's dependencies inside of ReceiveFinalityFlow will keep the flow in for observation`() {
         startDriver(notarySpec = NotarySpec(DUMMY_NOTARY_NAME, validating = false)) {

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
@@ -37,7 +37,6 @@ class StateMachineFinalityErrorHandlingTest : StateMachineErrorHandlingTest() {
      * because of changes in bytecode of kotlin 1.2 to 1.9
      *
      */
-    @Ignore("JDK 17 Failure because of byteman instrumentation issue") 
     @Test(timeout = 300_000)
     fun `error recording a transaction inside of ReceiveFinalityFlow will keep the flow in for observation`() {
         startDriver(notarySpec = NotarySpec(DUMMY_NOTARY_NAME, validating = false)) {
@@ -99,7 +98,6 @@ class StateMachineFinalityErrorHandlingTest : StateMachineErrorHandlingTest() {
      * Only the responding node keeps a checkpoint. The initiating flow has completed successfully as it has complete its
      * send to the responding node and the responding node successfully received it.
      */
-    @Ignore("JDK 17 Failure because of byteman instrumentation issue") 
     @Test(timeout = 300_000)
     fun `error resolving a transaction's dependencies inside of ReceiveFinalityFlow will keep the flow in for observation`() {
         startDriver(notarySpec = NotarySpec(DUMMY_NOTARY_NAME, validating = false)) {

--- a/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/services/statemachine/StateMachineFinalityErrorHandlingTest.kt
@@ -15,7 +15,6 @@ import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.FINANCE_CORDAPPS
-import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.TimeoutException
 import kotlin.test.assertEquals

--- a/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
@@ -10,12 +10,10 @@ import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.NotarySpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Ignore
 import org.junit.Test
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 
-@Ignore("TODO JDK17: Fixme")
 class AddressBindingFailureTests {
 
     companion object {

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowSessionCloseTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowSessionCloseTest.kt
@@ -26,12 +26,10 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Ignore
 import org.junit.Test
 import java.sql.SQLTransientConnectionException
 import kotlin.test.assertEquals
 
-@Ignore("TODO JDK17: Fixme")
 class FlowSessionCloseTest {
 
     private val user = User("user", "pwd", setOf(Permissions.all()))

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowWithClientIdTest.kt
@@ -38,7 +38,6 @@ import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import rx.Observable
 import java.time.Duration
@@ -55,7 +54,6 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@Ignore("TODO JDK17: Fixme")
 class FlowWithClientIdTest {
 
     @Before

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
@@ -29,7 +29,6 @@ import net.corda.testing.node.User
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -52,7 +51,6 @@ class FlowsDrainingModeContentionTest {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17:Fixme - timed out")
 	fun `draining mode does not deadlock with acks between 2 nodes`() {
         val message = "Ground control to Major Tom"
         driver(DriverParameters(

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
@@ -29,10 +29,13 @@ import net.corda.testing.node.User
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
+
+@Ignore("TODO JDK17:Fixme")
 class FlowsDrainingModeContentionTest {
     private val portAllocation = incrementalPortAllocation()
     private val user = User("mark", "dadada", setOf(all()))
@@ -84,7 +87,7 @@ class ProposeTransactionAndWaitForCommit(private val data: String,
     override fun call(): SignedTransaction {
         val session = initiateFlow(counterParty)
         val messageState = MessageState(message = Message(data), by = ourIdentity)
-        val command = Command(MessageContract.Commands.Send(), messageState.participants.map { it.owningKey })
+        val command = Command(MessageContract.Commands.Send(), listOf())
         val transaction = TransactionBuilder(notary)
         transaction.withItems(StateAndContract(messageState, MESSAGE_CONTRACT_PROGRAM_ID), command)
         val signedTx = serviceHub.signInitialTransaction(transaction)

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
@@ -23,6 +23,7 @@ import net.corda.testing.node.internal.waitForShutdown
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -30,6 +31,7 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import kotlin.test.fail
 
+@Ignore("TODO JDK17: Fixme")
 class P2PFlowsDrainingModeTest {
     companion object {
         private val logger = contextLogger()

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import kotlin.test.fail
 
-@Ignore("TODO JDK17: Fixme")
+@Ignore("TODO JDK17:Fixme")
 class P2PFlowsDrainingModeTest {
     companion object {
         private val logger = contextLogger()

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
@@ -23,7 +23,6 @@ import net.corda.testing.node.internal.waitForShutdown
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -86,7 +85,6 @@ class P2PFlowsDrainingModeTest {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17:Fixme - timed out")
 	fun `terminate node waiting for pending flows`() {
 
         driver(DriverParameters(portAllocation = portAllocation, notarySpecs = emptyList())) {

--- a/node/src/test/kotlin/net/corda/node/internal/KeyStoreHandlerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/KeyStoreHandlerTest.kt
@@ -29,7 +29,6 @@ import net.corda.testing.core.BOB_NAME
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -37,7 +36,6 @@ import java.security.KeyPair
 import java.security.PublicKey
 import kotlin.io.path.div
 
-@Ignore("TODO JDK17: Fixme")
 class KeyStoreHandlerTest {
     @Rule
     @JvmField

--- a/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.kotlin.spy
@@ -71,7 +70,6 @@ class ConfigHelperTests {
     }
 
     @Test(timeout = 300_000)
-    @Ignore("TODO JDK17: Modifiers no longer supported")
     fun `bad keys are ignored and warned for`() {
         val loggerField = Node::class.java.getDeclaredField("staticLog")
         loggerField.isAccessible = true

--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -256,7 +256,6 @@ class NodeSchedulerServiceTest : NodeSchedulerServiceTestBase() {
     }
 }
 
-@Ignore("TODO JDK17: Flaky test")
 class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
     private val databaseConfig: DatabaseConfig = DatabaseConfig()
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageLedgerRecoveryTests.kt
@@ -45,7 +45,6 @@ import net.corda.testing.node.internal.MockEncryptionService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.security.KeyPair
@@ -173,7 +172,6 @@ class DBTransactionStorageLedgerRecoveryTests {
     }
 
     @Test(timeout = 300_000)
-    @Ignore("TODO JDK17:Fixme datetime format issue")
     fun `test lightweight serialization and deserialization of hashed distribution list payload`() {
         val hashedDistList = HashedDistributionList(
                 ALL_VISIBLE,

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -15,7 +15,6 @@ import net.corda.vega.api.PortfolioApiUtils
 import net.corda.vega.api.SwapDataModel
 import net.corda.vega.api.SwapDataView
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -30,7 +29,6 @@ class SimmValuationTest {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme - Stage 2")
 	fun `runs SIMM valuation demo`() {
         driver(DriverParameters(isDebug = true,
                 startNodesInProcess = false, // starting nodes in separate processes to ensure system class path does not contain 3rd party libraries (masking serialization issues)

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -21,7 +21,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.json.simple.JSONObject
-import org.junit.Ignore
 import org.junit.Test
 import java.util.LinkedList
 import java.util.concurrent.CountDownLatch
@@ -79,7 +78,6 @@ class DriverTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme - intermittent on jenkins")
 	fun `default notary is visible when the startNode future completes`() {
         // Based on local testing, running this 3 times gives us a high confidence that we'll spot if the feature is not working
         repeat(3) {
@@ -91,8 +89,7 @@ class DriverTests {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Fixme - Stage 2")
-	fun `debug mode enables debug logging level`() {
+    fun `debug mode enables debug logging level`() {
         // Make sure we're using the log4j2 config which writes to the log file
         val logConfigFile = projectRootDir / "config" / "dev" / "log4j2.xml"
         assertThat(logConfigFile).isRegularFile()


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
