### PR TITLE
ENT-11722: Check at when load cordapp that the 4.12 cordapp is signed…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -220,7 +220,7 @@ class JarScanningCordappLoader(private val cordappJars: Set<Path>,
             if (legacyCertificates != nonLegacyCertificates) {
                 val errorMsg = "Newer contract CorDapp '${nonLegacyCordapp.jarFile}' signers do not match legacy contract CorDapp " +
                         "'${legacyCordapp.jarFile}' signers."
-                logger.error("$errorMsg Non legacy certificates: ${nonLegacyCertificates}, Legacy certificates: ${legacyCertificates}.")
+                logger.debug { "$errorMsg Non legacy certificates: ${nonLegacyCertificates}, Legacy certificates: ${legacyCertificates}." }
                 throw IllegalStateException(errorMsg)
             }
         }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -215,13 +215,11 @@ class JarScanningCordappLoader(private val cordappJars: Set<Path>,
         }
 
         private fun checkSignersMatch(legacyCordapp: CordappImpl, nonLegacyCordapp: CordappImpl) {
-            val legacyCertificates = legacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectCertificates)
-            val nonLegacyCertificates = nonLegacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectCertificates)
-            if (legacyCertificates != nonLegacyCertificates) {
-                val errorMsg = "Newer contract CorDapp '${nonLegacyCordapp.jarFile}' signers do not match legacy contract CorDapp " +
+            val legacySigners = legacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectSigners)
+            val nonLegacySigners = nonLegacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectSigners)
+            check(legacySigners == nonLegacySigners) {
+                "Newer contract CorDapp '${nonLegacyCordapp.jarFile}' signers do not match legacy contract CorDapp " +
                         "'${legacyCordapp.jarFile}' signers."
-                logger.debug { "$errorMsg Non legacy certificates: ${nonLegacyCertificates}, Legacy certificates: ${legacyCertificates}." }
-                throw IllegalStateException(errorMsg)
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -209,7 +209,19 @@ class JarScanningCordappLoader(private val cordappJars: Set<Path>,
                                 "(${newerCordapp.contractVersionId}) than corresponding legacy contract CorDapp " +
                                 "'${legacyCordapp.jarFile}' (${legacyCordapp.contractVersionId})"
                     }
+                    checkSignersMatch(legacyCordapp, newerCordapp)
                 }
+            }
+        }
+
+        private fun checkSignersMatch(legacyCordapp: CordappImpl, nonLegacyCordapp: CordappImpl) {
+            val legacyCertificates = legacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectCertificates)
+            val nonLegacyCertificates = nonLegacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectCertificates)
+            if (legacyCertificates != nonLegacyCertificates) {
+                val errorMsg = "Newer contract CorDapp '${nonLegacyCordapp.jarFile}' signers do not match legacy contract CorDapp " +
+                        "'${legacyCordapp.jarFile}' signers."
+                logger.error("$errorMsg Non legacy certificates: ${nonLegacyCertificates}, Legacy certificates: ${legacyCertificates}.")
+                throw IllegalStateException(errorMsg)
             }
         }
 


### PR DESCRIPTION
ENT-11722: Check when load cordapp that the 4.12 cordapp is signed by same signers as legacy cordapp.

The signers for 4.12 and legacy CorDapp must match, if they don't an exception is thrown at startup and the node fails to start.

