### PR TITLE
ENT-11892: Upgrade Snappy to 0.5

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -90,7 +90,7 @@ ghostdriverVersion=2.1.0
 jschVersion=0.1.55
 # Override Artemis version
 protonjVersion=0.33.0
-snappyVersion=0.4
+snappyVersion=0.5
 jcabiManifestsVersion=1.1
 picocliVersion=3.9.6
 commonsIoVersion=2.7


### PR DESCRIPTION
Upgrade Snappy to 0.5