### PR TITLE
ES-758: use remote cache for nightly publishing

### DIFF
--- a/.ci/dev/publish-branch/Jenkinsfile.nightly
+++ b/.ci/dev/publish-branch/Jenkinsfile.nightly
@@ -34,6 +34,10 @@ pipeline {
         // in the name
         ARTIFACTORY_BUILD_NAME = "Corda / Publish / Publish Nightly to Artifactory"
                 .replaceAll("/", " :: ")
+        BUILD_CACHE_CREDENTIALS = credentials('gradle-ent-cache-credentials')
+        BUILD_CACHE_PASSWORD = "${env.BUILD_CACHE_CREDENTIALS_PSW}"
+        BUILD_CACHE_USERNAME = "${env.BUILD_CACHE_CREDENTIALS_USR}"
+        USE_CACHE = 'corda-remotes'
         DOCKER_URL = "https://index.docker.io/v1/"
     }
 


### PR DESCRIPTION
* JFrog is shutting down JCenter completely and it is not longer available
* as very short-term solution switch nightly publishing to R3 Artifactory cache, which already has all necessary binaries downloaded from JCenter previously
* add missing configuration for Develocity (formerly Gradle Enterprise) for remote caches
* Jenkinsfile changes tested with https://ci01.dev.r3.com/blue/organizations/jenkins/Corda-Open-Source%2FRelease%20Branch%20Publish%20Nightly_%2Fcorda/detail/wzur-r3%2FES-758%2FExternal-Apps-build-failure-due-to-stale-Jfrog-artifacts-for-publish-branch-builds/2/pipeline