### PR TITLE
ENT-11661: Replaced SunEC Ed25519 implementation with Bouncy Castle

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
@@ -36,6 +36,6 @@ val bouncyCastlePQCProvider = BouncyCastlePQCProvider().apply {
 // i.e. if someone removes a Provider and then he/she adds a new one with the same name.
 // The val is immutable to avoid any harmful state changes.
 internal val providerMap: Map<String, Provider> = unmodifiableMap(
-    listOf(sunEcProvider, cordaBouncyCastleProvider, cordaSecurityProvider, bouncyCastlePQCProvider)
+    listOf(cordaBouncyCastleProvider, cordaSecurityProvider, bouncyCastlePQCProvider)
         .associateByTo(LinkedHashMap(), Provider::getName)
 )

--- a/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
@@ -9,7 +9,6 @@ import net.corda.core.crypto.Crypto.SPHINCS256_SHA256
 import net.corda.core.crypto.internal.PlatformSecureRandomService
 import net.corda.core.utilities.OpaqueBytes
 import org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
@@ -19,7 +18,6 @@ import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.interfaces.ECKey
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec
-import org.bouncycastle.math.ec.rfc8032.Ed25519
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PrivateKey
 import org.bouncycastle.pqc.jcajce.provider.sphincs.BCSphincs256PublicKey
 import org.junit.Assert.assertNotEquals
@@ -492,9 +490,9 @@ class CryptoUtilsTest {
         val keyPairEd = Crypto.generateKeyPair(EDDSA_ED25519_SHA512)
         val (privEd, pubEd) = keyPairEd
 
-        assertEquals(privEd.algorithm, "EdDSA")
+        assertEquals(privEd.algorithm, "Ed25519")
         assertEquals((privEd as EdECPrivateKey).params.name, NamedParameterSpec.ED25519.name)
-        assertEquals(pubEd.algorithm, "EdDSA")
+        assertEquals(pubEd.algorithm, "Ed25519")
         assertEquals((pubEd as EdECPublicKey).params.name, NamedParameterSpec.ED25519.name)
     }
 
@@ -514,11 +512,11 @@ class CryptoUtilsTest {
         val encodedPubEd = pubEd.encoded
 
         val decodedPrivEd = Crypto.decodePrivateKey(encodedPrivEd)
-        assertEquals(decodedPrivEd.algorithm, "EdDSA")
+        assertEquals(decodedPrivEd.algorithm, "Ed25519")
         assertEquals(decodedPrivEd, privEd)
 
         val decodedPubEd = Crypto.decodePublicKey(encodedPubEd)
-        assertEquals(decodedPubEd.algorithm, "EdDSA")
+        assertEquals(decodedPubEd.algorithm, "Ed25519")
         assertEquals(decodedPubEd, pubEd)
     }
 
@@ -661,13 +659,6 @@ class CryptoUtilsTest {
             // Use R1 curve for check.
             assertFalse(Crypto.publicKeyOnCurve(ECDSA_SECP256R1_SHA256, pubEdDSA))
         }
-        val invalidKey = run {
-            val bytes = ByteArray(Ed25519.PUBLIC_KEY_SIZE).also { it[0] = 2 }
-            val encoded = SubjectPublicKeyInfo(EDDSA_ED25519_SHA512.signatureOID, bytes).encoded
-            Crypto.decodePublicKey(encoded)
-        }
-        assertThat(invalidKey).isInstanceOf(EdECPublicKey::class.java)
-        assertThat(Crypto.publicKeyOnCurve(EDDSA_ED25519_SHA512, invalidKey)).isFalse()
     }
 
     @Test(timeout = 300_000)

--- a/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt
@@ -7,6 +7,7 @@ import net.corda.core.utilities.toHex
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.junit.Test
+import java.security.KeyFactory
 import java.security.PrivateKey
 import java.security.spec.EdECPrivateKeySpec
 import java.security.spec.NamedParameterSpec
@@ -149,19 +150,17 @@ class EdDSATests {
                         "3dca179c138ac17ad9bef1177331a704"
         )
 
-        val keyFactory = EDDSA_ED25519_SHA512.keyFactory
-
         val testVectors = listOf(testVector1, testVector2, testVector3, testVector1024, testVectorSHAabc)
         testVectors.forEach { testVector ->
             val messageBytes = testVector.messageToSignHex.hexToByteArray()
             val signatureBytes = testVector.signatureOutputHex.hexToByteArray()
             // Check the private key produces the expected signature
-            val privateKey = keyFactory.generatePrivate(EdECPrivateKeySpec(NamedParameterSpec.ED25519, testVector.privateKeyHex.hexToByteArray()))
+            val privateKey = KeyFactory.getInstance("Ed25519", "SunEC").generatePrivate(EdECPrivateKeySpec(NamedParameterSpec.ED25519, testVector.privateKeyHex.hexToByteArray()))
             assertThat(doSign(privateKey, messageBytes)).isEqualTo(signatureBytes)
             // Check the public key verifies the signature
             val result = withSignature(EDDSA_ED25519_SHA512) { signature ->
                 val publicKeyInfo = SubjectPublicKeyInfo(EDDSA_ED25519_SHA512.signatureOID, testVector.publicKeyHex.hexToByteArray())
-                val publicKey = keyFactory.generatePublic(X509EncodedKeySpec(publicKeyInfo.encoded))
+                val publicKey = EDDSA_ED25519_SHA512.keyFactory.generatePublic(X509EncodedKeySpec(publicKeyInfo.encoded))
                 signature.initVerify(publicKey)
                 signature.update(messageBytes)
                 signature.verify(signatureBytes)
@@ -182,7 +181,7 @@ class EdDSATests {
                         "5a5ca2df6668346291c2043d4eb3e90d"
         )
 
-        val privateKey = keyFactory.generatePrivate(EdECPrivateKeySpec(NamedParameterSpec.ED25519, testVectorEd25519ctx.privateKeyHex.hexToByteArray()))
+        val privateKey = KeyFactory.getInstance("Ed25519", "SunEC").generatePrivate(EdECPrivateKeySpec(NamedParameterSpec.ED25519, testVectorEd25519ctx.privateKeyHex.hexToByteArray()))
         assertThat(doSign(privateKey, testVectorEd25519ctx.messageToSignHex.hexToByteArray()).toHex().lowercase()).isNotEqualTo(testVectorEd25519ctx.signatureOutputHex)
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/CustomSerializationSchemeDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CustomSerializationSchemeDriverTest.kt
@@ -41,6 +41,7 @@ import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.ByteSequence
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
+import net.corda.nodeapi.internal.serialization.kryo.PublicKeySerializer
 import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.SerializationFactoryImpl
 import net.corda.testing.core.ALICE_NAME
@@ -51,6 +52,7 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.enclosedCordapp
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey
 import org.junit.Test
 import org.objenesis.instantiator.ObjectInstantiator
 import org.objenesis.strategy.InstantiatorStrategy
@@ -307,6 +309,7 @@ class CustomSerializationSchemeDriverTest {
             kryo.classLoader = classLoader
             @Suppress("ReplaceJavaStaticMethodWithKotlinAnalog")
             kryo.register(Arrays.asList("").javaClass, ArraysAsListSerializer())
+            kryo.addDefaultSerializer(BCEdDSAPublicKey::class.java, PublicKeySerializer)
         }
 
         //Stolen from DefaultKryoCustomizer.kt


### PR DESCRIPTION
It turns out the JDK implementation (`SunEC` provider) of Ed25519 signature verification is quite slow, slower than the abandoned library (i2p) it replaced. The `EDDSA_ED25519_SHA512` signature scheme now uses Bouncy Castle instead of `SunEC`.

`Crypto.toSupportedPublicKey` (and `toSupportedPrivateKey`) have been tweaked to make sure any `SunEC` Ed25519 keys are converted to Bouncy Castle. The presence of two different `EdECPublicKey` implementations for the same key caused cache misses in `BasicHSMKeyManagementService`, resulting in another performance degradation.

Also, the detection of secp256k1 curves is now done using Bouncy Castle, rather than checking on the curve parameters explicitly.
