### PR TITLE
ENT-12072 ENT-12073: Check notary whitelist when resolving old identities and don't depend on network map availability first for old network parameters

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -1,7 +1,11 @@
 package net.corda.core.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.*
+import net.corda.core.contracts.AttachmentResolutionException
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.TransactionResolutionException
+import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.internal.checkParameterHash
 import net.corda.core.internal.pushToLoggingContext
@@ -46,8 +50,8 @@ open class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSid
         val stx = otherSideSession.receive<SignedTransaction>().unwrap {
             it.pushToLoggingContext()
             logger.info("Received transaction acknowledgement request from party ${otherSideSession.counterparty}.")
-            checkParameterHash(it.networkParametersHash)
             subFlow(ResolveTransactionsFlow(it, otherSideSession, statesToRecord))
+            checkParameterHash(it.networkParametersHash)
             logger.info("Transaction dependencies resolution completed.")
             try {
                 it.verify(serviceHub, checkSufficientSignatures)

--- a/node/src/integration-test/kotlin/net/corda/node/services/identity/NotaryCertificateRotationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/identity/NotaryCertificateRotationTest.kt
@@ -186,7 +186,7 @@ class NotaryCertificateRotationTest(private val validating: Boolean) {
         }
 
         // Start notary with new identity and restart nodes.
-        val notary2 = mockNet.createNode(InternalMockNodeParameters(
+        mockNet.createNode(InternalMockNodeParameters(
                 legalName = DUMMY_NOTARY_NAME,
                 configOverrides = { doReturn(NotaryConfig(validating)).whenever(it).notary }
         ))

--- a/node/src/integration-test/kotlin/net/corda/node/services/identity/NotaryCertificateRotationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/identity/NotaryCertificateRotationTest.kt
@@ -31,6 +31,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @RunWith(Parameterized::class)
 class NotaryCertificateRotationTest(private val validating: Boolean) {
@@ -91,8 +93,9 @@ class NotaryCertificateRotationTest(private val validating: Boolean) {
         val bob2 = mockNet.restartNode(bob)
         val charlie = mockNet.createPartyNode(CHARLIE_NAME)
 
-        // Save previous network parameters for subsequent backchain verification.
-        mockNet.nodes.forEach { it.services.networkParametersService.saveParameters(ca.sign(mockNet.networkParameters)) }
+        // Save previous network parameters for subsequent backchain verification, because not persistent in mock network
+        alice2.internals.services.networkParametersService.saveParameters(ca.sign(mockNet.networkParameters))
+        bob2.internals.services.networkParametersService.saveParameters(ca.sign(mockNet.networkParameters))
 
         // Verify that notary identity has been changed.
         assertEquals(listOf(newNotaryIdentity), alice2.services.networkMapCache.notaryIdentities)
@@ -125,5 +128,94 @@ class NotaryCertificateRotationTest(private val validating: Boolean) {
         assertEquals(0.DOLLARS, alice2.services.getCashBalance(USD))
         assertEquals(0.DOLLARS, bob2.services.getCashBalance(USD))
         assertEquals(7300.DOLLARS, charlie.services.getCashBalance(USD))
+    }
+
+    @Test(timeout = 300_000)
+    fun `rotate notary identity and new node receives netparams and understands old notary`() {
+        mockNet = InternalMockNetwork(
+                cordappsForAllNodes = FINANCE_CORDAPPS,
+                notarySpecs = listOf(MockNetworkNotarySpec(DUMMY_NOTARY_NAME, validating)),
+                initialNetworkParameters = testNetworkParameters()
+        )
+        val alice = mockNet.createPartyNode(ALICE_NAME)
+        val bob = mockNet.createPartyNode(BOB_NAME)
+
+        // Issue states and notarize them with initial notary identity.
+        alice.services.startFlow(CashIssueFlow(1000.DOLLARS, ref, mockNet.defaultNotaryIdentity))
+        alice.services.startFlow(CashIssueAndPaymentFlow(2000.DOLLARS, ref, alice.party, false, mockNet.defaultNotaryIdentity))
+        alice.services.startFlow(CashIssueAndPaymentFlow(4000.DOLLARS, ref, bob.party, false, mockNet.defaultNotaryIdentity))
+        mockNet.runNetwork()
+
+        val oldHash = alice.services.networkParametersService.currentHash
+
+        // Rotate notary identity and update network parameters.
+        val newNotaryIdentity = DevIdentityGenerator.installKeyStoreWithNodeIdentity(
+                mockNet.baseDirectory(mockNet.nextNodeId),
+                DUMMY_NOTARY_NAME
+        )
+        val newNetworkParameters = testNetworkParameters(epoch = 2)
+                .addNotary(mockNet.defaultNotaryIdentity, validating)
+                .addNotary(newNotaryIdentity, validating)
+        val ca = createDevNetworkMapCa()
+        NetworkParametersCopier(newNetworkParameters, ca, overwriteFile = true).apply {
+            install(mockNet.baseDirectory(alice))
+            install(mockNet.baseDirectory(bob))
+            install(mockNet.baseDirectory(mockNet.nextNodeId))
+            install(mockNet.baseDirectory(mockNet.nextNodeId + 1).apply { createDirectories() })
+        }
+
+        // Start notary with new identity and restart nodes.
+        val notary2 = mockNet.createNode(InternalMockNodeParameters(
+                legalName = DUMMY_NOTARY_NAME,
+                configOverrides = { doReturn(NotaryConfig(validating)).whenever(it).notary }
+        ))
+        val alice2 = mockNet.restartNode(alice)
+        val bob2 = mockNet.restartNode(bob)
+        // We hide the old notary as trying to simulate it's replacement
+        mockNet.hideNode(mockNet.defaultNotaryNode)
+        val charlie = mockNet.createPartyNode(CHARLIE_NAME)
+
+        // Save previous network parameters for subsequent backchain verification, because not persistent in mock network
+        alice2.internals.services.networkParametersService.saveParameters(ca.sign(mockNet.networkParameters))
+        bob2.internals.services.networkParametersService.saveParameters(ca.sign(mockNet.networkParameters))
+
+        assertNotNull(alice2.services.networkParametersService.lookup(oldHash))
+        assertNotNull(bob2.services.networkParametersService.lookup(oldHash))
+        assertNull(charlie.services.networkParametersService.lookup(oldHash))
+
+        // Verify that notary identity has been changed.
+        assertEquals(listOf(newNotaryIdentity), alice2.services.networkMapCache.notaryIdentities)
+        assertEquals(listOf(newNotaryIdentity), bob2.services.networkMapCache.notaryIdentities)
+        assertEquals(listOf(newNotaryIdentity), charlie.services.networkMapCache.notaryIdentities)
+
+        assertEquals(newNotaryIdentity, alice2.services.identityService.wellKnownPartyFromX500Name(DUMMY_NOTARY_NAME))
+        assertEquals(newNotaryIdentity, bob2.services.identityService.wellKnownPartyFromX500Name(DUMMY_NOTARY_NAME))
+        assertEquals(newNotaryIdentity, charlie.services.identityService.wellKnownPartyFromX500Name(DUMMY_NOTARY_NAME))
+
+        assertEquals(newNotaryIdentity, alice2.services.identityService.wellKnownPartyFromAnonymous(mockNet.defaultNotaryIdentity))
+        assertEquals(newNotaryIdentity, bob2.services.identityService.wellKnownPartyFromAnonymous(mockNet.defaultNotaryIdentity))
+        //assertEquals(newNotaryIdentity, charlie.services.identityService.wellKnownPartyFromAnonymous(mockNet.defaultNotaryIdentity))
+
+        // Move states notarized with previous notary identity.
+        alice2.services.startFlow(CashPaymentFlow(3000.DOLLARS, bob2.party, false))
+        mockNet.runNetwork()
+        bob2.services.startFlow(CashPaymentFlow(7000.DOLLARS, charlie.party, false))
+        mockNet.runNetwork()
+        charlie.services.startFlow(CashPaymentFlow(7000.DOLLARS, alice2.party, false))
+        mockNet.runNetwork()
+
+        // Combine states notarized with previous and present notary identities.
+        bob2.services.startFlow(CashIssueAndPaymentFlow(300.DOLLARS, ref, alice2.party, false, notary2.party))
+        mockNet.runNetwork()
+        alice2.services.startFlow(CashPaymentFlow(7300.DOLLARS, charlie.party, false))
+        mockNet.runNetwork()
+
+        // Verify that the ledger contains expected states.
+        assertEquals(0.DOLLARS, alice2.services.getCashBalance(USD))
+        assertEquals(0.DOLLARS, bob2.services.getCashBalance(USD))
+        assertEquals(7300.DOLLARS, charlie.services.getCashBalance(USD))
+
+        // We unhide the old notary so it can be shutdown
+        mockNet.unhideNode(mockNet.defaultNotaryNode)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -398,7 +398,12 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
                 if (candidate != null && candidate != party) {
                     // Party doesn't match existing well-known party: check that the key is registered, otherwise return null.
                     require(party.name == candidate.name) { "Candidate party $candidate does not match expected $party" }
-                    keyToParty[party.owningKey.toStringShort()]?.let { candidate }
+                    // If the party is a whitelisted notary, then it was just a rotated notary key
+                    if (party in notaryIdentityCache) {
+                        candidate
+                    } else {
+                        keyToParty[party.owningKey.toStringShort()]?.let { candidate }
+                    }
                 } else {
                     // Party is a well-known party or well-known party doesn't exist: skip checks.
                     // If the notary is not in the network map cache, try getting it from the network parameters

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -503,6 +503,18 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
         return node
     }
 
+    fun hideNode(
+            node: TestStartedNode
+    ) {
+        _nodes.remove(node.internals)
+    }
+
+    fun unhideNode(
+            node: TestStartedNode
+    ) {
+        _nodes.add(node.internals)
+    }
+
     fun restartNode(
             node: TestStartedNode,
             parameters: InternalMockNodeParameters = InternalMockNodeParameters(),


### PR DESCRIPTION
Nodes currently will try and resolve network parameters from the network map and fail if it not available, rather than preferring the availability of a node they are currently interacting with.

A migrated notary identity could not be resolved on new nodes added post-migration, but the old identity is available in the network parameter notary whitelist.

Added a test that covers both bugs in a single reproduction test that simulates the scenario in which both were uncovered.