### PR TITLE
ENT-12960: Upgrade a few dependencies to latest for CENM 1.7

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -42,7 +42,7 @@ tcnativeVersion=2.0.48.Final
 # We must configure it manually to use the latest capsule version.
 capsuleVersion=1.0.4_r3
 asmVersion=9.5
-artemisVersion=2.36.0
+artemisVersion=2.40.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.17.2
 jacksonKotlinVersion=2.17.0
@@ -80,7 +80,7 @@ commonsCollectionsVersion=4.3
 beanutilsVersion=1.9.4
 shiroVersion=1.10.0
 hikariVersion=5.1.0
-liquibaseVersion=4.20.0
+liquibaseVersion=4.31.1
 dockerComposeRuleVersion=1.5.0
 seleniumVersion=3.141.59
 ghostdriverVersion=2.1.0

--- a/constants.properties
+++ b/constants.properties
@@ -42,7 +42,7 @@ tcnativeVersion=2.0.48.Final
 # We must configure it manually to use the latest capsule version.
 capsuleVersion=1.0.4_r3
 asmVersion=9.5
-artemisVersion=2.40.0
+artemisVersion=2.36.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.17.2
 jacksonKotlinVersion=2.17.0

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -5,7 +5,6 @@ import liquibase.Contexts
 import liquibase.LabelExpression
 import liquibase.Liquibase
 import liquibase.Scope
-import liquibase.ThreadLocalScopeManager
 import liquibase.database.jvm.JdbcConnection
 import liquibase.exception.LiquibaseException
 import liquibase.resource.ClassLoaderResourceAccessor
@@ -42,9 +41,6 @@ open class SchemaMigration(
         const val NODE_BASE_DIR_KEY = "liquibase.nodeDaseDir"
         const val NODE_X500_NAME = "liquibase.nodeName"
         val loader = ThreadLocal<CordappLoader>()
-        init {
-            Scope.setScopeManager(ThreadLocalScopeManager())
-        }
 
         @JvmStatic
         protected val mutex = ReentrantLock()


### PR DESCRIPTION
Upgrade a few dependencies which need to be upgraded to get rid of security vulnerabilities in CENM 1.7:
1. Liquibase to 4.31.1
