### PR TITLE
ES-2485: Update Docker Hub publishing repository name

### DIFF
--- a/.ci/dev/regression/Jenkinsfile
+++ b/.ci/dev/regression/Jenkinsfile
@@ -329,7 +329,7 @@ pipeline {
                             './gradlew',
                             COMMON_GRADLE_PARAMS,
                             'docker:pushDockerImage',
-                            '-Pdocker.image.repository=corda/community',
+                            '-Pdocker.image.repository=corda/open-source',
                             '--image OFFICIAL'
                             ].join(' ')
                 }


### PR DESCRIPTION
Update OS Docker hub publishing to `corda/open-source` rather than `corda/community`