### PR TITLE
ENT-11620: Set the thread context class loader so all fibres involved…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -320,6 +320,9 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     }
 
     private fun openThreadLocalWormhole() {
+        // This sets the Cordapp classloader on the contextClassLoader of the current thread.
+        // Needed because in previous versions of the finance app we used Thread.contextClassLoader to resolve services defined in cordapps.
+        Thread.currentThread().contextClassLoader = (serviceHub.cordappProvider as CordappProviderImpl).cordappLoader.appClassLoader
         val threadLocal = transientValues.database.hikariPoolThreadLocal
         if (threadLocal != null) {
             val valueFromThread = swappedOutThreadLocalValue(threadLocal)


### PR DESCRIPTION
ENT-11620: Set the thread context class loader so all fibres involved in a flow has the thread context class loader set to the app class loader.

