### PR TITLE
ENT-12039 - Security vulnerabilities

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -50,7 +50,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.1
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.13.5
+jacksonVersion=2.17.2
 jacksonKotlinVersion=2.9.7
 jettyVersion=9.4.56.v20240826
 jerseyVersion=2.25


### PR DESCRIPTION
Upgrade jackson (again) to get past security vulnerability.
