### PR TITLE
ENT-6914 Disabled module metadata generation for the node capsule

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -82,13 +82,19 @@ tasks.register('buildCordaJAR', FatCapsule) {
     }
 }
 
+tasks.whenTaskAdded { task ->
+    if (task.name.contains("generateMetadataFileForCordaJARPublication")) {
+        task.enabled = false
+    }
+}
+
 artifacts {
     runtimeArtifacts buildCordaJAR
 }
 
 publishing {
     publications {
-        maven(MavenPublication) {
+        cordaJAR(MavenPublication) {
             artifactId 'corda'
             artifact(buildCordaJAR)
             artifact(javadocJar)


### PR DESCRIPTION
The gradle module metadata for the node capsule being generated was invalid JSON, which in turn caused issues with clients needing the dependency. 

This change disabled the metadata until the root cause can be investigated and fixed.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
