### PR TITLE
ENT-11678: Mark Corda `SecureRandom` as thread safe

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
@@ -15,7 +15,7 @@ import java.security.SecureRandomSpi
 import kotlin.system.exitProcess
 
 class PlatformSecureRandomService(provider: Provider)
-    : Provider.Service(provider, "SecureRandom", ALGORITHM, PlatformSecureRandomSpi::class.java.name, null, null) {
+    : Provider.Service(provider, "SecureRandom", ALGORITHM, PlatformSecureRandomSpi::class.java.name, null, mapOf("ThreadSafe" to "true")) {
 
     companion object {
         const val ALGORITHM = "CordaPRNG"


### PR DESCRIPTION
This avoids a mutex contention as the JDK assumes it’s not thread safe.