### PR TITLE
ENT-12442: Add bcutil dependency for Bouncy Castle

### DIFF
--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     // Bouncy castle support needed for X509 certificate manipulation
     implementation "org.bouncycastle:bcprov-lts8on:${bouncycastle_version}"
     implementation "org.bouncycastle:bcpkix-lts8on:${bouncycastle_version}"
+    implementation "org.bouncycastle:bcutil-lts8on:${bouncycastle_version}"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
 
     testImplementation project(':finance:workflows')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     // AssertJ: for fluent assertions for testing
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.bouncycastle:bcpkix-lts8on:$bouncycastle_version"
+    testImplementation "org.bouncycastle:bcutil-lts8on:$bouncycastle_version"
     testImplementation "org.ow2.asm:asm:$asm_version"
 
     testRuntimeOnly "com.esotericsoftware:kryo:$kryo_version"

--- a/node-api-tests/build.gradle
+++ b/node-api-tests/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     // Bouncy castle support needed for X509 certificate manipulation
     testImplementation "org.bouncycastle:bcprov-lts8on:${bouncycastle_version}"
     testImplementation "org.bouncycastle:bcpkix-lts8on:${bouncycastle_version}"
+    testImplementation "org.bouncycastle:bcutil-lts8on:${bouncycastle_version}"
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit_vintage_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     // Bouncy castle support needed for X509 certificate manipulation
     implementation "org.bouncycastle:bcprov-lts8on:${bouncycastle_version}"
     implementation "org.bouncycastle:bcpkix-lts8on:${bouncycastle_version}"
+    implementation "org.bouncycastle:bcutil-lts8on:${bouncycastle_version}"
 
     implementation "io.reactivex:rxjava:$rxjava_version"
     implementation "javax.persistence:javax.persistence-api:2.2"

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -137,6 +137,7 @@ dependencies {
     // Bouncy castle support needed for X509 certificate manipulation
     implementation "org.bouncycastle:bcprov-lts8on:${bouncycastle_version}"
     implementation "org.bouncycastle:bcpkix-lts8on:${bouncycastle_version}"
+    implementation "org.bouncycastle:bcutil-lts8on:${bouncycastle_version}"
     implementation "com.esotericsoftware:kryo:$kryo_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"

--- a/serialization-tests/build.gradle
+++ b/serialization-tests/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     // Bouncy castle support needed for X509 certificate manipulation
     testImplementation "org.bouncycastle:bcprov-lts8on:${bouncycastle_version}"
     testImplementation "org.bouncycastle:bcpkix-lts8on:${bouncycastle_version}"
+    testImplementation "org.bouncycastle:bcutil-lts8on:${bouncycastle_version}"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
     testImplementation "junit:junit:$junit_version"

--- a/testing/core-test-utils/build.gradle
+++ b/testing/core-test-utils/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     // Bouncy castle support needed for X509 certificate manipulation
     implementation "org.bouncycastle:bcprov-lts8on:${bouncycastle_version}"
     implementation "org.bouncycastle:bcpkix-lts8on:${bouncycastle_version}"
+    implementation "org.bouncycastle:bcutil-lts8on:${bouncycastle_version}"
 
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "org.mockito.kotlin:mockito-kotlin:$mockito_kotlin_version"

--- a/testing/test-utils/build.gradle
+++ b/testing/test-utils/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     // Bouncy castle support needed for X509 certificate manipulation
     implementation "org.bouncycastle:bcprov-lts8on:${bouncycastle_version}"
     implementation "org.bouncycastle:bcpkix-lts8on:${bouncycastle_version}"
+    implementation "org.bouncycastle:bcutil-lts8on:${bouncycastle_version}"
 
     testImplementation "org.apache.commons:commons-lang3:$commons_lang3_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"


### PR DESCRIPTION
Automatic upgrade to Bouncy Castle 2.73.7 on 8th Nov introduced a mismatch due to the new `id_ml_dsa_44` identifier. That resulted in a few PQA-CorDapps which depend on Corda failing to build with `Exception in thread "main" java.lang.NoSuchFieldError: id_ml_dsa_44
	at org.bouncycastle.jcajce.provider.asymmetric.compositesignatures.KeyFactorySpi.<clinit>(Unknown Source)`.

 The fix is to explicitly specify `bcutil` dependency alongside `bcpkix` to ensure version compatibility.

Tested locally on a pqa-cordapp which fas failing before - fixed now.