### PR TITLE
ENT-6914 Fix generated pom

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -44,6 +44,7 @@ tasks.register('buildCordaJAR', FatCapsule) {
     dependsOn(nodeProject.tasks.named('jar'))
     applicationClass 'net.corda.node.Corda'
     archiveBaseName = 'corda'
+    archiveClassifier = ''
     archiveVersion = corda_release_version
     archiveName = archiveFileName.get()
     applicationSource = files(
@@ -89,10 +90,9 @@ publishing {
     publications {
         maven(MavenPublication) {
             artifactId 'corda'
-            artifact(buildCordaJAR) {
-                classifier ''
-            }
-            from components.java
+            artifact(buildCordaJAR)
+            artifact(javadocJar)
+            artifact(sourcesJar)
         }
     }
 }


### PR DESCRIPTION
The existing generated pom had an incorrect exclusion which caused the release pack to ignore the corda jar, this change fixes this issue.

There are two main changes in this PR:
1. Remove `from components.java ` , this fixes the issue with the generated pom. Removing this requires explicitly adding the sources and javadoc jar.
2. Move the archive classifier to the capsule generation, this is not strictly necessary and had been added to conform with the rest of the project.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
