### PR TITLE
ENT-11325: Fixed to not use API that will be discontinued in the future

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
 import com.fasterxml.jackson.databind.deser.std.NumberDeserializers
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import net.corda.client.jackson.internal.CordaModule
 import net.corda.client.jackson.internal.ToStringSerialize
 import net.corda.client.jackson.internal.jsonObject
@@ -197,7 +197,7 @@ object JacksonSupport {
                 addSerializer(Date::class.java, DateSerializer)
             })
             registerModule(CordaModule())
-            registerModule(KotlinModule().apply {
+            registerModule(kotlinModule().apply {
                 setDeserializerModifier(KotlinObjectDeserializerModifier)
             })
 


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

SSIA

# PR Checklist:
As for the bottom part, I could not confirm it with a 404.
It is not a particularly complicated change, so I am ignoring it.

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs/kdocs?
- [x] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
