### PR TITLE
ENT-12491: Commands were being deserialized in captured serialisation…

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -28,6 +28,7 @@ import net.corda.core.internal.SerializedStateAndRef
 import net.corda.core.internal.SerializedTransactionState
 import net.corda.core.internal.TransactionDeserialisationException
 import net.corda.core.internal.createComponentGroups
+import net.corda.core.internal.deserialiseCommands
 import net.corda.core.internal.deserialiseComponentGroup
 import net.corda.core.internal.equivalent
 import net.corda.core.internal.getGroup
@@ -196,10 +197,15 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
                 verificationSupport.getParties(signersGroup.flatten().toSet())
             }
         }
-        val authenticatedCommands = commands.lazyMapped { cmd, _ ->
-                val parties = verificationSupport.getParties(cmd.signers).filterNotNull()
-                CommandWithParties(cmd.signers, parties, cmd.value)
-            }
+
+        val lazyCommands: List<Command<*>> by lazy { deserialiseCommands(componentGroups, digestService = digestService) }
+        val commandsComponentGroup = componentGroups.getGroup(COMMANDS_GROUP)
+        val commandComponents = commandsComponentGroup?.components ?: emptyList()
+        val authenticatedCommands = commandComponents.lazyMapped { _, index ->
+            val cmd = lazyCommands[index]
+            val parties = verificationSupport.getParties(cmd.signers).filterNotNull()
+            CommandWithParties(cmd.signers, parties, cmd.value)
+        }
 
         // Ensure that the lazy mappings will use the correct SerializationContext.
         val serializationFactory = SerializationFactory.defaultFactory

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
@@ -87,7 +87,7 @@ class ExternalVerifier(private val channel: SocketChannel) {
         // Use a preliminary serialization context to receive the initialisation message
         _contextSerializationEnv.set(SerializationEnvironment.with(
                 verifierSerializationFactory(),
-                p2pContext = AMQP_P2P_CONTEXT
+                p2pContext = AMQP_P2P_CONTEXT.withoutCarpenter()
         ))
 
         log.info("Waiting for initialisation message from node...")


### PR DESCRIPTION
ENT-12491: Commands were being deserialized in captured serialisation context which did not include the serialisation context with attachments class loader. Now make the deserialisation lazy. Credit @rick-r3 for solution here. 


