### PR TITLE
ENT-12366: External verifier now sets appclassloader to legacy contra…

### DIFF
--- a/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
+++ b/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
@@ -13,7 +13,6 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
-import net.corda.core.utilities.seconds
 import net.corda.coretesting.internal.delete
 import net.corda.coretesting.internal.modifyJarManifest
 import net.corda.coretesting.internal.useZipFile

--- a/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
+++ b/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
@@ -26,7 +26,6 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
-import net.corda.testing.core.TestIdentity
 import net.corda.testing.core.internal.JarSignatureTestUtils.unsignJar
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.NodeHandle
@@ -102,8 +101,7 @@ class TransactionBuilderDriverTest {
                     additionalCordapps = listOf(currentContracts),
                     legacyContracts = listOf(legacyContracts)
             )).getOrThrow()
-
-            // Start the node with the legacy CorDapp but without the dependency
+            
             val nodeBob = startNode(NodeParameters(
                     BOB_NAME,
                     additionalCordapps = listOf(currentContracts),

--- a/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
+++ b/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
@@ -101,7 +101,7 @@ class TransactionBuilderDriverTest {
                     additionalCordapps = listOf(currentContracts),
                     legacyContracts = listOf(legacyContracts)
             )).getOrThrow()
-            
+
             val nodeBob = startNode(NodeParameters(
                     BOB_NAME,
                     additionalCordapps = listOf(currentContracts),
@@ -190,7 +190,7 @@ class TransactionBuilderDriverTest {
                 destination,
                 false,
                 defaultNotaryIdentity
-        ).returnValue.getOrThrow(20.seconds).stx
+        ).returnValue.getOrThrow().stx
     }
 
 

--- a/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
+++ b/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.TransactionState
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
 import net.corda.core.internal.hash
 import net.corda.core.internal.mapToSet
 import net.corda.core.internal.toPath
@@ -12,6 +13,7 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
 import net.corda.coretesting.internal.delete
 import net.corda.coretesting.internal.modifyJarManifest
 import net.corda.coretesting.internal.useZipFile
@@ -22,9 +24,14 @@ import net.corda.finance.flows.CashIssueAndPaymentFlow
 import net.corda.finance.issuedBy
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.TestIdentity
 import net.corda.testing.core.internal.JarSignatureTestUtils.unsignJar
+import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.NodeParameters
+import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.internal.DriverDSLImpl
 import net.corda.testing.node.internal.FINANCE_WORKFLOWS_CORDAPP
@@ -81,7 +88,8 @@ class TransactionBuilderDriverTest {
         internalDriver(
                 cordappsForAllNodes = listOf(FINANCE_WORKFLOWS_CORDAPP),
                 startNodesInProcess = false,
-                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4),
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = false))
         ) {
             val (legacyContracts, legacyDependency) = splitFinanceContractCordapp(legacyFinanceContractsJar)
             val currentContracts = TestCordapp.of(currentFinanceContractsJar.toUri()).asSigned() as TestCordappInternal
@@ -95,15 +103,24 @@ class TransactionBuilderDriverTest {
                     legacyContracts = listOf(legacyContracts)
             )).getOrThrow()
 
+            // Start the node with the legacy CorDapp but without the dependency
+            val nodeBob = startNode(NodeParameters(
+                    BOB_NAME,
+                    additionalCordapps = listOf(currentContracts),
+                    legacyContracts = listOf(legacyContracts,legacyDependency)
+            )).getOrThrow()
+            val bobParty = nodeBob.nodeInfo.singleIdentity()
+
+
             // First make sure the missing dependency causes an issue
             assertThatThrownBy {
-                createTransaction(node)
+                createTransaction(node, bobParty)
             }.hasMessageContaining("Transaction being built has a missing legacy attachment for class net/corda/finance/contracts/asset/")
 
             // Upload the missing dependency
             legacyDependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
 
-            val stx = createTransaction(node)
+            val stx = createTransaction(node, bobParty)
             assertThat(stx.tx.legacyAttachments).contains(legacyContracts.jarFile.hash, legacyDependency.jarFile.hash)
         }
     }
@@ -167,15 +184,15 @@ class TransactionBuilderDriverTest {
         )
     }
 
-    private fun DriverDSLImpl.createTransaction(node: NodeHandle): SignedTransaction {
+    private fun DriverDSLImpl.createTransaction(node: NodeHandle, destination: Party =  defaultNotaryIdentity): SignedTransaction {
         return node.rpc.startFlow(
                 ::CashIssueAndPaymentFlow,
                 1.DOLLARS,
                 OpaqueBytes.of(0x00),
-                defaultNotaryIdentity,
+                destination,
                 false,
                 defaultNotaryIdentity
-        ).returnValue.getOrThrow().stx
+        ).returnValue.getOrThrow(20.seconds).stx
     }
 
 

--- a/core-tests/src/smoke-test/kotlin/net/corda/coretests/verification/ExternalVerificationTests.kt
+++ b/core-tests/src/smoke-test/kotlin/net/corda/coretests/verification/ExternalVerificationTests.kt
@@ -203,7 +203,7 @@ class ExternalVerificationUnsignedCordappsTest {
                     clientRpcConfig = CordaRPCClientConfiguration(minimumServerProtocolVersion = 13),
                     version = "4.11"
             ))
-            newNode = factory.createNode(nodeParams(CordaX500Name("New", "York", "US"), currentCordapps))
+            newNode = factory.createNode(nodeParams(CordaX500Name("New", "York", "US"), currentCordapps, legacyCordapps))
         }
 
         @AfterClass

--- a/core-tests/src/smoke-test/kotlin/net/corda/coretests/verification/ExternalVerificationTests.kt
+++ b/core-tests/src/smoke-test/kotlin/net/corda/coretests/verification/ExternalVerificationTests.kt
@@ -193,17 +193,18 @@ class ExternalVerificationUnsignedCordappsTest {
         fun startNodes() {
             // The 4.11 finance CorDapp jars
             val legacyCordapps = listOf(unsignedResourceJar("corda-finance-contracts-4.11.jar"), smokeTestResource("corda-finance-workflows-4.11.jar"))
+            val legacyCordappsWithoutContracts = listOf(smokeTestResource("corda-finance-workflows-4.11.jar"))
             // The current version finance CorDapp jars
             val currentCordapps = listOf(unsignedResourceJar("corda-finance-contracts.jar"), smokeTestResource("corda-finance-workflows.jar"))
 
-            notary = factory.createNotaries(nodeParams(DUMMY_NOTARY_NAME, currentCordapps))[0]
+            notary = factory.createNotaries(nodeParams(DUMMY_NOTARY_NAME, currentCordapps, legacyCordapps))[0]
             oldNode = factory.createNode(nodeParams(
                     CordaX500Name("Old", "Delhi", "IN"),
                     legacyCordapps,
                     clientRpcConfig = CordaRPCClientConfiguration(minimumServerProtocolVersion = 13),
                     version = "4.11"
             ))
-            newNode = factory.createNode(nodeParams(CordaX500Name("New", "York", "US"), currentCordapps, legacyCordapps))
+            newNode = factory.createNode(nodeParams(CordaX500Name("New", "York", "US"), currentCordapps, legacyCordappsWithoutContracts))
         }
 
         @AfterClass

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/ContractUpgradeFlowRPCTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/ContractUpgradeFlowRPCTest.kt
@@ -24,8 +24,10 @@ import net.corda.coretesting.internal.matchers.rpc.willThrow
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.*
 import org.junit.AfterClass
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("Explicit contract upgrade not supported in 4.12")
 class ContractUpgradeFlowRPCTest : WithContracts, WithFinality {
     companion object {
         private val classMockNet = InternalMockNetwork(cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()))

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/ContractUpgradeFlowTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/ContractUpgradeFlowTest.kt
@@ -47,9 +47,11 @@ import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startFlow
 import org.junit.AfterClass
+import org.junit.Ignore
 import org.junit.Test
 import java.util.Currency
 
+@Ignore("Explicit contract upgrade not supported in 4.12")
 class ContractUpgradeFlowTest : WithContracts, WithFinality {
 
     companion object {

--- a/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt
@@ -240,6 +240,7 @@ class ResolveTransactionsFlowTest {
     }
 
     @Test(timeout=300_000)
+    @Ignore("Need to pass legacy contracts to internal mock network & need to create a legacy contract for test below")
 	fun `can resolve a chain of transactions containing a contract upgrade transaction`() {
         val tx = contractUpgradeChain()
         var numUpdates = 0

--- a/core/src/main/kotlin/net/corda/core/contracts/RotatedKeys.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/RotatedKeys.kt
@@ -60,6 +60,9 @@ data class RotatedKeys(val rotatedSigningKeys: List<List<SecureHash>> = emptyLis
     }
 
     fun canBeTransitioned(inputKeys: List<PublicKey>, outputKeys: List<PublicKey>): Boolean {
+        if (inputKeys.isEmpty() && outputKeys.isEmpty()) {
+            return true
+        }
         return canBeTransitioned(CompositeKey.Builder().addKeys(inputKeys).build(), CompositeKey.Builder().addKeys(outputKeys).build())
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -220,7 +220,7 @@ class JarScanningCordappLoader(private val cordappJars: Set<Path>,
         private fun checkSignersMatch(legacyCordapp: CordappImpl, nonLegacyCordapp: CordappImpl) {
             val legacySigners = legacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectSigners)
             val nonLegacySigners = nonLegacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectSigners)
-            if (legacySigners.size > 0 || nonLegacySigners.size > 0) {
+            if (legacySigners.isNotEmpty() || nonLegacySigners.isNotEmpty()) {
                 check(rotatedKeys.canBeTransitioned(legacySigners, nonLegacySigners)) {
                     "Newer contract CorDapp '${nonLegacyCordapp.jarFile}' signers do not match legacy contract CorDapp " +
                             "'${legacyCordapp.jarFile}' signers."

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -220,9 +220,11 @@ class JarScanningCordappLoader(private val cordappJars: Set<Path>,
         private fun checkSignersMatch(legacyCordapp: CordappImpl, nonLegacyCordapp: CordappImpl) {
             val legacySigners = legacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectSigners)
             val nonLegacySigners = nonLegacyCordapp.jarPath.openStream().let(::JarInputStream).use(JarSignatureCollector::collectSigners)
-            check(rotatedKeys.canBeTransitioned(legacySigners, nonLegacySigners)) {
-                "Newer contract CorDapp '${nonLegacyCordapp.jarFile}' signers do not match legacy contract CorDapp " +
-                        "'${legacyCordapp.jarFile}' signers."
+            if (legacySigners.size > 0 || nonLegacySigners.size > 0) {
+                check(rotatedKeys.canBeTransitioned(legacySigners, nonLegacySigners)) {
+                    "Newer contract CorDapp '${nonLegacyCordapp.jarFile}' signers do not match legacy contract CorDapp " +
+                            "'${legacyCordapp.jarFile}' signers."
+                }
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/verification/ExternalVerifierHandleImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/verification/ExternalVerifierHandleImpl.kt
@@ -58,6 +58,7 @@ import kotlin.io.path.div
 import kotlin.io.path.fileAttributesViewOrNull
 import kotlin.io.path.isExecutable
 import kotlin.io.path.isWritable
+import kotlin.io.path.notExists
 
 /**
  * Handle to the node's external verifier. The verifier process is started lazily on the first verification request.
@@ -116,6 +117,12 @@ class ExternalVerifierHandleImpl(
     }
 
     private fun startServer() {
+        val legacyContractsPath = (baseDirectory / "legacy-contracts")
+        if (legacyContractsPath.notExists()) {
+            log.error("Failed to start external verifier because $legacyContractsPath does not exist. Please create a legacy-contracts " +
+                    "directory under $baseDirectory and place your legacy contracts into this directory. See the documentation for details.")
+            throw IOException("Cannot start external verifier because $legacyContractsPath does not exist.")
+        }
         if (::socketFile.isInitialized) return
         // Try to create the UNIX domain file in /tmp to keep the full path under the 100 char limit. If we don't have access to it then
         // fallback to the temp dir specified by the JVM and hope it's short enough.

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/verifier/ExternalVerifierTypes.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/verifier/ExternalVerifierTypes.kt
@@ -52,7 +52,7 @@ sealed class ExternalVerifierInbound {
             val ctx: CoreTransaction,
             val ctxInputsAndReferences: Map<StateRef, SerializedTransactionState>
     ) : ExternalVerifierInbound() {
-        override fun toString(): String = "VerificationRequest(ctx=$ctx)"
+        override fun toString(): String = "VerificationRequest(transaction id=${ctx.id})"
     }
 
     data class PartiesResult(val parties: List<Party?>) : ExternalVerifierInbound()

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
@@ -124,7 +124,7 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
     }
 
     private fun createAppClassLoader(): ClassLoader {
-        val cordappJarUrls = (baseDirectory / "cordapps").listDirectoryEntries("*.jar")
+        val cordappJarUrls = (baseDirectory / "legacy-contracts").listDirectoryEntries("*.jar")
                 .stream()
                 .map { it.toUri().toURL() }
                 .toTypedArray()

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
@@ -86,7 +86,6 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
         initialise()
         while (true) {
             val request = channel.readCordaSerializable(VerificationRequest::class)
-            log.debug { "Received $request" }
             verifyTransaction(request)
         }
     }

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
@@ -86,7 +86,7 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
         initialise()
         while (true) {
             val request = channel.readCordaSerializable(VerificationRequest::class)
-            safeLog { log.debug { "Received $request" }}
+            log.debug { "Received $request" }
             verifyTransaction(request)
         }
     }
@@ -143,10 +143,10 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
                 is ContractUpgradeWireTransaction -> ctx.verifyInProcess(verificationContext)
                 else -> throw IllegalArgumentException("${ctx.toSimpleString()} not supported")
             }
-            safeLog { log.info("${ctx.toSimpleString()} verified") }
+            log.info("${ctx.toSimpleString()} verified")
             Try.Success(Unit)
         } catch (t: Throwable) {
-            safeLog { log.info("${request.ctx.toSimpleString()} failed to verify", t) }
+            log.info("${request.ctx.toSimpleString()} failed to verify", t)
             Try.Failure(t)
         }
         channel.writeCordaSerializable(VerificationResult(result))
@@ -222,15 +222,6 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
             inline fun <reified T : Any> Set<String>?.load(classLoader: ClassLoader?): Set<T> {
                 return this?.mapToSet { loadClassOfType<T>(it, classLoader = classLoader).kotlin.objectOrNewInstance() } ?: emptySet()
             }
-        }
-    }
-
-    private inline fun safeLog(block: () -> Unit) {
-        try {
-            block()
-        }
-        catch (ex: Exception) {
-            log.error("Exception raised while logging", ex)
         }
     }
 }

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
@@ -86,6 +86,7 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
         initialise()
         while (true) {
             val request = channel.readCordaSerializable(VerificationRequest::class)
+            safeLog { log.debug { "Received $request" }}
             verifyTransaction(request)
         }
     }
@@ -142,10 +143,10 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
                 is ContractUpgradeWireTransaction -> ctx.verifyInProcess(verificationContext)
                 else -> throw IllegalArgumentException("${ctx.toSimpleString()} not supported")
             }
-            log.info("${ctx.toSimpleString()} verified")
+            safeLog { log.info("${ctx.toSimpleString()} verified") }
             Try.Success(Unit)
         } catch (t: Throwable) {
-            log.info("${request.ctx.toSimpleString()} failed to verify", t)
+            safeLog { log.info("${request.ctx.toSimpleString()} failed to verify", t) }
             Try.Failure(t)
         }
         channel.writeCordaSerializable(VerificationResult(result))
@@ -221,6 +222,15 @@ class ExternalVerifier(private val baseDirectory: Path, private val channel: Soc
             inline fun <reified T : Any> Set<String>?.load(classLoader: ClassLoader?): Set<T> {
                 return this?.mapToSet { loadClassOfType<T>(it, classLoader = classLoader).kotlin.objectOrNewInstance() } ?: emptySet()
             }
+        }
+    }
+
+    private inline fun safeLog(block: () -> Unit) {
+        try {
+            block()
+        }
+        catch (ex: Exception) {
+            log.error("Exception raised while logging", ex)
         }
     }
 }


### PR DESCRIPTION
ENT-12366: External verifier now sets appclassloader to legacy contracts directory instead of the cordapps directory.

