### PR TITLE
ENT-12325,ENT-12326,ENT-12427 - Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -497,13 +497,8 @@ allprojects {
                     if (details.requested.group == 'org.apache.commons') {
                         if (details.requested.name == "commons-configuration2") {
                             details.useVersion commons_configuration2_version
-                        } else if (details.requested.name == "commons-text") {
-                            details.useVersion commons_text_version
                         }
                     }
-//                    if (details.requested.group == 'org.yaml' && details.requested.name == 'snakeyaml') {
-//                        details.useVersion snake_yaml_version
-//                    }
                 }
 
                 dependencySubstitution {

--- a/build.gradle
+++ b/build.gradle
@@ -501,9 +501,9 @@ allprojects {
                             details.useVersion commons_text_version
                         }
                     }
-                    if (details.requested.group == 'org.yaml' && details.requested.name == 'snakeyaml') {
-                        details.useVersion snake_yaml_version
-                    }
+//                    if (details.requested.group == 'org.yaml' && details.requested.name == 'snakeyaml') {
+//                        details.useVersion snake_yaml_version
+//                    }
                 }
 
                 dependencySubstitution {

--- a/constants.properties
+++ b/constants.properties
@@ -51,7 +51,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.1
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.13.5
+jacksonVersion=2.14.0
 jacksonKotlinVersion=2.9.7
 jettyVersion=9.4.56.v20240826
 jerseyVersion=2.25


### PR DESCRIPTION
Upgraded Jackson to 2.14.0. This depends on SnakeYaml 1.33, which resolves some security vulnerabilites and removes the need for Corda to force-override the version of SnakeYaml, and is also safe for Liquibase 3.6.3 to use.
Also removed forced-override of commons-text - it's no longer needed.