### PR TITLE
ENT-11951: Add support for multiple add-opens CLI args to CordaCaplet

### DIFF
--- a/node/capsule/src/main/java/CordaCaplet.java
+++ b/node/capsule/src/main/java/CordaCaplet.java
@@ -34,6 +34,8 @@ public class CordaCaplet extends Capsule {
     private Config nodeConfig = null;
     private String baseDir = null;
 
+    private final List<String> cmdLineAddOpens = new ArrayList<>();
+
     protected CordaCaplet(Capsule pred) {
         super(pred);
     }
@@ -101,6 +103,7 @@ public class CordaCaplet extends Capsule {
     protected ProcessBuilder prelaunch(List<String> jvmArgs, List<String> args) {
         checkJavaVersion();
         nodeConfig = parseConfigFile(args);
+        cmdLineAddOpens.addAll(jvmArgs.stream().filter(arg -> arg.startsWith("--add-opens")).collect(toList()));
         return super.prelaunch(jvmArgs, args);
     }
 
@@ -119,7 +122,9 @@ public class CordaCaplet extends Capsule {
     @Override
     protected int launch(ProcessBuilder pb) throws IOException, InterruptedException {
         List<String> args = pb.command();
-        args.addAll(1, getNodeJvmArgs());
+        List<String> nodeJvmArgs = getNodeJvmArgs();
+        nodeJvmArgs.addAll(cmdLineAddOpens);
+        args.addAll(1, nodeJvmArgs);
         pb.command(args);
         return super.launch(pb);
     }
@@ -168,6 +173,7 @@ public class CordaCaplet extends Capsule {
             boolean defaultOutOfMemoryErrorHandling = true;
             try {
                 List<String> configJvmArgs = nodeConfig.getStringList("custom.jvmArgs");
+                cmdLineAddOpens.addAll(configJvmArgs.stream().filter(arg -> arg.startsWith("--add-opens")).collect(toList()));
                 jvmArgs.clear();
                 jvmArgs.addAll(configJvmArgs);
                 log(LOG_VERBOSE, "Configured JVM args = " + jvmArgs);

--- a/node/capsule/src/main/resources/node-jvm-args.txt
+++ b/node/capsule/src/main/resources/node-jvm-args.txt
@@ -12,6 +12,7 @@
 --add-opens=java.base/java.time=ALL-UNNAMED
 --add-opens=java.base/java.util=ALL-UNNAMED
 --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
 --add-opens=java.base/java.util.regex=ALL-UNNAMED
 --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
 --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻
ENT-11951: Capsule now handles add-opens, i,e. multiple jvmArgs with same key.
ENT-11847: Added add-opens for `java.util.concurrent.atomic` which fixes [ENT-11847](https://r3-cev.atlassian.net/browse/ENT-11847)

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)


[ENT-11847]: https://r3-cev.atlassian.net/browse/ENT-11847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ