### PR TITLE
ENT-12033 - Recognise OU in DSL node X500 name

### DIFF
--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -140,15 +140,41 @@ class DriverTests {
         }
     }
 
+    /**
+     * The uniqueness of nodes by the DSL is checked using the node organisation name and, if specified,
+     * the organisation unit name.
+     * All other X500 components are ignored in this regard.
+     */
     @Test(timeout=300_000)
 	fun `driver rejects multiple nodes with the same organisation name`() {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             newNode(CordaX500Name(commonName = "Notary", organisation = "R3CEV", locality = "New York", country = "US"))().getOrThrow()
             assertThatIllegalArgumentException().isThrownBy {
-                newNode(CordaX500Name(commonName = "Regulator", organisation = "R3CEV", locality = "New York", country = "US"))().getOrThrow()
+                newNode(CordaX500Name(commonName = "Regulator", organisation = "R3CEV", locality = "Newcastle", country = "GB"))().getOrThrow()
             }
         }
     }
+
+    @Test(timeout=300_000)
+    fun `driver allows multiple nodes with the same organisation name but different organisation unit name`() {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+            newNode(CordaX500Name(commonName = "Notary", organisation = "R3CEV", organisationUnit = "Eric", locality = "New York", country = "US", state = null))().getOrThrow()
+            assertThatCode {
+                newNode(CordaX500Name(commonName = "Regulator", organisation = "R3CEV", organisationUnit = "Ernie", locality = "Newcastle", country = "GB", state = null))().getOrThrow()
+            }.doesNotThrowAnyException()
+        }
+    }
+
+    @Test(timeout=300_000)
+    fun `driver rejects multiple nodes with the same organisation name and organisation unit name`() {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+            newNode(CordaX500Name(commonName = "Notary", organisation = "R3CEV", organisationUnit = "Eric", locality = "New York", country = "US", state = null))().getOrThrow()
+            assertThatIllegalArgumentException().isThrownBy {
+                newNode(CordaX500Name(commonName = "Regulator", organisation = "R3CEV", organisationUnit = "Eric", locality = "Newcastle", country = "GB", state = null))().getOrThrow()
+            }
+        }
+    }
+    /** **** **/
 
     @Test(timeout=300_000)
 	fun `driver allows reusing names of nodes that have been stopped`() {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -666,7 +666,11 @@ class DriverDSLImpl(
     }
 
     override fun baseDirectory(nodeName: CordaX500Name): Path {
-        val nodeDirectoryName = nodeName.organisation.filter { !it.isWhitespace() }
+        val nodeDirectoryName = if (nodeName.organisationUnit != null) {
+            "${nodeName.organisation}-${nodeName.organisationUnit}"
+        } else {
+            nodeName.organisation
+        }.filter { !it.isWhitespace() }
         return driverDirectory / nodeDirectoryName
     }
 
@@ -1169,11 +1173,16 @@ private class NetworkVisibilityController {
 
     fun register(name: CordaX500Name): VisibilityHandle {
         val handle = VisibilityHandle()
+        val handleName = if (name.organisationUnit != null) {
+            "${name.organisation}-${name.organisationUnit}"
+        } else {
+            name.organisation
+        }
         nodeVisibilityHandles.locked {
-            require(name.organisation !in keys) {
-                "Node with organisation name ${name.organisation} is already started or starting"
+            require(handleName !in keys) {
+                "Node with the organisation name (+ unit name) \"$handleName\" is already started or starting"
             }
-            put(name.organisation, handle)
+            put(handleName, handle)
         }
         return handle
     }


### PR DESCRIPTION
Previously, when creating two test nodes using the DSL, whose X500 names were identical apart from the OU component, the second node would fail to start.

The NetworkVisibilityController class manages a collection of node handles, that was indexed by organisation name only, and it was from here that the failure was occurring. This has been changed to be indexed by the org name + unit name if supplied. Test in DriverTests have been updated to emphasise that fact that the org name and unit name ONLY are used for uniqueness checking.

Additionally, the each node's base directory was generated based on the organisation name. It now includes the organisation unit name as well, if one is supplied.