### PR TITLE
ES-2710: PR Code Checks only run Snyk Delta on PR's targeting release branch

### DIFF
--- a/.ci/dev/pr-code-checks/Jenkinsfile
+++ b/.ci/dev/pr-code-checks/Jenkinsfile
@@ -42,21 +42,12 @@ pipeline {
         }
 
         stage('Snyk Delta') {
-            agent {
-                docker {
-                    image 'build-zulu-openjdk:8'
-                    reuseNode true
-                    registryUrl 'https://engineering-docker.software.r3.com/'
-                    registryCredentialsId 'artifactory-credentials'
-                    args '-v /tmp:/host_tmp'
+            when {
+                expression {
+                    return CHANGE_TARGET.contains("release/os/")
                 }
             }
-            environment {
-                GRADLE_USER_HOME = "/host_tmp/gradle"
-            }
             steps {
-                authenticateGradleWrapper()
-                sh 'mkdir -p ${GRADLE_USER_HOME}'
                 snykDeltaScan(env.SNYK_API_TOKEN, env.C4_OS_SNYK_ORG_ID)
             }
         }


### PR DESCRIPTION
Verified change below creating a branch with a change in a `build.gradle` so Snyk Delta previously would be triggered but the target is not a release branch. 
- [PR](https://github.com/corda/corda/pull/7920)
- [Pipeline](https://ci01.dev.r3.com/job/Corda-Open-Source/job/Corda-OS-Pull-Request-Code-Checks/job/corda/job/PR-7920/)