### PR TITLE
ENT-11458: Make sure external verifier is involved when verifying transactions in collect signatures flow

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -183,7 +183,10 @@ class AttachmentsClassLoader(attachments: List<Attachment>,
 
     @Suppress("ThrowsCount", "ComplexMethod", "NestedBlockDepth")
     private fun checkAttachments(attachments: List<Attachment>) {
-        require(attachments.isNotEmpty()) { "attachments list is empty" }
+        require(attachments.isNotEmpty()) {
+            "Transaction attachments list is empty. This can happen if verifying a legacy transaction (4.11 or older) with " +
+                    "LedgerTransaction.verify(). Try using SignedTransaction.verify() instead."
+        }
 
         // Here is where we enforce the no-overlap and package ownership rules.
         //

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -240,6 +240,10 @@ private constructor(
      * The reason for this is that classes (contract states) deserialized in this classloader would actually be a different type from what
      * the calling code would expect.
      *
+     * If receiving [SignedTransaction]s over the wire from other nodes, then it is recommended the verification be done via
+     * [SignedTransaction.verify] directly rather than via [SignedTransaction.toLedgerTransaction]. If transaction is from a legacy node
+     * (4.11 or older) then the later solution will not work.
+     *
      * @throws TransactionVerificationException if anything goes wrong.
      */
     @Throws(TransactionVerificationException::class)

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -693,8 +693,8 @@ open class TransactionBuilder(
 
     @Throws(AttachmentResolutionException::class, TransactionResolutionException::class, TransactionVerificationException::class)
     fun verify(services: ServiceHub) {
-        // TODO ENT-11445: Need to verify via SignedTransaction to ensure legacy components also work
-        toLedgerTransaction(services).verify()
+        // Make sure the external verifier is involved if the transaction has a legacy component.
+        toWireTransaction(services).tryVerify(services.toVerifyingServiceHub()).enforceSuccess()
     }
 
     private fun checkNotary(stateAndRef: StateAndRef<*>) {

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -375,6 +375,12 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         sig.verify(id)
     }
 
+    /**
+     * Perform verification of this [WireTransaction] and return the result as a [VerificationResult]. Depending on what types of attachments
+     * this transaction has, verification may have been done in-process by the node, or via the external verifier, or both.
+     *
+     * It's important that [VerificationResult.enforceSuccess] be called to make sure the verification was successful or its value analysed.
+     */
     @CordaInternal
     @JvmSynthetic
     internal fun tryVerify(verificationSupport: NodeVerificationSupport): VerificationResult {


### PR DESCRIPTION
It's possible a 4.11 or older node can ask for signatures, in which case the verification of the transaction has to go through the external verifier. Calling `SignedTransaction.verify` which deals with this case, instead of `LedgerTransaction.verify` which will only works with non-legacy transactions.

The documentation for `LedgerTransaction.verify` has been updated to recommend using `SignedTransaction.verify` instead, and the error message from the attachments class loader when it detects an empty attachments list has been updated with this point as well.