### PR TITLE
ENT-12385 - Reverted Jackson version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ buildscript {
     ext.asm_version = '7.1'
     ext.artemis_version = '2.19.1'
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.17.2'
+    ext.jackson_version = '2.13.5'
     ext.jackson_kotlin_version = '2.9.7'
     ext.jetty_version = '9.4.56.v20240826'
     ext.jersey_version = '2.25'


### PR DESCRIPTION
Reverted Jackson back 2.13.5 since version 2.17.2 was pulling in SnakeYaml 2.2, which is incompatible with Liquibase 3.6.3. Although Corda also force-overrides SnakeYaml to 1.33, when external applications use Corda to set up test nodes, they do not see that forced-override and so Liquibase attempts to use SnakeYaml 2.2 - and fails.
