### PR TITLE
ENT-11676: Remove logging from debugging session

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappSigner.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappSigner.kt
@@ -1,6 +1,5 @@
 package net.corda.testing.node.internal
 
-import net.corda.core.internal.JarSignatureCollector
 import net.corda.core.internal.deleteRecursively
 import net.corda.testing.core.internal.JarSignatureTestUtils.containsKey
 import net.corda.testing.core.internal.JarSignatureTestUtils.generateKey
@@ -8,10 +7,8 @@ import net.corda.testing.core.internal.JarSignatureTestUtils.signJar
 import net.corda.testing.core.internal.JarSignatureTestUtils.unsignJar
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.jar.JarInputStream
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.copyTo
-import kotlin.io.path.inputStream
 import kotlin.io.path.name
 
 object TestCordappSigner {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappSigner.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappSigner.kt
@@ -34,7 +34,6 @@ object TestCordappSigner {
         jar.unsignJar()
         val signerDirToUse = signerDir ?: defaultSignerDir
         for (i in 1 .. signatureCount) {
-            println("On signer $i")
             // Note in the jarsigner tool if -sigfile is not specified then the first 8 chars of alias are used as the file
             // name for the .SF and .DSA files. (See jarsigner doc). So $i below needs to be at beginning so unique files are
             // created.
@@ -44,7 +43,6 @@ object TestCordappSigner {
                 signerDirToUse.generateKey(alias, password, "O=Test Company Ltd $i,OU=Test,L=London,C=GB", algorithm)
             }
             signerDirToUse.signJar(jar.absolutePathString(), alias, password)
-            println("Number of actual signers: ${JarInputStream(jar.inputStream()).use { JarSignatureCollector.collectSigners(it).size }}")
         }
     }
 }


### PR DESCRIPTION
Debugging logging statements leftover from https://github.com/corda/corda/pull/7704.

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
