### PR TITLE
ENT-12433 - Bouncy Castle docs generation

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -57,9 +57,11 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
         }
         externalDocumentationLink {
             url = new URL("https://downloads.bouncycastle.org/java/docs/bcpkix-jdk18on-javadoc/")
+            packageListUrl = new URL("https://downloads.bouncycastle.org/java/docs/bcpkix-jdk18on-javadoc/element-list")
         }
         externalDocumentationLink {
             url = new URL("https://downloads.bouncycastle.org/java/docs/bcprov-jdk18on-javadoc/")
+            packageListUrl = new URL("https://downloads.bouncycastle.org/java/docs/bcprov-jdk18on-javadoc/element-list")
         }
         internalPackagePrefixes.collect { packagePrefix ->
             perPackageOption {


### PR DESCRIPTION
It seems as though the package-list URL for the Bouncy Castle docs is dead, giving a 404 error and causing the docs:dokka task to fail.
The URL to use now is `<bouncy castle docs URL>/element-list`, and so the change proposed here configures that for the dokka task.
