### PR TITLE
Testing Snyk Delta - no target branch available on server

### DIFF
--- a/common/configuration-parsing/build.gradle
+++ b/common/configuration-parsing/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'corda.common-publishing'
 
 description 'Corda common-configuration-parsing module'
 
+//connelm/snyk-merge-branch update to trigger snyk delta
+
 dependencies {
     implementation group: "org.jetbrains.kotlin", name: "kotlin-reflect", version: kotlin_version
 


### PR DESCRIPTION
Testing [pipeline](https://ci01.dev.r3.com/job/Infrastructure/job/Snyk_Security_Scan/) to be used when a target branch for Snyk Delta does not exist [snykDeltaScan ](https://github.com/corda/corda-shared-build-pipeline-steps/blob/5.3/vars/snykDeltaScan.groovy) will trigger the above pipeline to scan the target to the Snyk server. 