### PR TITLE
ENT-12321,ENT-12322,ENT-12425 - Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,6 @@ buildscript {
     ext.docker_java_version = constants.getProperty("dockerJavaVersion")
     ext.commons_configuration2_version = constants.getProperty("commonsConfiguration2Version")
     ext.commons_text_version = constants.getProperty("commonsTextVersion")
-    ext.snake_yaml_version = constants.getProperty("snakeYamlVersion")
     ext.javaassist_version = constants.getProperty("javaassistVersion")
 
     if (JavaVersion.current().isJava8()) {
@@ -497,9 +496,6 @@ allprojects {
                         } else if (details.requested.name == "commons-text") {
                             details.useVersion commons_text_version
                         }
-                    }
-                    if (details.requested.group == 'org.yaml' && details.requested.name == 'snakeyaml') {
-                        details.useVersion snake_yaml_version
                     }
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -493,8 +493,6 @@ allprojects {
                     if (details.requested.group == 'org.apache.commons') {
                         if (details.requested.name == "commons-configuration2") {
                             details.useVersion commons_configuration2_version
-                        } else if (details.requested.name == "commons-text") {
-                            details.useVersion commons_text_version
                         }
                     }
                 }

--- a/constants.properties
+++ b/constants.properties
@@ -30,7 +30,6 @@ disruptorVersion=3.4.2
 typesafeConfigVersion=1.3.4
 jsr305Version=3.0.2
 artifactoryPluginVersion=4.16.1
-snakeYamlVersion=1.33
 caffeineVersion=2.9.3
 metricsVersion=4.1.0
 metricsNewRelicVersion=1.1.1
@@ -50,7 +49,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.1
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.13.5
+jacksonVersion=2.14.0
 jacksonKotlinVersion=2.9.7
 jettyVersion=9.4.56.v20240826
 jerseyVersion=2.25


### PR DESCRIPTION
Upgraded Jackson to 2.14.0. This depends on SnakeYaml 1.33, which resolves some security vulnerabilites and removes the need for Corda to force-override the version of SnakeYaml, and is also safe for Liquibase 3.6.3 to use.
Also removed forced-override of commons-text - it's no longer needed.
