### PR TITLE
ENT-11504: Bind to the same address that the server socket created.

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
@@ -10,12 +10,10 @@ import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.NotarySpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Ignore
 import org.junit.Test
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 
-@Ignore("TODO JDK17: Fixme")
 class AddressBindingFailureTests {
 
     companion object {
@@ -23,7 +21,7 @@ class AddressBindingFailureTests {
     }
 
     @Test(timeout=300_000)
-	fun `p2p address`() = assertBindExceptionForOverrides { address -> mapOf("p2pAddress" to address.toString()) }
+	fun `p2p address`() = assertBindExceptionForOverrides("localhost") { address -> mapOf("p2pAddress" to address.toString()) }
 
     @Test(timeout=300_000)
 	fun `rpc address`() = assertBindExceptionForOverrides { address -> mapOf("rpcSettings" to mapOf("address" to address.toString())) }
@@ -54,11 +52,12 @@ class AddressBindingFailureTests {
         }
     }
 
-    private fun assertBindExceptionForOverrides(overrides: (NetworkHostAndPort) -> Map<String, Any?>) {
+    private fun assertBindExceptionForOverrides(bindAddress: String? = null, overrides: (NetworkHostAndPort) -> Map<String, Any?>) {
 
         ServerSocket(0).use { socket ->
 
-            val address = InetSocketAddress("localhost", socket.localPort).toNetworkHostAndPort()
+            val address = bindAddress?.let { InetSocketAddress(it, socket.localPort).toNetworkHostAndPort() } ?:
+                InetSocketAddress(socket.inetAddress, socket.localPort).toNetworkHostAndPort()
             driver(DriverParameters(startNodesInProcess = true,
                                          notarySpecs = emptyList(),
                                          inMemoryDB = false,


### PR DESCRIPTION
ENT-11504: Bind to the same address that the server socket created.