### PR TITLE
ENT-12072: Now check network parameters hash after ResolveTrasactions…

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -46,8 +46,8 @@ open class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSid
         val stx = otherSideSession.receive<SignedTransaction>().unwrap {
             it.pushToLoggingContext()
             logger.info("Received transaction acknowledgement request from party ${otherSideSession.counterparty}.")
-            checkParameterHash(it.networkParametersHash)
             subFlow(ResolveTransactionsFlow(it, otherSideSession, statesToRecord))
+            checkParameterHash(it.networkParametersHash)
             logger.info("Transaction dependencies resolution completed.")
             try {
                 it.verify(serviceHub, checkSufficientSignatures)


### PR DESCRIPTION
ENT-12072: Now check network parameters hash after ResolveTrasactionsFlow. So if the network parameters don't exist they will be downloaded via the ResolveTransactionsFlow.

