### PR TITLE
ENT-12317,ENT-12333,ENT-12431 - Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -502,8 +502,6 @@ allprojects {
                     if (details.requested.group == 'org.apache.commons') {
                         if (details.requested.name == "commons-configuration2") {
                             details.useVersion commons_configuration2_version
-                        } else if (details.requested.name == "commons-text") {
-                            details.useVersion commons_text_version
                         }
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ buildscript {
     ext.asm_version = '7.1'
     ext.artemis_version = '2.19.1'
     // TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-    ext.jackson_version = '2.13.5'
+    ext.jackson_version = '2.14.0'
     ext.jackson_kotlin_version = '2.9.7'
     ext.jetty_version = '9.4.56.v20240826'
     ext.jersey_version = '2.25'
@@ -505,9 +505,6 @@ allprojects {
                         } else if (details.requested.name == "commons-text") {
                             details.useVersion commons_text_version
                         }
-                    }
-                    if (details.requested.group == 'org.yaml' && details.requested.name == 'snakeyaml') {
-                        details.useVersion snake_yaml_version
                     }
                 }
             }


### PR DESCRIPTION
Upgraded Jackson to 2.14.0. This depends on SnakeYaml 1.33, which resolves some security vulnerabilites and removes the need for Corda to force-override the version of SnakeYaml, and is also safe for Liquibase 3.6.3 to use.
Also removed forced-override of commons-text - it's no longer needed.