### PR TITLE
ENT-11523: Dont instrument due to the synchronization. Quasar was thr…

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
@@ -276,7 +276,7 @@ open class AMQPBridgeManager(keyStore: CertificateStore,
                     closeConsumer()
                     consumer = null
                     val closingSession = session
-                    eventLoop.execute {
+                    eventLoop.execute @DontInstrument {
                         synchronized(artemis!!) {
                             if (session == closingSession) {
                                 artemis(ArtemisState.STOPPING) {


### PR DESCRIPTION
ENT-11523: Dont instrument due to the synchronization. Quasar was throwing unable to instrument exception.

The unable to instrument exception can be seen when running the FlowsDrainingModeContentionTest

NullPointerExceptions from quasar seen as well, which are a result of the root cause which is....

[quasar] WARNING: UnableToInstrumentException encountered when instrumenting net/corda/nodeapi/internal/bridging/AMQPBridgeManager$AMQPBridge$onSocketConnected$3#invoke$lambda$1(Lnet/corda/nodeapi/internal/bridging/AMQPBridgeManager;Lnet/corda/nodeapi/internal/bridging/AMQPBridgeManager$AMQPBridge;Lorg/apache/activemq/artemis/api/core/client/ClientSession;Lnet/corda/nodeapi/internal/bridging/AMQPBridgeManager$ArtemisState;)V: Unable to instrument net/corda/nodeapi/internal/bridging/AMQPBridgeManager$AMQPBridge$onSocketConnected$3#invoke$lambda$1(Lnet/corda/nodeapi/internal/bridging/AMQPBridgeManager;Lnet/corda/nodeapi/internal/bridging/AMQPBridgeManager$AMQPBridge;Lorg/apache/activemq/artemis/api/core/client/ClientSession;Lnet/corda/nodeapi/internal/bridging/AMQPBridgeManager$ArtemisState;)V because of synchronization