### PR TITLE
ES-2371: Consume H2 DB snapshot version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -438,16 +438,9 @@ allprojects {
                     includeGroup 'com.github.detro'
                 }
             }
-            // required until h2database 2.2.229 is released
+            // required until next version of h2database is released post 2.2.224
             maven {
-                url "${artifactory_contextUrl}/corda-dependencies-dev"
-                authentication {
-                    basic(BasicAuthentication)
-                }
-                credentials {
-                    username = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
-                    password = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
-                }
+                url "${publicArtifactURL}/corda-dependencies-dev"
                 content {
                     includeGroupByRegex 'com\\.h2database(\\..*)?'
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -438,6 +438,20 @@ allprojects {
                     includeGroup 'com.github.detro'
                 }
             }
+            // required until h2database 2.2.229 is released
+            maven {
+                url "${artifactory_contextUrl}/corda-dependencies-dev"
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    username = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+                }
+                content {
+                    includeGroupByRegex 'com\\.h2database(\\..*)?'
+                }
+            }
             maven {
                 url "${publicArtifactURL}/corda-dev"
                 content {

--- a/constants.properties
+++ b/constants.properties
@@ -78,7 +78,7 @@ joptSimpleVersion=5.0.2
 jansiVersion=1.18
 hibernateVersion=5.6.14.Final
 # h2Version - Update docs if renamed or removed.
-h2Version=2.2.224
+h2Version=2.2.229-SNAPSHOT
 rxjavaVersion=1.3.8
 dokkaVersion=0.10.1
 eddsaVersion=0.3.0

--- a/constants.properties
+++ b/constants.properties
@@ -78,7 +78,7 @@ joptSimpleVersion=5.0.2
 jansiVersion=1.18
 hibernateVersion=5.6.14.Final
 # h2Version - Update docs if renamed or removed.
-h2Version=2.2.229-SNAPSHOT
+h2Version=2.2.224-R3
 rxjavaVersion=1.3.8
 dokkaVersion=0.10.1
 eddsaVersion=0.3.0


### PR DESCRIPTION
- Update `h2Version` to be the custom version published from our fork
- This artifact is stored in our internal artifactory, therefore we need to update the build.gradle file to allow the project to pull from `corda-dependencies-dev` repository, this new repo declaration is scoped to only take the `com.h2database` artifact from that repo, so this will affect no other dependencies . 