### PR TITLE
ENT-11113 Test case no longer using reflection to change final modifier on node logger

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -330,7 +330,6 @@ jar {
 tasks.named('test', Test) {
     maxHeapSize = "3g"
     maxParallelForks = (System.env.CORDA_NODE_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_TESTING_FORKS".toInteger()
-    jvmArgs(['--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED', '--add-opens', 'java.base/java.util=ALL-UNNAMED'])
 }
 
 publishing {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -330,6 +330,7 @@ jar {
 tasks.named('test', Test) {
     maxHeapSize = "3g"
     maxParallelForks = (System.env.CORDA_NODE_TESTING_FORKS == null) ? 1 : "$System.env.CORDA_NODE_TESTING_FORKS".toInteger()
+    jvmArgs(['--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED', '--add-opens', 'java.base/java.util=ALL-UNNAMED'])
 }
 
 publishing {

--- a/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
@@ -7,12 +7,12 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.slf4j.Logger
+import java.lang.invoke.MethodHandles
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.nio.file.Files
@@ -71,13 +71,12 @@ class ConfigHelperTests {
     }
 
     @Test(timeout = 300_000)
-    @Ignore("TODO JDK17: Modifiers no longer supported")
     fun `bad keys are ignored and warned for`() {
         val loggerField = Node::class.java.getDeclaredField("staticLog")
         loggerField.isAccessible = true
-        val modifiersField = Field::class.java.getDeclaredField("modifiers")
-        modifiersField.isAccessible = true
-        modifiersField.setInt(loggerField, loggerField.modifiers and Modifier.FINAL.inv())
+        val fieldLookup = MethodHandles.privateLookupIn(Field::class.java, MethodHandles.lookup());
+        val modifiersField = fieldLookup.findVarHandle(Field::class.java, "modifiers", Int::class.javaPrimitiveType)
+        modifiersField.set(loggerField, loggerField.modifiers and Modifier.FINAL.inv())
         val originalLogger = loggerField.get(null) as Logger
         val spyLogger = spy(originalLogger)
         loggerField.set(null, spyLogger)

--- a/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/ConfigHelperTests.kt
@@ -68,17 +68,16 @@ class ConfigHelperTests {
 
     @Test(timeout = 300_000)
     fun `bad keys are ignored and warned for`() {
-        val outContent = ByteArrayOutputStream()
-        val errContent = ByteArrayOutputStream()
         val originalOut = System.out
-        val originalErr = System.err
-        System.setOut(PrintStream(outContent));
-        System.setErr(PrintStream(errContent));
-        val config = loadConfig("corda_bad_key" to "2077")
-        assertTrue(outContent.toString().contains("(property or environment variable) cannot be mapped to an existing Corda"))
-        assertFalse(config?.hasPath("corda_bad_key") ?: true)
-        System.setOut(originalOut);
-        System.setErr(originalErr);
+        try {
+            val outContent = ByteArrayOutputStream()
+            System.setOut(PrintStream(outContent));
+            val config = loadConfig("corda_bad_key" to "2077")
+            assertTrue(outContent.toString().contains("(property or environment variable) cannot be mapped to an existing Corda"))
+            assertFalse(config?.hasPath("corda_bad_key") ?: true)
+        } finally {
+            System.setOut(originalOut);
+        }
     }
 
     /**


### PR DESCRIPTION
Instead, it's using `System.setOut` to capture and assert on the output of the logging.