### PR TITLE
ENT-11351 - Compiler warnings pass 4

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -315,8 +315,7 @@ object JacksonSupport {
 
     private class CertPathSerializer : JsonSerializer<CertPath>() {
         override fun serialize(value: CertPath, gen: JsonGenerator, serializers: SerializerProvider) {
-            val certificates = value.certificates as List<X509Certificate>
-            gen.writeObject(CertPathWrapper(value.type, certificates))
+            gen.writeObject(CertPathWrapper(value.type, uncheckedCast(value.certificates)))
         }
     }
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
@@ -85,11 +85,8 @@ class FastThreadLocalTest {
     }
 
     private class UnserializableObj {
-        @Suppress("unused")
-        private val fail : Nothing
-            get() {
-                throw UnsupportedOperationException("Nice try.")
-            }
+        @Suppress("unused", "IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION")
+        private val fail: Nothing by lazy { throw UnsupportedOperationException("Nice try.") }
     }
 
     @Test(timeout=300_000)

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
@@ -86,7 +86,10 @@ class FastThreadLocalTest {
 
     private class UnserializableObj {
         @Suppress("unused")
-        private val fail: Nothing by lazy { throw UnsupportedOperationException("Nice try.") }
+        private val fail : Nothing
+            get() {
+                throw UnsupportedOperationException("Nice try.")
+            }
     }
 
     @Test(timeout=300_000)

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FlowExternalOperationTest.kt
@@ -257,7 +257,7 @@ class FlowExternalOperationTest : AbstractFlowExternalOperationTest() {
         @Suspendable
         override fun testCode() {
             val e = createException()
-            await(ExternalOperation(serviceHub, (SerializableLambda2 { _, _ -> throw e })))
+            await<Nothing>(ExternalOperation(serviceHub, (SerializableLambda2 { _, _ -> throw e })))
         }
 
         private fun createException() = when (exceptionType) {
@@ -273,7 +273,7 @@ class FlowExternalOperationTest : AbstractFlowExternalOperationTest() {
 
         @Suspendable
         override fun testCode(): Any = try {
-            await(ExternalOperation(serviceHub) { _, _ ->
+            await<Nothing>(ExternalOperation(serviceHub) { _, _ ->
                 throw IllegalStateException("threw exception in background process")
             })
         } catch (e: IllegalStateException) {
@@ -287,7 +287,7 @@ class FlowExternalOperationTest : AbstractFlowExternalOperationTest() {
 
         @Suspendable
         override fun testCode(): Any =
-            await(ExternalOperation(serviceHub) { serviceHub, _ ->
+            await<Nothing>(ExternalOperation(serviceHub) { serviceHub, _ ->
                 serviceHub.cordaService(FutureService::class.java).throwHospitalHandledException()
             })
     }
@@ -298,7 +298,7 @@ class FlowExternalOperationTest : AbstractFlowExternalOperationTest() {
         @Suspendable
         override fun testCode(): Any {
             try {
-                await(ExternalOperation(serviceHub) { _, _ ->
+                await<Nothing>(ExternalOperation(serviceHub) { _, _ ->
                     serviceHub.cordaService(FutureService::class.java).throwHospitalHandledException()
                 })
             } catch (e: NullPointerException) {

--- a/experimental/blobwriter/src/main/kotlin/net/corda/blobwriter/BlobWriter.kt
+++ b/experimental/blobwriter/src/main/kotlin/net/corda/blobwriter/BlobWriter.kt
@@ -74,7 +74,7 @@ data class _L_i__ (val listy: List<_i_>)
 
 data class _ALd_ (val a: Array<List<Double>>)
 
-@Suppress("UNUSED_PARAMETER")
+@Suppress("UNUSED_PARAMETER", "DEPRECATION", "REMOVAL")
 fun main (args: Array<String>) {
     initialiseSerialization()
     val path = "../cpp-serializer/bin/test-files";

--- a/experimental/blobwriter/src/main/kotlin/net/corda/blobwriter/BlobWriter.kt
+++ b/experimental/blobwriter/src/main/kotlin/net/corda/blobwriter/BlobWriter.kt
@@ -74,12 +74,12 @@ data class _L_i__ (val listy: List<_i_>)
 
 data class _ALd_ (val a: Array<List<Double>>)
 
-@Suppress("UNUSED_PARAMETER", "DEPRECATION", "REMOVAL")
+@Suppress("UNUSED_PARAMETER", "PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 fun main (args: Array<String>) {
     initialiseSerialization()
     val path = "../cpp-serializer/bin/test-files";
     File("$path/_i_").writeBytes (_i_ (69).serialize().bytes)
-    File("$path/_Oi_").writeBytes (_Oi_ (Integer (1)).serialize().bytes)
+    File("$path/_Oi_").writeBytes (_Oi_ (Integer.valueOf (1) as Integer).serialize().bytes)
     File("$path/_l_").writeBytes (_l_ (100000000000L).serialize().bytes)
     File("$path/_Li_").writeBytes (_Li_(listOf (1, 2, 3, 4, 5, 6)).serialize().bytes)
     File("$path/_Ai_").writeBytes (_Ai_(arrayOf (1, 2, 3, 4, 5, 6)).serialize().bytes)

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
@@ -116,7 +116,6 @@ abstract class AbstractCashSelection(private val maxRetries : Int = 8, private v
         return stateAndRefs
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun attemptSpend(services: ServiceHub, amount: Amount<Currency>, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>, stateAndRefs: MutableList<StateAndRef<Cash.State>>): Boolean {
         val connection = services.jdbcSession()
         try {
@@ -139,6 +138,7 @@ abstract class AbstractCashSelection(private val maxRetries : Int = 8, private v
 
                 if (stateRefs.isNotEmpty()) {
                     // TODO: future implementation to retrieve contract states from a Vault BLOB store
+                    @Suppress("UNCHECKED_CAST")
                     stateAndRefs.addAll(services.loadStates(stateRefs) as Collection<out StateAndRef<Cash.State>>)
                 }
 

--- a/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
@@ -116,6 +116,7 @@ abstract class AbstractCashSelection(private val maxRetries : Int = 8, private v
         return stateAndRefs
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun attemptSpend(services: ServiceHub, amount: Amount<Currency>, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>, stateAndRefs: MutableList<StateAndRef<Cash.State>>): Boolean {
         val connection = services.jdbcSession()
         try {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -8,6 +8,7 @@ import net.corda.core.crypto.newSecureRandom
 import net.corda.core.internal.CertRole
 import net.corda.core.internal.SignedDataWithCert
 import net.corda.core.internal.signWithCert
+import net.corda.core.internal.uncheckedCast
 import net.corda.core.internal.validate
 import net.corda.core.utilities.days
 import net.corda.core.utilities.millis
@@ -424,7 +425,7 @@ val CertPath.x509Certificates: List<X509Certificate>
     get() {
         require(type == "X.509") { "Not an X.509 cert path: $this" }
         // We're not mapping the list to avoid creating a new one.
-        return certificates as List<X509Certificate>
+        return uncheckedCast(certificates)
     }
 
 val Certificate.x509: X509Certificate get() = requireNotNull(this as? X509Certificate) { "Not an X.509 certificate: $this" }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/Kryo.kt
@@ -490,7 +490,8 @@ class ThrowableSerializer<T>(kryo: Kryo, type: Class<T>) : Serializer<Throwable>
         }
     }
 
-    private val delegate: Serializer<Throwable> = uncheckedCast(SerializerFactory.ReflectionSerializerFactory.newSerializer(kryo, FieldSerializer::class.java, type)) as Serializer<Throwable>
+    @Suppress("UNCHECKED_CAST")
+    private val delegate: Serializer<Throwable> = SerializerFactory.ReflectionSerializerFactory.newSerializer(kryo, FieldSerializer::class.java, type) as Serializer<Throwable>
 
     override fun write(kryo: Kryo, output: Output, throwable: Throwable) {
         delegate.write(kryo, output, throwable)

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeSSLContextFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeSSLContextFactory.kt
@@ -9,7 +9,6 @@ import org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultOpenSSLContextF
 import org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultSSLContextFactory
 import org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextConfig
 import org.apache.activemq.artemis.utils.ClassloadingUtil
-import org.apache.commons.io.IOUtils
 import java.io.File
 import java.io.InputStream
 import java.net.MalformedURLException

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeSSLContextFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeSSLContextFactory.kt
@@ -125,4 +125,12 @@ private fun findResource(resourceName: String): URL {
  * This is an inline function for [InputStream] so it can be closed and
  * ignore an exception.
  */
-private fun InputStream?.closeQuietly() = IOUtils.closeQuietly(this)
+private fun InputStream?.closeQuietly() {
+    try {
+        this?.close()
+    }
+    catch ( ex : Exception ) {
+        // quietly absorb problems
+    }
+}
+

--- a/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyDescriptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyDescriptor.kt
@@ -52,13 +52,14 @@ class AbstractPartyDescriptor(private val wellKnownPartyFromX500Name: (CordaX500
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun <X : Any> unwrap(value: AbstractParty?, type: Class<X>, options: WrapperOptions): X? {
         return if (value != null) {
             if (AbstractParty::class.java.isAssignableFrom(type)) {
                 return uncheckedCast(value)
             }
             if (String::class.java.isAssignableFrom(type)) {
-                return uncheckedCast(toString(value)) as X?
+                return toString(value) as X?
             }
             throw unknownUnwrap(type)
         } else {

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -594,6 +594,7 @@ class CheckpointDumperImpl(private val checkpointStorage: CheckpointStorage, pri
             gen.writeEndArray()
         }
 
-        override fun handledType(): Class<Map<Any, Any>> = uncheckedCast(Map::class.java) as Class<Map<Any, Any>>
+        @Suppress("UNCHECKED_CAST")
+        override fun handledType(): Class<Map<Any, Any>> = Map::class.java as Class<Map<Any, Any>>
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/CheckpointDumperImpl.kt
@@ -38,7 +38,6 @@ import net.corda.core.internal.FlowIORequest
 import net.corda.core.internal.WaitForStateConsumption
 import net.corda.core.internal.declaredField
 import net.corda.core.internal.objectOrNewInstance
-import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.AppServiceHub.Companion.SERVICE_PRIORITY_NORMAL
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SerializeAsToken

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt
@@ -40,7 +40,7 @@ internal class RpcBrokerConfiguration(baseDirectory: Path, maxMessageSize: Int, 
         queueConfigs = queueConfigurations()
 
         managementNotificationAddress = SimpleString(ArtemisMessagingComponent.NOTIFICATIONS_ADDRESS)
-        addressesSettings = mapOf(
+        addressSettings = mapOf(
                 "${RPCApi.RPC_CLIENT_QUEUE_NAME_PREFIX}.#" to AddressSettings().apply {
                     maxSizeBytes = 5L * maxMessageSize
                     addressFullMessagePolicy = AddressFullMessagePolicy.PAGE

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -1232,6 +1232,7 @@ internal class SingleThreadedStateMachineManager(
         }
         )
 
+    @Suppress("UNCHECKED_CAST")
     override fun <T> reattachFlowWithClientId(clientId: String, user: Principal): FlowStateMachineHandle<T>? {
         return innerState.withLock {
             clientIdsToFlowIds[clientId]?.let {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -1232,7 +1232,6 @@ internal class SingleThreadedStateMachineManager(
         }
         )
 
-    @Suppress("UNCHECKED_CAST")
     override fun <T> reattachFlowWithClientId(clientId: String, user: Principal): FlowStateMachineHandle<T>? {
         return innerState.withLock {
             clientIdsToFlowIds[clientId]?.let {
@@ -1240,6 +1239,7 @@ internal class SingleThreadedStateMachineManager(
                     null
                 } else {
                     val existingFuture = activeOrRemovedClientIdFutureForReattach(it, clientId)
+                    @Suppress("UNCHECKED_CAST")
                     existingFuture?.let {existingFuture.get() } as FlowStateMachineHandle<T>
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -837,9 +837,9 @@ class NodeVaultService(
      * transaction.
      */
     @Throws(VaultQueryException::class)
-    @Suppress("UNCHECKED_CAST")
     override fun <T : ContractState> _trackBy(criteria: QueryCriteria, paging: PageSpecification, sorting: Sort, contractStateType: Class<out T>): DataFeed<Vault.Page<T>, Vault.Update<T>> {
         return mutex.locked {
+            @Suppress("UNCHECKED_CAST")
             val updates: Observable<Vault.Update<T>> = _updatesPublisher.bufferUntilSubscribed() as Observable<Vault.Update<T>>
             if (contextTransactionOrNull != null) {
                 log.warn("trackBy is called with an already existing, open DB transaction. As a result, there might be states missing from both the snapshot and observable, included in the returned data feed, because of race conditions.")

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -837,9 +837,10 @@ class NodeVaultService(
      * transaction.
      */
     @Throws(VaultQueryException::class)
+    @Suppress("UNCHECKED_CAST")
     override fun <T : ContractState> _trackBy(criteria: QueryCriteria, paging: PageSpecification, sorting: Sort, contractStateType: Class<out T>): DataFeed<Vault.Page<T>, Vault.Update<T>> {
         return mutex.locked {
-            val updates: Observable<Vault.Update<T>> = uncheckedCast(_updatesPublisher.bufferUntilSubscribed()) as Observable<Vault.Update<T>>
+            val updates: Observable<Vault.Update<T>> = _updatesPublisher.bufferUntilSubscribed() as Observable<Vault.Update<T>>
             if (contextTransactionOrNull != null) {
                 log.warn("trackBy is called with an already existing, open DB transaction. As a result, there might be states missing from both the snapshot and observable, included in the returned data feed, because of race conditions.")
             }

--- a/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmart.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/bftsmart/BFTSmart.kt
@@ -26,6 +26,7 @@ import net.corda.core.internal.notary.NotaryInternalException
 import net.corda.core.internal.notary.isConsumedByTheSameTx
 import net.corda.core.internal.notary.validateTimeWindow
 import net.corda.core.internal.toTypedArray
+import net.corda.core.internal.uncheckedCast
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SingletonSerializeAsToken
@@ -215,7 +216,7 @@ object BFTSmart {
         }
 
         override fun appExecuteBatch(command: Array<ByteArray>, mcs: Array<MessageContext>): Array<ByteArray?> {
-            return Arrays.stream(command).map(this::executeCommand).toTypedArray() as Array<ByteArray?>
+            return uncheckedCast(Arrays.stream(command).map(this::executeCommand).toTypedArray())
         }
 
         /**

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -15,7 +15,6 @@ import net.corda.core.flows.StartableByRPC
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
 import net.corda.core.internal.RPC_UPLOADER
-import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.startFlow

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -405,9 +405,9 @@ class CordaRPCOpsImplTest {
     }
 
     @Test(timeout=300_000)
-    @Suppress("UNCHECKED_CAST")
 	fun `non-ContractState class for the contractStateType param in vault queries`() {
         CURRENT_RPC_CONTEXT.set(RpcAuthContext(InvocationContext.rpc(testActor()), buildSubject("TEST_USER", emptySet())))
+        @Suppress("UNCHECKED_CAST")
         val nonContractStateClass = Cash::class.java as Class<ContractState>
         withPermissions(invokeRpc("vaultTrack"), invokeRpc("vaultQuery")) {
             assertThatThrownBy { rpc.vaultQuery(nonContractStateClass) }.hasMessageContaining(Cash::class.java.name)

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -406,9 +406,10 @@ class CordaRPCOpsImplTest {
     }
 
     @Test(timeout=300_000)
+    @Suppress("UNCHECKED_CAST")
 	fun `non-ContractState class for the contractStateType param in vault queries`() {
         CURRENT_RPC_CONTEXT.set(RpcAuthContext(InvocationContext.rpc(testActor()), buildSubject("TEST_USER", emptySet())))
-        val nonContractStateClass = uncheckedCast(Cash::class.java) as Class<ContractState>
+        val nonContractStateClass = Cash::class.java as Class<ContractState>
         withPermissions(invokeRpc("vaultTrack"), invokeRpc("vaultQuery")) {
             assertThatThrownBy { rpc.vaultQuery(nonContractStateClass) }.hasMessageContaining(Cash::class.java.name)
             assertThatThrownBy { rpc.vaultTrack(nonContractStateClass) }.hasMessageContaining(Cash::class.java.name)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowClientIdTests.kt
@@ -598,7 +598,7 @@ class FlowClientIdTests {
     @Test(timeout = 300_000)
     fun `flow that fails does not retain its checkpoint nor its exception in the database if not started with a client id`() {
         assertFailsWith<IllegalStateException> {
-            aliceNode.services.startFlow(ExceptionFlow { IllegalStateException("another exception") }).resultFuture.getOrThrow()
+            aliceNode.services.startFlow(ExceptionFlow { IllegalStateException("another exception") }).resultFuture.getOrThrow<Nothing>()
         }
 
         aliceNode.services.database.transaction {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -775,7 +775,7 @@ class FlowFrameworkTests {
         assertFailsWith<TimeoutException> {
             val fiber = aliceNode.services.startFlow(ExceptionFlow { HospitalizeFlowException("Overnight observation") })
             flowId = fiber.id
-            fiber.resultFuture.getOrThrow(10.seconds)
+            fiber.resultFuture.getOrThrow<Nothing>(10.seconds)
         }
 
         aliceNode.database.transaction {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -204,7 +204,7 @@ data class RPCDriverDSL(
                     QueueConfiguration(RPCApi.RPC_CLIENT_BINDING_ADDITIONS).setAddress(NOTIFICATION_ADDRESS)
                             .setFilterString(RPCApi.RPC_CLIENT_BINDING_ADDITION_FILTER_EXPRESSION).setDurable(false)
             )
-            addressesSettings = mapOf(
+            addressSettings = mapOf(
                     "${RPCApi.RPC_CLIENT_QUEUE_NAME_PREFIX}.#" to AddressSettings().apply {
                         maxSizeBytes = maxBufferedBytesPerClient
                         addressFullMessagePolicy = AddressFullMessagePolicy.PAGE

--- a/testing/testserver/src/main/kotlin/net/corda/webserver/converters/Converters.kt
+++ b/testing/testserver/src/main/kotlin/net/corda/webserver/converters/Converters.kt
@@ -1,7 +1,6 @@
 package net.corda.webserver.converters
 
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.internal.uncheckedCast
 import java.lang.reflect.Type
 import javax.ws.rs.ext.ParamConverter
 import javax.ws.rs.ext.ParamConverterProvider

--- a/testing/testserver/src/main/kotlin/net/corda/webserver/converters/Converters.kt
+++ b/testing/testserver/src/main/kotlin/net/corda/webserver/converters/Converters.kt
@@ -14,9 +14,10 @@ object CordaX500NameConverter : ParamConverter<CordaX500Name> {
 
 @Provider
 object CordaConverterProvider : ParamConverterProvider {
+    @Suppress("UNCHECKED_CAST")
     override fun <T : Any> getConverter(rawType: Class<T>, genericType: Type?, annotations: Array<out Annotation>?): ParamConverter<T>? {
         if (rawType == CordaX500Name::class.java) {
-            return uncheckedCast(CordaX500NameConverter) as ParamConverter<T>?
+            return CordaX500NameConverter as ParamConverter<T>?
         }
         return null
     }


### PR DESCRIPTION
## Removal of compiler warnings
### Pass 4 - Unchecked casts, Nothing return types, more deprecations
The fourth instalment of changes to address compiler warnings. These changes required a little bit more reading, discussion, and head-scratching, than the previous changes. In [Fiend's Cauldron](https://www.kidicaruswiki.org/wiki/Fiend's_Cauldron) terms, these changes are at the "Tougher" level :)

**Unchecked Casts**
There were quite a few varieties of these warnings that boiled down into two distinct categories. The discussion here revealed that Kotlin 1.9's cast handling has taken a step backwards (or made things harder to just "do what you want", depends on your take), and that JVM's use of generics doesn't play nice and can make code less elegant/intuitive to look at than we would like.
In all cases it appeared that the casts being made were valid and intentional, it's just they had seemingly become more difficult to express. The two categories were:

_object-of-type-A as type-B_
These were handled by wrapping the warning site with an `uncheckedCast()` function call.

_uncheckedCast(object-of-type-A) as type-B_
Warnings of the second type were handled by UN-wrapping the use of `uncheckedCast()`, and adding a
`Suppress("UNCHECKED_CAST")` annotation to the code.
The existing use of `uncheckedCast()` shows we are happy for the cast to take place but using `uncheckedCast()` doesn't quite cut the mustard as far as the compiler is concerned, and so unhooking the function call and adding in the suppression annotation directly seemed reasonable here.

**Returning type parameter has been inferred to Nothing implicitly**
These warnings typically appeared in code where exceptions were being thrown.
Occurrences in `FlowExternalOperationTest.kt,` `FlowClientIdTests.kt` and `FlowFrameworkTests.kt `were cured by adding a type qualifier to the offending function call, to stop the compiler doing that implicitly.
e.g.
`getOrThrow()` becomes `getOrThrow<Nothing>()`

The only other occurrence of this warning was in `FastThreadLocalTest.kt`. Couldn't find any way to add a type-specifier into that particular line of code, or a way to re-jig that in a way that didn't break the tests, so I added a warning suppression instead.

**Deprecations**
`IOUtilities.closeQuietly()` is deprecated, nothing replaces it.
`org.apache.activemq.artemis.core.config.impl.setAddressesSettings()` is deprecated, replaced by `setAddressSettings() `in the same package. Looks like it does the same thing.
Constructor `Integer(Int)` is deprecated - this was being used in `BlobWriter.kt` in code concerning data serialization. I didn't want to actually change anything here given the area it is in, so just added the suppression annotation.



