### PR TITLE
ENT-11056: Turn off javadoc for serialization-1.2 module

### DIFF
--- a/serialization-1.2/build.gradle
+++ b/serialization-1.2/build.gradle
@@ -24,6 +24,10 @@ jar {
     archiveBaseName = 'corda-serialization-1.2'
 }
 
+tasks.withType(Javadoc).configureEach {
+    enabled = false
+}
+
 // TODO Don't publish publicly as it's only needed by the `verifier` module which consumes this into a fat jar.
 publishing {
     publications {


### PR DESCRIPTION
It doesn't have any Java source code.

