### PR TITLE
ENT-12355 - Javassist runtime dependency

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -233,6 +233,9 @@ dependencies {
 
     // used by FinalityFlowErrorHandlingTest
     slowIntegrationTestCompile project(':testing:cordapps:cashobservers')
+
+    // ENT-12355 javassist required for runtime by the checkpoint agent.
+    runtime "org.javassist:javassist:$javaassist_version"
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -233,9 +233,6 @@ dependencies {
 
     // used by FinalityFlowErrorHandlingTest
     slowIntegrationTestCompile project(':testing:cordapps:cashobservers')
-
-    // ENT-12355 javassist required for runtime by the checkpoint agent.
-    runtime "org.javassist:javassist:$javaassist_version"
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/tools/checkpoint-agent/build.gradle
+++ b/tools/checkpoint-agent/build.gradle
@@ -6,22 +6,12 @@ apply plugin: 'com.jfrog.artifactory'
 description 'A javaagent to allow hooking into Kryo checkpoints'
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compileOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compileOnly "org.javassist:javassist:$javaassist_version"
+    compile "org.javassist:javassist:$javaassist_version"
     compileOnly "com.esotericsoftware:kryo:$kryo_version"
-    compileOnly "co.paralleluniverse:quasar-core:$quasar_version"
 
     compileOnly (project(':core')) {
-        transitive = false
+        transitive = true
     }
-
-    // Unit testing helpers.
-    testCompile "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
-    testCompile "junit:junit:$junit_version"
-
-    // SLF4J: commons-logging bindings for a SLF4J back end
-    compileOnly "org.slf4j:slf4j-api:$slf4j_version"
 }
 
 jar {


### PR DESCRIPTION
The checkpoint agent depends on javassist, but it is not declared as a dependency in the project. Prior to 4.11, use of the checkpoint agent got away with this because javassist was pulled in by the capsule jar, via Hibernate.
Corda 4.11 saw an upgrade to Hibernate that no longer depends on javassist. Consequently, running Corda 4.11 with the checkpoint agent would cause `ClassNotFound` failures for the javassist classes. 

The changes proposed here add javassist as a compile dependency of the checkpoint-agent sub-project.

Tested by building the checkpoint agent jar and confirming that javassist classes (in the `javassist` directory) was included within; previously that was not the case.
