### PR TITLE
ENT-11090: Removed all JDK 8/11 conditional code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,6 @@ allprojects {
     targetCompatibility = VERSION_17
 
     jacoco {
-        // JDK11 official support (https://github.com/jacoco/jacoco/releases/tag/v0.8.3)
         toolVersion = "0.8.7"
     }
 

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
@@ -120,7 +120,7 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
     }
 
     /**
-     * Uses either Kotlin or Java 8 reflection to learn the names of the parameters to a method.
+     * Uses either Kotlin or Java reflection to learn the names of the parameters to a method.
      */
     open fun paramNamesFromMethod(method: Method): List<String> {
         val kf: KFunction<*>? = method.kotlinFunction
@@ -135,7 +135,7 @@ open class StringToMethodCallParser<in T : Any> @JvmOverloads constructor(
     }
 
     /**
-     * Uses either Kotlin or Java 8 reflection to learn the names of the parameters to a constructor.
+     * Uses either Kotlin or Java reflection to learn the names of the parameters to a constructor.
      */
     open fun paramNamesFromConstructor(ctor: Constructor<*>): List<String> {
         val kf: KFunction<*>? = ctor.kotlinFunction

--- a/constants.properties
+++ b/constants.properties
@@ -17,7 +17,6 @@ platformVersion=140
 openTelemetryVersion=1.20.1
 openTelemetrySemConvVersion=1.20.1-alpha
 guavaVersion=28.0-jre
-# Quasar version to use with Java 8:
 quasarVersion=0.9.0_r3
 dockerJavaVersion=3.2.5
 proguardVersion=7.3.1

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     testImplementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastle_version"
     testImplementation "org.ow2.asm:asm:$asm_version"
 
-    // JDK11: required by Quasar at run-time
     testRuntimeOnly "com.esotericsoftware:kryo:$kryo_version"
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -1,4 +1,4 @@
-@file:Suppress("TooManyFunctions")
+@file:Suppress("MatchingDeclarationName")
 package net.corda.core.internal
 
 import net.corda.core.contracts.ContractClassName
@@ -33,24 +33,6 @@ fun checkMinimumPlatformVersion(minimumPlatformVersion: Int, requiredMinPlatform
                         "$requiredMinPlatformVersion. The current zone is only enforcing a minimum platform version of " +
                         "$minimumPlatformVersion. Please contact your zone operator."
         )
-    }
-}
-
-// JDK11: revisit (JDK 9+ uses different numbering scheme: see https://docs.oracle.com/javase/9/docs/api/java/lang/Runtime.Version.html)
-@Throws(NumberFormatException::class)
-fun getJavaUpdateVersion(javaVersion: String): Long = javaVersion.substringAfter("_").substringBefore("-").toLong()
-
-enum class JavaVersion(val versionString: String) {
-    Java_1_8("1.8"),
-    Java_11("11");
-
-    companion object {
-        fun isVersionAtLeast(version: JavaVersion): Boolean {
-            return currentVersion.toFloat() >= version.versionString.toFloat()
-        }
-
-        private val currentVersion: String = System.getProperty("java.specification.version") ?:
-                                               throw IllegalStateException("Unable to retrieve system property java.specification.version")
     }
 }
 

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -61,7 +61,6 @@ dependencies {
 
     runtimeOnly 'com.mattbertolini:liquibase-slf4j:2.0.0'
 
-    // JDK11: required by Quasar at run-time
     runtimeOnly "com.esotericsoftware:kryo:$kryo_version"
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockito_kotlin_version"

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/CordaClosureSerializer.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/kryo/CordaClosureSerializer.kt
@@ -19,11 +19,3 @@ object CordaClosureSerializer : ClosureSerializer() {
         return target is Serializable
     }
 }
-
-object CordaClosureBlacklistSerializer : ClosureSerializer() {
-    const val ERROR_MESSAGE = "Java 8 Lambda expressions are not supported for serialization."
-
-    override fun write(kryo: Kryo, output: Output, target: Any) {
-        throw IllegalArgumentException(ERROR_MESSAGE)
-    }
-}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/kryo/KryoTests.kt
@@ -6,8 +6,6 @@ import com.esotericsoftware.kryo.KryoSerializable
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.google.common.primitives.Ints
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.whenever
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.SignatureAttachmentConstraint
 import net.corda.core.crypto.Crypto
@@ -37,8 +35,6 @@ import net.corda.serialization.internal.encodingNotPermittedFormat
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.core.internal.CheckpointSerializationEnvironmentRule
-import org.apache.commons.lang3.JavaVersion
-import org.apache.commons.lang3.SystemUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.catchThrowable
@@ -50,6 +46,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
 import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.time.Instant
@@ -67,7 +65,7 @@ class KryoTests(private val compression: CordaSerializationEncoding?) {
         private val ALICE_PUBKEY = TestIdentity(ALICE_NAME, 70).publicKey
         @Parameters(name = "{0}")
         @JvmStatic
-        fun compression() = arrayOf<CordaSerializationEncoding?>(null) + CordaSerializationEncoding.values()
+        fun compression(): List<CordaSerializationEncoding?> = CordaSerializationEncoding.entries + null
     }
 
     @get:Rule
@@ -399,11 +397,7 @@ class KryoTests(private val compression: CordaSerializationEncoding?) {
         val obj = Holder(ByteArray(20000))
         val uncompressedSize = obj.checkpointSerialize(context.withEncoding(null)).size
         val compressedSize = obj.checkpointSerialize(context.withEncoding(CordaSerializationEncoding.SNAPPY)).size
-        // If these need fixing, sounds like Kryo wire format changed and checkpoints might not survive an upgrade.
-        if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_11))
-            assertEquals(20127, uncompressedSize)
-        else
-            assertEquals(20234, uncompressedSize)
+        assertEquals(20127, uncompressedSize)
         assertEquals(1095, compressedSize)
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPClientSslErrorsTest.kt
@@ -3,7 +3,6 @@ package net.corda.node.amqp
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import net.corda.core.internal.JavaVersion
 import net.corda.core.toFuture
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
@@ -23,8 +22,8 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.internal.fixedCrlSource
-import org.junit.Assume.assumeFalse
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -43,6 +42,7 @@ import kotlin.test.assertTrue
  *
  * In order to have control over handshake internals a simple TLS server is created which may have a configurable handshake delay.
  */
+@Ignore  // These tests were disabled for JDK11+ very shortly after being introduced (https://github.com/corda/corda/pull/6560)
 @RunWith(Parameterized::class)
 class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
 
@@ -144,10 +144,7 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
     }
 
     @Test(timeout = 300_000)
-    fun trivialClientServerExchange() {
-        // SSL works quite differently in JDK 11 and re-work is needed
-        assumeFalse(JavaVersion.isVersionAtLeast(JavaVersion.Java_11))
-
+    fun `trivial client server exchange`() {
         val serverPort = portAllocation.nextPort()
         val serverThread = ServerThread(serverKeyManagerFactory, serverTrustManagerFactory, serverPort).also { it.start() }
 
@@ -182,10 +179,7 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
     }
 
     @Test(timeout = 300_000)
-    fun amqpClientServerConnect() {
-        // SSL works quite differently in JDK 11 and re-work is needed
-        assumeFalse(JavaVersion.isVersionAtLeast(JavaVersion.Java_11))
-
+    fun `amqp client server connect`() {
         val serverPort = portAllocation.nextPort()
         val serverThread = ServerThread(serverKeyManagerFactory, serverTrustManagerFactory, serverPort)
                 .also { it.start() }
@@ -205,10 +199,7 @@ class AMQPClientSslErrorsTest(@Suppress("unused") private val iteration: Int) {
     }
 
     @Test(timeout = 300_000)
-    fun amqpClientServerHandshakeTimeout() {
-        // SSL works quite differently in JDK 11 and re-work is needed
-        assumeFalse(JavaVersion.isVersionAtLeast(JavaVersion.Java_11))
-
+    fun `amqp client server handshake timeout`() {
         val serverPort = portAllocation.nextPort()
         val serverThread = ServerThread(serverKeyManagerFactory, serverTrustManagerFactory, serverPort, 5.seconds)
                 .also { it.start() }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1155,9 +1155,6 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         return NodeVaultService(platformClock, keyManagementService, services, database, schemaService, cordappLoader.appClassLoader)
     }
 
-    // JDK 11: switch to directly instantiating jolokia server (rather than indirectly via dynamically self attaching Java Agents,
-    // which is no longer supported from JDK 9 onwards (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8180425).
-    // No longer need to use https://github.com/electronicarts/ea-agent-loader either (which is also deprecated)
     private fun initialiseJolokia() {
         configuration.jmxMonitoringHttpPort?.let { port ->
             val config = JolokiaServerConfig(mapOf("port" to port.toString()))

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -17,7 +17,6 @@ import net.corda.core.internal.Emoji
 import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.internal.errors.AddressBindingException
-import net.corda.core.internal.getJavaUpdateVersion
 import net.corda.core.internal.notary.NotaryService
 import net.corda.core.messaging.RPCOps
 import net.corda.core.node.NetworkParameters
@@ -170,7 +169,7 @@ open class Node(configuration: NodeConfiguration,
 
         fun isInvalidJavaVersion(): Boolean {
             if (!hasMinimumJavaVersion()) {
-                println("You are using a version of Java that is not supported (${SystemUtils.JAVA_VERSION}). Please upgrade to the latest version of Java 8.")
+                println("You are using a version of Java that is not supported (${SystemUtils.JAVA_VERSION}). Please upgrade to the latest version of Java 17.")
                 println("Corda will now exit...")
                 return true
             }
@@ -178,17 +177,7 @@ open class Node(configuration: NodeConfiguration,
         }
 
         private fun hasMinimumJavaVersion(): Boolean {
-            // JDK 11: review naming convention and checking of 'minUpdateVersion' and 'distributionType` (OpenJDK, Oracle, Zulu, AdoptOpenJDK, Cornetto)
-            return try {
-                if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_11))
-                    return true
-                else {
-                    val update = getJavaUpdateVersion(SystemUtils.JAVA_VERSION) // To filter out cases like 1.8.0_202-ea
-                    (SystemUtils.IS_JAVA_1_8 && update >= 171)
-                }
-            } catch (e: NumberFormatException) { // custom JDKs may not have the update version (e.g. 1.8.0-adoptopenjdk)
-                false
-            }
+            return SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_17)
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -279,8 +279,6 @@ open class NodeStartup : NodeStartupLogging {
         logger.info("PID: ${ProcessHandle.current().pid()}")
         logger.info("Main class: ${NodeConfiguration::class.java.location.toURI().path}")
         logger.info("CommandLine Args: ${info.inputArguments.joinToString(" ")}")
-        // JDK 11 (bootclasspath no longer supported from JDK 9)
-        if (info.isBootClassPathSupported) logger.info("bootclasspath: ${info.bootClassPath}")
         logger.info("classpath: ${info.classPath}")
         logger.info("VM ${info.vmName} ${info.vmVendor} ${info.vmVersion}")
         logger.info("Machine: ${lookupMachineNameAndMaybeWarn()}")

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -111,7 +111,7 @@ class NodeSchedulerService(private val clock: CordaClock,
         }
 
         /**
-         * Convert a Guava [ListenableFuture] or JDK8 [CompletableFuture] to Quasar implementation and set to true when a result
+         * Convert a Guava [ListenableFuture] or JDK [CompletableFuture] to Quasar implementation and set to true when a result
          * or [Throwable] is available in the original.
          *
          * We need this so that we do not block the actual thread when calling get(), but instead allow a Quasar context

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowCreator.kt
@@ -213,7 +213,7 @@ class FlowCreator(
     }
 
     private fun verifyFlowLogicIsSuspendable(logic: FlowLogic<Any?>) {
-        // Quasar requires (in Java 8) that at least the call method be annotated suspendable. Unfortunately, it's
+        // Quasar requires that at least the call method be annotated suspendable. Unfortunately, it's
         // easy to forget to add this when creating a new flow, so we check here to give the user a better error.
         //
         // The Kotlin compiler can sometimes generate a synthetic bridge method from a single call declaration, which

--- a/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
@@ -1,7 +1,6 @@
 package net.corda.node.internal
 
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.internal.getJavaUpdateVersion
 import net.corda.core.internal.readObject
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.serialize
@@ -25,7 +24,6 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.internal.configureDatabase
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -38,7 +36,6 @@ import kotlin.io.path.deleteExisting
 import kotlin.io.path.name
 import kotlin.io.path.useDirectoryEntries
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class NodeTest {
@@ -141,11 +138,11 @@ class NodeTest {
                 serial = nodeInfo1.serial
         )
 
-        configureDatabase(configuration.dataSourceProperties, configuration.database, { null }, { null }).use {
-            it.transaction {
+        configureDatabase(configuration.dataSourceProperties, configuration.database, { null }, { null }).use { persistence ->
+            persistence.transaction {
                 session.save(persistentNodeInfo1)
             }
-            it.transaction {
+            persistence.transaction {
                 session.save(persistentNodeInfo2)
             }
 
@@ -158,16 +155,6 @@ class NodeTest {
             //this throws an exception with old behaviour
             node.generateNodeInfo()
         }
-    }
-
-    // JDK11: revisit (JDK 9+ uses different numbering scheme: see https://docs.oracle.com/javase/9/docs/api/java/lang/Runtime.Version.html)
-    @Ignore
-    @Test(timeout=300_000)
-	fun `test getJavaUpdateVersion`() {
-        assertThat(getJavaUpdateVersion("1.8.0_202-ea")).isEqualTo(202)
-        assertThat(getJavaUpdateVersion("1.8.0_202")).isEqualTo(202)
-        assertFailsWith<NumberFormatException> { getJavaUpdateVersion("1.8.0_202wrong-format") }
-        assertFailsWith<NumberFormatException> { getJavaUpdateVersion("1.8.0-adoptopenjdk") }
     }
 
     private fun getAllInfos(database: CordaPersistence): List<NodeInfoSchemaV1.PersistentNodeInfo> {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectBuilder.kt
@@ -50,17 +50,11 @@ private class SetterCaller(val setter: Method) : (Any, Any?) -> Unit {
         try {
             setter.invoke(target, value)
         } catch (e: InvocationTargetException) {
-            @Suppress("DEPRECATION")    // JDK11: isAccessible() should be replaced with canAccess() (since 9)
             throw NotSerializableException(
-                    "Setter ${setter.declaringClass}.${setter.name} (isAccessible=${setter.isAccessible} " +
-                            "failed when called with parameter $value: ${e.cause!!.message}"
+                    "Setter ${setter.declaringClass}.${setter.name} failed when called with parameter $value: ${e.cause?.message}"
             )
         } catch (e: IllegalAccessException) {
-            @Suppress("DEPRECATION")    // JDK11: isAccessible() should be replaced with canAccess() (since 9)
-            throw NotSerializableException(
-                    "Setter ${setter.declaringClass}.${setter.name} (isAccessible=${setter.isAccessible} " +
-                            "not accessible: ${e.message}"
-            )
+            throw NotSerializableException("Setter ${setter.declaringClass}.${setter.name} not accessible: ${e.message}")
         }
     }
 }
@@ -206,7 +200,7 @@ private class SetterBasedObjectBuilder(
  * and calling a constructor with those parameters to obtain the configured object instance.
  */
 private class ConstructorBasedObjectBuilder(
-        private val constructorInfo: LocalConstructorInformation,
+        constructorInfo: LocalConstructorInformation,
         private val slotToCtorArgIdx: IntArray
 ) : ObjectBuilder {
 

--- a/testing/testserver/src/main/kotlin/net/corda/webserver/WebServer.kt
+++ b/testing/testserver/src/main/kotlin/net/corda/webserver/WebServer.kt
@@ -54,8 +54,6 @@ fun main(args: Array<String>) {
     val info = ManagementFactory.getRuntimeMXBean()
     log.info("CommandLine Args: ${info.inputArguments.joinToString(" ")}")
     log.info("Application Args: ${args.joinToString(" ")}")
-    // JDK 11 (bootclasspath no longer supported from JDK 9)
-    if (info.isBootClassPathSupported) log.info("bootclasspath: ${info.bootClassPath}")
     log.info("classpath: ${info.classPath}")
     log.info("VM ${info.vmName} ${info.vmVendor} ${info.vmVersion}")
     log.info("Machine: ${InetAddress.getLocalHost().hostName}")


### PR DESCRIPTION
Except for `AMQPClientSslErrorsTest` which has never worked for JDK11+ (https://github.com/corda/corda/pull/6560).