### PR TITLE
ENT-13857: fix metrics registry in mock services

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -1,5 +1,6 @@
 package net.corda.testing.node
 
+import com.codahale.metrics.MetricRegistry
 import com.google.common.collect.MutableClassToInstanceMap
 import net.corda.core.CordaInternal
 import net.corda.core.contracts.Attachment
@@ -558,7 +559,14 @@ open class MockServices private constructor(
     /** Returns a dummy Attachment, in context of signature constrains non-downgrade rule this default to contract class version `1`. */
     override fun loadContractAttachment(stateRef: StateRef) = dummyAttachment
 
-    override fun <T> getMetricsRegistry(type: Class<T>): T  = throw UnsupportedOperationException()
+    override fun <T> getMetricsRegistry(type: Class<T>): T {
+        if (type == MetricRegistry::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            return MetricRegistry() as T
+        } else {
+            throw IllegalArgumentException("Only ${MetricRegistry::class.java} is currently supported")
+        }
+    }
     
     /**
      * All [ServiceHub]s must also implement [VerifyingServiceHub]. However, since [MockServices] is part of the public API, making it


### PR DESCRIPTION
Fix getMetricsRegistry in MockServices;

# PR Checklist:

- [X] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [X] If you added public APIs, did you write the JavaDocs/kdocs?
- [X] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [X] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
