### PR TITLE
ENT-12327,ENT-12328,ENT-12428 - Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,9 +114,6 @@ buildscript {
     ext.controlsfx_version = constants.getProperty("controlsfxVersion")
     ext.detekt_version = constants.getProperty('detektVersion')
     ext.docker_java_version = constants.getProperty("dockerJavaVersion")
-    ext.commons_configuration2_version = constants.getProperty("commonsConfiguration2Version")
-    ext.commons_text_version = constants.getProperty("commonsTextVersion")
-    ext.snake_yaml_version = constants.getProperty("snakeYamlVersion")
     ext.fontawesomefx_commons_version = constants.getProperty("fontawesomefxCommonsVersion")
     ext.fontawesomefx_fontawesome_version = constants.getProperty("fontawesomefxFontawesomeVersion")
     ext.javaassist_version = constants.getProperty("javaassistVersion")
@@ -435,20 +432,6 @@ allprojects {
                         } else {
                             details.useVersion netty_version
                         }
-                    }
-
-                    if (details.requested.group == 'org.apache.commons') {
-                        if (details.requested.name == "commons-configuration2") {
-                            details.useVersion commons_configuration2_version
-                        } else if (details.requested.name == "commons-text") {
-                            details.useVersion commons_text_version
-                        }
-                    }
-                    if (details.requested.group == 'org.yaml' && details.requested.name == 'snakeyaml') {
-                        details.useVersion snake_yaml_version
-                    }
-                    if (details.requested.group == 'commons-io' && details.requested.name == "commons-io") {
-                        details.useVersion commons_io_version
                     }
                 }
 

--- a/constants.properties
+++ b/constants.properties
@@ -27,7 +27,6 @@ disruptorVersion=3.4.2
 typesafeConfigVersion=1.3.4
 jsr305Version=3.0.2
 artifactoryPluginVersion=4.16.1
-snakeYamlVersion=2.2
 caffeineVersion=3.1.8
 metricsVersion=4.1.0
 metricsNewRelicVersion=1.1.1
@@ -36,8 +35,6 @@ openSourceSamplesBranch=https://github.com/corda/samples/blob/release-V4
 jolokiaAgentVersion=1.6.1
 detektVersion=1.0.1
 tcnativeVersion=2.0.48.Final
-commonsConfiguration2Version=2.11.0
-commonsTextVersion=1.10.0
 
 # ENT-6607 all third party version in here now
 
@@ -56,7 +53,7 @@ assertjVersion=3.12.2
 slf4JVersion=2.0.12
 log4JVersion=2.23.1
 okhttpVersion=4.12.0
-nettyVersion=4.1.109.Final
+nettyVersion=4.1.115.Final
 fileuploadVersion=2.0.0-M1
 kryoVersion=5.5.0
 kryoSerializerVersion=0.43


### PR DESCRIPTION
Removed dependency force-overrides that are no longer needed - they were introduced to address security issues but the dependencies used by 4.12 have moved past those.
Upgraded netty to get past a separate security issue.
