### PR TITLE
ENT-12844 - Build default jars for snyk scans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -774,6 +774,14 @@ subprojects {
                 "tools:explorer": "corda-tools-explorer",
                 "node:capsule": "corda"
         ]
+        // map dependency name to actual jar/artifact name
+        def dependencyDict = [
+                "contracts": "corda-finance-contracts",
+                "workflows": "corda-finance-workflows",
+                "cliutils": "corda-tools-cliutils",
+                "worldmap": "worldmap"
+        ]
+
         def lookupName = "${project.parent.name}:${project.name}".toString()
 
         if (projectDict.containsKey(lookupName)) {
@@ -782,11 +790,42 @@ subprojects {
             publishing {
                 publications {
                     "$jarName-jarPublication"(MavenPublication) {
-                        from components.java
                         artifactId = "$jarName-snyk-scanner"
                         pom {
                             name = "$jarName-snyk-scanner"
                             description = "Corda ${project.name} for use with Snyk"
+
+                            // This block controls dependencies that go into the POM,
+                            // since the jar isn't part of the publication.
+                            withXml {
+                                def dependenciesNode = asNode().appendNode('dependencies')
+
+                                def addDeps = { config, scope ->
+                                    configurations[config].allDependencies.each { dep ->
+                                        if (dep.group && dep.name && dep.version) {
+                                            def depNode = dependenciesNode.appendNode('dependency')
+                                            depNode.appendNode('groupId', dep.group)
+
+                                            def artifactId = dep.name
+                                            if (dependencyDict.containsKey(dep.name)) {
+                                                // the the dependency dictionary specifies an artifact name, use it
+                                                artifactId = dependencyDict[dep.name]
+                                            } else if (dep.group == 'net.corda') {
+                                                // otherwise if it's a dependency within corda, prepend with "corda-"
+                                                artifactId = "corda-${dep.name}"
+                                            }
+                                            depNode.appendNode('artifactId', artifactId)
+                                            depNode.appendNode('version', dep.version)
+                                            depNode.appendNode('scope', scope)
+                                        }
+                                    }
+                                }
+
+                                // the dependency scopes to be included in the pom
+                                addDeps('implementation', 'compile')
+                                addDeps('compileOnly', 'provided')
+                                addDeps('runtimeOnly', 'runtime')
+                            }
                         }
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -774,14 +774,6 @@ subprojects {
                 "tools:explorer": "corda-tools-explorer",
                 "node:capsule": "corda"
         ]
-        // map dependency name to actual jar/artifact name
-        def dependencyDict = [
-                "contracts": "corda-finance-contracts",
-                "workflows": "corda-finance-workflows",
-                "cliutils": "corda-tools-cliutils",
-                "worldmap": "worldmap"
-        ]
-
         def lookupName = "${project.parent.name}:${project.name}".toString()
 
         if (projectDict.containsKey(lookupName)) {
@@ -790,42 +782,11 @@ subprojects {
             publishing {
                 publications {
                     "$jarName-jarPublication"(MavenPublication) {
+                        from components.java
                         artifactId = "$jarName-snyk-scanner"
                         pom {
                             name = "$jarName-snyk-scanner"
                             description = "Corda ${project.name} for use with Snyk"
-
-                            // This block controls dependencies that go into the POM,
-                            // since the jar isn't part of the publication.
-                            withXml {
-                                def dependenciesNode = asNode().appendNode('dependencies')
-
-                                def addDeps = { config, scope ->
-                                    configurations[config].allDependencies.each { dep ->
-                                        if (dep.group && dep.name && dep.version) {
-                                            def depNode = dependenciesNode.appendNode('dependency')
-                                            depNode.appendNode('groupId', dep.group)
-
-                                            def artifactId = dep.name
-                                            if (dependencyDict.containsKey(dep.name)) {
-                                                // the the dependency dictionary specifies an artifact name, use it
-                                                artifactId = dependencyDict[dep.name]
-                                            } else if (dep.group == 'net.corda') {
-                                                // otherwise if it's a dependency within corda, prepend with "corda-"
-                                                artifactId = "corda-${dep.name}"
-                                            }
-                                            depNode.appendNode('artifactId', artifactId)
-                                            depNode.appendNode('version', dep.version)
-                                            depNode.appendNode('scope', scope)
-                                        }
-                                    }
-                                }
-
-                                // the dependency scopes to be included in the pom
-                                addDeps('implementation', 'compile')
-                                addDeps('compileOnly', 'provided')
-                                addDeps('runtimeOnly', 'runtime')
-                            }
                         }
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -764,7 +764,7 @@ artifactory {
 
 // Publish the default jar for fat-jar sub-modules that do not currently publish their dependencies.
 // These are not for external consumption.
-// We must generate a jar which has a pom.xml with a full dependency list for Snyk to evaluate.
+// We must generate a jar which has a pom.xml with a full dependency list for vulnerability tools to evaluate.
 subprojects {
     afterEvaluate { project ->
         // map project to actual jar name, since some sub-project jars are not
@@ -772,6 +772,8 @@ subprojects {
         def projectDict = [
                 "testing:testserver": "corda-testserver",
                 "tools:explorer": "corda-tools-explorer",
+                "opentelemetry:opentelemetry-driver": "corda-opentelemetry-driver",
+                "tools:network-builder": "corda-tools-network-builder",
                 "node:capsule": "corda"
         ]
         def lookupName = "${project.parent.name}:${project.name}".toString()
@@ -783,10 +785,10 @@ subprojects {
                 publications {
                     "$jarName-jarPublication"(MavenPublication) {
                         from components.java
-                        artifactId = "$jarName-snyk-scanner"
+                        artifactId = "$jarName-thin-with-deps"
                         pom {
-                            name = "$jarName-snyk-scanner"
-                            description = "Corda ${project.name} for use with Snyk"
+                            name = "$jarName-thin-with-deps"
+                            description = "Corda ${project.name} for vulnerability checking."
                         }
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -755,11 +755,49 @@ artifactory {
         defaults {
             // Root project applies the plugin (for this block) but does not need to be published
             if (project != rootProject) {
-                publications(project.extensions.publish.name())
+                def pubNames = project.publishing.publications*.name
+                publications(pubNames.toArray(new String[0]))
             }
         }
     }
 }
+
+// Publish the default jar for fat-jar sub-modules that do not currently publish their dependencies.
+// These are not for external consumption.
+// We must generate a jar which has a pom.xml with a full dependency list for Snyk to evaluate.
+subprojects {
+    afterEvaluate { project ->
+        // map project to actual jar name, since some sub-project jars are not
+        // published with the same name as their sub-project.
+        def projectDict = [
+                "testing:testserver": "corda-testserver",
+                "tools:explorer": "corda-tools-explorer"
+        ]
+        def lookupName = "${project.parent.name}:${project.name}".toString()
+
+        if (projectDict.containsKey(lookupName)) {
+            apply plugin: 'maven-publish'
+            def jarName = projectDict[lookupName]
+            publishing {
+                publications {
+                    "$jarName-jarPublication"(MavenPublication) {
+                        from components.java
+                        artifactId = "$jarName-snyk-scanner"
+                        pom {
+                            name = "$jarName-snyk-scanner"
+                            description = "Corda ${project.name} for use with Snyk"
+                        }
+                    }
+                }
+            }
+
+            jar {
+                archiveClassifier = 'R3-internal'
+            }
+        }
+    }
+}
+
 
 tasks.register('generateApi', net.corda.plugins.apiscanner.GenerateApi) {
     baseName = "api-corda"

--- a/build.gradle
+++ b/build.gradle
@@ -771,7 +771,8 @@ subprojects {
         // published with the same name as their sub-project.
         def projectDict = [
                 "testing:testserver": "corda-testserver",
-                "tools:explorer": "corda-tools-explorer"
+                "tools:explorer": "corda-tools-explorer",
+                "node:capsule": "corda"
         ]
         def lookupName = "${project.parent.name}:${project.name}".toString()
 

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     capsuleRuntime "com.typesafe:config:$typesafe_config_version"
     compileOnly "com.typesafe:config:$typesafe_config_version"
     testRuntimeOnly "com.typesafe:config:$typesafe_config_version"
+    
+    // 'implementation' for the benefit of the snyk-scanner POM file
+    implementation "com.typesafe:config:$typesafe_config_version"
 
     // Capsule is a library for building independently executable fat JARs.
     // We only need this dependency to compile our Caplet against.
@@ -30,7 +33,7 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 }
 
-jar.enabled = false
+jar.enabled = true
 
 capsule {
     version capsule_version

--- a/opentelemetry/opentelemetry-driver/build.gradle
+++ b/opentelemetry/opentelemetry-driver/build.gradle
@@ -30,7 +30,7 @@ artifacts {
 }
 
 jar {
-    enabled = false
+    enabled = true
 }
 
 publish {

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -88,7 +88,7 @@ artifacts {
 }
 
 jar {
-    enabled = false
+    enabled = true
 }
 
 publish {


### PR DESCRIPTION
Based on [the changes made for corda-shell](https://github.com/corda/corda-shell/pull/126), the build now includes default jars for sub-modules that otherwise produce fat jars, and whose POM files currently do not list any dependencies. The default jars include a POM file that lists all the jar's dependencies, allowing them to be scanned by Snyk.

Although there a several fat jars produced by Corda OS, only handled here are:
- `corda`
- `corda-opentelemetry-driver`
- `corda-testserver`
- `corda-tools-explorer`
- `corda-tools-network-builder`

because:
- they are published
- they are included in the OS release pack
- their existing POM file does NOT specify any dependencies

Other fat jars are not targeted in these changes because they do not meet the above criteria. The only exception to this is `corda-tools-checkpoint-agent`, which appears to be a fully self-contained jar with no external dependencies.

This is summarised below:

|Module|Type|Published?|Rel-pack?|POM Dependencies?|
|---|:-:|:-:|:-:|:-:|
|avalanche|shadow|N|N|not published / don't care|
|corda|fat capsule|Y|Y|N|
|corda-opentelemetry-driver|shadow|Y|Y|N|
|corda-testserver|fat|Y|Y|N|
|corda-tools-blob-inspector|fat|Y|Y|Y|
|corda-tools-checkpoint-agent|fat|Y|Y|N|
|corda-tools-cliutils|fat|Y|Y|Y|
|corda-tools-error-utils|shadow|N|N|not published / don't care|
|corda-tools-explorer|fat|Y|Y|N|
|corda-tools-network-bootstrapper|fat|Y|Y|Y|
|corda-tools-network-builder|shadow|Y|Y|N|



