### PR TITLE
ENT-11387: Fix to prevent interleaved stop/start causing bridge to be started with null session.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
@@ -205,10 +205,10 @@ open class AMQPBridgeManager(keyStore: CertificateStore,
                 eventLoop.execute {
                     artemis(ArtemisState.STOPPING) {
                         stopSession(session)
-                        session = null
                         if(session != closingSession) {
                             stopSession(closingSession)
                         }
+                        session = null
                         ArtemisState.STOPPED
                     }
                 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
@@ -201,10 +201,14 @@ open class AMQPBridgeManager(keyStore: CertificateStore,
                 logInfoWithMDC("Stopping Artemis because stopping AMQP bridge")
                 closeConsumer()
                 consumer = null
+                val closingSession = session
                 eventLoop.execute {
                     artemis(ArtemisState.STOPPING) {
-                        stopSession()
+                        stopSession(session)
                         session = null
+                        if(session != closingSession) {
+                            stopSession(closingSession)
+                        }
                         ArtemisState.STOPPED
                     }
                 }
@@ -271,19 +275,28 @@ open class AMQPBridgeManager(keyStore: CertificateStore,
                     logInfoWithMDC("Stopping Artemis because AMQP bridge disconnected")
                     closeConsumer()
                     consumer = null
+                    val closingSession = session
                     eventLoop.execute {
-                        artemis(ArtemisState.STOPPING) {
-                            stopSession()
-                            session = null
-                            when (precedingState) {
-                                ArtemisState.AMQP_STOPPED ->
-                                                   ArtemisState.STOPPED_AMQP_START_SCHEDULED(scheduledArtemis(artemisHeartbeatPlusBackoff,
-                                                                   TimeUnit.MILLISECONDS, ArtemisState.AMQP_STARTING) { startOutbound() })
-                                ArtemisState.AMQP_RESTARTED -> {
-                                    artemis(ArtemisState.AMQP_STARTING) { startOutbound() }
-                                    ArtemisState.AMQP_STARTING
+                        synchronized(artemis!!) {
+                            if (session == closingSession) {
+                                artemis(ArtemisState.STOPPING) {
+                                    stopSession(session)
+                                    session = null
+                                    when (precedingState) {
+                                        ArtemisState.AMQP_STOPPED ->
+                                            ArtemisState.STOPPED_AMQP_START_SCHEDULED(scheduledArtemis(artemisHeartbeatPlusBackoff,
+                                                    TimeUnit.MILLISECONDS, ArtemisState.AMQP_STARTING) { startOutbound() })
+
+                                        ArtemisState.AMQP_RESTARTED -> {
+                                            artemis(ArtemisState.AMQP_STARTING) { startOutbound() }
+                                            ArtemisState.AMQP_STARTING
+                                        }
+
+                                        else -> ArtemisState.STOPPED
+                                    }
                                 }
-                                else -> ArtemisState.STOPPED
+                            } else {
+                                stopSession(closingSession)
                             }
                         }
                     }
@@ -339,10 +352,10 @@ open class AMQPBridgeManager(keyStore: CertificateStore,
             }
         }
 
-        private fun stopSession(): Boolean {
+        private fun stopSession(localSession: ClientSession?): Boolean {
             var stopped = false
             try {
-                session?.apply {
+                localSession?.apply {
                     if (!isClosed) {
                         stop()
                     }
@@ -356,7 +369,7 @@ open class AMQPBridgeManager(keyStore: CertificateStore,
         }
 
         private fun restartSession(): Boolean {
-            if (!stopSession()) {
+            if (!stopSession(session)) {
                 // Session timed out stopping.  The request/responses can be out of sequence on the session now, so abandon it.
                 session = null
                 // The consumer is also dead now too as attached to the dead session.


### PR DESCRIPTION
In rare circumstances (SUP-3411) it is possible the bridge can lose connectivity with its peer. 

This can occur when artemis is stopping:
(1) First the consumer is closed down 
(2) Then put the closing of the session onto event queue (to make sure all messages are handled - https://github.com/corda/enterprise/pull/2887)

However a new connection may come in after (1) from above but before (2) (millesec later potentially). This then creates a session and assigns it.
However in (2) above we then set the session to null and overwrite what was done on the new connection setup above.
This results in the bridge thinking it has a artemis session setup, but it does not.

PR fixes this by capturing the session in (1) and then checking it again in (2). If different we know a new session has been created in the meantime, and in this case we just close the old session. If the session is same between (1) and (2) above then we know no new connection has come in, so processing continues as before to shutdown and clear session. (Credit @rick-r3 for analysis & solution)
 