### PR TITLE
ENT-12154 - Remove Hibernate sessions when done with them

### DIFF
--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     }
 
     implementation "co.paralleluniverse:quasar-core:$quasar_version"
+    implementation "org.hibernate:hibernate-core:$hibernate_version"
 }
 
 compileJava {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -83,6 +83,7 @@ import java.time.Clock
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import org.hibernate.internal.SessionFactoryRegistry
 import kotlin.io.path.createDirectories
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.div
@@ -620,6 +621,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
             }
             messagingNetwork.stop()
         }
+        SessionFactoryRegistry.INSTANCE.clearRegistrations()
     }
 
     /** Block until all scheduled activity, active flows and network activity has ceased. */


### PR DESCRIPTION
Apparent memory leak when creating lots of mock networks.
The leak seems to be evident within Hibernate - a container of SessionFactory objects - which are added when a DB session is created, does not have the sessions removed.

The proposed changes are for the mock network to clear down the container when the network is stopped. In the case of the reported issue, mock networks are being created/destroyed in succession. So although technically there is a leak for the duration of the lifetime of a single mock network, the demise of the network will remove the session objects.
