### PR TITLE
ENT-11443 - Support OS to Ent fwd-merge

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ClientCacheFactory.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/ClientCacheFactory.kt
@@ -7,12 +7,12 @@ import com.github.benmanes.caffeine.cache.LoadingCache
 import net.corda.core.internal.NamedCacheFactory
 
 class ClientCacheFactory : NamedCacheFactory {
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         checkCacheName(name)
         return caffeine.build<K, V>()
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         checkCacheName(name)
         return caffeine.build<K, V>(loader)
     }

--- a/core/src/main/kotlin/net/corda/core/internal/NamedCache.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/NamedCache.kt
@@ -22,11 +22,11 @@ interface NamedCacheFactory {
         require(allowedChars.matches(name)) { "Invalid characters in cache name" }
     }
 
-    fun <K, V> buildNamed(name: String): Cache<K, V> = buildNamed(Caffeine.newBuilder(), name)
+    fun <K : Any, V : Any> buildNamed(name: String): Cache<K, V> = buildNamed(Caffeine.newBuilder(), name)
 
-    fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V>
+    fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V>
 
-    fun <K, V> buildNamed(name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> = buildNamed(Caffeine.newBuilder(), name, loader)
+    fun <K : Any, V : Any> buildNamed(name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> = buildNamed(Caffeine.newBuilder(), name, loader)
 
-    fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V>
+    fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V>
 }

--- a/core/src/test/kotlin/net/corda/core/internal/NamedCacheTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/NamedCacheTest.kt
@@ -8,11 +8,11 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class NamedCacheTest : NamedCacheFactory {
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         throw IllegalStateException("Should not be called")
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         throw IllegalStateException("Should not be called")
     }
 

--- a/node/src/main/kotlin/net/corda/node/migration/MigrationNamedCacheFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/MigrationNamedCacheFactory.kt
@@ -44,11 +44,11 @@ class MigrationNamedCacheFactory(private val metricRegistry: MetricRegistry?,
         }
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         return configuredForNamed(caffeine, name).build()
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         return configuredForNamed(caffeine, name).build(loader)
     }
 

--- a/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
@@ -79,12 +79,12 @@ open class DefaultNamedCacheFactory protected constructor(private val metricRegi
         checkNotNull(nodeConfiguration)
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         checkState(name)
         return configuredForNamed(caffeine, name).build<K, V>()
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         checkState(name)
         return configuredForNamed(caffeine, name).build<K, V>(loader)
     }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/TestingNamedCacheFactory.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/TestingNamedCacheFactory.kt
@@ -16,12 +16,12 @@ class TestingNamedCacheFactory private constructor(private val sizeOverride: Lon
     override fun bindWithMetrics(metricRegistry: MetricRegistry): BindableNamedCacheFactory = TestingNamedCacheFactory(sizeOverride, metricRegistry, this.nodeConfiguration)
     override fun bindWithConfig(nodeConfiguration: NodeConfiguration): BindableNamedCacheFactory = TestingNamedCacheFactory(sizeOverride, this.metricRegistry, nodeConfiguration)
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         // Does not check metricRegistry or nodeConfiguration, because for tests we don't care.
         return caffeine.maximumSize(sizeOverride).build<K, V>()
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         // Does not check metricRegistry or nodeConfiguration, because for tests we don't care.
         val configuredCaffeine = when (name) {
             "DBTransactionStorage_transactions" -> caffeine.maximumWeight(1.MB)

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifierNamedCacheFactory.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifierNamedCacheFactory.kt
@@ -12,12 +12,12 @@ class ExternalVerifierNamedCacheFactory : NamedCacheFactory {
         private const val DEFAULT_CACHE_SIZE = 1024L
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         checkCacheName(name)
         return configure(caffeine, name).build()
     }
 
-    override fun <K, V> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
+    override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         checkCacheName(name)
         return configure(caffeine, name).build(loader)
     }


### PR DESCRIPTION
### Function signature changes to support removing enterprise compiler warnings

Whilst performing the OS-to-Ent merge for the 4.12 compiler warnings previously fixed in OS, compiler errors were encountered for functions/methods in the Enterprise 4.12 build, of the type:
```
'put' overrides nothing
Type mismatch: inferred type is K but K & Any was expected
Type mismatch: inferred type is V but V & Any was expected
```
In each case, Intelli-J suggested making the following change to the class signature:
`private open class TracingCacheWrapper<K, V>`
became:
`private open class TracingCacheWrapper<K : Any, V : Any>`

This cured the errors, but caused more - again for methods - the errors being:
```
Type mismatch: inferred type is K! but Any was expected
Type mismatch: inferred type is V! but Any was expected
```

And fixing these caused _even more_ errors, saying that the updated methods don't override anything. This was because an override method _buildNamed_ has the type:
`override fun <K : Any, V : Any>buildNamed(...)`
but is trying to override a method like this in the superclass:
`fun <K, V>buildNamed(...)`

The solution I found worked was to change all the affected method signatures to have type `<K : Any, V : Any>`, and in their superclasses too, all the way up the class chain.

To test this, I made the changes in this PR and published the OS build to my local maven repo, then built by Ent 4.12 project against that. I had to make a plethora of similar changes in Enterprise (derived classes) - there will be an enterprise PR for those.
The enterprise project successfully compiled without error.

If/when this PR is approved/merged, I can publish a new Open Core, and integrate that into the OS-to-Ent forward merge PR - [PR-5067](https://github.com/corda/enterprise/pull/5067) - which should then rebuild successfully.


