### PR TITLE
ENT-11502: Upgrade platform version to 140.

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -110,11 +110,11 @@ class CordaRPCClientReconnectionTest {
 
             assertThatThrownBy {
                 val node = startNode ()
-                val client = CordaRPCClient(node.rpcAddress, config.copy(minimumServerProtocolVersion = 999, maxReconnectAttempts = 1))
+                val client = CordaRPCClient(node.rpcAddress, config.copy(minimumServerProtocolVersion = 100, maxReconnectAttempts = 1))
                 client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect)
             }
                     .isInstanceOf(UnrecoverableRPCException::class.java)
-                    .hasMessageStartingWith("Requested minimum protocol version (999) is higher than the server's supported protocol version ")
+                    .hasMessageStartingWith("Requested minimum protocol version (100) is higher than the server's supported protocol version ")
         }
     }
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpcreconnect/CordaRPCClientReconnectionTest.kt
@@ -110,11 +110,11 @@ class CordaRPCClientReconnectionTest {
 
             assertThatThrownBy {
                 val node = startNode ()
-                val client = CordaRPCClient(node.rpcAddress, config.copy(minimumServerProtocolVersion = 100, maxReconnectAttempts = 1))
+                val client = CordaRPCClient(node.rpcAddress, config.copy(minimumServerProtocolVersion = 999, maxReconnectAttempts = 1))
                 client.start(rpcUser.username, rpcUser.password, gracefulReconnect = gracefulReconnect)
             }
                     .isInstanceOf(UnrecoverableRPCException::class.java)
-                    .hasMessageStartingWith("Requested minimum protocol version (100) is higher than the server's supported protocol version ")
+                    .hasMessageStartingWith("Requested minimum protocol version (999) is higher than the server's supported protocol version ")
         }
     }
 

--- a/constants.properties
+++ b/constants.properties
@@ -13,7 +13,7 @@ internalPublishVersion=1.+
 # When incrementing platformVersion make sure to update          #
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #
 # ***************************************************************#
-platformVersion=40
+platformVersion=140
 openTelemetryVersion=1.20.1
 openTelemetrySemConvVersion=1.20.1-alpha
 guavaVersion=28.0-jre

--- a/constants.properties
+++ b/constants.properties
@@ -13,7 +13,7 @@ internalPublishVersion=1.+
 # When incrementing platformVersion make sure to update          #
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #
 # ***************************************************************#
-platformVersion=14
+platformVersion=140
 openTelemetryVersion=1.20.1
 openTelemetrySemConvVersion=1.20.1-alpha
 guavaVersion=28.0-jre

--- a/constants.properties
+++ b/constants.properties
@@ -13,7 +13,7 @@ internalPublishVersion=1.+
 # When incrementing platformVersion make sure to update          #
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #
 # ***************************************************************#
-platformVersion=140
+platformVersion=40
 openTelemetryVersion=1.20.1
 openTelemetrySemConvVersion=1.20.1-alpha
 guavaVersion=28.0-jre

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -20,7 +20,7 @@ import java.security.PublicKey
 
 
 // When incrementing platformVersion make sure to update PLATFORM_VERSION in constants.properties as well.
-const val PLATFORM_VERSION = 140
+const val PLATFORM_VERSION = 40
 
 fun ServicesForResolution.ensureMinimumPlatformVersion(requiredMinPlatformVersion: Int, feature: String) {
     checkMinimumPlatformVersion(networkParameters.minimumPlatformVersion, requiredMinPlatformVersion, feature)

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -20,7 +20,7 @@ import java.security.PublicKey
 
 
 // When incrementing platformVersion make sure to update PLATFORM_VERSION in constants.properties as well.
-const val PLATFORM_VERSION = 40
+const val PLATFORM_VERSION = 140
 
 fun ServicesForResolution.ensureMinimumPlatformVersion(requiredMinPlatformVersion: Int, feature: String) {
     checkMinimumPlatformVersion(networkParameters.minimumPlatformVersion, requiredMinPlatformVersion, feature)

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -20,7 +20,7 @@ import java.security.PublicKey
 
 
 // When incrementing platformVersion make sure to update PLATFORM_VERSION in constants.properties as well.
-const val PLATFORM_VERSION = 14
+const val PLATFORM_VERSION = 140
 
 fun ServicesForResolution.ensureMinimumPlatformVersion(requiredMinPlatformVersion: Int, feature: String) {
     checkMinimumPlatformVersion(networkParameters.minimumPlatformVersion, requiredMinPlatformVersion, feature)

--- a/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplSerializerLogWithSameSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplSerializerLogWithSameSerializerTest.kt
@@ -15,13 +15,13 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 import java.time.Duration
 
-class DuplicateSerializerLogWithSameSerializerTest {
+class DuplSerializerLogWithSameSerializerTest {
     @Test(timeout=300_000)
     fun `check duplicate serialisers are logged not logged for the same class`() {
 
         // Duplicate the cordapp in this node
         driver(DriverParameters(cordappsForAllNodes = listOf(this.enclosedCordapp(), this.enclosedCordapp()))) {
-            val node = startNode(startInSameProcess = true).getOrThrow()
+            val node = startNode(startInSameProcess = false).getOrThrow()
             node.rpc.startFlow(::TestFlow).returnValue.get()
 
             val text = node.logFile().readLines().filter { it.startsWith("[WARN") }

--- a/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplSerializerLogWithSameSerializerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/customcheckpointserializer/DuplSerializerLogWithSameSerializerTest.kt
@@ -21,7 +21,7 @@ class DuplicateSerializerLogWithSameSerializerTest {
 
         // Duplicate the cordapp in this node
         driver(DriverParameters(cordappsForAllNodes = listOf(this.enclosedCordapp(), this.enclosedCordapp()))) {
-            val node = startNode(startInSameProcess = false).getOrThrow()
+            val node = startNode(startInSameProcess = true).getOrThrow()
             node.rpc.startFlow(::TestFlow).returnValue.get()
 
             val text = node.logFile().readLines().filter { it.startsWith("[WARN") }


### PR DESCRIPTION
ENT-11502: Upgrade platform version to 140.

Test name changed because it resulted in a cordapp name of length 129 characters. Max length of cordapp name in node_flow_metadata is 128 chars.