### PR TITLE
ENT-12093: Updated BC api docs url.

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -56,7 +56,10 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
             url = new URL("https://docs.oracle.com/javafx/2/api/")
         }
         externalDocumentationLink {
-            url = new URL("https://www.bouncycastle.org/docs/docs1.5on/")
+            url = new URL("https://downloads.bouncycastle.org/java/docs/bcpkix-jdk15to18-javadoc/")
+        }
+        externalDocumentationLink {
+            url = new URL("https://downloads.bouncycastle.org/java/docs/bcprov-jdk15to18-javadoc/")
         }
         internalPackagePrefixes.collect { packagePrefix ->
             perPackageOption {


### PR DESCRIPTION
ENT-12093: Updated BC api docs url.