### PR TITLE
ENT-12595: Missing legacy attachments must also be present in the legacy-contracts folder

### DIFF
--- a/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
+++ b/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
@@ -37,6 +37,7 @@ import net.corda.testing.node.internal.TestCordappInternal
 import net.corda.testing.node.internal.UriTestCordapp
 import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.internalDriver
+import org.apache.commons.io.FileUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy
 import org.junit.Test
@@ -114,10 +115,20 @@ class TransactionBuilderDriverTest {
                 createTransaction(node, bobParty)
             }.hasMessageContaining("Transaction being built has a missing legacy attachment for class net/corda/finance/contracts/asset/")
 
-            // Upload the missing dependency
-            legacyDependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+            node.stop()
+            FileUtils.deleteDirectory(node.baseDirectory.toFile());
 
-            val stx = createTransaction(node, bobParty)
+            // Now restart the node with the missing dependency
+            val restartedNode = startNode(NodeParameters(
+                    ALICE_NAME,
+                    additionalCordapps = listOf(currentContracts),
+                    legacyContracts = listOf(legacyContracts, legacyDependency)
+            )).getOrThrow()
+
+            // Attachment does not have a contract in it so needs to be manually installed into attachment db storage
+            legacyDependency.jarFile.inputStream().use(restartedNode.rpc::uploadAttachment)
+
+            val stx = createTransaction(restartedNode, bobParty)
             assertThat(stx.tx.legacyAttachments).contains(legacyContracts.jarFile.hash, legacyDependency.jarFile.hash)
         }
     }

--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappProviderInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappProviderInternal.kt
@@ -11,6 +11,7 @@ interface CordappProviderInternal : CordappProvider {
     val appClassLoader: ClassLoader
     val attachmentFixups: AttachmentFixups
     val cordapps: List<CordappImpl>
+    val legacyContractCordapps: List<CordappImpl>
     fun getCordappForFlow(flowLogic: FlowLogic<*>): Cordapp?
 
     /**

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -349,9 +349,9 @@ open class TransactionBuilder(
 
         val attachments = serviceHub.getTrustedClassAttachments(missingClass)
         val attachment = if (isLegacy) {
-            // Any attachment which contains the class but isn't a non-legacy CorDapp is *probably* the legacy attachment we're looking for
-            val nonLegacyCordapps = serviceHub.cordappProvider.cordapps.mapToSet { it.jarHash }
-            attachments.firstOrNull { it.id !in nonLegacyCordapps }
+            // Any (legacy) missing attachments must also be present in the legacy-contracts folder to be attached to a transaction
+            val legacyContractCordapps = serviceHub.cordappProvider.legacyContractCordapps.mapToSet { it.jarHash }
+            attachments.firstOrNull { it.id in legacyContractCordapps } 
         } else {
             attachments.firstOrNull()
         }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
@@ -38,6 +38,8 @@ open class CordappProviderImpl(private val cordappLoader: CordappLoader,
      */
     override val cordapps: List<CordappImpl> get() = cordappLoader.cordapps
 
+    override val legacyContractCordapps: List<CordappImpl> get() = cordappLoader.legacyContractCordapps
+
     fun start() {
         loadContractsIntoAttachmentStore(cordappLoader.cordapps)
         loadContractsIntoAttachmentStore(cordappLoader.legacyContractCordapps)


### PR DESCRIPTION
ENT-12595: Now missing legacy attachments must also be present in the legacy-contracts folder.

Previously the attachment storage table was searched for an attachment containing the missing class. The only check performed was to make sure this attachment was not also in the cordapps folder. If it wasn't in the cordapps folder it was assumed it was a legacy attachment. But this ignores the fact that there could be multiple JDK17 attachments in the db (same CorDapp different versions), with only the latest one in the cordapps folder.
So now we still check the attachments table, but also filter against contents of the legacy-contracts folder.
