### PR TITLE
ENT-11343: Dont instrument files starting with jdk as well now.

### DIFF
--- a/tools/checkpoint-agent/build.gradle
+++ b/tools/checkpoint-agent/build.gradle
@@ -6,7 +6,7 @@ description 'A javaagent to allow hooking into Kryo checkpoints'
 
 dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compileOnly "org.javassist:javassist:$javaassist_version"
+    implementation "org.javassist:javassist:$javaassist_version"
     compileOnly "com.esotericsoftware:kryo:$kryo_version"
     compileOnly "co.paralleluniverse:quasar-core:$quasar_version"
 

--- a/tools/checkpoint-agent/src/main/kotlin/net/corda/tools/CheckpointAgent.kt
+++ b/tools/checkpoint-agent/src/main/kotlin/net/corda/tools/CheckpointAgent.kt
@@ -127,7 +127,8 @@ object CheckpointHook : ClassFileTransformer {
             protectionDomain: ProtectionDomain?,
             classfileBuffer: ByteArray
     ): ByteArray? {
-        if (className.startsWith("java") || className.startsWith("javassist") || className.startsWith("kotlin")) {
+        if (className.startsWith("java") || className.startsWith("javassist") || className.startsWith("kotlin")
+                || className.startsWith("jdk")) {
             return null
         }
         return try {

--- a/tools/checkpoint-agent/src/main/kotlin/net/corda/tools/CheckpointAgent.kt
+++ b/tools/checkpoint-agent/src/main/kotlin/net/corda/tools/CheckpointAgent.kt
@@ -127,6 +127,7 @@ object CheckpointHook : ClassFileTransformer {
             protectionDomain: ProtectionDomain?,
             classfileBuffer: ByteArray
     ): ByteArray? {
+        @Suppress("ComplexCondition")
         if (className.startsWith("java") || className.startsWith("javassist") || className.startsWith("kotlin")
                 || className.startsWith("jdk")) {
             return null


### PR DESCRIPTION
ENT-11343: Dont instrument files starting with jdk as well now. And also include javassist in the generated jar.
For the checkpoint-agent.