### PR TITLE
ES-2349: update Crons to not run at the weekend

### DIFF
--- a/.ci/dev/publish-branch/Jenkinsfile.nightly
+++ b/.ci/dev/publish-branch/Jenkinsfile.nightly
@@ -26,7 +26,7 @@ pipeline {
     }
 
     triggers {
-        cron '@midnight'
+        cron 'H 0 * * 1-5'
     }
 
     environment {


### PR DESCRIPTION
We should only run our automated cron jobs Monday - Friday.

This has no functional impact on these projects as if there is a push event over the weekend, the release branch will still be triggered.

This allows us on the DevOps team to have a window to do vital maintenance on servers outside of core office hours.
