### PR TITLE
ENT-12045 - Updated Jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ buildscript {
     ext.asm_version = '7.1'
     ext.artemis_version = '2.6.2'
     // TODO Upgrade to Jackson Kotlin 2.10+ only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.13.5'
+    ext.jackson_version = '2.17.2'
     ext.jackson_kotlin_version = '2.9.7'
     ext.jetty_version = '9.4.19.v20190610'
     ext.jersey_version = '2.25'


### PR DESCRIPTION
Updated Jackson to get past vulnerability CWE-400 / SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538 reported in CE 4 .8 release pack.





























































