### PR TITLE
ENT-11351 - Compiler warnings pass 2

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -315,8 +315,7 @@ object JacksonSupport {
 
     private class CertPathSerializer : JsonSerializer<CertPath>() {
         override fun serialize(value: CertPath, gen: JsonGenerator, serializers: SerializerProvider) {
-            val certificates = value.certificates as List<X509Certificate>
-            gen.writeObject(CertPathWrapper(value.type, certificates))
+            gen.writeObject(CertPathWrapper(value.type, uncheckedCast(value.certificates)))
         }
     }
 

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -315,7 +315,8 @@ object JacksonSupport {
 
     private class CertPathSerializer : JsonSerializer<CertPath>() {
         override fun serialize(value: CertPath, gen: JsonGenerator, serializers: SerializerProvider) {
-            gen.writeObject(CertPathWrapper(value.type, uncheckedCast(value.certificates)))
+            val certificates = value.certificates as List<X509Certificate>
+            gen.writeObject(CertPathWrapper(value.type, certificates))
         }
     }
 

--- a/common/configuration-parsing/src/test/kotlin/net/corda/common/configuration/parsing/internal/SpecificationTest.kt
+++ b/common/configuration-parsing/src/test/kotlin/net/corda/common/configuration/parsing/internal/SpecificationTest.kt
@@ -61,7 +61,7 @@ class SpecificationTest {
 
             override fun parseValid(configuration: Config, options: Configuration.Options): Valid<AtomicLong> {
                 val config = configuration.withOptions(options)
-                return valid(AtomicLong(config[maxElement]!!))
+                return valid(AtomicLong(config[maxElement]))
             }
         }
 
@@ -103,7 +103,7 @@ class SpecificationTest {
             if (elements.any { element -> element <= 1  }) {
                 return invalid(Configuration.Validation.Error.BadValue.of("elements cannot be less than or equal to 1"))
             }
-            return valid(elements.max()!!)
+            return valid(elements.max())
         }
 
         val spec = object : Configuration.Specification<AtomicLong>("AtomicLong") {

--- a/core-tests/src/test/kotlin/net/corda/coretests/contracts/AmountTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/contracts/AmountTests.kt
@@ -56,8 +56,8 @@ class AmountTests {
                 val splits = baseAmount.splitEvenly(partitionCount)
                 assertEquals(partitionCount, splits.size)
                 assertEquals(baseAmount, splits.sumOrZero(baseAmount.token))
-                val min = splits.min()!!
-                val max = splits.max()!!
+                val min = splits.min()
+                val max = splits.max()
                 assertTrue(max.quantity - min.quantity <= 1L, "Amount quantities should differ by at most one token")
             }
         }

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
@@ -292,7 +292,7 @@ class CompatibleTransactionTests {
         ftxCompatibleNoInputs.verify()
         assertFailsWith<ComponentVisibilityException> { ftxCompatibleNoInputs.checkAllComponentsVisible(INPUTS_GROUP) }
         assertEquals(wireTransactionCompatibleA.componentGroups.size - 1, ftxCompatibleNoInputs.filteredComponentGroups.size)
-        assertEquals(wireTransactionCompatibleA.componentGroups.map { it.groupIndex }.max()!!, ftxCompatibleNoInputs.groupHashes.size - 1)
+        assertEquals(wireTransactionCompatibleA.componentGroups.map { it.groupIndex }.max(), ftxCompatibleNoInputs.groupHashes.size - 1)
     }
 
     @Test(timeout=300_000)

--- a/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
@@ -2,11 +2,8 @@ package net.corda.coretests.utilities
 
 import com.esotericsoftware.kryo.KryoException
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.eagerDeserialise
-import net.corda.core.internal.lazyMapped
 import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.internal.checkpointDeserialize
 import net.corda.core.serialization.internal.checkpointSerialize
 import net.corda.core.utilities.transient
@@ -17,8 +14,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.rules.ExpectedException
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 object EmptyWhitelist : ClassWhitelist {

--- a/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
@@ -5,11 +5,8 @@ import net.corda.core.internal.lazyMapped
 import net.corda.core.internal.TransactionDeserialisationException
 import net.corda.core.internal.eagerDeserialise
 import net.corda.core.serialization.MissingAttachmentsException
-import org.junit.Rule
 import org.junit.Test
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.assertThrows
-import org.junit.rules.ExpectedException
 import kotlin.test.assertEquals
 
 class LazyMappedListTest {

--- a/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
@@ -7,13 +7,12 @@ import net.corda.core.internal.eagerDeserialise
 import net.corda.core.serialization.MissingAttachmentsException
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.assertThrows
 import org.junit.rules.ExpectedException
 import kotlin.test.assertEquals
 
 class LazyMappedListTest {
-
-    @get:Rule
-    val exception: ExpectedException = ExpectedException.none()
 
     @Test(timeout=300_000)
 	fun `LazyMappedList works`() {
@@ -44,14 +43,13 @@ class LazyMappedListTest {
 
     @Test(timeout=300_000)
 	fun testMissingAttachments() {
-        exception.expect(MissingAttachmentsException::class.java)
-        exception.expectMessage("Uncatchable!")
-
-        val lazyList = (0 until 5).toList().lazyMapped<Int, Int> { _, _ ->
-            throw MissingAttachmentsException(emptyList(), "Uncatchable!")
+        val anException = assertThrows<MissingAttachmentsException> {
+            val lazyList = (0 until 5).toList().lazyMapped<Int, Int> { _, _ ->
+                throw MissingAttachmentsException(emptyList(), "Uncatchable!")
+            }
+            lazyList.eagerDeserialise { _, _ -> -999 }
         }
-
-        lazyList.eagerDeserialise { _, _ -> -999 }
+        assertEquals("Uncatchable!", anException.message)
     }
 
     @Test(timeout=300_000)

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
@@ -8,7 +8,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.StatesNotAvailableException
 import net.corda.core.utilities.*
@@ -139,7 +138,7 @@ abstract class AbstractCashSelection(private val maxRetries : Int = 8, private v
 
                 if (stateRefs.isNotEmpty()) {
                     // TODO: future implementation to retrieve contract states from a Vault BLOB store
-                    stateAndRefs.addAll(uncheckedCast(services.loadStates(stateRefs)))
+                    stateAndRefs.addAll(services.loadStates(stateRefs) as Collection<out StateAndRef<Cash.State>>)
                 }
 
                 val success = stateAndRefs.isNotEmpty() && totalPennies >= amount.quantity

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
@@ -8,6 +8,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
+import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.StatesNotAvailableException
 import net.corda.core.utilities.*
@@ -138,7 +139,7 @@ abstract class AbstractCashSelection(private val maxRetries : Int = 8, private v
 
                 if (stateRefs.isNotEmpty()) {
                     // TODO: future implementation to retrieve contract states from a Vault BLOB store
-                    stateAndRefs.addAll(services.loadStates(stateRefs) as Collection<out StateAndRef<Cash.State>>)
+                    stateAndRefs.addAll(uncheckedCast(services.loadStates(stateRefs)))
                 }
 
                 val success = stateAndRefs.isNotEmpty() && totalPennies >= amount.quantity

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
@@ -29,7 +29,6 @@ import net.corda.nodeapi.internal.network.PackageOwner
 import net.corda.nodeapi.internal.network.SignedNetworkParameters
 import net.corda.nodeapi.internal.network.TestContractsJar
 import net.corda.nodeapi.internal.network.verifiedNetworkParametersCert
-import net.corda.nodeapi.internal.serialization.kryo.CordaClassResolver
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
@@ -42,7 +41,6 @@ import org.junit.AfterClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.rules.ExpectedException
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Files
 import java.nio.file.Path

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
@@ -29,6 +29,7 @@ import net.corda.nodeapi.internal.network.PackageOwner
 import net.corda.nodeapi.internal.network.SignedNetworkParameters
 import net.corda.nodeapi.internal.network.TestContractsJar
 import net.corda.nodeapi.internal.network.verifiedNetworkParametersCert
+import net.corda.nodeapi.internal.serialization.kryo.CordaClassResolver
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
@@ -40,6 +41,7 @@ import org.junit.After
 import org.junit.AfterClass
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.rules.ExpectedException
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Files
@@ -54,15 +56,12 @@ import kotlin.io.path.readBytes
 import kotlin.io.path.useDirectoryEntries
 import kotlin.io.path.writeBytes
 import kotlin.io.path.writeText
+import kotlin.test.assertEquals
 
 class NetworkBootstrapperTest {
     @Rule
     @JvmField
     val tempFolder = TemporaryFolder()
-
-    @Rule
-    @JvmField
-    val expectedEx: ExpectedException = ExpectedException.none()
 
     @Rule
     @JvmField
@@ -304,9 +303,10 @@ class NetworkBootstrapperTest {
         assertContainsPackageOwner("alice", mapOf(Pair(greedyNamespace, alice.publicKey)))
         // register overlapping package name
         createNodeConfFile("bob", bobConfig)
-        expectedEx.expect(IllegalArgumentException::class.java)
-        expectedEx.expectMessage("Multiple packages added to the packageOwnership overlap.")
-        bootstrap(packageOwnership = mapOf(Pair(greedyNamespace, alice.publicKey), Pair(bobPackageName, bob.publicKey)))
+        val anException = assertThrows<IllegalArgumentException> {
+            bootstrap(packageOwnership = mapOf(Pair(greedyNamespace, alice.publicKey), Pair(bobPackageName, bob.publicKey)))
+        }
+        assertEquals("Multiple packages added to the packageOwnership overlap.", anException.message)
     }
 
     @Test(timeout=300_000)

--- a/node/src/integration-test-slow/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt
@@ -60,7 +60,7 @@ class NodeStatePersistenceTests {
             result
         }
         assertNotNull(stateAndRef)
-        val retrievedMessage = stateAndRef!!.state.data.message
+        val retrievedMessage = stateAndRef.state.data.message
         assertEquals(message, retrievedMessage)
     }
 
@@ -96,7 +96,7 @@ class NodeStatePersistenceTests {
             result
         }
         assertNotNull(stateAndRef)
-        val retrievedMessage = stateAndRef!!.state.data.message
+        val retrievedMessage = stateAndRef.state.data.message
         assertEquals(message, retrievedMessage)
     }
 }

--- a/node/src/integration-test-slow/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test-slow/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -65,7 +65,7 @@ class NodeRegistrationTest {
                 pollInterval = 1.seconds,
                 hostAndPort = portAllocation.nextHostAndPort(),
                 myHostNameValue = "localhost",
-                additionalServices = *arrayOf(registrationHandler))
+                additionalServices = arrayOf(registrationHandler))
         serverHostAndPort = server.start()
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -306,11 +306,11 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging,
                     log.info("Error ${index + 1} of ${errors.size}:", error)
                     val diagnoses: Map<Diagnosis, List<Staff>> = staff.groupBy { it.consult(flowFiber, currentState, error, medicalHistory) }
                     // We're only interested in the highest priority diagnosis for the error
-                    val (diagnosis, by) = diagnoses.entries.minBy { it.key }!!
+                    val (diagnosis, by) = diagnoses.entries.minBy { it.key }
                     ConsultationReport(error, diagnosis, by)
                 }
                 // And we're only interested in the error with the highest priority diagnosis
-                .minBy { it.diagnosis }!!
+                .minBy { it.diagnosis }
     }
 
     private data class ConsultationReport(val error: Throwable, val diagnosis: Diagnosis, val by: List<Staff>)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowMetadataRecordingTest.kt
@@ -412,7 +412,7 @@ class FlowMetadataRecordingTest {
             metadata!!.let {
                 assertNull(it.finishInstant)
                 assertNotNull(finishTime)
-                assertTrue(finishTime!! >= it.startInstant)
+                assertTrue(finishTime >= it.startInstant)
             }
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
@@ -11,7 +11,6 @@ import net.corda.testing.core.*
 import net.corda.testing.internal.vault.DummyLinearStateSchemaV1
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.*
-import org.junit.rules.ExpectedException
 
 class VaultQueryExceptionsTests : VaultQueryParties by rule {
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
@@ -32,10 +32,6 @@ class VaultQueryExceptionsTests : VaultQueryParties by rule {
 
     @Rule
     @JvmField
-    val expectedEx: ExpectedException = ExpectedException.none()
-
-    @Rule
-    @JvmField
     val rollbackRule = VaultQueryRollbackRule(this)
 
     @Test(timeout=300_000)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -7,15 +7,12 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
-import net.corda.core.internal.eagerDeserialise
-import net.corda.core.internal.lazyMapped
 import net.corda.core.internal.packageName
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.*
 import net.corda.core.node.services.Vault.ConstraintInfo.Type.*
 import net.corda.core.node.services.vault.*
 import net.corda.core.node.services.vault.QueryCriteria.*
-import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.*
@@ -50,7 +47,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.assertThrows
-import org.junit.rules.ExpectedException
 import org.junit.rules.ExternalResource
 import java.time.Duration
 import java.time.Instant
@@ -58,7 +54,6 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.*
-import kotlin.test.assertEquals
 
 interface VaultQueryParties {
     val alice: TestIdentity

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -7,12 +7,15 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.internal.eagerDeserialise
+import net.corda.core.internal.lazyMapped
 import net.corda.core.internal.packageName
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.*
 import net.corda.core.node.services.Vault.ConstraintInfo.Type.*
 import net.corda.core.node.services.vault.*
 import net.corda.core.node.services.vault.QueryCriteria.*
+import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.*
@@ -45,6 +48,8 @@ import org.junit.ClassRule
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertThrows
 import org.junit.rules.ExpectedException
 import org.junit.rules.ExternalResource
 import java.time.Duration
@@ -53,6 +58,7 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.*
+import kotlin.test.assertEquals
 
 interface VaultQueryParties {
     val alice: TestIdentity
@@ -148,7 +154,7 @@ open class VaultQueryTestRule(private val persistentServices: Boolean) : Externa
                     cordappPackages,
                     makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity),
                     megaCorp,
-                    moreKeys = *arrayOf(DUMMY_NOTARY_KEY)
+                    moreKeys = arrayOf(DUMMY_NOTARY_KEY)
             )
         }
         database = databaseAndServices.first
@@ -183,10 +189,6 @@ class VaultQueryRollbackRule(private val vaultQueryParties: VaultQueryParties) :
 }
 
 abstract class VaultQueryTestsBase : VaultQueryParties {
-
-    @Rule
-    @JvmField
-    val expectedEx: ExpectedException = ExpectedException.none()
 
     companion object {
         @ClassRule @JvmField
@@ -1006,10 +1008,11 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             assertThat(resultsUnlockedAndByLockIds.states).hasSize(5)
 
             // missing lockId
-            expectedEx.expect(VaultQueryException::class.java)
-            expectedEx.expectMessage("Must specify one or more lockIds")
-            val criteriaMissingLockId = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.UNLOCKED_AND_SPECIFIED))
-            vaultService.queryBy<ContractState>(criteriaMissingLockId)
+            val anException = assertThrows<VaultQueryException> {
+                val criteriaMissingLockId = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.UNLOCKED_AND_SPECIFIED))
+                vaultService.queryBy<ContractState>(criteriaMissingLockId)
+            }
+            anException.message?.let { assertTrue(it.contains("Must specify one or more lockIds")) }
         }
     }
 
@@ -1707,44 +1710,43 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     // pagination: invalid page number
     @Test(timeout=300_000)
 	fun `invalid page number`() {
-        expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("Page specification: invalid page number")
-
-        database.transaction {
-            vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
-            val pagingSpec = PageSpecification(0, 10)
-
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
+        val anException = assertThrows<VaultQueryException> {
+            database.transaction {
+                vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
+                val pagingSpec = PageSpecification(0, 10)
+                val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+                vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
+            }
         }
+        anException.message?.let { assertTrue(it.contains("Page specification: invalid page number")) }
     }
 
     // pagination: invalid page size
     @Suppress("INTEGER_OVERFLOW")
     @Test(timeout=300_000)
 	fun `invalid page size`() {
-        expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("Page specification: invalid page size")
-
-        database.transaction {
-            vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
-            val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, Integer.MAX_VALUE + 1)  // overflow = -2147483648
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
+        val anException = assertThrows<VaultQueryException> {
+            database.transaction {
+                vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
+                val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, Integer.MAX_VALUE + 1)  // overflow = -2147483648
+                val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+                vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
+            }
         }
+        anException.message?.let { assertTrue(it.contains("Page specification: invalid page size")) }
     }
 
     // pagination not specified but more than DEFAULT_PAGE_SIZE results available (fail-fast test)
     @Test(timeout=300_000)
 	fun `pagination not specified but more than default results available`() {
-        expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("provide a PageSpecification")
-
-        database.transaction {
-            vaultFiller.fillWithSomeTestCash(201.DOLLARS, notaryServices, 201, DUMMY_CASH_ISSUER)
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            vaultService.queryBy<ContractState>(criteria)
+        val anException = assertThrows<VaultQueryException> {
+            database.transaction {
+                vaultFiller.fillWithSomeTestCash(201.DOLLARS, notaryServices, 201, DUMMY_CASH_ISSUER)
+                val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+                vaultService.queryBy<ContractState>(criteria)
+            }
         }
+        anException.message?.let { assertTrue(it.contains("provide a PageSpecification")) }
     }
 
     // example of querying states with paging using totalStatesAvailable

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -83,7 +83,7 @@ class VaultWithCashTest {
                 makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity),
                 TestIdentity(MEGA_CORP.name, servicesKey),
                 networkParameters,
-                moreKeys = *arrayOf(dummyNotary.keyPair))
+                moreKeys = arrayOf(dummyNotary.keyPair))
         database = databaseAndServices.first
         services = databaseAndServices.second
         vaultFiller = VaultFiller(services, dummyNotary)

--- a/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
+++ b/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
@@ -131,7 +131,7 @@ object SimmFlow {
 
             val valuer = serviceHub.identityService.wellKnownPartyFromAnonymous(state.valuer)
             require(valuer != null) { "Valuer party must be known to this node" }
-            val valuation = agreeValuation(portfolio, valuationDate, valuer!!)
+            val valuation = agreeValuation(portfolio, valuationDate, valuer)
             val update = PortfolioState.Update(valuation = valuation)
             return subFlow(StateRevisionFlowRequester(otherPartySession, stateRef, update)).state.data
         }

--- a/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt
+++ b/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt
@@ -25,7 +25,7 @@ object SimmRevaluation {
             if (ourIdentity == curState.participants[0]) {
                 val otherParty = serviceHub.identityService.wellKnownPartyFromAnonymous(curState.participants[1])
                 require(otherParty != null) { "Other party must be known by this node" }
-                subFlow(SimmFlow.Requester(otherParty!!, valuationDate, stateAndRef))
+                subFlow(SimmFlow.Requester(otherParty, valuationDate, stateAndRef))
             }
         }
     }

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
@@ -12,11 +12,8 @@ import com.esotericsoftware.kryo.util.MapReferenceResolver
 import net.corda.core.contracts.TransactionVerificationException.UntrustedAttachmentsException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
-import net.corda.core.internal.eagerDeserialise
-import net.corda.core.internal.lazyMapped
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.internal.AttachmentsClassLoader
 import net.corda.core.serialization.internal.CheckpointSerializationContext
 import net.corda.coretesting.internal.rigorousMock
@@ -28,10 +25,8 @@ import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.services.InternalMockAttachmentStorage
 import net.corda.testing.services.MockAttachmentStorage
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.rules.ExpectedException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
@@ -12,8 +12,11 @@ import com.esotericsoftware.kryo.util.MapReferenceResolver
 import net.corda.core.contracts.TransactionVerificationException.UntrustedAttachmentsException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
+import net.corda.core.internal.eagerDeserialise
+import net.corda.core.internal.lazyMapped
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.internal.AttachmentsClassLoader
 import net.corda.core.serialization.internal.CheckpointSerializationContext
 import net.corda.coretesting.internal.rigorousMock
@@ -27,6 +30,7 @@ import net.corda.testing.services.MockAttachmentStorage
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.rules.ExpectedException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -267,16 +271,15 @@ class CordaClassResolverTests {
     }
 
     // Blacklist tests. Note: leave the variable public or else expected messages do not work correctly
-    @get:Rule
-    val expectedEx = ExpectedException.none()!!
 
     @Test(timeout=300_000)
 	fun `Check blacklisted class`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("Class java.util.HashSet is blacklisted, so it cannot be used in serialization.")
-        val resolver = CordaClassResolver(allButBlacklistedContext)
-        // HashSet is blacklisted.
-        resolver.getRegistration(HashSet::class.java)
+        val anException = assertThrows<IllegalStateException> {
+            val resolver = CordaClassResolver(allButBlacklistedContext)
+            // HashSet is blacklisted.
+            resolver.getRegistration(HashSet::class.java)
+        }
+        assertEquals("Class java.util.HashSet is blacklisted, so it cannot be used in serialization.", anException.message)
     }
 
     @Test(timeout=300_000)
@@ -349,33 +352,37 @@ class CordaClassResolverTests {
 
     @Test(timeout=300_000)
 	fun `Check blacklisted subclass`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubHashSet is blacklisted, so it cannot be used in serialization.")
-        val resolver = CordaClassResolver(allButBlacklistedContext)
-        // SubHashSet extends the blacklisted HashSet.
-        resolver.getRegistration(SubHashSet::class.java)
+        val anException = assertThrows<IllegalStateException> {
+            val resolver = CordaClassResolver(allButBlacklistedContext)
+            // SubHashSet extends the blacklisted HashSet.
+            resolver.getRegistration(SubHashSet::class.java)
+        }
+        assertEquals("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubHashSet is blacklisted, so it cannot be used in serialization.", anException.message)
     }
 
     class SubSubHashSet<E> : SubHashSet<E>()
 
     @Test(timeout=300_000)
 	fun `Check blacklisted subsubclass`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubSubHashSet is blacklisted, so it cannot be used in serialization.")
-        val resolver = CordaClassResolver(allButBlacklistedContext)
-        // SubSubHashSet extends SubHashSet, which extends the blacklisted HashSet.
-        resolver.getRegistration(SubSubHashSet::class.java)
+        val anException = assertThrows<IllegalStateException> {
+            val resolver = CordaClassResolver(allButBlacklistedContext)
+            // SubSubHashSet extends SubHashSet, which extends the blacklisted HashSet.
+            resolver.getRegistration(SubSubHashSet::class.java)
+        }
+        assertEquals("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubSubHashSet is blacklisted, so it cannot be used in serialization.", anException.message)
+
     }
 
     class ConnectionImpl(private val connection: Connection) : Connection by connection
 
     @Test(timeout=300_000)
 	fun `Check blacklisted interface impl`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$ConnectionImpl is blacklisted, so it cannot be used in serialization.")
-        val resolver = CordaClassResolver(allButBlacklistedContext)
-        // ConnectionImpl implements blacklisted Connection.
-        resolver.getRegistration(ConnectionImpl::class.java)
+        val anException = assertThrows<IllegalStateException> {
+            val resolver = CordaClassResolver(allButBlacklistedContext)
+            // ConnectionImpl implements blacklisted Connection.
+            resolver.getRegistration(ConnectionImpl::class.java)
+        }
+        assertEquals("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$ConnectionImpl is blacklisted, so it cannot be used in serialization.", anException.message)
     }
 
     interface SubConnection : Connection
@@ -383,11 +390,13 @@ class CordaClassResolverTests {
 
     @Test(timeout=300_000)
 	fun `Check blacklisted super-interface impl`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$SubConnectionImpl is blacklisted, so it cannot be used in serialization.")
-        val resolver = CordaClassResolver(allButBlacklistedContext)
-        // SubConnectionImpl implements SubConnection, which extends the blacklisted Connection.
-        resolver.getRegistration(SubConnectionImpl::class.java)
+        val anException = assertThrows<IllegalStateException> {
+            val resolver = CordaClassResolver(allButBlacklistedContext)
+            // SubConnectionImpl implements SubConnection, which extends the blacklisted Connection.
+            resolver.getRegistration(SubConnectionImpl::class.java)
+        }
+        assertEquals("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$SubConnectionImpl is blacklisted, so it cannot be used in serialization.", anException.message)
+
     }
 
     @Test(timeout=300_000)
@@ -402,10 +411,11 @@ class CordaClassResolverTests {
 
     @Test(timeout=300_000)
 	fun `Check blacklist precedes CordaSerializable`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$CordaSerializableHashSet is blacklisted, so it cannot be used in serialization.")
-        val resolver = CordaClassResolver(allButBlacklistedContext)
-        // CordaSerializableHashSet is @CordaSerializable, but extends the blacklisted HashSet.
-        resolver.getRegistration(CordaSerializableHashSet::class.java)
+        val anException = assertThrows<IllegalStateException> {
+            val resolver = CordaClassResolver(allButBlacklistedContext)
+            // CordaSerializableHashSet is @CordaSerializable, but extends the blacklisted HashSet.
+            resolver.getRegistration(CordaSerializableHashSet::class.java)
+        }
+        assertEquals("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$CordaSerializableHashSet is blacklisted, so it cannot be used in serialization.", anException.message)
     }
 }

--- a/testing/core-test-utils/src/main/kotlin/net/corda/coretesting/internal/RigorousMock.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/coretesting/internal/RigorousMock.kt
@@ -79,7 +79,7 @@ private class SpectatorDefaultAnswer : DefaultAnswer() {
                     ?: method.returnType!!
         }
 
-        private fun newSpectator(invocation: InvocationOnMock) = spectator(type)!!.also { log.info("New spectator {} for: {}", it, invocation.arguments) }
+        private fun newSpectator(invocation: InvocationOnMock) = spectator(type).also { log.info("New spectator {} for: {}", it, invocation.arguments) }
         private val spectators = try {
             val first = newSpectator(invocation)
             ConcurrentHashMap<InvocationOnMock, Any>().apply { put(invocation, first) }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -232,7 +232,7 @@ class NetworkMapServer(private val pollInterval: Duration,
                 null
             }
             requireNotNull(requestedParameters)
-            return Response.ok(requestedParameters!!.serialize().bytes).build()
+            return Response.ok(requestedParameters.serialize().bytes).build()
         }
 
         @GET

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt
@@ -57,7 +57,7 @@ class TransactionViewer : CordaView("Transactions") {
     override val widgets = listOf(CordaWidget(title, TransactionWidget(), icon)).observable()
 
     private var scrollPosition: Int = 0
-    private lateinit var expander: ExpanderColumn<TransactionViewer.Transaction>
+    private var expander: ExpanderColumn<TransactionViewer.Transaction>
     private var txIdToScroll: SecureHash? = null // Passed as param.
 
     /**

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt
@@ -47,7 +47,7 @@ class NodeConnection(val remoteNode: RemoteNode, private val jSchSession: Sessio
         val connection = rpcConnection
         require(connection != null) { "doWhileClientStopped called with no running client" }
         log.info("Stopping RPC proxy to ${remoteNode.hostname}, tunnel at $localTunnelAddress")
-        connection!!.close()
+        connection.close()
         try {
             return action()
         } finally {


### PR DESCRIPTION
## Removal of compiler warnings
### Pass 2 - Assertions, More deprecations
As with [PR-7652](https://github.com/corda/corda/pull/7652), some fairly low-hanging fruit dealt with here.
Some non-null assertion-related warnings, and exception-related deprecations that needed slightly more work than the previous PR.

Any deprecation warnings that require any amount of 'proper thought' (e.g. entire classes being deprecated) are not included here - will be in a later PR.
Changes to the main core and serialization code have NOT been made - due to the complexity of supporting builds for both Kotlin 1.2 and 1.7 - will be in a later PR.

**Unnecessary non-null assertions**
Unnecessary uses of the !! operator spotted by the compiler; these were simply removed.

**'none(): ExpectedException!' is deprecated**
The deprecation of the `none()` method means that the tests that use the `ExpectedException` class needed to be updated, and the do not need to use `ExpectedException` any more.
Tests of the form:
```
val expectedEx = ExpectedException.none()

expectedException.expect( <some type of exception here> )
expectedException.expectMessage( <expected exception message here> )
...do some stuff that will throw the exception...
```

are re-written to use `assertThrows`, and `assertEquals`, something like:

```
val anException = assertThrows< <some type of exception here> > {
    ...do some stuff that will throw the exception...
}
assertEquals( <expected exception message here>,  anException.message)

```
**Redundant spread(*) operator**
These were just removed.




