### PR TITLE
ENT-11382: Add missing Pom meta data and JavaDoc Jars

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -5,6 +5,38 @@ import groovy.transform.CompileStatic
 if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('cordaArtifactoryUsername')) {
     logger.info("Internal R3 user - resolving publication build dependencies from internal plugins")
     pluginManager.apply('com.r3.internal.gradle.plugins.r3Publish')
+    afterEvaluate {
+        publishing {
+            publications {
+                configureEach {
+                    def repo = "https://github.com/corda/corda"
+                    pom {
+                        description = project.description
+                        name = project.name
+                        url = repo
+                        scm {
+                            url = repo
+                        }
+                        licenses {
+                            license {
+                                name = 'Apache-2.0'
+                                url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                                distribution = 'repo'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                id = 'R3'
+                                name = 'R3'
+                                email = 'dev@corda.net'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 } else {
     logger.info("External user - using standard maven publishing")
     pluginManager.apply('maven-publish')

--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -47,6 +47,7 @@ publishing {
         maven(MavenPublication) {
             artifactId 'corda-confidential-identities'
             from components.cordapp
+            artifact javadocJar
         }
     }
 }

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -64,6 +64,7 @@ publishing {
         maven(MavenPublication) {
             artifactId 'corda-finance-contracts'
             from components.cordapp
+            artifact javadocJar
         }
     }
 }

--- a/finance/workflows/build.gradle
+++ b/finance/workflows/build.gradle
@@ -93,6 +93,7 @@ publishing {
         maven(MavenPublication) {
             artifactId 'corda-finance-workflows'
             from components.cordapp
+            artifact javadocJar
         }
     }
 }


### PR DESCRIPTION
Post-refectoring 4.12, we lost some `pom.xml` metadata, which is required for Maven Central upload. This PR reintroduced that data.

This results in the following sections being injected into the pom, OpenTelemetry module just used as an example, each sub-module will pick up it's own description / name

Also add missing JavaDoc Jars which are also required for maven central

```
  <name>opentelemetry</name>
  <description>OpenTelemetry SDK Bundle</description>
  <url>https://github.com/corda/corda</url>
  <licenses>
    <license>
      <name>Apache-2.0</name>
      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>R3</id>
      <name>R3</name>
      <email>dev@corda.net</email>
    </developer>
  </developers>
  <scm>
    <url>https://github.com/corda/corda</url>
  </scm>
```