### PR TITLE
ENT-11384: Cleanup JarScanningCordappLoader

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -53,7 +53,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-
 class CordaRPCClientReconnectionTest {
 
     private val portAllocator = incrementalPortAllocation()

--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -109,9 +109,9 @@ dependencies {
     smokeTestImplementation project(":client:rpc")
     smokeTestImplementation project(':smoke-test-utils')
     smokeTestImplementation project(':core-test-utils')
-    smokeTestImplementation project(":finance:contracts")
     smokeTestImplementation project(":finance:workflows")
     smokeTestImplementation project(":testing:cordapps:4.11-workflows")
+    smokeTestImplementation project(":finance:contracts")
     smokeTestImplementation "org.assertj:assertj-core:${assertj_version}"
     smokeTestImplementation "org.bouncycastle:bcprov-jdk18on:${bouncycastle_version}"
     smokeTestImplementation "co.paralleluniverse:quasar-core:$quasar_version"

--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -138,27 +138,19 @@ fun <T> List<T>.indexOfOrThrow(item: T): Int {
  * Similar to [Iterable.map] except it maps to a [Set] which preserves the iteration order.
  */
 @Suppress("INVISIBLE_MEMBER", "RemoveExplicitTypeArguments")   // Because the external verifier uses Kotlin 1.2
-inline fun <T, R> Iterable<T>.mapToSet(transform: (T) -> R): Set<R> {
-    return if (this is Collection) {
-        when (size) {
-            0 -> return emptySet()
-            1 -> return setOf(transform(first()))
-            else -> mapTo(LinkedHashSet<R>(mapCapacity(size)), transform)
-        }
-    } else {
-        mapTo(LinkedHashSet<R>(), transform)
+inline fun <T, R> Collection<T>.mapToSet(transform: (T) -> R): Set<R> {
+    return when (size) {
+        0 -> return emptySet()
+        1 -> return setOf(transform(first()))
+        else -> mapTo(LinkedHashSet<R>(mapCapacity(size)), transform)
     }
 }
 
 /**
  * Similar to [Iterable.flatMap] except it maps to a [Set] which preserves the iteration order.
  */
-inline fun <T, R> Iterable<T>.flatMapToSet(transform: (T) -> Iterable<R>): Set<R> {
-    return if (this is Collection && isEmpty()) {
-        emptySet()
-    } else {
-        flatMapTo(LinkedHashSet(), transform)
-    }
+inline fun <T, R> Collection<T>.flatMapToSet(transform: (T) -> Iterable<R>): Set<R> {
+    return if (isEmpty()) emptySet() else flatMapTo(LinkedHashSet(), transform)
 }
 
 fun InputStream.copyTo(target: Path, vararg options: CopyOption): Long = Files.copy(this, target, *options)

--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
@@ -6,7 +6,6 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.internal.PLATFORM_VERSION
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.notary.NotaryService
-import net.corda.core.internal.toPath
 import net.corda.core.internal.telemetry.TelemetryComponent
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.serialization.CheckpointCustomSerializer
@@ -14,10 +13,12 @@ import net.corda.core.serialization.SerializationCustomSerializer
 import net.corda.core.serialization.SerializationWhitelist
 import net.corda.core.serialization.SerializeAsToken
 import java.net.URL
+import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.name
 
 data class CordappImpl(
+        val jarFile: Path,
         override val contractClassNames: List<String>,
         override val initiatedFlows: List<Class<out FlowLogic<*>>>,
         override val rpcFlows: List<Class<out FlowLogic<*>>>,
@@ -30,7 +31,6 @@ data class CordappImpl(
         override val checkpointCustomSerializers: List<CheckpointCustomSerializer<*, *>>,
         override val customSchemas: Set<MappedSchema>,
         override val allFlows: List<Class<out FlowLogic<*>>>,
-        override val jarPath: URL,
         override val info: Cordapp.Info,
         override val jarHash: SecureHash.SHA256,
         override val minimumPlatformVersion: Int,
@@ -41,7 +41,11 @@ data class CordappImpl(
         private val explicitCordappClasses: List<String> = emptyList(),
         val isVirtual: Boolean = false
 ) : Cordapp {
-    override val name: String = jarName(jarPath)
+    override val jarPath: URL
+        get() = jarFile.toUri().toURL()
+
+    override val name: String
+        get() = jarName(jarFile)
 
     // TODO: Also add [SchedulableFlow] as a Cordapp class
     override val cordappClasses: List<String> = run {
@@ -50,7 +54,7 @@ data class CordappImpl(
     }
 
     companion object {
-        fun jarName(url: URL): String = url.toPath().name.removeSuffix(".jar")
+        fun jarName(url: Path): String = url.name.removeSuffix(".jar")
 
         /** CorDapp manifest entries */
         const val CORDAPP_CONTRACT_NAME = "Cordapp-Contract-Name"
@@ -74,6 +78,7 @@ data class CordappImpl(
 
         @VisibleForTesting
         val TEST_INSTANCE = CordappImpl(
+                jarFile = Paths.get(""),
                 contractClassNames = emptyList(),
                 initiatedFlows = emptyList(),
                 rpcFlows = emptyList(),
@@ -85,7 +90,6 @@ data class CordappImpl(
                 serializationCustomSerializers = emptyList(),
                 checkpointCustomSerializers = emptyList(),
                 customSchemas = emptySet(),
-                jarPath = Paths.get("").toUri().toURL(),
                 info = UNKNOWN_INFO,
                 allFlows = emptyList(),
                 jarHash = SecureHash.allOnesHash,

--- a/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
@@ -4,6 +4,7 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.TransactionState
 import net.corda.core.flows.FlowException
 import net.corda.core.internal.Version
+import net.corda.core.internal.mapToSet
 import net.corda.core.serialization.CordaSerializable
 
 /**
@@ -14,6 +15,8 @@ import net.corda.core.serialization.CordaSerializable
 @CordaSerializable
 class MissingContractAttachments
 @JvmOverloads
-constructor(val states: List<TransactionState<ContractState>>, contractsClassName: String? = null, minimumRequiredContractClassVersion: Version? = null) : FlowException(
-        "Cannot find contract attachments for " +
-        "${contractsClassName ?: states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}.")
+constructor(val states: List<TransactionState<ContractState>>,
+            contractsClassName: String? = null,
+            minimumRequiredContractClassVersion: Version? = null
+) : FlowException("Cannot find contract attachments for " +
+        "${contractsClassName ?: states.mapToSet { it.contract }}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"} ?: ""}.")

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/VirtualCordapps.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/VirtualCordapps.kt
@@ -5,6 +5,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.ContractUpgradeFlow
 import net.corda.core.internal.cordapp.CordappImpl
 import net.corda.core.internal.location
+import net.corda.core.internal.toPath
 import net.corda.node.VersionInfo
 import net.corda.notary.experimental.bftsmart.BFTSmartNotarySchemaV1
 import net.corda.notary.experimental.bftsmart.BFTSmartNotaryService
@@ -24,6 +25,7 @@ internal object VirtualCordapp {
     /** A Cordapp representing the core package which is not scanned automatically. */
     fun generateCore(versionInfo: VersionInfo): CordappImpl {
         return CordappImpl(
+                jarFile = ContractUpgradeFlow.javaClass.location.toPath(), // Core JAR location
                 contractClassNames = listOf(),
                 initiatedFlows = listOf(),
                 rpcFlows = coreRpcFlows,
@@ -37,7 +39,6 @@ internal object VirtualCordapp {
                 customSchemas = setOf(),
                 info = Cordapp.Info.Default("corda-core", versionInfo.vendor, versionInfo.releaseVersion, "Open Source (Apache 2)"),
                 allFlows = listOf(),
-                jarPath = ContractUpgradeFlow.javaClass.location, // Core JAR location
                 jarHash = SecureHash.allOnesHash,
                 minimumPlatformVersion = versionInfo.platformVersion,
                 targetPlatformVersion = versionInfo.platformVersion,
@@ -49,6 +50,7 @@ internal object VirtualCordapp {
     /** A Cordapp for the built-in notary service implementation. */
     fun generateJPANotary(versionInfo: VersionInfo): CordappImpl {
         return CordappImpl(
+                jarFile = JPANotaryService::class.java.location.toPath(),
                 contractClassNames = listOf(),
                 initiatedFlows = listOf(),
                 rpcFlows = listOf(),
@@ -62,7 +64,6 @@ internal object VirtualCordapp {
                 customSchemas = setOf(JPANotarySchemaV1),
                 info = Cordapp.Info.Default("corda-notary", versionInfo.vendor, versionInfo.releaseVersion, "Open Source (Apache 2)"),
                 allFlows = listOf(),
-                jarPath = JPANotaryService::class.java.location,
                 jarHash = SecureHash.allOnesHash,
                 minimumPlatformVersion = versionInfo.platformVersion,
                 targetPlatformVersion = versionInfo.platformVersion,
@@ -75,6 +76,7 @@ internal object VirtualCordapp {
     /** A Cordapp for the built-in Raft notary service implementation. */
     fun generateRaftNotary(versionInfo: VersionInfo): CordappImpl {
         return CordappImpl(
+                jarFile = RaftNotaryService::class.java.location.toPath(),
                 contractClassNames = listOf(),
                 initiatedFlows = listOf(),
                 rpcFlows = listOf(),
@@ -88,7 +90,6 @@ internal object VirtualCordapp {
                 customSchemas = setOf(RaftNotarySchemaV1),
                 info = Cordapp.Info.Default("corda-notary-raft", versionInfo.vendor, versionInfo.releaseVersion, "Open Source (Apache 2)"),
                 allFlows = listOf(),
-                jarPath = RaftNotaryService::class.java.location,
                 jarHash = SecureHash.allOnesHash,
                 minimumPlatformVersion = versionInfo.platformVersion,
                 targetPlatformVersion = versionInfo.platformVersion,
@@ -100,6 +101,7 @@ internal object VirtualCordapp {
     /** A Cordapp for the built-in BFT-Smart notary service implementation. */
     fun generateBFTSmartNotary(versionInfo: VersionInfo): CordappImpl {
         return CordappImpl(
+                jarFile = BFTSmartNotaryService::class.java.location.toPath(),
                 contractClassNames = listOf(),
                 initiatedFlows = listOf(),
                 rpcFlows = listOf(),
@@ -113,7 +115,6 @@ internal object VirtualCordapp {
                 customSchemas = setOf(BFTSmartNotarySchemaV1),
                 info = Cordapp.Info.Default("corda-notary-bft-smart", versionInfo.vendor, versionInfo.releaseVersion, "Open Source (Apache 2)"),
                 allFlows = listOf(),
-                jarPath = BFTSmartNotaryService::class.java.location,
                 jarHash = SecureHash.allOnesHash,
                 minimumPlatformVersion = versionInfo.platformVersion,
                 targetPlatformVersion = versionInfo.platformVersion,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -128,7 +128,7 @@ open class MockServices private constructor(
 ) : ServiceHub {
     companion object {
         private fun cordappLoaderForPackages(packages: Iterable<String>, versionInfo: VersionInfo = VersionInfo.UNKNOWN): CordappLoader {
-            return JarScanningCordappLoader.fromJarUrls(cordappsForPackages(packages).map { it.jarFile.toUri().toURL() }, versionInfo)
+            return JarScanningCordappLoader.fromJarUrls(cordappsForPackages(packages).mapToSet { it.jarFile }, versionInfo)
         }
 
         /**

--- a/testing/smoke-test-utils/build.gradle
+++ b/testing/smoke-test-utils/build.gradle
@@ -3,10 +3,11 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 description 'Utilities needed for smoke tests in Corda'
 
 dependencies {
+    api project(':test-common')
+
     // Smoke tests do NOT have any Node code on the classpath!
     implementation project(':core')
     implementation project(':node-api')
-    implementation project(':test-common')
     implementation project(':client:rpc')
 
     implementation "com.google.guava:guava:$guava_version"

--- a/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeParams.kt
+++ b/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeParams.kt
@@ -9,6 +9,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.nodeapi.internal.config.User
 import net.corda.nodeapi.internal.config.toConfig
 import java.nio.file.Path
+import kotlin.io.path.absolutePathString
 
 class NodeParams @JvmOverloads constructor(
         val legalName: CordaX500Name,
@@ -17,6 +18,7 @@ class NodeParams @JvmOverloads constructor(
         val rpcAdminPort: Int,
         val users: List<User>,
         val cordappJars: List<Path> = emptyList(),
+        val jarDirs: List<Path> = emptyList(),
         val clientRpcConfig: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
         val devMode: Boolean = true,
         val version: String? = null
@@ -37,6 +39,7 @@ class NodeParams @JvmOverloads constructor(
                         .root())
                 .withValue("rpcUsers", valueFor(users.map { it.toConfig().root().unwrapped() }.toList()))
                 .withValue("useTestClock", valueFor(true))
+                .withValue("jarDirs", valueFor(jarDirs.map(Path::absolutePathString)))
                 .withValue("devMode", valueFor(devMode))
         return if (isNotary) {
             config.withValue("notary", ConfigValueFactory.fromMap(mapOf("validating" to true)))


### PR DESCRIPTION
* It uses URLs when in fact CorDapps are jar files, and so should being Path. It also does URL equality, something which is not recommended and gives a warning
* Removed `RestrictedURL`, which is not needed (and has been a TODO for a long time!)

Also, back-ported some minor changes from https://github.com/corda/enterprise/pull/5057.
