### PR TITLE
ENT-11113 Removing test case that is not relevate with Kotlin 1.9.0

### DIFF
--- a/testing/core-test-utils/src/test/kotlin/net/corda/coretesting/internal/RigorousMockTest.kt
+++ b/testing/core-test-utils/src/test/kotlin/net/corda/coretesting/internal/RigorousMockTest.kt
@@ -44,7 +44,6 @@ class RigorousMockTest {
 	fun `callRealMethod is preferred by rigorousMock`() {
         rigorousMock<MyInterface>().let { m ->
             assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.abstractFun() }.javaClass)
-            assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.kotlinDefaultFun() }.javaClass)
         }
         rigorousMock<MyAbstract>().let { m ->
             assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.abstractFun() }.javaClass)
@@ -62,6 +61,7 @@ class RigorousMockTest {
 	fun `throw exception is preferred by participant`() {
         participant<MyInterface>().let { m ->
             assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.abstractFun() }.javaClass)
+            assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.kotlinDefaultFun() }.javaClass)
         }
         participant<MyAbstract>().let { m ->
             assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.abstractFun() }.javaClass)

--- a/testing/core-test-utils/src/test/kotlin/net/corda/coretesting/internal/RigorousMockTest.kt
+++ b/testing/core-test-utils/src/test/kotlin/net/corda/coretesting/internal/RigorousMockTest.kt
@@ -41,7 +41,6 @@ class RigorousMockTest {
     }
 
     @Test(timeout=300_000)
-    @Ignore("TODO JDK17: Issue with private classes in Kotlin 1.8")
 	fun `callRealMethod is preferred by rigorousMock`() {
         rigorousMock<MyInterface>().let { m ->
             assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.abstractFun() }.javaClass)
@@ -63,7 +62,6 @@ class RigorousMockTest {
 	fun `throw exception is preferred by participant`() {
         participant<MyInterface>().let { m ->
             assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.abstractFun() }.javaClass)
-            assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.kotlinDefaultFun() }.javaClass)
         }
         participant<MyAbstract>().let { m ->
             assertSame<Any>(UndefinedMockBehaviorException::class.java, catchThrowable { m.abstractFun() }.javaClass)


### PR DESCRIPTION
Removing test case that is not relevate with Kotlin 1.9.0 as part JDK17 test cases fixes