### PR TITLE
ENT-11858: Add missing add-opens for CRAFT4 Archiving CorDapp

### DIFF
--- a/node/capsule/src/main/resources/node-jvm-args.txt
+++ b/node/capsule/src/main/resources/node-jvm-args.txt
@@ -22,5 +22,6 @@
 --add-opens=java.management/sun.management=ALL-UNNAMED
 --add-opens=java.logging/java.util.logging=ALL-UNNAMED
 --add-opens=java.sql/java.sql=ALL-UNNAMED
+--add-opens=jdk.crypto.ec/sun.security.ec=ALL-UNNAMED
 --add-opens=jdk.crypto.ec/sun.security.ec.ed=ALL-UNNAMED
 --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

CRAFT4 Archiving CorDapp fails with `Unable to make field private java.security.spec.ECPoint sun.security.ec.ECPublicKeyImpl.w accessible: module jdk.crypto.ec does not "opens sun.security.ec" to unnamed module @43195e57` - this is due to that one add-opens missing in `node-jvm-args.txt`

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
