### PR TITLE
ENT-11728: Force use of LTS version of BC everywhere.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -383,8 +383,6 @@ allprojects {
                 url "${publicArtifactURL}/corda-dependencies-dev"
                 content {
                     includeGroup 'co.paralleluniverse'
-                    // Remove below when BC 2.73.6 is released
-                    includeGroup 'org.bouncycastle'
                 }
             }
             maven {

--- a/build.gradle
+++ b/build.gradle
@@ -240,6 +240,8 @@ allprojects {
         )
     }
 
+    tasks.register("allDependencies", DependencyReportTask) {}
+
     dependencyCheck {
         suppressionFile = '.ci/dependency-checker/suppressedLibraries.xml'
         cveValidForHours = 1
@@ -464,6 +466,11 @@ allprojects {
 
                     // Effectively delete this unused and unwanted transitive dependency of Artemis.
                     substitute module('org.jgroups:jgroups') with module("org.apache.activemq:artemis-commons:$artemis_version")
+
+                    // Force use of LTS version of BC everywhere
+                    substitute module('org.bouncycastle:bcutil-jdk18on') with module("org.bouncycastle:bcutil-lts8on:$bouncycastle_version")
+                    substitute module('org.bouncycastle:bcprov-jdk18on') with module("org.bouncycastle:bcprov-lts8on:$bouncycastle_version")
+                    substitute module('org.bouncycastle:bcpkix-jdk18on') with module("org.bouncycastle:bcpkix-lts8on:$bouncycastle_version")
                 }
 
                 // FORCE Gradle to use latest SNAPSHOT dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -240,8 +240,6 @@ allprojects {
         )
     }
 
-    tasks.register("allDependencies", DependencyReportTask) {}
-
     dependencyCheck {
         suppressionFile = '.ci/dependency-checker/suppressedLibraries.xml'
         cveValidForHours = 1

--- a/constants.properties
+++ b/constants.properties
@@ -21,7 +21,7 @@ quasarVersion=0.9.0_r3
 dockerJavaVersion=3.2.5
 proguardVersion=7.3.1
 # Switch to release version when out
-bouncycastleVersion=2.73.6-SNAPSHOT
+bouncycastleVersion=2.73.6
 classgraphVersion=4.8.135
 disruptorVersion=3.4.2
 typesafeConfigVersion=1.3.4


### PR DESCRIPTION
ENT-11728: Force use of LTS version of BC everywhere.
And also revert to the now released 2.73.6 version of BC.