### PR TITLE
ENT-11445: Support legacy contract CorDapp dependencies

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -552,8 +552,6 @@ public interface net.corda.core.contracts.Attachment extends net.corda.core.cont
 public interface net.corda.core.contracts.AttachmentConstraint
   public abstract boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
 ##
-public final class net.corda.core.contracts.AttachmentConstraintKt extends java.lang.Object
-##
 @CordaSerializable
 public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)

--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -57,55 +57,61 @@ processSmokeTestResources {
     from(configurations.corda4_11)
 }
 
+processIntegrationTestResources {
+    from(tasks.getByPath(":finance:contracts:jar")) {
+        rename 'corda-finance-contracts-.*.jar', 'corda-finance-contracts.jar'
+    }
+    from(configurations.corda4_11)
+}
+
 processTestResources {
     from(configurations.corda4_11)
 }
 
 dependencies {
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
-    testImplementation "junit:junit:$junit_version"
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
-
-    testImplementation "commons-fileupload:commons-fileupload:$fileupload_version"
     testImplementation project(":core")
-    testImplementation project(path: ':core', configuration: 'testArtifacts')
-
+    testImplementation project(":serialization")
+    testImplementation project(":finance:contracts")
+    testImplementation project(":finance:workflows")
     testImplementation project(":node")
     testImplementation project(":node-api")
     testImplementation project(":client:rpc")
-    testImplementation project(":serialization")
     testImplementation project(":common-configuration-parsing")
-    testImplementation project(":finance:contracts")
-    testImplementation project(":finance:workflows")
     testImplementation project(":core-test-utils")
     testImplementation project(":test-utils")
-    testImplementation project(path: ':core', configuration: 'testArtifacts')
-
+    testImplementation project(":node-driver")
+    // used by FinalityFlowTests
+    testImplementation project(':testing:cordapps:cashobservers')
+    testImplementation(project(path: ':core', configuration: 'testArtifacts')) {
+        transitive = false
+    }
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+    testImplementation "junit:junit:$junit_version"
+    testImplementation "commons-fileupload:commons-fileupload:$fileupload_version"
     // Guava: Google test library (collections test suite)
     testImplementation "com.google.guava:guava-testlib:$guava_version"
     testImplementation "com.google.jimfs:jimfs:1.1"
-    testImplementation group: "com.typesafe", name: "config", version: typesafe_config_version
-
-    // Bring in the MockNode infrastructure for writing protocol unit tests.
-    testImplementation project(":node-driver")
-
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testImplementation "com.typesafe:config:$typesafe_config_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-
     // Hamkrest, for fluent, composable matchers
     testImplementation "com.natpryce:hamkrest:$hamkrest_version"
-
-    // SLF4J: commons-logging bindings for a SLF4J back end
-    implementation "org.slf4j:jcl-over-slf4j:$slf4j_version"
-    implementation "org.slf4j:slf4j-api:$slf4j_version"
-
+    testImplementation 'org.hamcrest:hamcrest-library:2.1'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockito_kotlin_version"
+    testImplementation "org.mockito:mockito-core:$mockito_version"
     // AssertJ: for fluent assertions for testing
     testImplementation "org.assertj:assertj-core:${assertj_version}"
-
     // Guava: Google utilities library.
     testImplementation "com.google.guava:guava:$guava_version"
+    testImplementation "com.esotericsoftware:kryo:$kryo_version"
+    testImplementation "co.paralleluniverse:quasar-core:$quasar_version"
+    testImplementation "org.hibernate:hibernate-core:$hibernate_version"
+    testImplementation "org.bouncycastle:bcprov-jdk18on:${bouncycastle_version}"
+    testImplementation "io.netty:netty-common:$netty_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 
     // Smoke tests do NOT have any Node code on the classpath!
     smokeTestImplementation project(":core")
@@ -126,9 +132,6 @@ dependencies {
     smokeTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
     smokeTestRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
     smokeTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
-
-    // used by FinalityFlowTests
-    testImplementation project(':testing:cordapps:cashobservers')
 
     corda4_11 "net.corda:corda-finance-contracts:4.11"
     corda4_11 "net.corda:corda-finance-workflows:4.11"

--- a/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
+++ b/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
@@ -1,0 +1,159 @@
+package net.corda.coretests.transactions
+
+import net.corda.core.internal.copyToDirectory
+import net.corda.core.internal.hash
+import net.corda.core.internal.toPath
+import net.corda.core.messaging.startFlow
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.getOrThrow
+import net.corda.coretesting.internal.delete
+import net.corda.coretesting.internal.modifyJarManifest
+import net.corda.coretesting.internal.useZipFile
+import net.corda.finance.DOLLARS
+import net.corda.finance.flows.CashIssueAndPaymentFlow
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.internal.JarSignatureTestUtils.generateKey
+import net.corda.testing.core.internal.JarSignatureTestUtils.signJar
+import net.corda.testing.core.internal.JarSignatureTestUtils.unsignJar
+import net.corda.testing.driver.NodeHandle
+import net.corda.testing.driver.NodeParameters
+import net.corda.testing.node.internal.DriverDSLImpl
+import net.corda.testing.node.internal.FINANCE_WORKFLOWS_CORDAPP
+import net.corda.testing.node.internal.internalDriver
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.copyTo
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteExisting
+import kotlin.io.path.div
+import kotlin.io.path.inputStream
+
+class TransactionBuilderDriverTest {
+    companion object {
+        val currentFinanceContractsJar = this::class.java.getResource("/corda-finance-contracts.jar")!!.toPath()
+        val legacyFinanceContractsJar = this::class.java.getResource("/corda-finance-contracts-4.11.jar")!!.toPath()
+    }
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    @Before
+    fun initJarSigner() {
+        tempFolder.root.toPath().generateKey("testAlias", "testPassword", ALICE_NAME.toString())
+    }
+
+    private fun signJar(jar: Path) {
+        tempFolder.root.toPath().signJar(jar.absolutePathString(), "testAlias", "testPassword")
+    }
+
+    @Test(timeout=300_000)
+    fun `adds CorDapp dependencies`() {
+        val (cordapp, dependency) = splitFinanceContractCordapp(currentFinanceContractsJar)
+        internalDriver(cordappsForAllNodes = listOf(FINANCE_WORKFLOWS_CORDAPP), startNodesInProcess = false) {
+            cordapp.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+            dependency.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+
+            // Start the node with the CorDapp but without the dependency
+            cordapp.copyToDirectory((baseDirectory(ALICE_NAME) / "cordapps").createDirectories())
+            val node = startNode(NodeParameters(ALICE_NAME)).getOrThrow()
+
+            // First make sure the missing dependency causes an issue
+            assertThatThrownBy {
+                createTransaction(node)
+            }.hasMessageContaining("java.lang.NoClassDefFoundError: net/corda/finance/contracts/asset")
+
+            // Upload the missing dependency
+            dependency.inputStream().use(node.rpc::uploadAttachment)
+
+            val stx = createTransaction(node)
+            assertThat(stx.tx.attachments).contains(cordapp.hash, dependency.hash)
+        }
+    }
+
+    @Test(timeout=300_000)
+    fun `adds legacy contracts CorDapp dependencies`() {
+        val (legacyContracts, legacyDependency) = splitFinanceContractCordapp(legacyFinanceContractsJar)
+
+        // Re-sign the current finance contracts CorDapp with the same key as the split legacy CorDapp
+        val currentContracts = currentFinanceContractsJar.copyTo(Path("${currentFinanceContractsJar.toString().substringBeforeLast(".")}-RESIGNED.jar"), overwrite = true)
+        currentContracts.unsignJar()
+        signJar(currentContracts)
+
+        internalDriver(
+                cordappsForAllNodes = listOf(FINANCE_WORKFLOWS_CORDAPP),
+                startNodesInProcess = false,
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+        ) {
+            currentContracts.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+
+            // Start the node with the legacy CorDapp but without the dependency
+            legacyContracts.copyToDirectory((baseDirectory(ALICE_NAME) / "legacy-contracts").createDirectories())
+            currentContracts.copyToDirectory((baseDirectory(ALICE_NAME) / "cordapps").createDirectories())
+            val node = startNode(NodeParameters(ALICE_NAME)).getOrThrow()
+
+            // First make sure the missing dependency causes an issue
+            assertThatThrownBy {
+                createTransaction(node)
+            }.hasMessageContaining("java.lang.NoClassDefFoundError: net/corda/finance/contracts/asset")
+
+            // Upload the missing dependency
+            legacyDependency.inputStream().use(node.rpc::uploadAttachment)
+
+            val stx = createTransaction(node)
+            assertThat(stx.tx.legacyAttachments).contains(legacyContracts.hash, legacyDependency.hash)
+        }
+    }
+
+    /**
+     * Split the given finance contracts jar into two such that the second jar becomes a dependency to the first.
+     */
+    private fun splitFinanceContractCordapp(contractsJar: Path): Pair<Path, Path> {
+        val cordapp = tempFolder.newFile("cordapp.jar").toPath()
+        val dependency = tempFolder.newFile("cordapp-dep.jar").toPath()
+
+        // Split the CorDapp into two
+        contractsJar.copyTo(cordapp, overwrite = true)
+        cordapp.useZipFile { cordappZipFs ->
+            dependency.useZipFile { depZipFs ->
+                val targetDir = depZipFs.getPath("net/corda/finance/contracts/asset").createDirectories()
+                // CashUtilities happens to be a class that is only invoked in Cash.verify and so it's absence is only detected during
+                // verification
+                val clazz = cordappZipFs.getPath("net/corda/finance/contracts/asset/CashUtilities.class")
+                clazz.copyToDirectory(targetDir)
+                clazz.deleteExisting()
+            }
+        }
+        cordapp.modifyJarManifest { manifest ->
+            manifest.mainAttributes.delete("Sealed")
+        }
+        cordapp.unsignJar()
+
+        // Sign both current and legacy CorDapps with the same key
+        signJar(cordapp)
+        // The dependency needs to be signed as it contains a package from the main jar
+        signJar(dependency)
+
+        return Pair(cordapp, dependency)
+    }
+
+    private fun DriverDSLImpl.createTransaction(node: NodeHandle): SignedTransaction {
+        return node.rpc.startFlow(
+                ::CashIssueAndPaymentFlow,
+                1.DOLLARS,
+                OpaqueBytes.of(0x00),
+                defaultNotaryIdentity,
+                false,
+                defaultNotaryIdentity
+        ).returnValue.getOrThrow().stx
+    }
+}

--- a/core-tests/src/smoke-test/kotlin/net/corda/coretests/verification/ExternalVerificationTests.kt
+++ b/core-tests/src/smoke-test/kotlin/net/corda/coretests/verification/ExternalVerificationTests.kt
@@ -213,7 +213,7 @@ class ExternalVerificationUnsignedCordappsTest {
             ).returnValue.getOrThrow()
         }
 
-        assertThat(newNode.externalVerifierLogs()).contains("$issuanceTx failed to verify")
+        assertThat(newNode.externalVerifierLogs()).contains("WireTransaction(id=${issuanceTx.id}) failed to verify")
     }
 }
 
@@ -265,10 +265,10 @@ private fun NodeProcess.assertTransactionsWereVerified(verificationType: Verific
     val nodeLogs = logs("node")!!
     val externalVerifierLogs = externalVerifierLogs()
     for (txId in txIds) {
-        assertThat(nodeLogs).contains("Transaction $txId has verification type $verificationType")
+        assertThat(nodeLogs).contains("WireTransaction(id=$txId) will be verified ${verificationType.logStatement}")
         if (verificationType != VerificationType.IN_PROCESS) {
             assertThat(externalVerifierLogs).describedAs("External verifier was not started").isNotNull()
-            assertThat(externalVerifierLogs).contains("SignedTransaction(id=$txId) verified")
+            assertThat(externalVerifierLogs).contains("WireTransaction(id=$txId) verified")
         }
     }
 }
@@ -283,5 +283,12 @@ private fun NodeProcess.logs(name: String): String? {
 }
 
 private enum class VerificationType {
-    IN_PROCESS, EXTERNAL, BOTH
+    IN_PROCESS, EXTERNAL, BOTH;
+
+    val logStatement: String
+        get() = when (this) {
+            IN_PROCESS -> "in-process"
+            EXTERNAL -> "by the external verifer"
+            BOTH -> "both in-process and by the external verifer"
+        }
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
@@ -11,12 +11,11 @@ import net.corda.core.internal.utilities.Internable
 import net.corda.core.internal.utilities.PrivateInterner
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import java.lang.annotation.Inherited
 import java.security.PublicKey
-
-private val log = loggerFor<AttachmentConstraint>()
 
 /**
  * This annotation should only be added to [Contract] classes.
@@ -49,8 +48,11 @@ object AlwaysAcceptAttachmentConstraint : AttachmentConstraint {
  */
 data class HashAttachmentConstraint(val attachmentId: SecureHash) : AttachmentConstraint {
     companion object {
+        private val log = contextLogger()
+
         val disableHashConstraints = System.getProperty("net.corda.node.disableHashConstraints")?.toBoolean() ?: false
     }
+
     override fun isSatisfiedBy(attachment: Attachment): Boolean {
         return if (attachment is AttachmentWithContext) {
             log.debug("Checking attachment uploader ${attachment.contractAttachment.uploader} is trusted")
@@ -68,6 +70,8 @@ data class HashAttachmentConstraint(val attachmentId: SecureHash) : AttachmentCo
  * It allows for centralized control over the cordapps that can be used.
  */
 object WhitelistedByZoneAttachmentConstraint : AttachmentConstraint {
+    private val log = loggerFor<WhitelistedByZoneAttachmentConstraint>()
+
     override fun isSatisfiedBy(attachment: Attachment): Boolean {
         return if (attachment is AttachmentWithContext) {
             val whitelist = attachment.whitelistedContractImplementations
@@ -120,6 +124,8 @@ data class SignatureAttachmentConstraint(val key: PublicKey) : AttachmentConstra
     }
 
     companion object : Internable<SignatureAttachmentConstraint> {
+        private val log = contextLogger()
+
         @CordaInternal
         override val interner = PrivateInterner<SignatureAttachmentConstraint>()
 

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -450,7 +450,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
         // The notary signature(s) are allowed to be missing but no others.
         if (notary != null) transaction.verifySignaturesExcept(notary.owningKey) else transaction.verifyRequiredSignatures()
         // TODO= [CORDA-3267] Remove duplicate signature verification
-        val ltx = transaction.verifyInternal(serviceHub.toVerifyingServiceHub(), checkSufficientSignatures = false) as LedgerTransaction?
+        val ltx = transaction.verifyInternal(serviceHub.toVerifyingServiceHub(), checkSufficientSignatures = false)
         // verifyInternal returns null if the transaction was verified externally, which *could* happen on a very odd scenerio of a 4.11
         // node creating the transaction but a 4.12 kicking off finality. In that case, we still want a LedgerTransaction object for
         // recording to the vault, etc. Note that calling verify() on this will fail as it doesn't have the necessary non-legacy attachments

--- a/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
@@ -68,7 +68,7 @@ abstract class AbstractAttachment(dataLoader: () -> ByteArray, val uploader: Str
 
     override fun equals(other: Any?) = other === this || other is Attachment && other.id == this.id
     override fun hashCode() = id.hashCode()
-    override fun toString() = "${javaClass.simpleName}(id=$id)"
+    override fun toString() = toSimpleString()
 }
 
 @Throws(IOException::class)

--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -2,6 +2,7 @@
 package net.corda.core.internal
 
 import net.corda.core.contracts.ContractClassName
+import net.corda.core.contracts.NamedByHash
 import net.corda.core.contracts.TransactionResolutionException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.DataVendingFlow
@@ -93,3 +94,5 @@ fun TransactionStorage.getRequiredTransaction(txhash: SecureHash): SignedTransac
 }
 
 fun ServiceHub.getRequiredTransaction(txhash: SecureHash): SignedTransaction = validatedTransactions.getRequiredTransaction(txhash)
+
+fun NamedByHash.toSimpleString(): String = "${javaClass.simpleName}(id=$id)"

--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -148,8 +148,8 @@ fun <T> List<T>.indexOfOrThrow(item: T): Int {
 @Suppress("INVISIBLE_MEMBER", "RemoveExplicitTypeArguments")   // Because the external verifier uses Kotlin 1.2
 inline fun <T, R> Collection<T>.mapToSet(transform: (T) -> R): Set<R> {
     return when (size) {
-        0 -> return emptySet()
-        1 -> return setOf(transform(first()))
+        0 -> emptySet()
+        1 -> setOf(transform(first()))
         else -> mapTo(LinkedHashSet<R>(mapCapacity(size)), transform)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/internal/verification/ExternalVerifierHandle.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/verification/ExternalVerifierHandle.kt
@@ -1,7 +1,7 @@
 package net.corda.core.internal.verification
 
-import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.CoreTransaction
 
 interface ExternalVerifierHandle : AutoCloseable {
-    fun verifyTransaction(stx: SignedTransaction, checkSufficientSignatures: Boolean)
+    fun verifyTransaction(ctx: CoreTransaction)
 }

--- a/core/src/main/kotlin/net/corda/core/internal/verification/VerificationResult.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/verification/VerificationResult.kt
@@ -1,0 +1,64 @@
+package net.corda.core.internal.verification
+
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.utilities.Try
+import net.corda.core.utilities.Try.Failure
+import net.corda.core.utilities.Try.Success
+
+sealed class VerificationResult {
+    /**
+     * The in-process result for the current version of the transcaction.
+     */
+    abstract val inProcessResult: Try<LedgerTransaction?>?
+
+    /**
+     * The external verifier result for the legacy version of the transaction.
+     */
+    abstract val externalResult: Try<Unit>?
+
+    abstract fun enforceSuccess(): LedgerTransaction?
+
+
+    data class InProcess(override val inProcessResult: Try<LedgerTransaction?>) : VerificationResult() {
+        override val externalResult: Try<Unit>?
+            get() = null
+
+        override fun enforceSuccess(): LedgerTransaction? = inProcessResult.getOrThrow()
+    }
+
+    data class External(override val externalResult: Try<Unit>) : VerificationResult() {
+        override val inProcessResult: Try<LedgerTransaction?>?
+            get() = null
+
+        override fun enforceSuccess(): LedgerTransaction? {
+            externalResult.getOrThrow()
+            // We could create a LedgerTransaction here, and except for calling `verify()`, it would be valid to use. However, it's best
+            // we let the caller deal with that, since we can't prevent them from calling it.
+            return null
+        }
+    }
+
+    data class InProcessAndExternal(
+            override val inProcessResult: Try<LedgerTransaction>,
+            override val externalResult: Try<Unit>
+    ) : VerificationResult() {
+        override fun enforceSuccess(): LedgerTransaction {
+            return when (externalResult) {
+                is Success -> when (inProcessResult) {
+                    is Success -> inProcessResult.value
+                    is Failure -> throw IllegalStateException(
+                            "Current version of transaction failed to verify, but legacy version did verify (in external verifier)",
+                            inProcessResult.exception
+                    )
+                }
+                is Failure -> throw when (inProcessResult) {
+                    is Success -> IllegalStateException(
+                            "Current version of transaction verified, but legacy version failed to verify (in external verifier)",
+                            externalResult.exception
+                    )
+                    is Failure -> inProcessResult.exception.apply { addSuppressed(externalResult.exception) }
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/internal/verification/VerificationSupport.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/verification/VerificationSupport.kt
@@ -34,7 +34,7 @@ interface VerificationSupport {
 
     fun isAttachmentTrusted(attachment: Attachment): Boolean
 
-    fun getTrustedClassAttachment(className: String): Attachment?
+    fun getTrustedClassAttachments(className: String): List<Attachment>
 
     fun getNetworkParameters(id: SecureHash?): NetworkParameters?
 

--- a/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
@@ -1,4 +1,3 @@
-
 package net.corda.core.node.services
 
 import net.corda.core.DoNotImplement

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt
@@ -1,16 +1,22 @@
 package net.corda.core.transactions
 
 import net.corda.core.DoNotImplement
-import net.corda.core.contracts.*
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.NamedByHash
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
 import net.corda.core.identity.Party
 import net.corda.core.internal.castIfPossible
 import net.corda.core.internal.indexOfOrThrow
+import net.corda.core.internal.toSimpleString
 import net.corda.core.internal.uncheckedCast
 import java.util.function.Predicate
 
 /**
  * An abstract class defining fields shared by all transaction types in the system.
  */
+@Suppress("RedundantSamConstructor")  // Because the external verifier uses Kotlin 1.2
 @DoNotImplement
 abstract class BaseTransaction : NamedByHash {
     /** A list of reusable reference data states which can be referred to by other contracts in this transaction. */
@@ -163,5 +169,5 @@ abstract class BaseTransaction : NamedByHash {
         return findOutRef(T::class.java, Predicate { predicate(it) })
     }
 
-    override fun toString(): String = "${javaClass.simpleName}(id=$id)"
+    override fun toString(): String = toSimpleString()
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -3,12 +3,12 @@ package net.corda.core.transactions
 import net.corda.core.CordaException
 import net.corda.core.CordaInternal
 import net.corda.core.CordaThrowable
-import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.AttachmentResolutionException
 import net.corda.core.contracts.NamedByHash
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TransactionResolutionException
 import net.corda.core.contracts.TransactionVerificationException
+import net.corda.core.contracts.TransactionVerificationException.TransactionNetworkParameterOrderingException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignableData
 import net.corda.core.crypto.SignatureMetadata
@@ -16,34 +16,26 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.sign
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.Party
-import net.corda.core.internal.TransactionDeserialisationException
 import net.corda.core.internal.VisibleForTesting
-import net.corda.core.internal.equivalent
-import net.corda.core.internal.isUploaderTrusted
+import net.corda.core.internal.getRequiredSigningKeysInternal
+import net.corda.core.internal.toSimpleString
 import net.corda.core.internal.verification.NodeVerificationSupport
-import net.corda.core.internal.verification.VerificationSupport
 import net.corda.core.internal.verification.toVerifyingServiceHub
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
-import net.corda.core.serialization.internal.MissingSerializerException
 import net.corda.core.serialization.serialize
-import net.corda.core.utilities.Try
-import net.corda.core.utilities.Try.Failure
-import net.corda.core.utilities.Try.Success
-import net.corda.core.utilities.contextLogger
-import net.corda.core.utilities.debug
-import java.io.NotSerializableException
+import net.corda.core.utilities.toBase58String
 import java.security.KeyPair
 import java.security.PublicKey
 import java.security.SignatureException
 import java.util.function.Predicate
 
 /**
- * SignedTransaction wraps a serialized WireTransaction. It contains one or more signatures, each one for
+ * SignedTransaction wraps a serialized [CoreTransaction], though it will almost exclusively be a [WireTransaction].
+ * It contains one or more signatures, each one for
  * a public key (including composite keys) that is mentioned inside a transaction command. SignedTransaction is the top level transaction type
  * and the type most frequently passed around the network and stored. The identity of a transaction is the hash of Merkle root
  * of a WireTransaction, therefore if you are storing data keyed by WT hash be aware that multiple different STs may
@@ -163,12 +155,6 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
         val verifyingServiceHub = services.toVerifyingServiceHub()
         // We need parameters check here, because finality flow calls stx.toLedgerTransaction() and then verify.
         resolveAndCheckNetworkParameters(verifyingServiceHub)
-        return toLedgerTransactionInternal(verifyingServiceHub, checkSufficientSignatures)
-    }
-
-    @JvmSynthetic
-    @CordaInternal
-    fun toLedgerTransactionInternal(verificationSupport: VerificationSupport, checkSufficientSignatures: Boolean): LedgerTransaction {
         // TODO: We could probably optimise the below by
         // a) not throwing if threshold is eventually satisfied, but some of the rest of the signatures are failing.
         // b) omit verifying signatures when threshold requirement is met.
@@ -176,12 +162,8 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
         // For the above to work, [checkSignaturesAreValid] should take the [requiredSigningKeys] as input
         // and probably combine logic from signature validation and key-fulfilment
         // in [TransactionWithSignatures.verifySignaturesExcept].
-        if (checkSufficientSignatures) {
-            verifyRequiredSignatures() // It internally invokes checkSignaturesAreValid().
-        } else {
-            checkSignaturesAreValid()
-        }
-        return tx.toLedgerTransactionInternal(verificationSupport)
+        verifySignatures(verifyingServiceHub, checkSufficientSignatures)
+        return tx.toLedgerTransactionInternal(verifyingServiceHub)
     }
 
     /**
@@ -210,250 +192,48 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
      */
     @CordaInternal
     @JvmSynthetic
-    internal fun verifyInternal(verificationSupport: NodeVerificationSupport, checkSufficientSignatures: Boolean = true): FullTransaction? {
+    internal fun verifyInternal(verificationSupport: NodeVerificationSupport, checkSufficientSignatures: Boolean = true): LedgerTransaction? {
         resolveAndCheckNetworkParameters(verificationSupport)
-        val verificationType = determineVerificationType()
-        log.debug { "Transaction $id has verification type $verificationType" }
-        return when (verificationType) {
-            VerificationType.IN_PROCESS -> verifyInProcess(verificationSupport, checkSufficientSignatures)
-            VerificationType.BOTH -> {
-                val inProcessResult = Try.on { verifyInProcess(verificationSupport, checkSufficientSignatures) }
-                val externalResult = Try.on { verificationSupport.externalVerifierHandle.verifyTransaction(this, checkSufficientSignatures) }
-                ensureSameResult(inProcessResult, externalResult)
-            }
-            VerificationType.EXTERNAL -> {
-                verificationSupport.externalVerifierHandle.verifyTransaction(this, checkSufficientSignatures)
-                // We could create a LedgerTransaction here, and except for calling `verify()`, it would be valid to use. However, it's best
-                // we let the caller deal with that, since we can't control what they will do with it.
-                null
-            }
-        }
-    }
-
-    private fun determineVerificationType(): VerificationType {
+        verifySignatures(verificationSupport, checkSufficientSignatures)
         val ctx = coreTransaction
-        return when (ctx) {
-            is WireTransaction -> {
-                when {
-                    ctx.legacyAttachments.isEmpty() -> VerificationType.IN_PROCESS
-                    ctx.nonLegacyAttachments.isEmpty() -> VerificationType.EXTERNAL
-                    else -> VerificationType.BOTH
-                }
-            }
-            // Contract upgrades only work on 4.11 and earlier
-            is ContractUpgradeWireTransaction -> VerificationType.EXTERNAL
-            else -> VerificationType.IN_PROCESS  // The default is always in-process
+        val verificationResult = when (ctx) {
+            // TODO: Verify contract constraints here as well as in LedgerTransaction to ensure that anything being deserialised
+            // from the attachment is trusted. This will require some partial serialisation work to not load the ContractState
+            // objects from the TransactionState.
+            is WireTransaction -> ctx.tryVerify(verificationSupport)
+            is ContractUpgradeWireTransaction -> ctx.tryVerify(verificationSupport)
+            is NotaryChangeWireTransaction -> ctx.tryVerify(verificationSupport)
+            else -> throw IllegalStateException("${ctx.toSimpleString()} cannot be verified")
         }
-    }
-
-    private fun ensureSameResult(inProcessResult: Try<FullTransaction>, externalResult: Try<*>): FullTransaction {
-        return when (externalResult) {
-            is Success -> when (inProcessResult) {
-                is Success -> inProcessResult.value
-                is Failure -> throw IllegalStateException("In-process verification of $id failed, but it succeeded in external verifier")
-                        .apply { addSuppressed(inProcessResult.exception) }
-            }
-            is Failure -> throw when (inProcessResult) {
-                is Success -> IllegalStateException("In-process verification of $id succeeded, but it failed in external verifier")
-                is Failure -> inProcessResult.exception  // Throw the in-process exception, with the external exception suppressed
-            }.apply { addSuppressed(externalResult.exception) }
-        }
-    }
-
-    private enum class VerificationType {
-        IN_PROCESS, EXTERNAL, BOTH
-    }
-
-    /**
-     * Verifies this transaction in-process. This assumes the current process has the correct classpath for all the contracts.
-     *
-     * @return The [FullTransaction] that was successfully verified
-     */
-    @CordaInternal
-    @JvmSynthetic
-    internal fun verifyInProcess(verificationSupport: VerificationSupport, checkSufficientSignatures: Boolean): FullTransaction {
-        return when (coreTransaction) {
-            is NotaryChangeWireTransaction -> verifyNotaryChangeTransaction(verificationSupport, checkSufficientSignatures)
-            is ContractUpgradeWireTransaction -> verifyContractUpgradeTransaction(verificationSupport, checkSufficientSignatures)
-            else -> verifyRegularTransaction(verificationSupport, checkSufficientSignatures)
-        }
+        return verificationResult.enforceSuccess()
     }
 
     @Suppress("ThrowsCount")
     private fun resolveAndCheckNetworkParameters(services: NodeVerificationSupport) {
         val hashOrDefault = networkParametersHash ?: services.networkParametersService.defaultHash
-        val txNetworkParameters = services.networkParametersService.lookup(hashOrDefault)
-                ?: throw TransactionResolutionException(id)
+        val txNetworkParameters = services.networkParametersService.lookup(hashOrDefault) ?: throw TransactionResolutionException(id)
         val groupedInputsAndRefs = (inputs + references).groupBy { it.txhash }
-        groupedInputsAndRefs.map { entry ->
-            val tx = services.validatedTransactions.getTransaction(entry.key)?.coreTransaction
-                    ?: throw TransactionResolutionException(id)
+        for ((txId, stateRefs) in groupedInputsAndRefs) {
+            val tx = services.validatedTransactions.getTransaction(txId)?.coreTransaction ?: throw TransactionResolutionException(id)
             val paramHash = tx.networkParametersHash ?: services.networkParametersService.defaultHash
             val params = services.networkParametersService.lookup(paramHash) ?: throw TransactionResolutionException(id)
-            if (txNetworkParameters.epoch < params.epoch)
-                throw TransactionVerificationException.TransactionNetworkParameterOrderingException(id, entry.value.first(), txNetworkParameters, params)
-        }
-    }
-
-    /** No contract code is run when verifying notary change transactions, it is sufficient to check invariants during initialisation. */
-    private fun verifyNotaryChangeTransaction(verificationSupport: VerificationSupport, checkSufficientSignatures: Boolean): NotaryChangeLedgerTransaction {
-        val ntx = NotaryChangeLedgerTransaction.resolve(verificationSupport, coreTransaction as NotaryChangeWireTransaction, sigs)
-        if (checkSufficientSignatures) ntx.verifyRequiredSignatures()
-        else checkSignaturesAreValid()
-        return ntx
-    }
-
-    /** No contract code is run when verifying contract upgrade transactions, it is sufficient to check invariants during initialisation. */
-    private fun verifyContractUpgradeTransaction(verificationSupport: VerificationSupport, checkSufficientSignatures: Boolean): ContractUpgradeLedgerTransaction {
-        val ctx = ContractUpgradeLedgerTransaction.resolve(verificationSupport, coreTransaction as ContractUpgradeWireTransaction, sigs)
-        if (checkSufficientSignatures) ctx.verifyRequiredSignatures()
-        else checkSignaturesAreValid()
-        return ctx
-    }
-
-    // TODO: Verify contract constraints here as well as in LedgerTransaction to ensure that anything being deserialised
-    // from the attachment is trusted. This will require some partial serialisation work to not load the ContractState
-    // objects from the TransactionState.
-    private fun verifyRegularTransaction(verificationSupport: VerificationSupport, checkSufficientSignatures: Boolean): LedgerTransaction {
-        val ltx = toLedgerTransactionInternal(verificationSupport, checkSufficientSignatures)
-        try {
-            ltx.verify()
-        } catch (e: NoClassDefFoundError) {
-            checkReverifyAllowed(e)
-            val missingClass = e.message ?: throw e
-            log.warn("Transaction {} has missing class: {}", ltx.id, missingClass)
-            reverifyWithFixups(ltx, verificationSupport, missingClass)
-        } catch (e: NotSerializableException) {
-            checkReverifyAllowed(e)
-            retryVerification(e, e, ltx, verificationSupport)
-        } catch (e: TransactionDeserialisationException) {
-            checkReverifyAllowed(e)
-            retryVerification(e.cause, e, ltx, verificationSupport)
-        }
-        return ltx
-    }
-
-    private fun checkReverifyAllowed(ex: Throwable) {
-        // If that transaction was created with and after Corda 4 then just fail.
-        // The lenient dependency verification is only supported for Corda 3 transactions.
-        // To detect if the transaction was created before Corda 4 we check if the transaction has the NetworkParameters component group.
-        if (networkParametersHash != null) {
-            log.warn("TRANSACTION VERIFY FAILED - No attempt to auto-repair as TX is Corda 4+")
-            throw ex
-        }
-    }
-
-    @Suppress("ThrowsCount")
-    private fun retryVerification(cause: Throwable?, ex: Throwable, ltx: LedgerTransaction, verificationSupport: VerificationSupport) {
-        when (cause) {
-            is MissingSerializerException -> {
-                log.warn("Missing serializers: typeDescriptor={}, typeNames={}", cause.typeDescriptor ?: "<unknown>", cause.typeNames)
-                reverifyWithFixups(ltx, verificationSupport, null)
+            if (txNetworkParameters.epoch < params.epoch) {
+                throw TransactionNetworkParameterOrderingException(id, stateRefs.first(), txNetworkParameters, params)
             }
-            is NotSerializableException -> {
-                val underlying = cause.cause
-                if (underlying is ClassNotFoundException) {
-                    val missingClass = underlying.message?.replace('.', '/') ?: throw ex
-                    log.warn("Transaction {} has missing class: {}", ltx.id, missingClass)
-                    reverifyWithFixups(ltx, verificationSupport, missingClass)
-                } else {
-                    throw ex
-                }
-            }
-            else -> throw ex
         }
     }
 
-    // Transactions created before Corda 4 can be missing dependencies on other CorDapps.
-    // This code has detected a missing custom serializer - probably located inside a workflow CorDapp.
-    // We need to extract this CorDapp from AttachmentStorage and try verifying this transaction again.
-    private fun reverifyWithFixups(ltx: LedgerTransaction, verificationSupport: VerificationSupport, missingClass: String?) {
-        log.warn("""Detected that transaction $id does not contain all cordapp dependencies.
-                    |This may be the result of a bug in a previous version of Corda.
-                    |Attempting to re-verify having applied this node's fix-up rules.
-                    |Please check with the originator that this is a valid transaction.""".trimMargin())
-
-        val replacementAttachments = computeReplacementAttachments(ltx, verificationSupport, missingClass)
-        log.warn("Reverifying transaction {} with attachments:{}", ltx.id, replacementAttachments)
-        ltx.verifyInternal(replacementAttachments.toList())
-    }
-
-    private fun computeReplacementAttachments(ltx: LedgerTransaction,
-                                              verificationSupport: VerificationSupport,
-                                              missingClass: String?): Collection<Attachment> {
-        val replacements = fixupAttachments(verificationSupport, ltx.attachments)
-        if (!replacements.equivalent(ltx.attachments)) {
-            return replacements
-        }
-
-        // We cannot continue unless we have some idea which class is missing from the attachments.
-        if (missingClass == null) {
-            throw TransactionVerificationException.BrokenTransactionException(
-                    txId = ltx.id,
-                    message = "No fix-up rules provided for broken attachments: $replacements"
-            )
-        }
-
-        /*
-         * The Node's fix-up rules have not been able to adjust the transaction's attachments,
-         * so resort to the original mechanism of trying to find an attachment that contains
-         * the missing class.
-         */
-        val extraAttachment = requireNotNull(verificationSupport.getTrustedClassAttachment(missingClass)) {
-            """Transaction $ltx is incorrectly formed. Most likely it was created during version 3 of Corda
-                |when the verification logic was more lenient. Attempted to find local dependency for class: $missingClass,
-                |but could not find one.
-                |If you wish to verify this transaction, please contact the originator of the transaction and install the
-                |provided missing JAR.
-                |You can install it using the RPC command: `uploadAttachment` without restarting the node.
-                |""".trimMargin()
-        }
-
-        return replacements.toMutableSet().apply {
-            /*
-             * Check our transaction doesn't already contain this extra attachment.
-             * It seems unlikely that we would, but better safe than sorry!
-             */
-            if (!add(extraAttachment)) {
-                throw TransactionVerificationException.BrokenTransactionException(
-                        txId = ltx.id,
-                        message = "Unlinkable class $missingClass inside broken attachments: $replacements"
-                )
+    private fun verifySignatures(verificationSupport: NodeVerificationSupport, checkSufficientSignatures: Boolean) {
+        if (checkSufficientSignatures) {
+            val ctx = coreTransaction
+            val tws: TransactionWithSignatures = when (ctx) {
+                is WireTransaction -> this  // SignedTransaction implements TransactionWithSignatures in terms of WireTransaction
+                else -> CoreTransactionWithSignatures(ctx, sigs, verificationSupport)
             }
-
-            log.warn("""Detected that transaction $ltx does not contain all cordapp dependencies.
-                    |This may be the result of a bug in a previous version of Corda.
-                    |Attempting to verify using the additional trusted dependency: $extraAttachment for class $missingClass.
-                    |Please check with the originator that this is a valid transaction.
-                    |YOU ARE ONLY SEEING THIS MESSAGE BECAUSE THE CORDAPPS THAT CREATED THIS TRANSACTION ARE BROKEN!
-                    |WE HAVE TRIED TO REPAIR THE TRANSACTION AS BEST WE CAN, BUT CANNOT GUARANTEE WE HAVE SUCCEEDED!
-                    |PLEASE FIX THE CORDAPPS AND MIGRATE THESE BROKEN TRANSACTIONS AS SOON AS POSSIBLE!
-                    |THIS MESSAGE IS **SUPPOSED** TO BE SCARY!!
-                    |""".trimMargin()
-            )
+            tws.verifyRequiredSignatures()  // Internally checkSignaturesAreValid is invoked
+        } else {
+            checkSignaturesAreValid()
         }
-    }
-
-    /**
-     * Apply this node's attachment fix-up rules to the given attachments.
-     *
-     * @param attachments A collection of [Attachment] objects, e.g. as provided by a transaction.
-     * @return The [attachments] with the node's fix-up rules applied.
-     */
-    private fun fixupAttachments(verificationSupport: VerificationSupport, attachments: Collection<Attachment>): Collection<Attachment> {
-        val attachmentsById = attachments.associateByTo(LinkedHashMap(), Attachment::id)
-        val replacementIds = verificationSupport.fixupAttachmentIds(attachmentsById.keys)
-        attachmentsById.keys.retainAll(replacementIds)
-        val extraIds = replacementIds - attachmentsById.keys
-        val extraAttachments = verificationSupport.getAttachments(extraIds)
-        for ((index, extraId) in extraIds.withIndex()) {
-            val extraAttachment = extraAttachments[index]
-            if (extraAttachment == null || !extraAttachment.isUploaderTrusted()) {
-                throw MissingAttachmentsException(listOf(extraId))
-            }
-            attachmentsById[extraId] = extraAttachment
-        }
-        return attachmentsById.values
     }
 
     /**
@@ -512,7 +292,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
         return ctx.resolve(services, sigs)
     }
 
-    override fun toString(): String = "${javaClass.simpleName}(id=$id)"
+    override fun toString(): String = toSimpleString()
 
     private companion object {
         private fun missingSignatureMsg(missing: Set<PublicKey>, descriptions: List<String>, id: SecureHash): String {
@@ -520,12 +300,27 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
                     "keys: ${missing.joinToString { it.toStringShort() }}, " +
                     "by signers: ${descriptions.joinToString()} "
         }
-
-        private val log = contextLogger()
     }
 
     class SignaturesMissingException(val missing: Set<PublicKey>, val descriptions: List<String>, override val id: SecureHash)
         : NamedByHash, SignatureException(missingSignatureMsg(missing, descriptions, id)), CordaThrowable by CordaException(missingSignatureMsg(missing, descriptions, id))
+
+    /**
+     * A [TransactionWithSignatures] wrapper for [CoreTransaction]s which need to resolve their input states in order to get at the signers
+     * list.
+     */
+    private data class CoreTransactionWithSignatures(
+            private val ctx: CoreTransaction,
+            override val sigs: List<TransactionSignature>,
+            private val verificationSupport: NodeVerificationSupport
+    ) : TransactionWithSignatures, NamedByHash by ctx {
+        override val requiredSigningKeys: Set<PublicKey>
+            get() = getRequiredSigningKeysInternal(ctx.inputs.asSequence().map(verificationSupport::getStateAndRef), ctx.notary)
+
+        override fun getKeyDescriptions(keys: Set<PublicKey>): List<String> = keys.map { it.toBase58String() }
+
+        override fun toString(): String = toSimpleString()
+    }
 
     //region Deprecated
     /** Returns the contained [NotaryChangeWireTransaction], or throws if this is a normal transaction. */

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -4,6 +4,7 @@ import net.corda.core.DoNotImplement
 import net.corda.core.contracts.NamedByHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.isFulfilledBy
+import net.corda.core.internal.mapToSet
 import net.corda.core.transactions.SignedTransaction.SignaturesMissingException
 import net.corda.core.utilities.toNonEmptySet
 import java.security.InvalidKeyException
@@ -99,9 +100,9 @@ interface TransactionWithSignatures : NamedByHash {
      * Return the [PublicKey]s for which we still need signatures.
      */
     fun getMissingSigners(): Set<PublicKey> {
-        val sigKeys = sigs.map { it.by }.toSet()
+        val sigKeys = sigs.mapToSet { it.by }
         // TODO Problem is that we can get single PublicKey wrapped as CompositeKey in allowedToBeMissing/mustSign
         //  equals on CompositeKey won't catch this case (do we want to single PublicKey be equal to the same key wrapped in CompositeKey with threshold 1?)
-        return requiredSigningKeys.filter { !it.isFulfilledBy(sigKeys) }.toSet()
+        return requiredSigningKeys.asSequence().filter { !it.isFulfilledBy(sigKeys) }.toSet()
     }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -205,8 +205,8 @@ class JarScanningCordappLoader(private val cordappJars: Set<Path>,
                                 "corresponding newer version (4.12 or later). Please add this corresponding CorDapp or remove the legacy one."
                     }
                     check(newerCordapp.contractVersionId > legacyCordapp.contractVersionId) {
-                        "Newer contract CorDapp '${newerCordapp.jarFile}' does not have a higher version number " +
-                                "(${newerCordapp.contractVersionId}) compared to corresponding legacy contract CorDapp " +
+                        "Newer contract CorDapp '${newerCordapp.jarFile}' does not have a higher versionId " +
+                                "(${newerCordapp.contractVersionId}) than corresponding legacy contract CorDapp " +
                                 "'${legacyCordapp.jarFile}' (${legacyCordapp.contractVersionId})"
                     }
                 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/verifier/ExternalVerifierTypes.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/verifier/ExternalVerifierTypes.kt
@@ -11,7 +11,7 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
-import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.CoreTransaction
 import net.corda.core.utilities.Try
 import java.io.DataInputStream
 import java.io.DataOutputStream
@@ -40,16 +40,17 @@ sealed class ExternalVerifierInbound {
     }
 
     data class VerificationRequest(
-            val stx: SignedTransaction,
-            val stxInputsAndReferences: Map<StateRef, SerializedTransactionState>,
-            val checkSufficientSignatures: Boolean
-    ) : ExternalVerifierInbound()
+            val ctx: CoreTransaction,
+            val ctxInputsAndReferences: Map<StateRef, SerializedTransactionState>
+    ) : ExternalVerifierInbound() {
+        override fun toString(): String = "VerificationRequest(ctx=$ctx)"
+    }
 
     data class PartiesResult(val parties: List<Party?>) : ExternalVerifierInbound()
     data class AttachmentResult(val attachment: AttachmentWithTrust?) : ExternalVerifierInbound()
     data class AttachmentsResult(val attachments: List<AttachmentWithTrust?>) : ExternalVerifierInbound()
     data class NetworkParametersResult(val networkParameters: NetworkParameters?) : ExternalVerifierInbound()
-    data class TrustedClassAttachmentResult(val id: SecureHash?) : ExternalVerifierInbound()
+    data class TrustedClassAttachmentsResult(val ids: List<SecureHash>) : ExternalVerifierInbound()
 }
 
 @CordaSerializable
@@ -59,12 +60,12 @@ data class AttachmentWithTrust(val attachment: Attachment, val isTrusted: Boolea
 sealed class ExternalVerifierOutbound {
     sealed class VerifierRequest : ExternalVerifierOutbound() {
         data class GetParties(val keys: Set<PublicKey>) : VerifierRequest() {
-            override fun toString(): String = "GetParty(keys=${keys.map { it.toStringShort() }}})"
+            override fun toString(): String = "GetParties(keys=${keys.map { it.toStringShort() }}})"
         }
         data class GetAttachment(val id: SecureHash) : VerifierRequest()
         data class GetAttachments(val ids: Set<SecureHash>) : VerifierRequest()
         data class GetNetworkParameters(val id: SecureHash) : VerifierRequest()
-        data class GetTrustedClassAttachment(val className: String) : VerifierRequest()
+        data class GetTrustedClassAttachments(val className: String) : VerifierRequest()
     }
 
     data class VerificationResult(val result: Try<Unit>) : ExternalVerifierOutbound()

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerificationContext.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerificationContext.kt
@@ -28,8 +28,8 @@ class ExternalVerificationContext(
 
     override fun isAttachmentTrusted(attachment: Attachment): Boolean = externalVerifier.getAttachment(attachment.id)!!.isTrusted
 
-    override fun getTrustedClassAttachment(className: String): Attachment? {
-        return externalVerifier.getTrustedClassAttachment(className)
+    override fun getTrustedClassAttachments(className: String): List<Attachment> {
+        return externalVerifier.getTrustedClassAttachments(className)
     }
 
     override fun getNetworkParameters(id: SecureHash?): NetworkParameters? = externalVerifier.getNetworkParameters(id)


### PR DESCRIPTION
The `TransactionBuilder` has been updated to look for any missing dependencies of legacy contract attachments, in the same way it does for missing dependencies for CorDapps in the "cordapps" directory,

Since `TransactionBuilder` does verification on the `WireTransaction` and not on a `SignedTransaction`, much of the verification logic in `SignedTransaction` had to be moved to `WireTransaction` to allow the external verifier to be involved. The external verifier receives a `CoreTransaction` to verify instead of a `SignedTransaction`. `SignedTransaction.verify` does the signature checks first in-process, before then delegating the reset of the verification to the `CoreTransaction`.

A legacy contract dependency is defined as an attachment containing the missing class which isn't also a non-legacy Cordapp (i.e. a CorDapp which isn't in the "cordapp" directory).