### PR TITLE
ENT-12096 - Upgraded sshd-common

### DIFF
--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -27,7 +27,7 @@ sourceSets {
 dependencies {
     compile project(':test-utils')
 
-    compile group: 'org.apache.sshd', name: 'sshd-common', version: '2.9.2'
+    compile group: 'org.apache.sshd', name: 'sshd-common', version: '2.13.2'
 
     // Integration test helpers
     testCompile "org.assertj:assertj-core:$assertj_version"


### PR DESCRIPTION
Upgraded sshd-common to get past CVE-2024-41909 / SNYK-JAVA-ORGAPACHESSHD-7676258.