### PR TITLE
ENT-11113: Increase timeout from 5 secs in scheduler test, see if sol…

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -99,7 +99,7 @@ open class NodeSchedulerServiceTestBase {
 
     protected fun assertStarted(flowLogic: FlowLogic<*>) {
         // Like in assertWaitingFor, use timeout to make verify wait as we often race the call to startFlow:
-        verify(flowStarter, timeout(5000)).startFlow(argForWhich<ExternalEvent.ExternalStartFlowEvent<*>> { this.flowLogic == flowLogic })
+        verify(flowStarter, timeout(120000)).startFlow(argForWhich<ExternalEvent.ExternalStartFlowEvent<*>> { this.flowLogic == flowLogic })
     }
 
     protected fun assertStarted(event: Event) = assertStarted(event.flowLogic)


### PR DESCRIPTION
ENT-11113: Increase timeout from 5 secs in scheduler test, see if solves intermittent failure on Jenkins.

