### PR TITLE
ENT-12884 - Scannable jars improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -767,23 +767,70 @@ artifactory {
 // We must generate a jar which has a pom.xml with a full dependency list for vulnerability tools to evaluate.
 subprojects {
     afterEvaluate { project ->
-        // map project to actual jar name, since some sub-project jars are not
-        // published with the same name as their sub-project.
+        // List of sub-projects that generate fat jars, and we need to also need a thin-with-deps equivalent.
+        // Note that this is NOT all of the fat jars in this project- merely the ones that are published.
+        // key = parent:project name
+        // value = [name: the name of the jar produced by the project
+        //          capsule: whether the jar is built using capsule; these are treated differently, see below.]
         def projectDict = [
-                "testing:testserver": "corda-testserver",
-                "tools:explorer": "corda-tools-explorer",
-                "opentelemetry:opentelemetry-driver": "corda-opentelemetry-driver",
-                "tools:network-builder": "corda-tools-network-builder",
-                "node:capsule": "corda"
+                "testserver:testcapsule": [name: "corda-testserver", capsule: true],
+                "explorer:capsule": [name: "corda-tools-explorer", capsule: true],
+                "opentelemetry:opentelemetry-driver": [name: "corda-opentelemetry-driver", capsule: false],
+                "tools:bootstrapper": [name: "corda-tools-network-bootstrapper", capsule: false],
+                "tools:network-builder": [name: "corda-tools-network-builder", capsule: false],
+                "node:capsule": [name: "corda", capsule: true]
         ]
         def lookupName = "${project.parent.name}:${project.name}".toString()
 
-        if (projectDict.containsKey(lookupName)) {
+        if (projectDict.containsKey(lookupName) && projectDict[lookupName].capsule) {
+            // Capsule projects do not specify their dependencies directly; the dependencies are
+            // actually defined in their parent project. So, this arm of code generates the POM file
+            // manually by going through the parent dependencies and adding them in to the POM.
             apply plugin: 'maven-publish'
-            def jarName = projectDict[lookupName]
+            def jarName = projectDict[lookupName].name
             publishing {
                 publications {
-                    "$jarName-jarPublication"(MavenPublication) {
+                    "${jarName}-jarPublication"(MavenPublication) {
+                        from components.java
+                        artifactId = "${jarName}-thin-with-deps"
+
+                        pom.withXml {
+                            def rootNode = asNode()
+                            // Add name and description
+                            rootNode.appendNode('name', "${jarName}-thin-with-deps")
+                            rootNode.appendNode('description', "Corda ${project.name} for vulnerability checking.")
+                            // Find or create the <dependencies> node
+                            def dependenciesNode = rootNode.children().find { it.name() == 'dependencies' }
+                            if (!dependenciesNode) {
+                                dependenciesNode = rootNode.appendNode('dependencies')
+                            }
+                            def parentProject = project.parent
+                            if (parentProject != null) {
+                                parentProject.configurations.runtimeClasspath.resolvedConfiguration.firstLevelModuleDependencies.each { dep ->
+                                    // add each dependency as an element in the POM
+                                    def dnode = dependenciesNode.appendNode('dependency')
+                                    dnode.appendNode('groupId', "${dep.moduleGroup}")
+                                    dnode.appendNode('artifactId', "${dep.moduleName}")
+                                    dnode.appendNode('version', "${dep.moduleVersion}")
+                                    dnode.appendNode('scope', 'compile')
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            jar {
+                archiveClassifier = 'R3-internal'
+            }
+        } else if (projectDict.containsKey(lookupName) && !projectDict[lookupName].capsule) {
+            // For non-capsule projects, let the default pom-generation do it's thing;
+            // it gets published as "thin-with-deps".
+            apply plugin: 'maven-publish'
+            def jarName = projectDict[lookupName].name
+            publishing {
+                publications {
+                    "${jarName}-jarPublication"(MavenPublication) {
                         from components.java
                         artifactId = "$jarName-thin-with-deps"
                         pom {

--- a/build.gradle
+++ b/build.gradle
@@ -768,81 +768,106 @@ artifactory {
 subprojects {
     afterEvaluate { project ->
         // List of sub-projects that generate fat jars, and we need to also need a thin-with-deps equivalent.
-        // Note that this is NOT all of the fat jars in this project- merely the ones that are published.
+        // Note that this is NOT all of the fat jars in this project- merely the ones that are published
+        // without any dependencies in their POM.
+        //
         // key = parent:project name
         // value = [name: the name of the jar produced by the project
-        //          capsule: whether the jar is built using capsule; these are treated differently, see below.]
+        //          type: the way in which the sub-project is built/published]
+        // where type is one of
+        //              'capsule'   - capsule
+        //              'shadow'    - shadowJar
+        //              'corda'     - corda-publish
         def projectDict = [
-                "testserver:testcapsule": [name: "corda-testserver", capsule: true],
-                "explorer:capsule": [name: "corda-tools-explorer", capsule: true],
-                "opentelemetry:opentelemetry-driver": [name: "corda-opentelemetry-driver", capsule: false],
-                "tools:bootstrapper": [name: "corda-tools-network-bootstrapper", capsule: false],
-                "tools:network-builder": [name: "corda-tools-network-builder", capsule: false],
-                "node:capsule": [name: "corda", capsule: true]
+                "testserver:testcapsule":               [name: "corda-testserver", type: 'capsule'],
+                "explorer:capsule":                     [name: "corda-tools-explorer", type: 'capsule'],
+                "opentelemetry:opentelemetry-driver":   [name: "corda-opentelemetry-driver", type: 'shadow'],
+                "tools:network-builder":                [name: "corda-tools-network-builder", type: 'shadow'],
+                "node:capsule":                         [name: "corda", type: 'capsule'],
+                "corda-project:confidential-identities": [name: "corda-confidential-identities", type: 'corda'],
+                "finance:contracts":                    [name: "corda-finance-contracts", type: 'corda'],
+                "finance:workflows":                    [name: "corda-finance-workflows", type: 'corda']
         ]
         def lookupName = "${project.parent.name}:${project.name}".toString()
 
-        if (projectDict.containsKey(lookupName) && projectDict[lookupName].capsule) {
-            // Capsule projects do not specify their dependencies directly; the dependencies are
-            // actually defined in their parent project. So, this arm of code generates the POM file
-            // manually by going through the parent dependencies and adding them in to the POM.
-            apply plugin: 'maven-publish'
-            def jarName = projectDict[lookupName].name
-            publishing {
-                publications {
-                    "${jarName}-jarPublication"(MavenPublication) {
-                        from components.java
-                        artifactId = "${jarName}-thin-with-deps"
+        if (projectDict.containsKey(lookupName)) {
+            if (projectDict[lookupName].type == "corda" || projectDict[lookupName].type == "capsule")  {
+                // for 'corda' and 'capsule' types, their dependencies are not readily available so
+                // the POM file has to be crafted manually.
+                // The use of a 'thinWithDepsJarTask' task is to allow Gradle to resolve dependencies when
+                // another sub-project depends on on that is listed above. Without this, there are two
+                // artifacts published at the same 'location'
+                apply plugin: 'maven-publish'
+                group 'net.corda'
+                version "$corda_release_version"
 
-                        pom.withXml {
-                            def rootNode = asNode()
-                            // Add name and description
-                            rootNode.appendNode('name', "${jarName}-thin-with-deps")
-                            rootNode.appendNode('description', "Corda ${project.name} for vulnerability checking.")
-                            // Find or create the <dependencies> node
-                            def dependenciesNode = rootNode.children().find { it.name() == 'dependencies' }
-                            if (!dependenciesNode) {
-                                dependenciesNode = rootNode.appendNode('dependencies')
-                            }
-                            def parentProject = project.parent
-                            if (parentProject != null) {
-                                parentProject.configurations.runtimeClasspath.resolvedConfiguration.firstLevelModuleDependencies.each { dep ->
-                                    // add each dependency as an element in the POM
-                                    def dnode = dependenciesNode.appendNode('dependency')
-                                    dnode.appendNode('groupId', "${dep.moduleGroup}")
-                                    dnode.appendNode('artifactId', "${dep.moduleName}")
-                                    dnode.appendNode('version', "${dep.moduleVersion}")
-                                    dnode.appendNode('scope', 'compile')
+                def jarName = projectDict[lookupName].name
+
+                publishing {
+                    publications {
+                        def thinWithDepsJarTask = project.tasks.register("${jarName}ThinWithDepsJar", Jar) {
+                            archiveClassifier = 'R3-internal' // IMPORTANT: Give it a classifier
+                            from project.sourceSets.main.output // Include compiled classes and resources
+                        }
+                        // Now publish this *distinct* artifact with its custom POM
+                        "${jarName}-thin-with-deps"(MavenPublication) {
+                            // Link to the *newly created* thinWithDepsJarTask's output
+                            artifact(thinWithDepsJarTask.get())
+
+                            // Set coordinates for the thin-with-deps publication
+                            groupId = project.group
+                            artifactId = "${jarName}-thin-with-deps" // Distinct artifactId
+                            version = project.version
+
+                            pom.withXml {
+                                def rootNode = asNode()
+                                rootNode.appendNode('name', "${jarName}-thin-with-deps")
+                                rootNode.appendNode('description', "Corda ${project.name} for vulnerability checking.")
+
+                                def dependenciesNode = rootNode.children().find { it.name() == 'dependencies' }
+                                if (!dependenciesNode) {
+                                    dependenciesNode = rootNode.appendNode('dependencies')
+                                }
+                                def dependenciesProject = project
+                                if (projectDict[lookupName].type == "capsule") {
+                                    dependenciesProject = project.parent
+                                }
+                                if (dependenciesProject != null) {
+                                    dependenciesProject.configurations.runtimeClasspath.allDependencies.each { dep ->
+                                        // only care about external dependencies
+                                        if (dep instanceof ExternalModuleDependency) {
+                                            def dnode = dependenciesNode.appendNode('dependency')
+                                            dnode.appendNode('groupId', "${dep.group}")
+                                            dnode.appendNode('artifactId', "${dep.name}")
+                                            dnode.appendNode('version', "${dep.version}")
+                                            dnode.appendNode('scope', 'compile') // Default to compile scope for direct deps
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-
-            jar {
-                archiveClassifier = 'R3-internal'
-            }
-        } else if (projectDict.containsKey(lookupName) && !projectDict[lookupName].capsule) {
-            // For non-capsule projects, let the default pom-generation do it's thing;
-            // it gets published as "thin-with-deps".
-            apply plugin: 'maven-publish'
-            def jarName = projectDict[lookupName].name
-            publishing {
-                publications {
-                    "${jarName}-jarPublication"(MavenPublication) {
-                        from components.java
-                        artifactId = "$jarName-thin-with-deps"
-                        pom {
-                            name = "$jarName-thin-with-deps"
-                            description = "Corda ${project.name} for vulnerability checking."
+            } else {    // type = 'shadow'
+                // For shadow projects, let the default pom-generation do it's thing;
+                // it gets published as "thin-with-deps".
+                apply plugin: 'maven-publish'
+                def jarName = projectDict[lookupName].name
+                publishing {
+                    publications {
+                        "${jarName}-jarPublication"(MavenPublication) {
+                            from components.java
+                            artifactId = "$jarName-thin-with-deps"
+                            pom {
+                                name = "$jarName-thin-with-deps"
+                                description = "Corda ${project.name} for vulnerability checking."
+                            }
                         }
                     }
                 }
-            }
-
-            jar {
-                archiveClassifier = 'R3-internal'
+                jar {
+                    archiveClassifier = 'R3-internal'
+                }
             }
         }
     }

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -20,9 +20,6 @@ dependencies {
     capsuleRuntime "com.typesafe:config:$typesafe_config_version"
     compileOnly "com.typesafe:config:$typesafe_config_version"
     testRuntimeOnly "com.typesafe:config:$typesafe_config_version"
-    
-    // 'implementation' for the benefit of the snyk-scanner POM file
-    implementation "com.typesafe:config:$typesafe_config_version"
 
     // Capsule is a library for building independently executable fat JARs.
     // We only need this dependency to compile our Caplet against.

--- a/testing/testserver/testcapsule/build.gradle
+++ b/testing/testserver/testcapsule/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     capsuleRuntime "com.typesafe:config:$typesafe_config_version"
 }
 
-jar.enabled = false
+jar.enabled = true
 
 capsule {
     version capsule_version

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -51,7 +51,7 @@ artifacts {
 
 jar {
     classifier "ignore"
-    enabled = false
+    enabled = true
 }
 
 publish {


### PR DESCRIPTION
Improvement to how the scannabled jars (for security scanning) are built.

Extended the list of sub-jars covered by this festure.
Sub-projects that produce Capsule jars are better handled; their dependencies are actually specified in the capsule parent project, and so the POM files are ,manually created using the parent dependencies.
Sub-projects that are built using corda-publish can now have scannable jars produced for them; in this update these are `finance:contracts`, `finance:workflows`, and `confidential-identities`.
