### PR TITLE
ENT-11386: Port changes to `NodeAttachmentService` from ENT

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1201,7 +1201,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         override lateinit var networkParameters: NetworkParameters
 
         init {
-            this@AbstractNode.attachments.servicesForResolution = this
+            this@AbstractNode.attachments.nodeVerificationSupport = this
         }
 
         fun start(myInfo: NodeInfo, networkParameters: NetworkParameters) {

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -10,8 +10,8 @@ import net.corda.core.crypto.SecureHash;
 import net.corda.core.identity.AbstractParty;
 import net.corda.core.identity.CordaX500Name;
 import net.corda.core.identity.Party;
+import net.corda.core.internal.verification.NodeVerificationSupport;
 import net.corda.core.messaging.DataFeed;
-import net.corda.core.node.ServicesForResolution;
 import net.corda.core.node.services.AttachmentStorage;
 import net.corda.core.node.services.IdentityService;
 import net.corda.core.node.services.Vault;
@@ -97,9 +97,9 @@ public class VaultQueryJavaTests {
         vaultFiller = new VaultFiller(services, DUMMY_NOTARY);
         vaultService = services.getVaultService();
         storage = new NodeAttachmentService(new MetricRegistry(), new TestingNamedCacheFactory(100), database);
-        ServicesForResolution serviceForResolution = mock(ServicesForResolution.class);
-        ((NodeAttachmentService) storage).servicesForResolution = serviceForResolution;
-        doReturn(testNetworkParameters()).when(serviceForResolution).getNetworkParameters();
+        NodeVerificationSupport nodeVerificationSupport = mock(NodeVerificationSupport.class);
+        ((NodeAttachmentService) storage).nodeVerificationSupport = nodeVerificationSupport;
+        doReturn(testNetworkParameters()).when(nodeVerificationSupport).getNetworkParameters();
     }
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/attachments/AttachmentTrustCalculatorTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/attachments/AttachmentTrustCalculatorTest.kt
@@ -6,7 +6,7 @@ import net.corda.core.internal.AttachmentTrustCalculator
 import net.corda.core.internal.AttachmentTrustInfo
 import net.corda.core.internal.hash
 import net.corda.core.internal.read
-import net.corda.core.node.ServicesForResolution
+import net.corda.core.internal.verification.NodeVerificationSupport
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.nodeapi.internal.persistence.CordaPersistence
@@ -47,7 +47,7 @@ class AttachmentTrustCalculatorTest {
     private lateinit var database: CordaPersistence
     private lateinit var storage: NodeAttachmentService
     private lateinit var attachmentTrustCalculator: AttachmentTrustCalculator
-    private val services = rigorousMock<ServicesForResolution>().also {
+    private val nodeVerificationSupport = rigorousMock<NodeVerificationSupport>().also {
         doReturn(testNetworkParameters()).whenever(it).networkParameters
     }
     private val cacheFactory = TestingNamedCacheFactory()
@@ -61,7 +61,7 @@ class AttachmentTrustCalculatorTest {
                 it.start()
             }
         }
-        storage.servicesForResolution = services
+        storage.nodeVerificationSupport = nodeVerificationSupport
         attachmentTrustCalculator = NodeAttachmentTrustCalculator(storage, database, cacheFactory)
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -19,7 +19,7 @@ import net.corda.core.internal.cordapp.CordappImpl.Companion.DEFAULT_CORDAPP_VER
 import net.corda.core.internal.hash
 import net.corda.core.internal.read
 import net.corda.core.internal.readFully
-import net.corda.core.node.ServicesForResolution
+import net.corda.core.internal.verification.NodeVerificationSupport
 import net.corda.core.node.services.AttachmentId
 import net.corda.core.node.services.vault.AttachmentQueryCriteria.AttachmentsQueryCriteria
 import net.corda.core.node.services.vault.AttachmentSort
@@ -84,7 +84,7 @@ class NodeAttachmentServiceTest {
     private lateinit var database: CordaPersistence
     private lateinit var storage: NodeAttachmentService
     private lateinit var devModeStorage: NodeAttachmentService
-    private val services = rigorousMock<ServicesForResolution>().also {
+    private val nodeVerificationSupport = rigorousMock<NodeVerificationSupport>().also {
         doReturn(testNetworkParameters()).whenever(it).networkParameters
     }
 
@@ -105,13 +105,13 @@ class NodeAttachmentServiceTest {
                 it.start()
             }
         }
-        storage.servicesForResolution = services
+        storage.nodeVerificationSupport = nodeVerificationSupport
         devModeStorage = NodeAttachmentService(MetricRegistry(), TestingNamedCacheFactory(), database, true).also {
             database.transaction {
                 it.start()
             }
         }
-        devModeStorage.servicesForResolution = services
+        devModeStorage.nodeVerificationSupport = nodeVerificationSupport
     }
 
     @After


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! [ENT-11386](https://r3-cev.atlassian.net/browse/ENT-11386): Perform verification using `NodeVerificationSupport` !!!! 👮🏻👮🏻👮🏻

Requirement originated to keep ENT and OS in sync on changes related to using the `NodeVerificationSupport` instead of fat interface `ServicesForResolution` to verify transactions.
ENT PR: https://github.com/corda/enterprise/pull/5061

# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/en/platform/corda/4.8/open-source/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs/kdocs?
- [x] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`https://docs.r3.com/en/platform/corda/4.8/open-source/release-notes.html`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/en/platform/corda/4.8/open-source/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)


[ENT-11386]: https://r3-cev.atlassian.net/browse/ENT-11386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ