### PR TITLE
ENT-13054 - Security dependency updates

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -142,6 +142,19 @@ class CordaModule : SimpleModule("corda-core") {
 }
 
 private class CordaSerializableClassIntrospector(private val context: Module.SetupContext) : BasicClassIntrospector() {
+    override fun constructPropertyCollector(
+            config: MapperConfig<*>?,
+            ac: AnnotatedClass?,
+            type: JavaType,
+            forSerialization: Boolean,
+            mutatorPrefix: String?
+    ): POJOPropertiesCollector {
+        if (hasCordaSerializable(type.rawClass)) {
+            // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.
+            context.configOverride(type.rawClass).visibility = Value.defaultVisibility().withFieldVisibility(Visibility.ANY)
+        }
+        return super.constructPropertyCollector(config, ac, type, forSerialization, mutatorPrefix)
+    }
     override fun constructPropertyCollector(config: MapperConfig<*>?, classDef: AnnotatedClass?, type: JavaType, forSerialization: Boolean, accNaming: AccessorNamingStrategy?): POJOPropertiesCollector {
         if (hasCordaSerializable(type.rawClass)) {
             // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -155,6 +155,7 @@ private class CordaSerializableClassIntrospector(private val context: Module.Set
         }
         return super.constructPropertyCollector(config, ac, type, forSerialization, mutatorPrefix)
     }
+
     override fun constructPropertyCollector(config: MapperConfig<*>?, classDef: AnnotatedClass?, type: JavaType, forSerialization: Boolean, accNaming: AccessorNamingStrategy?): POJOPropertiesCollector {
         if (hasCordaSerializable(type.rawClass)) {
             // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -142,20 +142,6 @@ class CordaModule : SimpleModule("corda-core") {
 }
 
 private class CordaSerializableClassIntrospector(private val context: Module.SetupContext) : BasicClassIntrospector() {
-    override fun constructPropertyCollector(
-            config: MapperConfig<*>?,
-            ac: AnnotatedClass?,
-            type: JavaType,
-            forSerialization: Boolean,
-            mutatorPrefix: String?
-    ): POJOPropertiesCollector {
-        if (hasCordaSerializable(type.rawClass)) {
-            // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.
-            context.configOverride(type.rawClass).visibility = Value.defaultVisibility().withFieldVisibility(Visibility.ANY)
-        }
-        return super.constructPropertyCollector(config, ac, type, forSerialization, mutatorPrefix)
-    }
-
     override fun constructPropertyCollector(config: MapperConfig<*>?, classDef: AnnotatedClass?, type: JavaType, forSerialization: Boolean, accNaming: AccessorNamingStrategy?): POJOPropertiesCollector {
         if (hasCordaSerializable(type.rawClass)) {
             // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.

--- a/constants.properties
+++ b/constants.properties
@@ -52,7 +52,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.1
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.19.1
+jacksonVersion=2.17.3
 jacksonKotlinVersion=2.9.7
 jettyVersion=9.4.56.v20240826
 jerseyVersion=2.25

--- a/constants.properties
+++ b/constants.properties
@@ -52,7 +52,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.1
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.14.0
+jacksonVersion=2.19.1
 jacksonKotlinVersion=2.9.7
 jettyVersion=9.4.56.v20240826
 jerseyVersion=2.25


### PR DESCRIPTION
Updated Jackson to get past security issues.
Needed to remove overridden method; the superclass no longer has this method.
