### PR TITLE
ENT-13850 notary change support

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt
@@ -321,7 +321,12 @@ class ResolveTransactionsFlowTest {
     }
 
     private fun createNotaryChangeTransaction(inputs: List<StateRef>): SignedTransaction {
-        val notaryTx = NotaryChangeTransactionBuilder(inputs, notary, newNotary, notaryNode.services.networkParametersService.defaultHash).build()
+        val notaryTx = NotaryChangeTransactionBuilder(
+                inputs,
+                notary,
+                newNotary,
+                notaryNode.services.networkParametersService.defaultHash,
+                setOf(megaCorp.owningKey)).build()
         val notaryKey = notary.owningKey
         val signableData = SignableData(notaryTx.id, SignatureMetadata(4, Crypto.findSignatureScheme(notaryKey).schemeNumberID))
         val signature = notaryNode.services.keyManagementService.sign(signableData, notaryKey)

--- a/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
@@ -332,7 +332,7 @@ abstract class SignTransactionFlow @JvmOverloads constructor(val otherSideSessio
 
     @Suspendable
     private fun checkMySignaturesRequired(stx: SignedTransaction, signingKeys: Iterable<PublicKey>) {
-        require(signingKeys.all { it in stx.tx.requiredSigningKeys }) {
+        require(signingKeys.all { it in stx.requiredSigningKeys }) {
             "A signature was requested for a key that isn't part of the required signing keys for transaction ${stx.id}"
         }
     }

--- a/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
@@ -104,7 +104,7 @@ class CollectSignaturesFlow @JvmOverloads constructor(val partiallySignedTx: Sig
 
         // Determine who still needs to sign.
         progressTracker.currentStep = COLLECTING
-        val notaryKey = partiallySignedTx.notaryKey
+        val notaryKey = partiallySignedTx.notary?.owningKey
         // If present, we need to exclude the notary's PublicKey as the notary signature is collected separately with
         // the FinalityFlow.
         val unsigned = if (notaryKey != null) notSigned - notaryKey else notSigned

--- a/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
@@ -92,7 +92,7 @@ class CollectSignaturesFlow @JvmOverloads constructor(val partiallySignedTx: Sig
         // Usually just the Initiator and possibly an oracle would have signed at this point.
         val myKeys: Iterable<PublicKey> = myOptionalKeys ?: listOf(ourIdentity.owningKey)
         val signed = partiallySignedTx.sigs.mapToSet { it.by }
-        val notSigned = partiallySignedTx.tx.requiredSigningKeys - signed
+        val notSigned = partiallySignedTx.requiredSigningKeys - signed
 
         // One of the signatures collected so far MUST be from the initiator of this flow.
         require(partiallySignedTx.sigs.any { it.by in myKeys }) {
@@ -104,7 +104,7 @@ class CollectSignaturesFlow @JvmOverloads constructor(val partiallySignedTx: Sig
 
         // Determine who still needs to sign.
         progressTracker.currentStep = COLLECTING
-        val notaryKey = partiallySignedTx.tx.notary?.owningKey
+        val notaryKey = partiallySignedTx.notaryKey
         // If present, we need to exclude the notary's PublicKey as the notary signature is collected separately with
         // the FinalityFlow.
         val unsigned = if (notaryKey != null) notSigned - notaryKey else notSigned

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -458,7 +458,7 @@ object NotarySigCheck {
                 needsNotarisation && hasNoNotarySignature(stx)
             }
 
-            is NotaryChangeWireTransaction -> true
+            is NotaryChangeWireTransaction -> hasNoNotarySignature(stx)
             else -> throw IllegalArgumentException("Wrong input to NotarySigCheck - was expecting WireTransaction or NotaryChangeWireTransaction, got ${coreTx::class}")
         }
     }

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -442,7 +442,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
 
 
     private fun verifyTx(): Set<Party> {
-        val notaryKey = transaction.notaryKey
+        val notaryKey = transaction.notary?.owningKey
         // The notary signature(s) are allowed to be missing but no others.
         if (notaryKey != null) transaction.verifySignaturesExcept(notaryKey) else transaction.verifyRequiredSignatures()
         // TODO= [CORDA-3267] Remove duplicate signature verification
@@ -475,7 +475,7 @@ object NotarySigCheck {
     }
 
     private fun hasNoNotarySignature(stx: SignedTransaction): Boolean {
-        val notaryKey = stx.notaryKey
+        val notaryKey = stx.notary?.owningKey
         val signers = stx.sigs.asSequence().map { it.by }.toSet()
         return notaryKey?.isFulfilledBy(signers) != true
     }

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -5,6 +5,7 @@ import net.corda.core.CordaInternal
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.isFulfilledBy
+import net.corda.core.flows.NotarySigCheck.needsNotarySignature
 import net.corda.core.identity.Party
 import net.corda.core.identity.groupAbstractPartyByWellKnownParty
 import net.corda.core.internal.PlatformVersionSwitches
@@ -17,6 +18,8 @@ import net.corda.core.node.StatesToRecord
 import net.corda.core.node.StatesToRecord.ONLY_RELEVANT
 import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.transactions.NotaryChangeLedgerTransaction
+import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.ProgressTracker
@@ -172,7 +175,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     @Suppress("ComplexMethod", "NestedBlockDepth")
     @Throws(NotaryException::class)
     override fun call(): SignedTransaction {
-        require(transaction.coreTransaction is WireTransaction)  // Sanity check
+        // require(transaction.coreTransaction is WireTransaction)  // Sanity check
         if (!newApi) {
             logger.warnOnce("The current usage of FinalityFlow is unsafe. Please consider upgrading your CorDapp to use " +
                     "FinalityFlow with FlowSessions. (${serviceHub.getAppContext().cordapp.info})")
@@ -192,8 +195,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
 
         transaction.pushToLoggingContext()
         logCommandData()
-        val ledgerTransaction = verifyTx()
-        externalTxParticipants = extractExternalParticipants(ledgerTransaction)
+        externalTxParticipants = verifyTx()
 
         if (newApi) {
             val sessionParties = sessions.map { it.counterparty }.toSet()
@@ -428,46 +430,52 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
         }
     }
 
-    private fun needsNotarySignature(stx: SignedTransaction): Boolean {
-        val wtx = stx.tx
-        val needsNotarisation = wtx.inputs.isNotEmpty() || wtx.references.isNotEmpty() || wtx.timeWindow != null
-        return needsNotarisation && hasNoNotarySignature(stx)
-    }
-
-    private fun hasNoNotarySignature(stx: SignedTransaction): Boolean {
-        val notaryKey = stx.tx.notary?.owningKey
-        val signers = stx.sigs.asSequence().map { it.by }.toSet()
-        return notaryKey?.isFulfilledBy(signers) != true
-    }
-
     private fun extractExternalParticipants(ltx: LedgerTransaction): Set<Party> {
         val participants = ltx.outputStates.flatMap { it.participants } + ltx.inputStates.flatMap { it.participants }
         return groupAbstractPartyByWellKnownParty(serviceHub, participants).keys - serviceHub.myInfo.legalIdentities.toSet()
     }
 
-    private fun verifyTx(): LedgerTransaction {
-        val notary = transaction.tx.notary
+    private fun extractExternalParticipants(ltx: NotaryChangeLedgerTransaction): Set<Party> {
+        val participants = ltx.outputStates.flatMap { it.participants }
+        return groupAbstractPartyByWellKnownParty(serviceHub, participants).keys - serviceHub.myInfo.legalIdentities.toSet()
+    }
+
+
+    private fun verifyTx(): Set<Party> {
+        val notaryKey = transaction.notaryKey
         // The notary signature(s) are allowed to be missing but no others.
-        if (notary != null) transaction.verifySignaturesExcept(notary.owningKey) else transaction.verifyRequiredSignatures()
+        if (notaryKey != null) transaction.verifySignaturesExcept(notaryKey) else transaction.verifyRequiredSignatures()
         // TODO= [CORDA-3267] Remove duplicate signature verification
-        val ltx = transaction.verifyInternal(serviceHub.toVerifyingServiceHub(), checkSufficientSignatures = false)
+        val ftx = transaction.verifyInternal(serviceHub.toVerifyingServiceHub(), checkSufficientSignatures = false)
         // verifyInternal returns null if the transaction was verified externally, which *could* happen on a very odd scenerio of a 4.11
         // node creating the transaction but a 4.12 kicking off finality. In that case, we still want a LedgerTransaction object for
         // recording to the vault, etc. Note that calling verify() on this will fail as it doesn't have the necessary non-legacy attachments
         // for verification by the node.
-        return ltx ?: transaction.toLedgerTransaction(serviceHub, checkSufficientSignatures = false)
+        return when (ftx){
+            null -> extractExternalParticipants(transaction.toLedgerTransaction(serviceHub, checkSufficientSignatures = false))
+            is LedgerTransaction -> extractExternalParticipants(ftx)
+            is NotaryChangeLedgerTransaction -> extractExternalParticipants(ftx)
+            else -> throw IllegalArgumentException("Wrong input to FinalityFlow - was expecting LedgerTransaction or NotaryChangeLedgerTransaction, got ${ftx::class}")
+        }
     }
 }
 
 object NotarySigCheck {
     fun needsNotarySignature(stx: SignedTransaction): Boolean {
-        val wtx = stx.tx
-        val needsNotarisation = wtx.inputs.isNotEmpty() || wtx.references.isNotEmpty() || wtx.timeWindow != null
-        return needsNotarisation && hasNoNotarySignature(stx)
+        val coreTx = stx.coreTransaction
+        return when (coreTx) {
+            is WireTransaction -> {
+                val needsNotarisation = coreTx.inputs.isNotEmpty() || coreTx.references.isNotEmpty() || coreTx.timeWindow != null
+                needsNotarisation && hasNoNotarySignature(stx)
+            }
+
+            is NotaryChangeWireTransaction -> true
+            else -> throw IllegalArgumentException("Wrong input to NotarySigCheck - was expecting WireTransaction or NotaryChangeWireTransaction, got ${coreTx::class}")
+        }
     }
 
     private fun hasNoNotarySignature(stx: SignedTransaction): Boolean {
-        val notaryKey = stx.tx.notary?.owningKey
+        val notaryKey = stx.notaryKey
         val signers = stx.sigs.asSequence().map { it.by }.toSet()
         return notaryKey?.isFulfilledBy(signers) != true
     }

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -17,8 +17,7 @@ import net.corda.core.internal.warnOnce
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.StatesToRecord.ONLY_RELEVANT
 import net.corda.core.serialization.DeprecatedConstructorForDeserialization
-import net.corda.core.transactions.LedgerTransaction
-import net.corda.core.transactions.NotaryChangeLedgerTransaction
+import net.corda.core.transactions.FullTransaction
 import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
@@ -430,33 +429,23 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
         }
     }
 
-    private fun extractExternalParticipants(ltx: LedgerTransaction): Set<Party> {
-        val participants = ltx.outputStates.flatMap { it.participants } + ltx.inputStates.flatMap { it.participants }
+    private fun extractExternalParticipants(ftx: FullTransaction): Set<Party> {
+        val participants = ftx.outputStates.flatMap { it.participants } + ftx.inputs.map{it.state.data}.flatMap { it.participants }
         return groupAbstractPartyByWellKnownParty(serviceHub, participants).keys - serviceHub.myInfo.legalIdentities.toSet()
     }
-
-    private fun extractExternalParticipants(ltx: NotaryChangeLedgerTransaction): Set<Party> {
-        val participants = ltx.outputStates.flatMap { it.participants }
-        return groupAbstractPartyByWellKnownParty(serviceHub, participants).keys - serviceHub.myInfo.legalIdentities.toSet()
-    }
-
 
     private fun verifyTx(): Set<Party> {
         val notaryKey = transaction.notary?.owningKey
         // The notary signature(s) are allowed to be missing but no others.
         if (notaryKey != null) transaction.verifySignaturesExcept(notaryKey) else transaction.verifyRequiredSignatures()
         // TODO= [CORDA-3267] Remove duplicate signature verification
-        val ftx = transaction.verifyInternal(serviceHub.toVerifyingServiceHub(), checkSufficientSignatures = false)
         // verifyInternal returns null if the transaction was verified externally, which *could* happen on a very odd scenerio of a 4.11
         // node creating the transaction but a 4.12 kicking off finality. In that case, we still want a LedgerTransaction object for
         // recording to the vault, etc. Note that calling verify() on this will fail as it doesn't have the necessary non-legacy attachments
         // for verification by the node.
-        return when (ftx){
-            null -> extractExternalParticipants(transaction.toLedgerTransaction(serviceHub, checkSufficientSignatures = false))
-            is LedgerTransaction -> extractExternalParticipants(ftx)
-            is NotaryChangeLedgerTransaction -> extractExternalParticipants(ftx)
-            else -> throw IllegalArgumentException("Wrong input to FinalityFlow - was expecting LedgerTransaction or NotaryChangeLedgerTransaction, got ${ftx::class}")
-        }
+        val ftx = transaction.verifyInternal(serviceHub.toVerifyingServiceHub(), checkSufficientSignatures = false) ?:
+            transaction.toLedgerTransaction(serviceHub, checkSufficientSignatures = false)
+        return extractExternalParticipants(ftx)
     }
 }
 

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -174,7 +174,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     @Suppress("ComplexMethod", "NestedBlockDepth")
     @Throws(NotaryException::class)
     override fun call(): SignedTransaction {
-        // require(transaction.coreTransaction is WireTransaction)  // Sanity check
+        require(transaction.coreTransaction is WireTransaction || transaction.coreTransaction is NotaryChangeWireTransaction)  // Sanity check
         if (!newApi) {
             logger.warnOnce("The current usage of FinalityFlow is unsafe. Please consider upgrading your CorDapp to use " +
                     "FinalityFlow with FlowSessions. (${serviceHub.getAppContext().cordapp.info})")
@@ -435,9 +435,9 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     }
 
     private fun verifyTx(): Set<Party> {
-        val notaryKey = transaction.notary?.owningKey
+        val notary = transaction.notary
         // The notary signature(s) are allowed to be missing but no others.
-        if (notaryKey != null) transaction.verifySignaturesExcept(notaryKey) else transaction.verifyRequiredSignatures()
+        if (notary != null) transaction.verifySignaturesExcept(notary.owningKey) else transaction.verifyRequiredSignatures()
         // TODO= [CORDA-3267] Remove duplicate signature verification
         // verifyInternal returns null if the transaction was verified externally, which *could* happen on a very odd scenerio of a 4.11
         // node creating the transaction but a 4.12 kicking off finality. In that case, we still want a LedgerTransaction object for

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -430,7 +430,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     }
 
     private fun extractExternalParticipants(ftx: FullTransaction): Set<Party> {
-        val participants = ftx.outputStates.flatMap { it.participants } + ftx.inputs.map{it.state.data}.flatMap { it.participants }
+        val participants = ftx.outputStates.flatMap { it.participants } + ftx.inputs.map { it.state.data }.flatMap { it.participants }
         return groupAbstractPartyByWellKnownParty(serviceHub, participants).keys - serviceHub.myInfo.legalIdentities.toSet()
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
@@ -47,7 +47,7 @@ class MoveNotaryFlow<out T: ContractState>(
         fun tracker() = ProgressTracker(BUILDING, SIGNING, FINALIZING)
     }
 
-    private val oldNotary = states.map{it.state.notary}.singleOrNull()
+    private val oldNotary = states.map{it.state.notary}.toSet().singleOrNull()
 
     init {
         require(states.isNotEmpty()) { "Notary change flow must receive at least one state to work on" }

--- a/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
@@ -48,15 +48,16 @@ import java.security.PublicKey
  * - The new notary cannot be the same as the old notary
  */
 @InitiatingFlow
-class MoveNotaryFlow<out T: ContractState>(
+class MoveNotaryFlow<out T : ContractState>(
         val states: List<StateAndRef<T>>,
         val newNotary: Party,
         override val progressTracker: ProgressTracker = tracker()) : FlowLogic<List<StateAndRef<T>>>() {
     companion object {
         object BUILDING : ProgressTracker.Step("Resolving inputs and building transaction")
-        object SIGNING : ProgressTracker.Step("Requesting signatures from other parties"){
+        object SIGNING : ProgressTracker.Step("Requesting signatures from other parties") {
             override fun childProgressTracker() = CollectSignaturesFlow.tracker()
         }
+
         object FINALIZING : ProgressTracker.Step("Invoking finality") {
             override fun childProgressTracker() = FinalityFlow.tracker()
         }
@@ -64,7 +65,7 @@ class MoveNotaryFlow<out T: ContractState>(
         fun tracker() = ProgressTracker(BUILDING, SIGNING, FINALIZING)
     }
 
-    private val oldNotary = states.map{it.state.notary}.toSet().singleOrNull()
+    private val oldNotary = states.map { it.state.notary }.toSet().singleOrNull()
 
     init {
         require(states.isNotEmpty()) { "Notary change flow must receive at least one state to work on" }
@@ -83,7 +84,7 @@ class MoveNotaryFlow<out T: ContractState>(
         val finalized = subFlow(FinalityFlow(fullySigned, sessions, FINALIZING.childProgressTracker()))
         return finalized.resolveBaseTransaction(serviceHub).outputs
                 .take(states.size)
-                .mapIndexed{ index, state -> StateAndRef(uncheckedCast<TransactionState<ContractState>, TransactionState<T>>(state), StateRef(finalized.id, index))}
+                .mapIndexed { index, state -> StateAndRef(uncheckedCast<TransactionState<ContractState>, TransactionState<T>>(state), StateRef(finalized.id, index)) }
     }
 
     /**
@@ -106,25 +107,23 @@ class MoveNotaryFlow<out T: ContractState>(
                 serviceHub.digestService
         ).build()
 
-
         val myKeys = serviceHub.keyManagementService.filterMyKeys(participants.map { it.owningKey })
-        return SignedTransaction(tx, myKeys.map{ signTransaction(tx.id, it)}) to participants
+        return SignedTransaction(tx, myKeys.map { signTransaction(tx.id, it) }) to participants
     }
 
-    private fun signTransaction( id: SecureHash, key: PublicKey) : TransactionSignature {
+    private fun signTransaction(id: SecureHash, key: PublicKey): TransactionSignature {
         val signableData = SignableData(id, SignatureMetadata(serviceHub.myInfo.platformVersion, Crypto.findSignatureScheme(key).schemeNumberID))
         return serviceHub.keyManagementService.sign(signableData, key)
-
     }
 
     /**
      * Find any states encumbered by any of the input states. Process each state at max once.
      * At the end, reorder the ouput to have the original states first, then adding any additional encumbrances.
      */
-    private fun resolveEncumbrances() : List<StateAndRef<T>> {
+    private fun resolveEncumbrances(): List<StateAndRef<T>> {
         val resolvedStates = mutableSetOf<StateAndRef<T>>()
         states.forEach { state ->
-            if (!resolvedStates.contains(state)){
+            if (!resolvedStates.contains(state)) {
                 resolvedStates.addAll(resolveEncumbrancesForOneState(state))
             }
         }
@@ -132,7 +131,7 @@ class MoveNotaryFlow<out T: ContractState>(
     }
 
     /** Resolves the encumbrance state chain for the given [state]. */
-    private fun resolveEncumbrancesForOneState(state: StateAndRef<T>) : Set<StateAndRef<T>> {
+    private fun resolveEncumbrancesForOneState(state: StateAndRef<T>): Set<StateAndRef<T>> {
         val resolvedStates = mutableSetOf(state)
         while (resolvedStates.last().state.encumbrance != null) {
             val encumbranceStateRef = StateRef(resolvedStates.last().ref.txhash, resolvedStates.last().state.encumbrance!!)
@@ -143,12 +142,12 @@ class MoveNotaryFlow<out T: ContractState>(
     }
 
     private fun getParticipantSessions(participants: Set<AbstractParty>): List<FlowSession> {
-        return excludeHostNode(serviceHub, groupAbstractPartyByWellKnownParty(serviceHub, participants)).map { initiateFlow(it.key)  }
+        return excludeHostNode(serviceHub, groupAbstractPartyByWellKnownParty(serviceHub, participants)).map { initiateFlow(it.key) }
     }
 }
 
 @InitiatedBy(MoveNotaryFlow::class)
-class MoveNotaryResponder( val otherSideSession: FlowSession) : FlowLogic<Unit>() {
+class MoveNotaryResponder(val otherSideSession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         subFlow(object : SignTransactionFlow(otherSideSession) {

--- a/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
@@ -10,13 +10,18 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignableData
 import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.identity.excludeHostNode
 import net.corda.core.identity.groupAbstractPartyByWellKnownParty
 import net.corda.core.internal.NotaryChangeTransactionBuilder
+import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.digestService
 import net.corda.core.internal.uncheckedCast
+import net.corda.core.internal.verification.toVerifyingServiceHub
+import net.corda.core.transactions.NotaryChangeLedgerTransaction
+import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import java.security.PublicKey
@@ -127,5 +132,63 @@ class MoveNotaryFlow<out T: ContractState>(
 
     private fun getParticipantSessions(participants: Set<AbstractParty>): List<FlowSession> {
         return excludeHostNode(serviceHub, groupAbstractPartyByWellKnownParty(serviceHub, participants)).map { initiateFlow(it.key)  }
+    }
+}
+
+@InitiatedBy(MoveNotaryFlow::class)
+class MoveNotaryResponder( val otherSideSession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        subFlow(object : SignTransactionFlow(otherSideSession) {
+
+            override fun checkTransaction(stx: SignedTransaction) {
+                checkInitiatorSignedAppropriately(stx)
+            }
+        })
+
+        subFlow(ReceiveFinalityFlow(otherSideSession))
+    }
+
+    @VisibleForTesting
+    fun checkInitiatorSignedAppropriately(stx: SignedTransaction) {
+        val ltx = NotaryChangeLedgerTransaction.resolve(serviceHub.toVerifyingServiceHub(), stx.coreTransaction as NotaryChangeWireTransaction, stx.sigs)
+        val encumbranceGroups = groupOutputsByEncumbrances(ltx.outputs.mapIndexed { index, state -> StateAndRef(state, StateRef(ltx.id, index)) })
+        require(encumbranceGroups.first().all { stateRef ->
+            ltx.outputs[stateRef.index].data.participants.any { participant -> stx.sigs.any { sig -> participant.owningKey.isFulfilledBy(sig.by) } }
+        })
+        { "Initiator did not sign for all non-encumbered states!" }
+        require(encumbranceGroups.drop(1).all {
+            it.any { stateRef ->
+                ltx.outputs[stateRef.index].data.participants.any { participant -> stx.sigs.any { sig -> participant.owningKey.isFulfilledBy(sig.by) } }
+            }
+        }) { "Initiator added encumbered state and did not sign for any of the group of encumbered states." }
+    }
+
+    private fun groupOutputsByEncumbrances(outputs: List<StateAndRef<*>>): List<List<StateRef>> {
+        val seenStates = mutableSetOf<StateRef>()
+        val result = mutableListOf(mutableListOf<StateRef>())
+
+        outputs.forEach {
+            if (!seenStates.add(it.ref)) {  // add the state to the list of seen states - if it's already in the set, we have already seen it
+                return@forEach
+            }
+            if (it.state.encumbrance == null) { // if not encumbered, it goes into the first bin of the result
+                result[0].add(it.ref)
+                return@forEach
+            }
+
+            // We have an encumbered state - add a new bin to the result
+            result.add(mutableListOf())
+            var currentState = it
+            while (true) {
+                result.last().add(currentState.ref) // add state to the new bin
+                val encumbrance = currentState.state.encumbrance!! // get next encumbrance (can't be null because encumbrances need to cyclic)
+                currentState = outputs[encumbrance]  // fetch the encumbering state
+                if (!seenStates.add(currentState.ref)) { // try to add it to seen states - if it's already in, we're done with this set of encumbrances.
+                    break
+                }
+            }
+        }
+        return result
     }
 }

--- a/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
@@ -27,13 +27,25 @@ import net.corda.core.utilities.ProgressTracker
 import java.security.PublicKey
 
 /**
- * A flow to be used for moving a list of states to a different Notary. This is required since all input states to a
- * transaction must point to the same notary.
+ * A flow to be used for moving a list of states to a different Notary.
  *
  * This assembles the transaction for notary replacement and sends out change proposals to all participants
  * of the states. If participants agree to the proposed change, they each sign the transaction.
  * Finally, the transaction containing all signatures is sent back to each participant so they can record it and
  * use the new updated states for future transactions.
+ *
+ * The notary change transaction is constructed in a way that it can _only_ change the notary - it only accepts
+ * inputs and a new notary value. The inputs to this flow need to of type `StateAndRef` - i.e. the requestor
+ * needs to have access to the actual state, not just a state ref.
+ *
+ * If a notary move is requested for an encumbered state, all encumbrances are moved in the same transaction
+ *
+ * The requirements for using the flow are:
+ *
+ * - All input states must be on the same notary
+ * - The initiator needs to be a participant in all states that they request moving for.
+ * - Old and new notary need to be whitelisted notaries on the network, in the current version of the network parameters
+ * - The new notary cannot be the same as the old notary
  */
 @InitiatingFlow
 class MoveNotaryFlow<out T: ContractState>(

--- a/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
@@ -1,0 +1,127 @@
+package net.corda.core.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SignableData
+import net.corda.core.crypto.SignatureMetadata
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import net.corda.core.identity.excludeHostNode
+import net.corda.core.identity.groupAbstractPartyByWellKnownParty
+import net.corda.core.internal.NotaryChangeTransactionBuilder
+import net.corda.core.internal.digestService
+import net.corda.core.internal.uncheckedCast
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ProgressTracker
+import java.security.PublicKey
+
+/**
+ * A flow to be used for moving a list of states to a different Notary. This is required since all input states to a
+ * transaction must point to the same notary.
+ *
+ * This assembles the transaction for notary replacement and sends out change proposals to all participants
+ * of the states. If participants agree to the proposed change, they each sign the transaction.
+ * Finally, the transaction containing all signatures is sent back to each participant so they can record it and
+ * use the new updated states for future transactions.
+ */
+@InitiatingFlow
+class MoveNotaryFlow<out T: ContractState>(
+        val states: List<StateAndRef<T>>,
+        val newNotary: Party,
+        override val progressTracker: ProgressTracker = tracker()) : FlowLogic<List<StateAndRef<T>>>() {
+    companion object {
+        object BUILDING : ProgressTracker.Step("Resolving inputs and building transaction")
+        object SIGNING : ProgressTracker.Step("Requesting signatures from other parties"){
+            override fun childProgressTracker() = CollectSignaturesFlow.tracker()
+        }
+        object FINALIZING : ProgressTracker.Step("Invoking finality") {
+            override fun childProgressTracker() = FinalityFlow.tracker()
+        }
+
+        fun tracker() = ProgressTracker(BUILDING, SIGNING, FINALIZING)
+    }
+
+    private val oldNotary = states.map{it.state.notary}.singleOrNull()
+
+    init {
+        require(states.isNotEmpty()) { "Notary change flow must receive at least one state to work on" }
+        require(oldNotary != null) { "All input states must be on the same notary" }
+        require(oldNotary != newNotary) { "The new notary cannot be the same as the old notary" }
+    }
+
+    @Suspendable
+    override fun call(): List<StateAndRef<T>> {
+        progressTracker.currentStep = BUILDING
+        val (stx, participants) = assembleTx()
+        val sessions = getParticipantSessions(participants)
+        progressTracker.currentStep = SIGNING
+        val fullySigned = subFlow(CollectSignaturesFlow(stx, sessions, SIGNING.childProgressTracker()))
+        progressTracker.currentStep = FINALIZING
+        val finalized = subFlow(FinalityFlow(fullySigned, sessions, FINALIZING.childProgressTracker()))
+        return finalized.resolveBaseTransaction(serviceHub).outputs
+                .take(states.size)
+                .mapIndexed{ index, state -> StateAndRef(uncheckedCast<TransactionState<ContractState>, TransactionState<T>>(state), StateRef(finalized.id, index))}
+    }
+
+    /**
+     * This assembles the notary change transaction by resolving any encumbered states, adding all inputs and signing it.
+     * The original n states are the first n inputs/outputs, states added due to encumbrances are added at the end
+     */
+    private fun assembleTx(): Pair<SignedTransaction, Set<AbstractParty>> {
+        val inputs = resolveEncumbrances()
+        val participants = inputs.flatMap { it.state.data.participants }.toSet()
+        val tx = NotaryChangeTransactionBuilder(
+                inputs.map { it.ref },
+                oldNotary!!,
+                newNotary,
+                serviceHub.networkParametersService.currentHash,
+                participants.map { it.owningKey }.toSet(),
+                serviceHub.digestService
+        ).build()
+
+        // TODO: We need a much faster way of finding our key in the transaction
+        val myKeys = serviceHub.keyManagementService.filterMyKeys(participants.map { it.owningKey })
+        return SignedTransaction(tx, myKeys.map{ signTransaction(tx.id, it)}) to participants
+    }
+
+    private fun signTransaction( id: SecureHash, key: PublicKey) : TransactionSignature {
+        val signableData = SignableData(id, SignatureMetadata(serviceHub.myInfo.platformVersion, Crypto.findSignatureScheme(key).schemeNumberID))
+        return serviceHub.keyManagementService.sign(signableData, key)
+
+    }
+
+    /**
+     * Find any states encumbered by any of the input states. Process each state at max once.
+     * At the end, reorder the ouput to have the original states first, then adding any additional encumbrances.
+     */
+    private fun resolveEncumbrances() : List<StateAndRef<T>> {
+        val resolvedStates = mutableSetOf<StateAndRef<T>>()
+        states.forEach { state ->
+            if (!resolvedStates.contains(state)){
+                resolvedStates.addAll(resolveEncumbrancesForOneState(state))
+            }
+        }
+        return states + (resolvedStates - states)
+    }
+
+    /** Resolves the encumbrance state chain for the given [state]. */
+    private fun resolveEncumbrancesForOneState(state: StateAndRef<T>) : Set<StateAndRef<T>> {
+        val resolvedStates = mutableSetOf(state)
+        while (resolvedStates.last().state.encumbrance != null) {
+            val encumbranceStateRef = StateRef(resolvedStates.last().ref.txhash, resolvedStates.last().state.encumbrance!!)
+            val encumbranceState = serviceHub.toStateAndRef<T>(encumbranceStateRef)
+            if (!resolvedStates.add(encumbranceState)) break // Stop if there is a cycle.
+        }
+        return resolvedStates
+    }
+
+    private fun getParticipantSessions(participants: Set<AbstractParty>): List<FlowSession> {
+        return excludeHostNode(serviceHub, groupAbstractPartyByWellKnownParty(serviceHub, participants)).map { initiateFlow(it.key)  }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
@@ -74,6 +74,10 @@ class MoveNotaryFlow<out T: ContractState>(
      * The original n states are the first n inputs/outputs, states added due to encumbrances are added at the end
      */
     private fun assembleTx(): Pair<SignedTransaction, Set<AbstractParty>> {
+        require(states.all {
+            serviceHub.keyManagementService.filterMyKeys(it.state.data.participants.map { it.owningKey }).toList().isNotEmpty()
+        }) { "Cannot request move for state we are not a participant in" }
+
         val inputs = resolveEncumbrances()
         val participants = inputs.flatMap { it.state.data.participants }.toSet()
         val tx = NotaryChangeTransactionBuilder(
@@ -85,7 +89,7 @@ class MoveNotaryFlow<out T: ContractState>(
                 serviceHub.digestService
         ).build()
 
-        // TODO: We need a much faster way of finding our key in the transaction
+
         val myKeys = serviceHub.keyManagementService.filterMyKeys(participants.map { it.owningKey })
         return SignedTransaction(tx, myKeys.map{ signTransaction(tx.id, it)}) to participants
     }

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt
@@ -31,15 +31,17 @@ class NotaryChangeFlow<out T : ContractState>(
     override fun assembleTx(): AbstractStateReplacementFlow.UpgradeTx {
         val inputs = resolveEncumbrances(originalState)
 
+        val participantKeys = inputs.flatMap { it.state.data.participants }.map { it.owningKey }.toSet()
+
         val tx = NotaryChangeTransactionBuilder(
                 inputs.map { it.ref },
                 originalState.state.notary,
                 modification,
                 serviceHub.networkParametersService.currentHash,
+                participantKeys,
                 serviceHub.digestService
         ).build()
 
-        val participantKeys = inputs.flatMap { it.state.data.participants }.map { it.owningKey }.toSet()
         // TODO: We need a much faster way of finding our key in the transaction
         val myKey = serviceHub.keyManagementService.filterMyKeys(participantKeys).single()
         val signableData = SignableData(tx.id, SignatureMetadata(serviceHub.myInfo.platformVersion, Crypto.findSignatureScheme(myKey).schemeNumberID))

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -53,11 +53,12 @@ class NotaryChangeTransactionBuilder(val inputs: List<StateRef>,
                                      val notary: Party,
                                      val newNotary: Party,
                                      val networkParametersHash: SecureHash,
+                                     val requiredSignatures: Set<PublicKey>,
                                      val digestService: DigestService = DigestService.sha2_256) {
 
     fun build(): NotaryChangeWireTransaction {
         val components = listOf(inputs, notary, newNotary, networkParametersHash).map { it.serialize() }
-        return NotaryChangeWireTransaction(components, digestService)
+        return NotaryChangeWireTransaction(components, digestService, requiredSignatures)
     }
 }
 

--- a/core/src/main/kotlin/net/corda/core/internal/verification/VerificationResult.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/verification/VerificationResult.kt
@@ -1,5 +1,6 @@
 package net.corda.core.internal.verification
 
+import net.corda.core.transactions.FullTransaction
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.Try
 import net.corda.core.utilities.Try.Failure
@@ -9,28 +10,28 @@ sealed class VerificationResult {
     /**
      * The in-process result for the current version of the transcaction.
      */
-    abstract val inProcessResult: Try<LedgerTransaction?>?
+    abstract val inProcessResult: Try<FullTransaction?>?
 
     /**
      * The external verifier result for the legacy version of the transaction.
      */
     abstract val externalResult: Try<Unit>?
 
-    abstract fun enforceSuccess(): LedgerTransaction?
+    abstract fun enforceSuccess(): FullTransaction?
 
 
-    data class InProcess(override val inProcessResult: Try<LedgerTransaction?>) : VerificationResult() {
+    data class InProcess(override val inProcessResult: Try<FullTransaction?>) : VerificationResult() {
         override val externalResult: Try<Unit>?
             get() = null
 
-        override fun enforceSuccess(): LedgerTransaction? = inProcessResult.getOrThrow()
+        override fun enforceSuccess(): FullTransaction? = inProcessResult.getOrThrow()
     }
 
     data class External(override val externalResult: Try<Unit>) : VerificationResult() {
-        override val inProcessResult: Try<LedgerTransaction?>?
+        override val inProcessResult: Try<FullTransaction?>?
             get() = null
 
-        override fun enforceSuccess(): LedgerTransaction? {
+        override fun enforceSuccess(): FullTransaction? {
             externalResult.getOrThrow()
             // We could create a LedgerTransaction here, and except for calling `verify()`, it would be valid to use. However, it's best
             // we let the caller deal with that, since we can't prevent them from calling it.
@@ -42,7 +43,7 @@ sealed class VerificationResult {
             override val inProcessResult: Try<LedgerTransaction>,
             override val externalResult: Try<Unit>
     ) : VerificationResult() {
-        override fun enforceSuccess(): LedgerTransaction {
+        override fun enforceSuccess(): FullTransaction {
             return when (externalResult) {
                 is Success -> when (inProcessResult) {
                     is Success -> inProcessResult.value

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt
@@ -7,6 +7,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.checkNotaryWhitelisted
 import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
+import java.security.PublicKey
 
 /**
  * A transaction with the minimal amount of information required to compute the unique transaction [id], and
@@ -24,6 +25,9 @@ abstract class CoreTransaction : BaseTransaction() {
      * was created on older version of Corda (before 4), resolution will default to initial parameters.
      */
     abstract val networkParametersHash: SecureHash?
+
+    /** Public keys that need to be fulfilled by signatures in order for the transaction to be valid. */
+    abstract val requiredSigningKeys: Set<PublicKey>
 }
 
 /** A transaction with fully resolved components, such as input states. */

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -105,6 +105,8 @@ data class ContractUpgradeWireTransaction(
             serializedComponents[PARAMETERS_HASH.ordinal].deserialize<SecureHash>()
         } else null
     }
+    override val requiredSigningKeys: Set<PublicKey>
+        get() = TODO("Not yet implemented")
 
     init {
         check(inputs.isNotEmpty()) { "A contract upgrade transaction must have inputs" }
@@ -224,6 +226,8 @@ data class ContractUpgradeFilteredTransaction(
     override val networkParametersHash: SecureHash? by lazy {
         visibleComponents[PARAMETERS_HASH.ordinal]?.component?.deserialize<SecureHash>()
     }
+    override val requiredSigningKeys: Set<PublicKey>
+        get() = TODO("Not yet implemented")
     override val id: SecureHash by lazy {
         val totalComponents = visibleComponents.size + hiddenComponents.size
         val hashList = (0 until totalComponents).map { i ->

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -106,7 +106,7 @@ data class ContractUpgradeWireTransaction(
         } else null
     }
     override val requiredSigningKeys: Set<PublicKey>
-        get() = TODO("Not yet implemented")
+        get() = throw NotImplementedError("Not implemented - contract upgrade is no longer supported as of Corda 4.12")
 
     init {
         check(inputs.isNotEmpty()) { "A contract upgrade transaction must have inputs" }
@@ -226,8 +226,10 @@ data class ContractUpgradeFilteredTransaction(
     override val networkParametersHash: SecureHash? by lazy {
         visibleComponents[PARAMETERS_HASH.ordinal]?.component?.deserialize<SecureHash>()
     }
+
     override val requiredSigningKeys: Set<PublicKey>
-        get() = TODO("Not yet implemented")
+        get() = throw NotImplementedError("Not implemented - contract upgrade is no longer supported as of Corda 4.12")
+
     override val id: SecureHash by lazy {
         val totalComponents = visibleComponents.size + hiddenComponents.size
         val hashList = (0 until totalComponents).map { i ->

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -368,6 +368,9 @@ class FilteredTransaction internal constructor(
             throw ComponentVisibilityException(id, message.toString())
         }
     }
+
+    override val requiredSigningKeys: Set<PublicKey>
+        get() = TODO("Not yet implemented")
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -370,7 +370,7 @@ class FilteredTransaction internal constructor(
     }
 
     override val requiredSigningKeys: Set<PublicKey>
-        get() = TODO("Not yet implemented")
+        get() = throw NotImplementedError("A filtered transaction cannot reveal required signers.")
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -46,19 +46,24 @@ data class NotaryChangeWireTransaction(
          * may result in a different byte sequence depending on the serialization context.
          */
         val serializedComponents: List<OpaqueBytes>,
-        val digestService: DigestService
+        val digestService: DigestService,
+        val requiredSigningKeys: Set<PublicKey>
 ) : CoreTransaction() {
     /**
      * Old version of [NotaryChangeWireTransaction] constructor for ABI compatibility.
      */
+    @DeprecatedConstructorForDeserialization(2)
+    constructor(serializedComponents: List<OpaqueBytes>, digestService: DigestService) : this(serializedComponents, digestService, emptySet())
+
+
     @DeprecatedConstructorForDeserialization(1)
-    constructor(serializedComponents: List<OpaqueBytes>) : this(serializedComponents, DigestService.sha2_256)
+    constructor(serializedComponents: List<OpaqueBytes>) : this(serializedComponents, DigestService.sha2_256, emptySet())
 
     /**
      * Old version of [NotaryChangeWireTransaction.copy] for ABI compatibility.
      */
     fun copy(serializedComponents: List<OpaqueBytes>): NotaryChangeWireTransaction {
-        return NotaryChangeWireTransaction(serializedComponents, DigestService.sha2_256)
+        return NotaryChangeWireTransaction(serializedComponents, DigestService.sha2_256, requiredSigningKeys)
     }
 
     override val inputs: List<StateRef> = serializedComponents[INPUTS.ordinal].deserialize()
@@ -116,7 +121,6 @@ data class NotaryChangeWireTransaction(
         return VerificationResult.InProcess(Try.on {
             // No contract code is run when verifying notary change transactions, it is sufficient to check invariants during initialisation.
             NotaryChangeLedgerTransaction.resolve(verificationSupport, this, emptyList())
-            null
         })
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -47,7 +47,7 @@ data class NotaryChangeWireTransaction(
          */
         val serializedComponents: List<OpaqueBytes>,
         val digestService: DigestService,
-        override val requiredSigningKeys: Set<PublicKey>
+        final override val requiredSigningKeys: Set<PublicKey>
 ) : CoreTransaction() {
     /**
      * Old version of [NotaryChangeWireTransaction] constructor for ABI compatibility.
@@ -60,10 +60,14 @@ data class NotaryChangeWireTransaction(
     constructor(serializedComponents: List<OpaqueBytes>) : this(serializedComponents, DigestService.sha2_256, emptySet())
 
     /**
-     * Old version of [NotaryChangeWireTransaction.copy] for ABI compatibility.
+     * Old versions of [NotaryChangeWireTransaction.copy] for ABI compatibility.
      */
     fun copy(serializedComponents: List<OpaqueBytes>): NotaryChangeWireTransaction {
         return NotaryChangeWireTransaction(serializedComponents, DigestService.sha2_256, requiredSigningKeys)
+    }
+
+    fun copy(serializedComponents: List<OpaqueBytes>, digestService: DigestService) : NotaryChangeWireTransaction {
+        return NotaryChangeWireTransaction(serializedComponents, digestService, requiredSigningKeys )
     }
 
     override val inputs: List<StateRef> = serializedComponents[INPUTS.ordinal].deserialize()

--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -212,14 +212,12 @@ private constructor(
      */
     private fun checkEncumbrances() {
         val encumberedStates = inputs.asSequence().filter { it.state.encumbrance != null }.associateBy { it.ref }
-        if (encumberedStates.isNotEmpty()) {
-            inputs.forEach { (state, ref) ->
-                if (StateRef(ref.txhash, state.encumbrance!!) !in encumberedStates) {
-                    throw TransactionVerificationException.TransactionMissingEncumbranceException(
-                            id,
-                            state.encumbrance,
-                            TransactionVerificationException.Direction.INPUT)
-                }
+        encumberedStates.values.forEach { (state, ref) ->
+            if (StateRef(ref.txhash, state.encumbrance!!) !in encumberedStates) {
+                throw TransactionVerificationException.TransactionMissingEncumbranceException(
+                        id,
+                        state.encumbrance,
+                        TransactionVerificationException.Direction.INPUT)
             }
         }
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -47,7 +47,7 @@ data class NotaryChangeWireTransaction(
          */
         val serializedComponents: List<OpaqueBytes>,
         val digestService: DigestService,
-        val requiredSigningKeys: Set<PublicKey>
+        override val requiredSigningKeys: Set<PublicKey>
 ) : CoreTransaction() {
     /**
      * Old version of [NotaryChangeWireTransaction] constructor for ABI compatibility.

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -91,7 +91,26 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     /** Helper to access the network parameters hash for the contained transaction. */
     val networkParametersHash: SecureHash? get() = coreTransaction.networkParametersHash
 
-    override val requiredSigningKeys: Set<PublicKey> get() = tx.requiredSigningKeys
+    override val requiredSigningKeys: Set<PublicKey>
+        get() {
+            val coreTx = this.coreTransaction
+            return when (coreTx) {
+                is WireTransaction -> coreTx.requiredSigningKeys
+                is NotaryChangeWireTransaction -> coreTx.requiredSigningKeys
+                else -> throw IllegalArgumentException("Invalid input to CollectSignaturesFlow - core tx was ${coreTx::class}")
+            }
+        }
+
+    val notaryKey: PublicKey?
+        get() {
+            val coreTx = this.coreTransaction
+            return when (coreTx) {
+                is WireTransaction -> coreTx.notary?.owningKey
+                is NotaryChangeWireTransaction -> coreTx.notary.owningKey
+                else -> throw IllegalArgumentException("Invalid input to CollectSignaturesFlow - core tx was ${coreTx::class}")
+            }
+        }
+
 
     override fun getKeyDescriptions(keys: Set<PublicKey>): ArrayList<String> {
         // TODO: We need a much better way of structuring this data.
@@ -192,7 +211,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
      */
     @CordaInternal
     @JvmSynthetic
-    internal fun verifyInternal(verificationSupport: NodeVerificationSupport, checkSufficientSignatures: Boolean = true): LedgerTransaction? {
+    internal fun verifyInternal(verificationSupport: NodeVerificationSupport, checkSufficientSignatures: Boolean = true): FullTransaction? {
         resolveAndCheckNetworkParameters(verificationSupport)
         verifySignatures(verificationSupport, checkSufficientSignatures)
         val ctx = coreTransaction

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -101,17 +101,6 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
             }
         }
 
-    val notaryKey: PublicKey?
-        get() {
-            val coreTx = this.coreTransaction
-            return when (coreTx) {
-                is WireTransaction -> coreTx.notary?.owningKey
-                is NotaryChangeWireTransaction -> coreTx.notary.owningKey
-                else -> throw IllegalArgumentException("Invalid input to CollectSignaturesFlow - core tx was ${coreTx::class}")
-            }
-        }
-
-
     override fun getKeyDescriptions(keys: Set<PublicKey>): ArrayList<String> {
         // TODO: We need a much better way of structuring this data.
         val descriptions = ArrayList<String>()

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -91,7 +91,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     /** Helper to access the network parameters hash for the contained transaction. */
     val networkParametersHash: SecureHash? get() = coreTransaction.networkParametersHash
 
-    override val requiredSigningKeys: Set<PublicKey> = coreTransaction.requiredSigningKeys
+    override val requiredSigningKeys: Set<PublicKey> get() = coreTransaction.requiredSigningKeys
 
     override fun getKeyDescriptions(keys: Set<PublicKey>): ArrayList<String> {
         // TODO: We need a much better way of structuring this data.

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -91,15 +91,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     /** Helper to access the network parameters hash for the contained transaction. */
     val networkParametersHash: SecureHash? get() = coreTransaction.networkParametersHash
 
-    override val requiredSigningKeys: Set<PublicKey>
-        get() {
-            val coreTx = this.coreTransaction
-            return when (coreTx) {
-                is WireTransaction -> coreTx.requiredSigningKeys
-                is NotaryChangeWireTransaction -> coreTx.requiredSigningKeys
-                else -> throw IllegalArgumentException("Invalid input to CollectSignaturesFlow - core tx was ${coreTx::class}")
-            }
-        }
+    override val requiredSigningKeys: Set<PublicKey> = coreTransaction.requiredSigningKeys
 
     override fun getKeyDescriptions(keys: Set<PublicKey>): ArrayList<String> {
         // TODO: We need a much better way of structuring this data.

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -123,7 +123,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
     override val id: SecureHash get() = merkleTree.hash
 
     /** Public keys that need to be fulfilled by signatures in order for the transaction to be valid. */
-    override val requiredSigningKeys: Set<PublicKey>
+    final override val requiredSigningKeys: Set<PublicKey>
         get() {
             val keys = LinkedHashSet<PublicKey>()
             val signersGroup: List<List<PublicKey>> = uncheckedCast(deserialiseComponentGroup(componentGroups, List::class, SIGNERS_GROUP))

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -123,7 +123,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
     override val id: SecureHash get() = merkleTree.hash
 
     /** Public keys that need to be fulfilled by signatures in order for the transaction to be valid. */
-    val requiredSigningKeys: Set<PublicKey>
+    override val requiredSigningKeys: Set<PublicKey>
         get() {
             val keys = LinkedHashSet<PublicKey>()
             val signersGroup: List<List<PublicKey>> = uncheckedCast(deserialiseComponentGroup(componentGroups, List::class, SIGNERS_GROUP))

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -22,7 +22,6 @@ import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRefFactory
 import net.corda.core.flows.InitiatedBy
-import net.corda.core.flows.MoveNotaryFlow
 import net.corda.core.flows.NotaryChangeFlow
 import net.corda.core.flows.NotaryFlow
 import net.corda.core.flows.StateMachineRunId
@@ -88,7 +87,6 @@ import net.corda.node.internal.rpc.proxies.ThreadContextAdjustingRpcOpsProxy
 import net.corda.node.internal.shell.InteractiveShell
 import net.corda.node.services.ContractUpgradeHandler
 import net.corda.node.services.FinalityHandler
-import net.corda.node.services.MoveNotaryHandler
 import net.corda.node.services.NotaryChangeHandler
 import net.corda.node.services.api.AuditService
 import net.corda.node.services.api.DummyAuditService
@@ -1056,7 +1054,6 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         flowManager.registerInitiatedCoreFlowFactory(NotaryChangeFlow::class, NotaryChangeHandler::class, ::NotaryChangeHandler)
         flowManager.registerInitiatedCoreFlowFactory(ContractUpgradeFlow.Initiate::class, NotaryChangeHandler::class, ::ContractUpgradeHandler)
         flowManager.registerInitiatedCoreFlowFactory(SwapIdentitiesFlow::class, SwapIdentitiesHandler::class, ::SwapIdentitiesHandler)
-        flowManager.registerInitiatedCoreFlowFactory(MoveNotaryFlow::class, MoveNotaryHandler::class, ::MoveNotaryHandler)
     }
 
     // Ideally we should be disabling the FinalityHandler if it's not needed, to prevent any party from submitting transactions to us without

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -22,6 +22,7 @@ import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRefFactory
 import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.MoveNotaryFlow
 import net.corda.core.flows.NotaryChangeFlow
 import net.corda.core.flows.NotaryFlow
 import net.corda.core.flows.StateMachineRunId
@@ -87,6 +88,7 @@ import net.corda.node.internal.rpc.proxies.ThreadContextAdjustingRpcOpsProxy
 import net.corda.node.internal.shell.InteractiveShell
 import net.corda.node.services.ContractUpgradeHandler
 import net.corda.node.services.FinalityHandler
+import net.corda.node.services.MoveNotaryHandler
 import net.corda.node.services.NotaryChangeHandler
 import net.corda.node.services.api.AuditService
 import net.corda.node.services.api.DummyAuditService
@@ -1054,6 +1056,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         flowManager.registerInitiatedCoreFlowFactory(NotaryChangeFlow::class, NotaryChangeHandler::class, ::NotaryChangeHandler)
         flowManager.registerInitiatedCoreFlowFactory(ContractUpgradeFlow.Initiate::class, NotaryChangeHandler::class, ::ContractUpgradeHandler)
         flowManager.registerInitiatedCoreFlowFactory(SwapIdentitiesFlow::class, SwapIdentitiesHandler::class, ::SwapIdentitiesHandler)
+        flowManager.registerInitiatedCoreFlowFactory(MoveNotaryFlow::class, MoveNotaryHandler::class, ::MoveNotaryHandler)
     }
 
     // Ideally we should be disabling the FinalityHandler if it's not needed, to prevent any party from submitting transactions to us without

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/VirtualCordapps.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/VirtualCordapps.kt
@@ -3,6 +3,8 @@ package net.corda.node.internal.cordapp
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.ContractUpgradeFlow
+import net.corda.core.flows.MoveNotaryFlow
+import net.corda.core.flows.MoveNotaryResponder
 import net.corda.core.internal.cordapp.CordappImpl
 import net.corda.core.internal.location
 import net.corda.core.internal.toPath
@@ -19,7 +21,12 @@ internal object VirtualCordapp {
     private val coreRpcFlows = listOf(
             ContractUpgradeFlow.Initiate::class.java,
             ContractUpgradeFlow.Authorise::class.java,
-            ContractUpgradeFlow.Deauthorise::class.java
+            ContractUpgradeFlow.Deauthorise::class.java,
+            MoveNotaryFlow::class.java
+    )
+
+    private val coreInitiatedFlows = listOf(
+            MoveNotaryResponder::class.java
     )
 
     /** A Cordapp representing the core package which is not scanned automatically. */
@@ -27,7 +34,7 @@ internal object VirtualCordapp {
         return CordappImpl(
                 jarFile = ContractUpgradeFlow.javaClass.location.toPath(), // Core JAR location
                 contractClassNames = listOf(),
-                initiatedFlows = listOf(),
+                initiatedFlows = coreInitiatedFlows,
                 rpcFlows = coreRpcFlows,
                 serviceFlows = listOf(),
                 schedulableFlows = listOf(),

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -2,14 +2,21 @@ package net.corda.node.services
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.UpgradedContract
 import net.corda.core.contracts.requireThat
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.ContractUpgradeUtils
+import net.corda.core.internal.VisibleForTesting
+import net.corda.core.internal.verification.toVerifyingServiceHub
 import net.corda.core.internal.warnOnce
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.ContractUpgradeWireTransaction
+import net.corda.core.transactions.NotaryChangeLedgerTransaction
+import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.SignedTransaction
 
 class FinalityHandler(private val sender: FlowSession) : FlowLogic<Unit>() {
@@ -74,10 +81,53 @@ class MoveNotaryHandler( val otherSideSession: FlowSession) : FlowLogic<Unit>() 
         subFlow(object : SignTransactionFlow(otherSideSession) {
 
             override fun checkTransaction(stx: SignedTransaction) {
-                // no op for now
+                checkInitiatorSignedAppropriately(stx)
             }
         })
 
         subFlow(ReceiveFinalityFlow(otherSideSession))
+    }
+
+    @VisibleForTesting
+    fun checkInitiatorSignedAppropriately(stx: SignedTransaction) {
+        val ltx = NotaryChangeLedgerTransaction.resolve(serviceHub.toVerifyingServiceHub(), stx.coreTransaction as NotaryChangeWireTransaction, stx.sigs)
+        val encumbranceGroups = groupOutputsByEncumbrances(ltx.outputs.mapIndexed { index, state -> StateAndRef(state, StateRef(ltx.id, index)) })
+        require(encumbranceGroups.first().all { stateRef ->
+            ltx.outputs[stateRef.index].data.participants.any { participant -> stx.sigs.any { sig -> participant.owningKey.isFulfilledBy(sig.by) } }
+        })
+        { "Initiator did not sign for all non-encumbered states!" }
+        require(encumbranceGroups.drop(1).all {
+            it.any { stateRef ->
+                ltx.outputs[stateRef.index].data.participants.any { participant -> stx.sigs.any { sig -> participant.owningKey.isFulfilledBy(sig.by) } }
+            }
+        }) { "Initiator added encumbered state and did not sign for any of the group of encumbered states." }
+    }
+
+    private fun groupOutputsByEncumbrances(outputs: List<StateAndRef<*>>): List<List<StateRef>> {
+        val seenStates = mutableSetOf<StateRef>()
+        val result = mutableListOf(mutableListOf<StateRef>())
+
+        outputs.forEach {
+            if (!seenStates.add(it.ref)) {  // add the state to the list of seen states - if it's already in the set, we have already seen it
+                return@forEach
+            }
+            if (it.state.encumbrance == null) { // if not encumbered, it goes into the first bin of the result
+                result[0].add(it.ref)
+                return@forEach
+            }
+
+            // We have an encumbered state - add a new bin to the result
+            result.add(mutableListOf())
+            var currentState = it
+            while (true) {
+                result.last().add(currentState.ref) // add state to the new bin
+                val encumbrance = currentState.state.encumbrance!! // get next encumbrance (can't be null because encumbrances need to cyclic)
+                currentState = outputs[encumbrance]  // fetch the encumbering state
+                if (!seenStates.add(currentState.ref)) { // try to add it to seen states - if it's already in, we're done with this set of encumbrances.
+                    break
+                }
+            }
+        }
+        return result
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -2,21 +2,18 @@ package net.corda.node.services
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.ContractState
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.UpgradedContract
 import net.corda.core.contracts.requireThat
-import net.corda.core.crypto.isFulfilledBy
-import net.corda.core.flows.*
+import net.corda.core.flows.AbstractStateReplacementFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.ReceiveTransactionFlow
+import net.corda.core.flows.StateReplacementException
 import net.corda.core.identity.Party
 import net.corda.core.internal.ContractUpgradeUtils
-import net.corda.core.internal.VisibleForTesting
-import net.corda.core.internal.verification.toVerifyingServiceHub
 import net.corda.core.internal.warnOnce
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.ContractUpgradeWireTransaction
-import net.corda.core.transactions.NotaryChangeLedgerTransaction
-import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.SignedTransaction
 
 class FinalityHandler(private val sender: FlowSession) : FlowLogic<Unit>() {
@@ -72,62 +69,5 @@ class ContractUpgradeHandler(otherSide: FlowSession) : AbstractStateReplacementF
             "The proposed tx matches the expected tx for this upgrade" using (proposedTx == expectedTx)
         }
         proposedTx.resolve(serviceHub, stx.sigs)
-    }
-}
-
-class MoveNotaryHandler( val otherSideSession: FlowSession) : FlowLogic<Unit>() {
-    @Suspendable
-    override fun call() {
-        subFlow(object : SignTransactionFlow(otherSideSession) {
-
-            override fun checkTransaction(stx: SignedTransaction) {
-                checkInitiatorSignedAppropriately(stx)
-            }
-        })
-
-        subFlow(ReceiveFinalityFlow(otherSideSession))
-    }
-
-    @VisibleForTesting
-    fun checkInitiatorSignedAppropriately(stx: SignedTransaction) {
-        val ltx = NotaryChangeLedgerTransaction.resolve(serviceHub.toVerifyingServiceHub(), stx.coreTransaction as NotaryChangeWireTransaction, stx.sigs)
-        val encumbranceGroups = groupOutputsByEncumbrances(ltx.outputs.mapIndexed { index, state -> StateAndRef(state, StateRef(ltx.id, index)) })
-        require(encumbranceGroups.first().all { stateRef ->
-            ltx.outputs[stateRef.index].data.participants.any { participant -> stx.sigs.any { sig -> participant.owningKey.isFulfilledBy(sig.by) } }
-        })
-        { "Initiator did not sign for all non-encumbered states!" }
-        require(encumbranceGroups.drop(1).all {
-            it.any { stateRef ->
-                ltx.outputs[stateRef.index].data.participants.any { participant -> stx.sigs.any { sig -> participant.owningKey.isFulfilledBy(sig.by) } }
-            }
-        }) { "Initiator added encumbered state and did not sign for any of the group of encumbered states." }
-    }
-
-    private fun groupOutputsByEncumbrances(outputs: List<StateAndRef<*>>): List<List<StateRef>> {
-        val seenStates = mutableSetOf<StateRef>()
-        val result = mutableListOf(mutableListOf<StateRef>())
-
-        outputs.forEach {
-            if (!seenStates.add(it.ref)) {  // add the state to the list of seen states - if it's already in the set, we have already seen it
-                return@forEach
-            }
-            if (it.state.encumbrance == null) { // if not encumbered, it goes into the first bin of the result
-                result[0].add(it.ref)
-                return@forEach
-            }
-
-            // We have an encumbered state - add a new bin to the result
-            result.add(mutableListOf())
-            var currentState = it
-            while (true) {
-                result.last().add(currentState.ref) // add state to the new bin
-                val encumbrance = currentState.state.encumbrance!! // get next encumbrance (can't be null because encumbrances need to cyclic)
-                currentState = outputs[encumbrance]  // fetch the encumbering state
-                if (!seenStates.add(currentState.ref)) { // try to add it to seen states - if it's already in, we're done with this set of encumbrances.
-                    break
-                }
-            }
-        }
-        return result
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -67,3 +67,17 @@ class ContractUpgradeHandler(otherSide: FlowSession) : AbstractStateReplacementF
         proposedTx.resolve(serviceHub, stx.sigs)
     }
 }
+
+class MoveNotaryHandler( val otherSideSession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        subFlow(object : SignTransactionFlow(otherSideSession) {
+
+            override fun checkTransaction(stx: SignedTransaction) {
+                // no op for now
+            }
+        })
+
+        subFlow(ReceiveFinalityFlow(otherSideSession))
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services
 
 import net.corda.core.contracts.Command
+import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.flows.MoveNotaryFlow
@@ -9,6 +10,7 @@ import net.corda.core.flows.StateReplacementException
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.getRequiredTransaction
+import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.ServiceHub
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
@@ -154,8 +156,16 @@ class MoveNotaryTests {
         mockNet.runNetwork()
 
         return future.getOrThrow().first()
-
     }
+
+    private fun <T: ContractState> moveNotary(states: List<StateAndRef<T>>, node: StartedMockNode, newNotary: Party): List<StateAndRef<T>> {
+        val flow = MoveNotaryFlow(states, newNotary)
+        val future = node.startFlow(flow)
+        mockNet.runNetwork()
+
+        return future.getOrThrow()
+    }
+
 
     private fun moveState(state: StateAndRef<DummyContract.SingleOwnerState>, fromNode: StartedMockNode, toNode: StartedMockNode): StateAndRef<DummyContract.SingleOwnerState> {
         val tx = DummyContract.move(state, toNode.info.singleIdentity())
@@ -194,10 +204,56 @@ class MoveNotaryTests {
 
     // TODO: Add more test cases once we have a general flow/service exception handling mechanism:
     //       - A participant is offline/can't be found on the network
-    //       - The requesting party is not a participant
     //       - The requesting party wants to change additional state fields
     //       - Multiple states in a single "notary change" transaction
     //       - Transaction contains additional states and commands with business logic
     //       - The transaction type is not a notary change transaction at all.
+
+
+    // moving notary for two states from the same tx works
+
+    // moving notary for two states from different tx works
+    @Test( timeout = 300_000)
+    fun `should change notary for two states with single participant from different txs`() {
+        val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state1.state.notary, oldNotaryParty)
+        val state2 = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state2.state.notary, oldNotaryParty)
+
+        val newStates = moveNotary(listOf(state1, state2), clientNodeA, newNotaryParty)
+        assertEquals(2, newStates.size)
+        assertEquals(newStates.first().state.notary, newNotaryParty)
+        assertEquals(state1.state.data.magicNumber, newStates.first().state.data.magicNumber)
+        assertEquals(newStates.last().state.notary, newNotaryParty)
+        assertEquals(state2.state.data.magicNumber, newStates.last().state.data.magicNumber)
+    }
+
+    // moving notary for one encumbered state A and an unencumbered state B returns A', B', encumbrances
+    @Test( timeout = 300_000)
+    fun `Adding encumbrances should not change the order of inputs vs outputs`() {
+        val issueTx = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
+        val state1 = StateAndRef<DummyContract.SingleOwnerState>(uncheckedCast(issueTx.outputs.first()), StateRef(issueTx.id, 0))
+        assertEquals(state1.state.notary, oldNotaryParty)
+        val state2 = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state2.state.notary, oldNotaryParty)
+
+        val newStates = moveNotary(listOf(state1, state2), clientNodeA, newNotaryParty)
+        assertEquals(2, newStates.size)
+        assertEquals(newStates.first().state.notary, newNotaryParty)
+        assertEquals(state1.state.data.magicNumber, newStates.first().state.data.magicNumber)
+        assertEquals(newStates.last().state.notary, newNotaryParty)
+        assertEquals(state2.state.data.magicNumber, newStates.last().state.data.magicNumber)
+    }
+
+    // moving a state with encumbrances that require different signers works
+
+    // moving a state to the same notary fails
+
+    // moving states that are on different notaries fails
+
+    // moving a state we're not a participant in fails
+
+
+
 }
 

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -1,0 +1,297 @@
+package net.corda.node.services
+
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.MoveNotaryFlow
+import net.corda.core.flows.NotaryFlow
+import net.corda.core.flows.StateReplacementException
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.internal.getRequiredTransaction
+import net.corda.core.node.ServiceHub
+import net.corda.core.serialization.SerializedBytes
+import net.corda.core.transactions.NotaryChangeWireTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.getOrThrow
+import net.corda.serialization.internal.amqp.DeserializationInput
+import net.corda.testing.common.internal.ProjectStructure.projectRootDir
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkNotarySpec
+import net.corda.testing.node.MockNetworkParameters
+import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import java.net.URI
+import java.util.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MoveNotaryTests {
+    private val oldNotaryName = CordaX500Name("Old Notary", "Zurich", "CH")
+    private val newNotaryName = CordaX500Name("New Notary", "Zurich", "CH")
+
+    private lateinit var mockNet: MockNetwork
+    private lateinit var oldNotaryNode: StartedMockNode
+    private lateinit var clientNodeA: StartedMockNode
+    private lateinit var clientNodeB: StartedMockNode
+    private lateinit var newNotaryParty: Party
+    private lateinit var oldNotaryParty: Party
+    private lateinit var clientA: Party
+
+    @Before
+    fun setUp() {
+        mockNet = MockNetwork(MockNetworkParameters(
+                notarySpecs = listOf(MockNetworkNotarySpec(oldNotaryName), MockNetworkNotarySpec(newNotaryName)),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP)
+        ))
+        clientNodeA = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
+        clientNodeB = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))
+        clientA = clientNodeA.info.singleIdentity()
+        oldNotaryNode = mockNet.notaryNodes[0]
+        oldNotaryParty = clientNodeA.services.networkMapCache.getNotary(oldNotaryName)!!
+        newNotaryParty = clientNodeA.services.networkMapCache.getNotary(newNotaryName)!!
+    }
+
+    @After
+    fun cleanUp() {
+        mockNet.stopNodes()
+    }
+
+    @Test(timeout=300_000)
+	fun `should change notary for a state with single participant`() {
+        val state = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state.state.notary, oldNotaryParty)
+        val newState = moveNotaryForSingleState(state, clientNodeA, newNotaryParty)
+        assertEquals(newState.state.notary, newNotaryParty)
+    }
+
+    @Test(timeout=300_000)
+	fun `should change notary for a state with multiple participants`() {
+        val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+        val newNotary = newNotaryParty
+        val flow = MoveNotaryFlow(listOf(state), newNotary)
+        val future = clientNodeA.startFlow(flow)
+
+        mockNet.runNetwork()
+
+        val newState = future.getOrThrow().single()
+        assertEquals(newState.state.notary, newNotary)
+        val loadedStateA = clientNodeA.services.loadState(newState.ref)
+        val loadedStateB = clientNodeB.services.loadState(newState.ref)
+        assertEquals(loadedStateA, loadedStateB)
+    }
+
+    // TODO: Re-enable the test when parameter currentness checks are in place, ENT-2666.
+    @Test(timeout=300_000)
+@Ignore
+    fun `should throw when a participant refuses to change Notary`() {
+        val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+
+        val flow = MoveNotaryFlow(listOf(state), newNotaryParty)
+        val future = clientNodeA.startFlow(flow)
+
+        mockNet.runNetwork()
+
+        assertThatExceptionOfType(StateReplacementException::class.java).isThrownBy {
+            future.getOrThrow()
+        }
+    }
+
+    @Test(timeout=300_000)
+	fun `should not break encumbrance links`() {
+        val issueTx = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
+
+        val state = StateAndRef(issueTx.outputs.first(), StateRef(issueTx.id, 0))
+        val newNotary = newNotaryParty
+        val flow = MoveNotaryFlow(listOf(state), newNotary)
+        val future = clientNodeA.startFlow(flow)
+        mockNet.runNetwork()
+        val newStates = future.getOrThrow()
+        assertTrue(newStates.all{ it.state.notary == newNotary})
+
+        val recordedTx = clientNodeA.services.getRequiredTransaction(newStates.first().ref.txhash)
+        val notaryChangeTx = recordedTx.resolveNotaryChangeTransaction(clientNodeA.services)
+
+        // Check that all encumbrances have been propagated to the outputs
+        val originalOutputs = issueTx.outputStates
+        val newOutputs = notaryChangeTx.outputStates
+        assertTrue(originalOutputs.size == newOutputs.size && originalOutputs.containsAll(newOutputs))
+
+        // Check if encumbrance linking between states has not changed.
+        val originalLinkedStates = issueTx.outputs.asSequence().filter { it.encumbrance != null }
+                .map { Pair(it.data, issueTx.outputs[it.encumbrance!!].data) }.toSet()
+        val notaryChangeLinkedStates = notaryChangeTx.outputs.asSequence().filter { it.encumbrance != null }
+                .map { Pair(it.data, notaryChangeTx.outputs[it.encumbrance!!].data) }.toSet()
+
+        assertTrue { originalLinkedStates.size == notaryChangeLinkedStates.size && originalLinkedStates.containsAll(notaryChangeLinkedStates) }
+    }
+
+    @Test(timeout=300_000)
+	fun `notary change and regular transactions are properly handled during resolution in longer chains`() {
+        val issued = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        val moved = moveState(issued, clientNodeA, clientNodeB)
+
+        // We don't to tx resolution when moving state to another node, so need to add the issue transaction manually
+        // to node B. The resolution process is tested later during notarisation.
+        clientNodeB.services.recordTransactions(clientNodeA.services.getRequiredTransaction(issued.ref.txhash))
+
+        val changedNotary = moveNotaryForSingleState(moved, clientNodeB, newNotaryParty)
+        val movedBack = moveState(changedNotary, clientNodeB, clientNodeA)
+        val changedNotaryBack = moveNotaryForSingleState(movedBack, clientNodeA, oldNotaryParty)
+
+        assertEquals(issued.state, changedNotaryBack.state)
+    }
+
+    private fun moveNotaryForSingleState(movedState: StateAndRef<DummyContract.SingleOwnerState>, node: StartedMockNode, newNotary: Party): StateAndRef<DummyContract.SingleOwnerState> {
+        val flow = MoveNotaryFlow(listOf(movedState), newNotary)
+        val future = node.startFlow(flow)
+        mockNet.runNetwork()
+
+        return future.getOrThrow().first()
+
+    }
+
+    private fun moveState(state: StateAndRef<DummyContract.SingleOwnerState>, fromNode: StartedMockNode, toNode: StartedMockNode): StateAndRef<DummyContract.SingleOwnerState> {
+        val tx = DummyContract.move(state, toNode.info.singleIdentity())
+        val stx = fromNode.services.signInitialTransaction(tx)
+
+        val notaryFlow = NotaryFlow.Client(stx)
+        val future = fromNode.startFlow(notaryFlow)
+        mockNet.runNetwork()
+
+        val notarySignature = future.getOrThrow()
+        val finalTransaction = stx + notarySignature
+
+        fromNode.services.recordTransactions(finalTransaction)
+        toNode.services.recordTransactions(finalTransaction)
+
+        return finalTransaction.tx.outRef(0)
+    }
+
+    private fun issueEncumberedState(services: ServiceHub, nodeIdentity: Party, notaryIdentity: Party): WireTransaction {
+        val owner = nodeIdentity.ref(0)
+        val stateA = DummyContract.SingleOwnerState(Random().nextInt(), owner.party)
+        val stateB = DummyContract.SingleOwnerState(Random().nextInt(), owner.party)
+        val stateC = DummyContract.SingleOwnerState(Random().nextInt(), owner.party)
+
+        // Ensure encumbrances form a cycle.
+        val tx = TransactionBuilder(null).apply {
+            addCommand(Command(DummyContract.Commands.Create(), owner.party.owningKey))
+            addOutputState(stateA, DummyContract.PROGRAM_ID, notaryIdentity, encumbrance = 2) // Encumbered by stateB
+            addOutputState(stateC, DummyContract.PROGRAM_ID, notaryIdentity, encumbrance = 0) // Encumbered by stateA
+            addOutputState(stateB, DummyContract.PROGRAM_ID, notaryIdentity, encumbrance = 1) // Encumbered by stateC
+        }
+        val stx = services.signInitialTransaction(tx)
+        services.recordTransactions(stx)
+        return tx.toWireTransaction(services)
+    }
+
+    // TODO: Add more test cases once we have a general flow/service exception handling mechanism:
+    //       - A participant is offline/can't be found on the network
+    //       - The requesting party is not a participant
+    //       - The requesting party wants to change additional state fields
+    //       - Multiple states in a single "notary change" transaction
+    //       - Transaction contains additional states and commands with business logic
+    //       - The transaction type is not a notary change transaction at all.
+
+    /*
+    Change in NotaryChangeWireTransaction in 4.13 (https://r3-cev.atlassian.net/browse/ENT-13850)
+    The NotaryChangeWireTransaction gets an extra field `requiredSigningKeys` so collect signatures
+    and finality flow can be adapted to work with NotaryChangeWireTransactions as well as
+    normal WireTransactions.
+    These tests use pre-canned, serialized NotaryChangeWireTransactions from before the change
+    and from after the change to prove that the change is forwards and backwards compatible on
+    the wire.
+     */
+
+    // When regenerating the test files this needs to be set to the file system location of the resource files
+    @Suppress("UNUSED")
+    var localPath: URI = projectRootDir.toUri().resolve(
+            "node/src/test/resources/net/corda/node/services/")
+
+    // Read in a serialized NotaryChangeWireTransaction from 4.12 (or earlier)
+    // `requiredSigningKeys` did not exist as a field when serializing
+    @Test(timeout = 300_000)
+    fun deserializeNotaryChangeTransactionWithoutSigners(){
+        val resource = "NotaryChangeTest.transactionWithoutSigners"
+        val sf = testDefaultFactory()
+
+        val stateRef = StateRef(SecureHash.create("61A2ECDC1C54F31B7351F2C39F767D700A5658150C3E3C49F0458D487862A70D"), 0)
+
+        // uncomment to recreate the data.
+        // This has to be run on a version of Corda that does not have required signers on NotaryChangeWireTransaction
+        // val networkParamsHash = SecureHash.randomSHA256()
+        // val notaryChangeTx = NotaryChangeTransactionBuilder(listOf(stateRef), oldNotaryParty, newNotaryParty, networkParamsHash  ).build()
+        // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(notaryChangeTx, testSerializationContext).bytes)
+
+        val url = NotaryChangeTests::class.java.getResource(resource)!!
+        val sc2 = url.readBytes()
+        val deserializedTx = DeserializationInput(sf).deserialize(SerializedBytes<NotaryChangeWireTransaction>(sc2), testSerializationContext)
+
+        assertEquals(1, deserializedTx.inputs.size)
+        assertEquals(stateRef, deserializedTx.inputs.first())
+        assertTrue(deserializedTx.requiredSigningKeys.isEmpty())
+    }
+
+    // Read in a serialized NotaryChangeWireTransaction from 4.13+, with requiredSigningKeys
+    // populated from https://github.com/corda/corda/pull/7953
+    @Test(timeout = 300_000)
+    fun deserializeNotaryChangeTransactionWithSigners(){
+        val resource = "NotaryChangeTest.transactionWithSigners"
+        val sf = testDefaultFactory()
+
+        val stateRef = StateRef(SecureHash.create("36C3ECDC1C54F31B7351F2C39F767D700A5658150C3E3C49F0458D487862A70D"), 0)
+
+        // uncomment to recreate the data.
+        // This has to be run on a version of Corda that _has_ requiredSigningKeys on NotaryChangeWireTransaction
+        // val networkParamsHash = SecureHash.randomSHA256()
+        // val notaryChangeTx = NotaryChangeTransactionBuilder(listOf(stateRef), oldNotaryParty, newNotaryParty, networkParamsHash, setOf(clientA.owningKey)  ).build()
+        // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(notaryChangeTx, testSerializationContext).bytes)
+
+        val url = NotaryChangeTests::class.java.getResource(resource)!!
+        val sc2 = url.readBytes()
+        val deserializedTx = DeserializationInput(sf).deserialize(SerializedBytes<NotaryChangeWireTransaction>(sc2), testSerializationContext)
+
+        assertEquals(1, deserializedTx.inputs.size)
+        assertEquals(stateRef, deserializedTx.inputs.first())
+        assertEquals(1, deserializedTx.requiredSigningKeys.size)
+    }
+
+    // Read in a serialized NotaryChangeWireTransaction from 4.13+, with requiredSigningKeys
+    // present, but not populated.
+    @Test(timeout = 300_000)
+    fun deserializeNotaryChangeTransactionWithEmptySigners(){
+        val resource = "NotaryChangeTest.transactionWithEmptySigners"
+        val sf = testDefaultFactory()
+
+        val stateRef = StateRef(SecureHash.create("45D3ECDC1C54F3113351F2C39F767D700A5658150C3E3C49F0458D487862A70D"), 0)
+
+        // uncomment to recreate the data
+        // This has to be run on a version of Corda that _has_ requiredSigningKeys on NotaryChangeWireTransaction
+        // val networkParamsHash = SecureHash.randomSHA256()
+        // val notaryChangeTx = NotaryChangeTransactionBuilder(listOf(stateRef), oldNotaryParty, newNotaryParty, networkParamsHash, emptySet()).build()
+        // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(notaryChangeTx, testSerializationContext).bytes)
+
+        val url = NotaryChangeTests::class.java.getResource(resource)!!
+        val sc2 = url.readBytes()
+        val deserializedTx = DeserializationInput(sf).deserialize(SerializedBytes<NotaryChangeWireTransaction>(sc2), testSerializationContext)
+
+        assertEquals(1, deserializedTx.inputs.size)
+        assertEquals(stateRef, deserializedTx.inputs.first())
+        assertTrue(deserializedTx.requiredSigningKeys.isEmpty())
+    }
+
+}
+

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -4,21 +4,33 @@ import net.corda.core.contracts.Command
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SignableData
+import net.corda.core.crypto.SignatureMetadata
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
 import net.corda.core.flows.MoveNotaryFlow
 import net.corda.core.flows.NotaryFlow
-import net.corda.core.flows.StateReplacementException
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.NotaryChangeTransactionBuilder
 import net.corda.core.internal.getRequiredTransaction
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.ServiceHub
+import net.corda.core.transactions.CoreTransaction
+import net.corda.core.transactions.NotaryChangeWireTransaction
+import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.UntrustworthyData
 import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.loggerFor
 import net.corda.node.services.transactions.keyService
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetworkNotarySpec
@@ -26,13 +38,14 @@ import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.MockNodeParameters
 import net.corda.testing.node.StartedMockNode
 import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import java.security.PublicKey
 import java.util.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -45,9 +58,11 @@ class MoveNotaryTests {
     private lateinit var oldNotaryNode: StartedMockNode
     private lateinit var clientNodeA: StartedMockNode
     private lateinit var clientNodeB: StartedMockNode
+    private lateinit var clientNodeC: StartedMockNode
     private lateinit var newNotaryParty: Party
     private lateinit var oldNotaryParty: Party
     private lateinit var clientA: Party
+    private val nonExistentNotary = Party.create( CordaX500Name("Pirates", "Concarneau", "FR"), keyService.freshKey())
 
     @Before
     fun setUp() {
@@ -57,6 +72,7 @@ class MoveNotaryTests {
         ))
         clientNodeA = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         clientNodeB = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))
+        clientNodeC = mockNet.createNode(MockNodeParameters(legalName = CHARLIE_NAME))
         clientA = clientNodeA.info.singleIdentity()
         oldNotaryNode = mockNet.notaryNodes[0]
         oldNotaryParty = clientNodeA.services.networkMapCache.getNotary(oldNotaryName)!!
@@ -90,22 +106,6 @@ class MoveNotaryTests {
         val loadedStateA = clientNodeA.services.loadState(newState.ref)
         val loadedStateB = clientNodeB.services.loadState(newState.ref)
         assertEquals(loadedStateA, loadedStateB)
-    }
-
-    // TODO: Re-enable the test when parameter currentness checks are in place, ENT-2666.
-    @Test(timeout=300_000)
-@Ignore
-    fun `should throw when a participant refuses to change Notary`() {
-        val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
-
-        val flow = MoveNotaryFlow(listOf(state), newNotaryParty)
-        val future = clientNodeA.startFlow(flow)
-
-        mockNet.runNetwork()
-
-        assertThatExceptionOfType(StateReplacementException::class.java).isThrownBy {
-            future.getOrThrow()
-        }
     }
 
     @Test(timeout=300_000)
@@ -205,15 +205,7 @@ class MoveNotaryTests {
         return tx.toWireTransaction(services)
     }
 
-    // TODO: Add more test cases once we have a general flow/service exception handling mechanism:
-    //       - A participant is offline/can't be found on the network
-    //       - The requesting party wants to change additional state fields
-    //       - Multiple states in a single "notary change" transaction
-    //       - Transaction contains additional states and commands with business logic
-    //       - The transaction type is not a notary change transaction at all.
-
-
-    @Test(timeout = 314_159)
+    @Test(timeout = 300_000)
     fun `moving notary for two states from the same tx works`(){
         val inputStates = issueTwoStateTx(clientNodeA.services, clientA, oldNotaryParty).outRefsOfType<DummyContract.SingleOwnerState>()
         val newStates  = moveNotary(inputStates, clientNodeA, newNotaryParty)
@@ -223,9 +215,7 @@ class MoveNotaryTests {
         assertEquals(inputStates.first().state.data.magicNumber, newStates.first().state.data.magicNumber)
         assertEquals(newStates.last().state.notary, newNotaryParty)
         assertEquals(inputStates.last().state.data.magicNumber, newStates.last().state.data.magicNumber)
-
     }
-
 
     // moving notary for two states from different tx works
     @Test( timeout = 300_000)
@@ -280,7 +270,6 @@ class MoveNotaryTests {
         assertEquals(newStates[2].state.notary, newNotaryParty)
         assertEquals(state3.state.data.magicNumber, newStates[2].state.data.magicNumber)
     }
-
 
     // moving a state with encumbrances that require different signers works
     @Test(timeout = 300_000)
@@ -383,12 +372,12 @@ class MoveNotaryTests {
         assertEquals(tx2.outputStates.map{(it as DummyContract.SingleOwnerState).magicNumber}.toSet(), result[2].map{ it.second}.toSet())
     }
 
-    fun groupOutputsByEncumbrances(  outputs: List<StateAndRef<DummyContract.SingleOwnerState>> ) : List<List<Pair<StateRef, Int>>> {
+    private fun groupOutputsByEncumbrances(outputs: List<StateAndRef<DummyContract.SingleOwnerState>> ) : List<List<Pair<StateRef, Int>>> {
         val seenStates = mutableSetOf<StateRef>()
         val result = mutableListOf(mutableListOf<Pair<StateRef, Int>>())
 
         outputs.forEach {
-            if (!seenStates.add(it.ref)){  // add the state to the list of seen states
+            if (!seenStates.add(it.ref)){  // add the state to the list of seen states - if it's already in the set, we have already seen it
                 return@forEach
             }
             if (it.state.encumbrance == null){ // if not encumbered, it goes into the first bin of the result
@@ -449,8 +438,6 @@ class MoveNotaryTests {
     fun `cannot change notary to non-existent notary`(){
         val state = issueState(clientNodeA.services, clientA, oldNotaryParty)
 
-        val nonExistentNotary = Party.create( CordaX500Name("Pirates", "Concarneau", "FR"), keyService.freshKey())
-
         val flow = MoveNotaryFlow(listOf(state), nonExistentNotary)
         val future = clientNodeA.startFlow(flow)
         mockNet.runNetwork()
@@ -458,18 +445,150 @@ class MoveNotaryTests {
        assertThatThrownBy {  future.get() }.hasMessageContaining("The output notary ${nonExistentNotary.description()} is not whitelisted in the attached network parameters")
     }
 
-    // test receiving flow:
-    // create tx
-    // mock session
-    // use service hub from node b
-    // mock state machine -> subflow
-    // call receiving flow directly
+    // Initiated flow tests - mocking the sending side/flow state machine/flow session so we can send in malicious transactions
+    // that the notary change flow would not build
+    class MockFlowStateMachine<T>(override val serviceHub: ServiceHub) : FlowStateMachine<T> by mock() {
+        override fun <SUBFLOWRETURN> subFlow(currentFlow: FlowLogic<*>, subFlow: FlowLogic<SUBFLOWRETURN>): SUBFLOWRETURN {
+            subFlow.stateMachine = this
+            return subFlow.call()
+        }
 
-    // works with confidential identities
+        override val logger = loggerFor<MockFlowStateMachine<T>>()
+    }
+
+    private fun ServiceHub.signCoreTransaction(tx: CoreTransaction, key: PublicKey): SignedTransaction {
+        val signableData = SignableData(tx.id, SignatureMetadata(this.myInfo.platformVersion, Crypto.findSignatureScheme(key).schemeNumberID))
+        return SignedTransaction(tx, listOf(this.keyManagementService.sign(signableData, key)))
+    }
+
+    @Test(timeout = 300_000)
+    fun `check error on the receiving side - non-existent notary`() {
+        val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+
+        val transaction = NotaryChangeTransactionBuilder(
+                listOf(state.ref),
+                oldNotaryParty,
+                nonExistentNotary,
+                clientNodeA.services.networkParametersService.currentHash,
+                setOf(clientA.owningKey, clientNodeB.info.singleIdentity().owningKey)
+        ).build()
+
+        val stx = clientNodeA.services.signCoreTransaction(transaction, clientA.owningKey)
+
+        val flowSession = mock<FlowSession>()
+        whenever(flowSession.receive<Any>()).thenReturn(UntrustworthyData(stx))
+        whenever(flowSession.receive<List<PublicKey>>()).thenReturn(UntrustworthyData(listOf(clientA.owningKey, clientNodeB.info.singleIdentity().owningKey)))
+        whenever(flowSession.counterparty).thenReturn(clientA)
+
+        val stateMachine = MockFlowStateMachine<Unit>(clientNodeB.services)
+
+        val flow = MoveNotaryHandler(flowSession)
+        flow.stateMachine = stateMachine
+
+        assertThatThrownBy { flow.call() }
+                .hasMessage("The output notary ${nonExistentNotary.description()} is not whitelisted in the attached network parameters.")
+    }
+
+    @Test(timeout = 300_000)
+    fun `check the signature presence check logic in MoveNotaryHandler`() {
+        val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+
+        val validTransaction = NotaryChangeTransactionBuilder(
+                listOf(state.ref),
+                oldNotaryParty,
+                newNotaryParty,
+                clientNodeA.services.networkParametersService.currentHash,
+                setOf(clientA.owningKey, clientNodeB.info.singleIdentity().owningKey)
+        ).build()
+
+        runInitiatorAppropriateSigningCheck(validTransaction)
+
+        val multiEncumberedIssueTx = issueMultiPartyEncumberedState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+        val multiEncumberedTx = NotaryChangeTransactionBuilder(
+                List(multiEncumberedIssueTx.outputStates.size) { i -> StateRef(multiEncumberedIssueTx.id, i) },
+                oldNotaryParty,
+                newNotaryParty,
+                clientNodeA.services.networkParametersService.currentHash,
+                setOf(clientA.owningKey, clientNodeB.info.singleIdentity().owningKey)
+        ).build()
+
+        runInitiatorAppropriateSigningCheck(multiEncumberedTx)
+    }
+
+    @Test(timeout = 300_000)
+    fun `check the signature presence check logic in MoveNotaryHandler failures`() {
+        val state = issueMultiPartyState(clientNodeC, clientNodeB, oldNotaryNode, oldNotaryParty)
+
+        val inValidTransaction = NotaryChangeTransactionBuilder(
+                listOf(state.ref),
+                oldNotaryParty,
+                newNotaryParty,
+                clientNodeA.services.networkParametersService.currentHash,
+                setOf(clientNodeC.info.singleIdentity().owningKey, clientNodeB.info.singleIdentity().owningKey)
+        ).build()
+
+        assertThatThrownBy { runInitiatorAppropriateSigningCheck(inValidTransaction) }.hasMessage("Initiator did not sign for all non-encumbered states!")
+
+        val multiEncumberedIssueTx = issueMultiPartyEncumberedState(clientNodeC, clientNodeB, oldNotaryNode, oldNotaryParty)
+
+        val multiEncumberedTx = NotaryChangeTransactionBuilder(
+                List(multiEncumberedIssueTx.outputStates.size) { i -> StateRef(multiEncumberedIssueTx.id, i) },
+                oldNotaryParty,
+                newNotaryParty,
+                clientNodeA.services.networkParametersService.currentHash,
+                setOf(clientNodeC.info.singleIdentity().owningKey, clientNodeB.info.singleIdentity().owningKey)
+        ).build()
+
+        assertThatThrownBy { runInitiatorAppropriateSigningCheck(multiEncumberedTx) }
+                .hasMessage("Initiator added encumbered state and did not sign for any of the group of encumbered states.")
+    }
+
+    private fun runInitiatorAppropriateSigningCheck(transaction: NotaryChangeWireTransaction) {
+        val stx = clientNodeA.services.signCoreTransaction(transaction, clientA.owningKey)
+
+        val flowSession = mock<FlowSession>()
+        whenever(flowSession.receive<Any>()).thenReturn(UntrustworthyData(stx))
+        whenever(flowSession.receive<List<PublicKey>>()).thenReturn(UntrustworthyData(listOf(clientA.owningKey, clientNodeB.info.singleIdentity().owningKey)))
+        whenever(flowSession.counterparty).thenReturn(clientA)
+
+        val stateMachine = MockFlowStateMachine<Unit>(clientNodeB.services)
+
+        val flow = MoveNotaryHandler(flowSession)
+        flow.stateMachine = stateMachine
+
+        flow.checkInitiatorSignedAppropriately(stx)
+    }
+
+    @Test(timeout = 300_000)
+    fun `check that incomplete encumbrances are caught on the receiving side`() {
+        val issueTx = issueMultiPartyEncumberedState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+
+        val transaction = NotaryChangeTransactionBuilder(
+                listOf(StateRef(issueTx.id, 0)),
+                oldNotaryParty,
+                nonExistentNotary,
+                clientNodeA.services.networkParametersService.currentHash,
+                setOf(clientA.owningKey, clientNodeB.info.singleIdentity().owningKey)
+        ).build()
+
+        val stx = clientNodeA.services.signCoreTransaction(transaction, clientA.owningKey)
+
+        val flowSession = mock<FlowSession>()
+        whenever(flowSession.receive<Any>()).thenReturn(UntrustworthyData(stx))
+        whenever(flowSession.receive<List<PublicKey>>()).thenReturn(UntrustworthyData(listOf(clientA.owningKey, clientNodeB.info.singleIdentity().owningKey)))
+        whenever(flowSession.counterparty).thenReturn(clientA)
+
+        val stateMachine = MockFlowStateMachine<Unit>(clientNodeB.services)
+
+        val flow = MoveNotaryHandler(flowSession)
+        flow.stateMachine = stateMachine
+
+        assertThatThrownBy { flow.call() }
+                .hasMessageContaining("Missing required encumbrance 2 in INPUT, transaction:")
+    }
 }
 
 fun issueMultiPartyEncumberedState(nodeA: StartedMockNode, nodeB: StartedMockNode, notaryNode: StartedMockNode, notaryIdentity: Party): WireTransaction {
-
     val participants = listOf(nodeA.info.singleIdentity(), nodeB.info.singleIdentity())
     val stateA = DummyContract.MultiOwnerState(0, participants)
     val stateB = DummyContract.SingleOwnerState(Random().nextInt(), nodeA.info.singleIdentity())
@@ -491,7 +610,6 @@ fun issueMultiPartyEncumberedState(nodeA: StartedMockNode, nodeB: StartedMockNod
 
     return stx.tx
 }
-
 
 fun issueTwoStateTx( services: ServiceHub, participant: Party, notary: Party ) : WireTransaction {
     val stateA = DummyContract.SingleOwnerState(Random().nextInt(), participant)

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -10,6 +10,7 @@ import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.MoveNotaryFlow
+import net.corda.core.flows.MoveNotaryResponder
 import net.corda.core.flows.NotaryFlow
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
@@ -482,7 +483,7 @@ class MoveNotaryTests {
 
         val stateMachine = MockFlowStateMachine<Unit>(clientNodeB.services)
 
-        val flow = MoveNotaryHandler(flowSession)
+        val flow = MoveNotaryResponder(flowSession)
         flow.stateMachine = stateMachine
 
         assertThatThrownBy { flow.call() }
@@ -553,7 +554,7 @@ class MoveNotaryTests {
 
         val stateMachine = MockFlowStateMachine<Unit>(clientNodeB.services)
 
-        val flow = MoveNotaryHandler(flowSession)
+        val flow = MoveNotaryResponder(flowSession)
         flow.stateMachine = stateMachine
 
         flow.checkInitiatorSignedAppropriately(stx)
@@ -580,7 +581,7 @@ class MoveNotaryTests {
 
         val stateMachine = MockFlowStateMachine<Unit>(clientNodeB.services)
 
-        val flow = MoveNotaryHandler(flowSession)
+        val flow = MoveNotaryResponder(flowSession)
         flow.stateMachine = stateMachine
 
         assertThatThrownBy { flow.call() }

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -19,6 +19,9 @@ import net.corda.core.internal.NotaryChangeTransactionBuilder
 import net.corda.core.internal.getRequiredTransaction
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.ServiceHub
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.node.services.vault.Sort
+import net.corda.core.node.services.vault.SortAttribute
 import net.corda.core.transactions.CoreTransaction
 import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.SignedTransaction
@@ -206,8 +209,26 @@ class MoveNotaryTests {
     }
 
     @Test(timeout = 300_000)
+    fun `vault query works after notary move`(){
+        val state = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state.state.notary, oldNotaryParty)
+        val newState = moveNotaryForSingleState(state, clientNodeA, newNotaryParty)
+        assertEquals(newState.state.notary, newNotaryParty)
+
+        val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Standard(Sort.VaultStateAttribute.RECORDED_TIME), Sort.Direction.ASC)))
+
+        val page = clientNodeA.services.vaultService.queryBy(DummyContract.SingleOwnerState::class.java, QueryCriteria.VaultQueryCriteria(), sorting)
+        assertEquals(2, page.states.size)
+        assertEquals( StateRef(state.ref.txhash, 1), page.statesMetadata.first().ref)
+        assertEquals(newState, page.states.last())
+    }
+
+    @Test(timeout = 300_000)
     fun `moving notary for two states from the same tx works`() {
-        val inputStates = issueTwoStateTx(clientNodeA.services, clientA, oldNotaryParty).outRefsOfType<DummyContract.SingleOwnerState>()
+        issueState(clientNodeA.services, clientA, oldNotaryParty)
+        // Making use of the fact that `issueState` issues a tx with two outputs (but returns only one)
+        val inputStates = clientNodeA.services.vaultService.queryBy(DummyContract.SingleOwnerState::class.java).states
+
         val newStates = moveNotary(inputStates, clientNodeA, newNotaryParty)
 
         assertEquals(2, newStates.size)
@@ -609,19 +630,5 @@ fun issueMultiPartyEncumberedState(nodeA: StartedMockNode, nodeB: StartedMockNod
     nodeA.services.recordTransactions(stx)
     nodeB.services.recordTransactions(stx)
 
-    return stx.tx
-}
-
-fun issueTwoStateTx(services: ServiceHub, participant: Party, notary: Party): WireTransaction {
-    val stateA = DummyContract.SingleOwnerState(Random().nextInt(), participant)
-    val stateB = DummyContract.SingleOwnerState(Random().nextInt(), participant)
-
-    val tx = TransactionBuilder(notary = notary).apply {
-        addCommand(Command(DummyContract.Commands.Create(), participant.owningKey))
-        addOutputState(stateA, DummyContract.PROGRAM_ID, notary)
-        addOutputState(stateB, DummyContract.PROGRAM_ID, notary)
-    }
-    val stx = services.signInitialTransaction(tx)
-    services.recordTransactions(stx)
     return stx.tx
 }

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -62,7 +62,7 @@ class MoveNotaryTests {
     private lateinit var newNotaryParty: Party
     private lateinit var oldNotaryParty: Party
     private lateinit var clientA: Party
-    private val nonExistentNotary = Party.create( CordaX500Name("Pirates", "Concarneau", "FR"), keyService.freshKey())
+    private val nonExistentNotary = Party.create(CordaX500Name("Pirates", "Concarneau", "FR"), keyService.freshKey())
 
     @Before
     fun setUp() {
@@ -84,16 +84,16 @@ class MoveNotaryTests {
         mockNet.stopNodes()
     }
 
-    @Test(timeout=300_000)
-	fun `should change notary for a state with single participant`() {
+    @Test(timeout = 300_000)
+    fun `should change notary for a state with single participant`() {
         val state = issueState(clientNodeA.services, clientA, oldNotaryParty)
         assertEquals(state.state.notary, oldNotaryParty)
         val newState = moveNotaryForSingleState(state, clientNodeA, newNotaryParty)
         assertEquals(newState.state.notary, newNotaryParty)
     }
 
-    @Test(timeout=300_000)
-	fun `should change notary for a state with multiple participants`() {
+    @Test(timeout = 300_000)
+    fun `should change notary for a state with multiple participants`() {
         val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
         val newNotary = newNotaryParty
         val flow = MoveNotaryFlow(listOf(state), newNotary)
@@ -108,8 +108,8 @@ class MoveNotaryTests {
         assertEquals(loadedStateA, loadedStateB)
     }
 
-    @Test(timeout=300_000)
-	fun `should not break encumbrance links`() {
+    @Test(timeout = 300_000)
+    fun `should not break encumbrance links`() {
         val issueTx = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
 
         val state = StateAndRef(issueTx.outputs.first(), StateRef(issueTx.id, 0))
@@ -118,7 +118,7 @@ class MoveNotaryTests {
         val future = clientNodeA.startFlow(flow)
         mockNet.runNetwork()
         val newStates = future.getOrThrow()
-        assertTrue(newStates.all{ it.state.notary == newNotary})
+        assertTrue(newStates.all { it.state.notary == newNotary })
 
         val recordedTx = clientNodeA.services.getRequiredTransaction(newStates.first().ref.txhash)
         val notaryChangeTx = recordedTx.resolveNotaryChangeTransaction(clientNodeA.services)
@@ -137,8 +137,8 @@ class MoveNotaryTests {
         assertTrue { originalLinkedStates.size == notaryChangeLinkedStates.size && originalLinkedStates.containsAll(notaryChangeLinkedStates) }
     }
 
-    @Test(timeout=300_000)
-	fun `notary change and regular transactions are properly handled during resolution in longer chains`() {
+    @Test(timeout = 300_000)
+    fun `notary change and regular transactions are properly handled during resolution in longer chains`() {
         val issued = issueState(clientNodeA.services, clientA, oldNotaryParty)
         val moved = moveState(issued, clientNodeA, clientNodeB)
 
@@ -161,14 +161,13 @@ class MoveNotaryTests {
         return future.getOrThrow().first()
     }
 
-    private fun <T: ContractState> moveNotary(states: List<StateAndRef<T>>, node: StartedMockNode, newNotary: Party): List<StateAndRef<T>> {
+    private fun <T : ContractState> moveNotary(states: List<StateAndRef<T>>, node: StartedMockNode, newNotary: Party): List<StateAndRef<T>> {
         val flow = MoveNotaryFlow(states, newNotary)
         val future = node.startFlow(flow)
         mockNet.runNetwork()
 
         return future.getOrThrow()
     }
-
 
     private fun moveState(state: StateAndRef<DummyContract.SingleOwnerState>, fromNode: StartedMockNode, toNode: StartedMockNode): StateAndRef<DummyContract.SingleOwnerState> {
         val tx = DummyContract.move(state, toNode.info.singleIdentity())
@@ -206,9 +205,9 @@ class MoveNotaryTests {
     }
 
     @Test(timeout = 300_000)
-    fun `moving notary for two states from the same tx works`(){
+    fun `moving notary for two states from the same tx works`() {
         val inputStates = issueTwoStateTx(clientNodeA.services, clientA, oldNotaryParty).outRefsOfType<DummyContract.SingleOwnerState>()
-        val newStates  = moveNotary(inputStates, clientNodeA, newNotaryParty)
+        val newStates = moveNotary(inputStates, clientNodeA, newNotaryParty)
 
         assertEquals(2, newStates.size)
         assertEquals(newStates.first().state.notary, newNotaryParty)
@@ -218,7 +217,7 @@ class MoveNotaryTests {
     }
 
     // moving notary for two states from different tx works
-    @Test( timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `should change notary for two states with single participant from different txs`() {
         val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
         assertEquals(state1.state.notary, oldNotaryParty)
@@ -234,7 +233,7 @@ class MoveNotaryTests {
     }
 
     // moving notary for one encumbered state A and an unencumbered state B returns A', B', encumbrances
-    @Test( timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `Adding encumbrances should not change the order of inputs vs outputs`() {
         val issueTx = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
         val state1 = StateAndRef<DummyContract.SingleOwnerState>(uncheckedCast(issueTx.outputs.first()), StateRef(issueTx.id, 0))
@@ -251,7 +250,7 @@ class MoveNotaryTests {
     }
 
     // Adding more than one encumbered state does not mess up the ordering
-    @Test( timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `Adding more than one encumbered state does not mess up the ordering`() {
         val issueTx = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
         val state1 = StateAndRef<DummyContract.SingleOwnerState>(uncheckedCast(issueTx.outputs.first()), StateRef(issueTx.id, 0))
@@ -347,11 +346,11 @@ class MoveNotaryTests {
     }
 
     @Test(timeout = 300_000)
-    fun `notary changing two sets of encumbered states should not mess up encumbrances`(){
+    fun `notary changing two sets of encumbered states should not mess up encumbrances`() {
         val tx1 = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
         val tx2 = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
 
-        val newStates = moveNotary(listOf(tx1.outRef(0), tx2.outRef(0)),clientNodeA, newNotaryParty)
+        val newStates = moveNotary(listOf(tx1.outRef(0), tx2.outRef(0)), clientNodeA, newNotaryParty)
 
         assertEquals(newStates.size, 2)
         assertEquals(newStates[0].state.notary, newNotaryParty)
@@ -368,19 +367,21 @@ class MoveNotaryTests {
 
         val result = groupOutputsByEncumbrances(notaryChangeTx.outRefsOfType(DummyContract.SingleOwnerState::class.java))
         assertEquals(3, result.size)
-        assertEquals(tx1.outputStates.map{(it as DummyContract.SingleOwnerState).magicNumber}.toSet(), result[1].map{ it.second}.toSet())
-        assertEquals(tx2.outputStates.map{(it as DummyContract.SingleOwnerState).magicNumber}.toSet(), result[2].map{ it.second}.toSet())
+        assertEquals(tx1.outputStates.map { (it as DummyContract.SingleOwnerState).magicNumber }.toSet(), result[1].map { it.second }
+                .toSet())
+        assertEquals(tx2.outputStates.map { (it as DummyContract.SingleOwnerState).magicNumber }.toSet(), result[2].map { it.second }
+                .toSet())
     }
 
-    private fun groupOutputsByEncumbrances(outputs: List<StateAndRef<DummyContract.SingleOwnerState>> ) : List<List<Pair<StateRef, Int>>> {
+    private fun groupOutputsByEncumbrances(outputs: List<StateAndRef<DummyContract.SingleOwnerState>>): List<List<Pair<StateRef, Int>>> {
         val seenStates = mutableSetOf<StateRef>()
         val result = mutableListOf(mutableListOf<Pair<StateRef, Int>>())
 
         outputs.forEach {
-            if (!seenStates.add(it.ref)){  // add the state to the list of seen states - if it's already in the set, we have already seen it
+            if (!seenStates.add(it.ref)) {  // add the state to the list of seen states - if it's already in the set, we have already seen it
                 return@forEach
             }
-            if (it.state.encumbrance == null){ // if not encumbered, it goes into the first bin of the result
+            if (it.state.encumbrance == null) { // if not encumbered, it goes into the first bin of the result
                 result[0].add(it.ref to it.state.data.magicNumber)
                 return@forEach
             }
@@ -388,11 +389,11 @@ class MoveNotaryTests {
             // We have an encumbered state - add a new bin to the result
             result.add(mutableListOf())
             var currentState = it
-            while (true){
+            while (true) {
                 result.last().add(currentState.ref to currentState.state.data.magicNumber) // add state to the new bin
                 val encumbrance = currentState.state.encumbrance!! // get next encumbrance (can't be null because encumbrances need to cyclic)
                 currentState = outputs[encumbrance]  // fetch the encumbering state
-                if (!seenStates.add(currentState.ref)){ // try to add it to seen states - if it's already in, we're done with this set of encumbrances.
+                if (!seenStates.add(currentState.ref)) { // try to add it to seen states - if it's already in, we're done with this set of encumbrances.
                     break
                 }
             }
@@ -400,13 +401,12 @@ class MoveNotaryTests {
         return result
     }
 
-    @Test( timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `moving a state to the same notary fails`() {
         val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
         assertEquals(state1.state.notary, oldNotaryParty)
         assertThatThrownBy { MoveNotaryFlow(listOf(state1), oldNotaryParty) }.hasMessage("The new notary cannot be the same as the old notary")
     }
-
 
     @Test(timeout = 299_327)
     fun `moving states that are on different notaries fails`() {
@@ -417,32 +417,32 @@ class MoveNotaryTests {
         assertThatThrownBy { MoveNotaryFlow(listOf(state1, state2), newNotaryParty) }.hasMessage("All input states must be on the same notary")
     }
 
-    @Test( timeout = 300_000)
+    @Test(timeout = 300_000)
     fun `Invoking notary change without states fails`() {
         assertThatThrownBy { MoveNotaryFlow(listOf<StateAndRef<ContractState>>(), newNotaryParty) }
                 .hasMessage("Notary change flow must receive at least one state to work on")
     }
 
-    @Test( timeout = 300_000)
-    fun `moving a state we're not a participant in fails`(){
+    @Test(timeout = 300_000)
+    fun `moving a state we're not a participant in fails`() {
         val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
         assertEquals(state1.state.notary, oldNotaryParty)
         val flow = MoveNotaryFlow(listOf(state1), newNotaryParty)
         val future = clientNodeB.startFlow(flow)
         mockNet.runNetwork()
-        assertThatThrownBy{ future.get() }
+        assertThatThrownBy { future.get() }
                 .hasMessage("java.lang.IllegalArgumentException: Cannot request move for state we are not a participant in")
     }
 
-    @Test( timeout = 300_000)
-    fun `cannot change notary to non-existent notary`(){
+    @Test(timeout = 300_000)
+    fun `cannot change notary to non-existent notary`() {
         val state = issueState(clientNodeA.services, clientA, oldNotaryParty)
 
         val flow = MoveNotaryFlow(listOf(state), nonExistentNotary)
         val future = clientNodeA.startFlow(flow)
         mockNet.runNetwork()
 
-       assertThatThrownBy {  future.get() }.hasMessageContaining("The output notary ${nonExistentNotary.description()} is not whitelisted in the attached network parameters")
+        assertThatThrownBy { future.get() }.hasMessageContaining("The output notary ${nonExistentNotary.description()} is not whitelisted in the attached network parameters")
     }
 
     // Initiated flow tests - mocking the sending side/flow state machine/flow session so we can send in malicious transactions
@@ -611,7 +611,7 @@ fun issueMultiPartyEncumberedState(nodeA: StartedMockNode, nodeB: StartedMockNod
     return stx.tx
 }
 
-fun issueTwoStateTx( services: ServiceHub, participant: Party, notary: Party ) : WireTransaction {
+fun issueTwoStateTx(services: ServiceHub, participant: Party, notary: Party): WireTransaction {
     val stateA = DummyContract.SingleOwnerState(Random().nextInt(), participant)
     val stateB = DummyContract.SingleOwnerState(Random().nextInt(), participant)
 

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -224,6 +224,26 @@ class MoveNotaryTests {
     }
 
     @Test(timeout = 300_000)
+    fun `vault query works on other participant node after notary move`(){
+        val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+        val newNotary = newNotaryParty
+        val flow = MoveNotaryFlow(listOf(state), newNotary)
+        val future = clientNodeA.startFlow(flow)
+
+        mockNet.runNetwork()
+
+        val newState = future.getOrThrow().single()
+        assertEquals(newState.state.notary, newNotary)
+        val loadedStateA = clientNodeA.services.loadState(newState.ref)
+        val loadedStateB = clientNodeB.services.loadState(newState.ref)
+        assertEquals(loadedStateA, loadedStateB)
+
+        val page = clientNodeB.services.vaultService.queryBy(DummyContract.MultiOwnerState::class.java)
+        assertEquals(1, page.states.size)
+        assertEquals(newState, page.states.first())
+    }
+
+    @Test(timeout = 300_000)
     fun `moving notary for two states from the same tx works`() {
         issueState(clientNodeA.services, clientA, oldNotaryParty)
         // Making use of the fact that `issueState` issues a tx with two outputs (but returns only one)

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -357,6 +357,60 @@ class MoveNotaryTests {
         assertTrue { originalLinkedStates.size == notaryChangeLinkedStates.size && originalLinkedStates.containsAll(notaryChangeLinkedStates) }
     }
 
+    @Test(timeout = 300_000)
+    fun `notary changing two sets of encumbered states should not mess up encumbrances`(){
+        val tx1 = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
+        val tx2 = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
+
+        val newStates = moveNotary(listOf(tx1.outRef(0), tx2.outRef(0)),clientNodeA, newNotaryParty)
+
+        assertEquals(newStates.size, 2)
+        assertEquals(newStates[0].state.notary, newNotaryParty)
+        assertEquals(newStates[1].state.notary, newNotaryParty)
+
+        val recordedTx = clientNodeA.services.getRequiredTransaction(newStates[0].ref.txhash)
+        assertEquals(3, recordedTx.sigs.size)
+
+        val recordedSigners = recordedTx.sigs.map { it.by }
+        assertTrue { recordedSigners.contains(clientNodeA.info.singleIdentity().owningKey) }
+
+        val notaryChangeTx = recordedTx.resolveNotaryChangeTransaction(clientNodeA.services)
+        assertEquals(6, notaryChangeTx.outputs.size)
+
+        val result = groupOutputsByEncumbrances(notaryChangeTx.outRefsOfType(DummyContract.SingleOwnerState::class.java))
+        assertEquals(3, result.size)
+        assertEquals(tx1.outputStates.map{(it as DummyContract.SingleOwnerState).magicNumber}.toSet(), result[1].map{ it.second}.toSet())
+        assertEquals(tx2.outputStates.map{(it as DummyContract.SingleOwnerState).magicNumber}.toSet(), result[2].map{ it.second}.toSet())
+    }
+
+    fun groupOutputsByEncumbrances(  outputs: List<StateAndRef<DummyContract.SingleOwnerState>> ) : List<List<Pair<StateRef, Int>>> {
+        val seenStates = mutableSetOf<StateRef>()
+        val result = mutableListOf(mutableListOf<Pair<StateRef, Int>>())
+
+        outputs.forEach {
+            if (!seenStates.add(it.ref)){  // add the state to the list of seen states
+                return@forEach
+            }
+            if (it.state.encumbrance == null){ // if not encumbered, it goes into the first bin of the result
+                result[0].add(it.ref to it.state.data.magicNumber)
+                return@forEach
+            }
+
+            // We have an encumbered state - add a new bin to the result
+            result.add(mutableListOf())
+            var currentState = it
+            while (true){
+                result.last().add(currentState.ref to currentState.state.data.magicNumber) // add state to the new bin
+                val encumbrance = currentState.state.encumbrance!! // get next encumbrance (can't be null because encumbrances need to cyclic)
+                currentState = outputs[encumbrance]  // fetch the encumbering state
+                if (!seenStates.add(currentState.ref)){ // try to add it to seen states - if it's already in, we're done with this set of encumbrances.
+                    break
+                }
+            }
+        }
+        return result
+    }
+
     @Test( timeout = 300_000)
     fun `moving a state to the same notary fails`() {
         val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
@@ -403,6 +457,13 @@ class MoveNotaryTests {
 
        assertThatThrownBy {  future.get() }.hasMessageContaining("The output notary ${nonExistentNotary.description()} is not whitelisted in the attached network parameters")
     }
+
+    // test receiving flow:
+    // create tx
+    // mock session
+    // use service hub from node b
+    // mock state machine -> subflow
+    // call receiving flow directly
 
     // works with confidential identities
 }

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -15,6 +15,7 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.transactions.keyService
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
@@ -388,6 +389,19 @@ class MoveNotaryTests {
         mockNet.runNetwork()
         assertThatThrownBy{ future.get() }
                 .hasMessage("java.lang.IllegalArgumentException: Cannot request move for state we are not a participant in")
+    }
+
+    @Test( timeout = 300_000)
+    fun `cannot change notary to non-existent notary`(){
+        val state = issueState(clientNodeA.services, clientA, oldNotaryParty)
+
+        val nonExistentNotary = Party.create( CordaX500Name("Pirates", "Concarneau", "FR"), keyService.freshKey())
+
+        val flow = MoveNotaryFlow(listOf(state), nonExistentNotary)
+        val future = clientNodeA.startFlow(flow)
+        mockNet.runNetwork()
+
+       assertThatThrownBy {  future.get() }.hasMessageContaining("The output notary ${nonExistentNotary.description()} is not whitelisted in the attached network parameters")
     }
 
     // works with confidential identities

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -26,7 +26,9 @@ import net.corda.testing.node.MockNodeParameters
 import net.corda.testing.node.StartedMockNode
 import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -210,7 +212,19 @@ class MoveNotaryTests {
     //       - The transaction type is not a notary change transaction at all.
 
 
-    // moving notary for two states from the same tx works
+    @Test(timeout = 314_159)
+    fun `moving notary for two states from the same tx works`(){
+        val inputStates = issueTwoStateTx(clientNodeA.services, clientA, oldNotaryParty).outRefsOfType<DummyContract.SingleOwnerState>()
+        val newStates  = moveNotary(inputStates, clientNodeA, newNotaryParty)
+
+        assertEquals(2, newStates.size)
+        assertEquals(newStates.first().state.notary, newNotaryParty)
+        assertEquals(inputStates.first().state.data.magicNumber, newStates.first().state.data.magicNumber)
+        assertEquals(newStates.last().state.notary, newNotaryParty)
+        assertEquals(inputStates.last().state.data.magicNumber, newStates.last().state.data.magicNumber)
+
+    }
+
 
     // moving notary for two states from different tx works
     @Test( timeout = 300_000)
@@ -245,15 +259,175 @@ class MoveNotaryTests {
         assertEquals(state2.state.data.magicNumber, newStates.last().state.data.magicNumber)
     }
 
+    // Adding more than one encumbered state does not mess up the ordering
+    @Test( timeout = 300_000)
+    fun `Adding more than one encumbered state does not mess up the ordering`() {
+        val issueTx = issueEncumberedState(clientNodeA.services, clientA, oldNotaryParty)
+        val state1 = StateAndRef<DummyContract.SingleOwnerState>(uncheckedCast(issueTx.outputs.first()), StateRef(issueTx.id, 0))
+        val state3 = StateAndRef<DummyContract.SingleOwnerState>(uncheckedCast(issueTx.outputs[2]), StateRef(issueTx.id, 2))
+        assertEquals(state1.state.notary, oldNotaryParty)
+        assertEquals(state3.state.notary, oldNotaryParty)
+        val state2 = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state2.state.notary, oldNotaryParty)
+
+        val newStates = moveNotary(listOf(state1, state2, state3), clientNodeA, newNotaryParty)
+        assertEquals(3, newStates.size)
+        assertEquals(newStates.first().state.notary, newNotaryParty)
+        assertEquals(state1.state.data.magicNumber, newStates.first().state.data.magicNumber)
+        assertEquals(newStates[1].state.notary, newNotaryParty)
+        assertEquals(state2.state.data.magicNumber, newStates[1].state.data.magicNumber)
+        assertEquals(newStates[2].state.notary, newNotaryParty)
+        assertEquals(state3.state.data.magicNumber, newStates[2].state.data.magicNumber)
+    }
+
+
     // moving a state with encumbrances that require different signers works
+    @Test(timeout = 300_000)
+    fun `should get correct signers for multi party encumbrance if signed by all`() {
+        val issueTx = issueMultiPartyEncumberedState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+        val state = StateAndRef(issueTx.outputs.first(), StateRef(issueTx.id, 0))
 
-    // moving a state to the same notary fails
+        val newNotary = newNotaryParty
+        val flow = MoveNotaryFlow(listOf(state), newNotary)
 
-    // moving states that are on different notaries fails
+        val future = clientNodeA.startFlow(flow)
+        mockNet.runNetwork()
 
-    // moving a state we're not a participant in fails
+        val newState = future.getOrThrow().single()
+        assertEquals(newState.state.notary, newNotary)
+
+        val recordedTx = clientNodeA.services.getRequiredTransaction(newState.ref.txhash)
+        val notaryChangeTx = recordedTx.resolveNotaryChangeTransaction(clientNodeA.services)
+
+        // Check that all encumbrances have been propagated to the outputs
+        val originalOutputs = issueTx.outputStates
+        val newOutputs = notaryChangeTx.outputStates
+        assertTrue(originalOutputs.size == newOutputs.size && originalOutputs.containsAll(newOutputs))
+
+        // Check if encumbrance linking between states has not changed.
+        val originalLinkedStates = issueTx.outputs.asSequence().filter { it.encumbrance != null }
+                .map { Pair(it.data, issueTx.outputs[it.encumbrance!!].data) }.toSet()
+        val notaryChangeLinkedStates = notaryChangeTx.outputs.asSequence().filter { it.encumbrance != null }
+                .map { Pair(it.data, notaryChangeTx.outputs[it.encumbrance!!].data) }.toSet()
+        assertTrue { originalLinkedStates.size == notaryChangeLinkedStates.size && originalLinkedStates.containsAll(notaryChangeLinkedStates) }
+    }
+
+    @Test(timeout = 300_000)
+    fun `should get correct signers for multi party encumbrance if signed by one`() {
+        val issueTx = issueMultiPartyEncumberedState(clientNodeA, clientNodeB, oldNotaryNode, oldNotaryParty)
+
+        // use the third state, only signed by nodeA
+        val state = StateAndRef(issueTx.outputs[2], StateRef(issueTx.id, 2))
+        assertTrue(state.state.data.participants.contains(clientNodeA.info.singleIdentity()),
+                "Expected ${clientNodeA.info.singleIdentity()}, got ${state.state.data.participants}")
+
+        assertFalse(state.state.data.participants.contains(clientNodeB.info.singleIdentity()))
+        val newNotary = newNotaryParty
+
+        val flow = MoveNotaryFlow(listOf(state), newNotary)
+
+        val future = clientNodeA.startFlow(flow)
+        mockNet.runNetwork()
+
+        val newState = future.getOrThrow().single()
+
+        assertEquals(newState.state.notary, newNotary)
+
+        val recordedTx = clientNodeA.services.getRequiredTransaction(newState.ref.txhash)
+        assertEquals(3, recordedTx.sigs.size)
+
+        val recordedSigners = recordedTx.sigs.map { it.by }
+        assertTrue { recordedSigners.contains(clientNodeA.info.singleIdentity().owningKey) }
+        assertTrue { recordedSigners.contains(clientNodeB.info.singleIdentity().owningKey) }
+
+        val notaryChangeTx = recordedTx.resolveNotaryChangeTransaction(clientNodeA.services)
+
+        // Check that all encumbrances have been propagated to the outputs
+        val originalOutputs = issueTx.outputStates
+        val newOutputs = notaryChangeTx.outputStates
+        assertTrue(originalOutputs.size == newOutputs.size && originalOutputs.containsAll(newOutputs))
+
+        // Check if encumbrance linking between states has not changed.
+        val originalLinkedStates = issueTx.outputs.asSequence().filter { it.encumbrance != null }
+                .map { Pair(it.data, issueTx.outputs[it.encumbrance!!].data) }.toSet()
+
+        val notaryChangeLinkedStates = notaryChangeTx.outputs.asSequence().filter { it.encumbrance != null }
+                .map { Pair(it.data, notaryChangeTx.outputs[it.encumbrance!!].data) }.toSet()
+        assertTrue { originalLinkedStates.size == notaryChangeLinkedStates.size && originalLinkedStates.containsAll(notaryChangeLinkedStates) }
+    }
+
+    @Test( timeout = 300_000)
+    fun `moving a state to the same notary fails`() {
+        val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state1.state.notary, oldNotaryParty)
+        assertThatThrownBy { MoveNotaryFlow(listOf(state1), oldNotaryParty) }.hasMessage("The new notary cannot be the same as the old notary")
+    }
 
 
+    @Test(timeout = 299_327)
+    fun `moving states that are on different notaries fails`() {
+        val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state1.state.notary, oldNotaryParty)
+        val state2 = issueState(clientNodeA.services, clientA, newNotaryParty)
+        assertEquals(state2.state.notary, newNotaryParty)
+        assertThatThrownBy { MoveNotaryFlow(listOf(state1, state2), newNotaryParty) }.hasMessage("All input states must be on the same notary")
+    }
 
+    @Test( timeout = 300_000)
+    fun `Invoking notary change without states fails`() {
+        assertThatThrownBy { MoveNotaryFlow(listOf<StateAndRef<ContractState>>(), newNotaryParty) }
+                .hasMessage("Notary change flow must receive at least one state to work on")
+    }
+
+    @Test( timeout = 300_000)
+    fun `moving a state we're not a participant in fails`(){
+        val state1 = issueState(clientNodeA.services, clientA, oldNotaryParty)
+        assertEquals(state1.state.notary, oldNotaryParty)
+        val flow = MoveNotaryFlow(listOf(state1), newNotaryParty)
+        val future = clientNodeB.startFlow(flow)
+        mockNet.runNetwork()
+        assertThatThrownBy{ future.get() }
+                .hasMessage("java.lang.IllegalArgumentException: Cannot request move for state we are not a participant in")
+    }
+
+    // works with confidential identities
 }
 
+fun issueMultiPartyEncumberedState(nodeA: StartedMockNode, nodeB: StartedMockNode, notaryNode: StartedMockNode, notaryIdentity: Party): WireTransaction {
+
+    val participants = listOf(nodeA.info.singleIdentity(), nodeB.info.singleIdentity())
+    val stateA = DummyContract.MultiOwnerState(0, participants)
+    val stateB = DummyContract.SingleOwnerState(Random().nextInt(), nodeA.info.singleIdentity())
+    val stateC = DummyContract.SingleOwnerState(Random().nextInt(), nodeB.info.singleIdentity())
+
+    val tx = TransactionBuilder(notary = notaryIdentity).apply {
+        addCommand(Command(DummyContract.Commands.Create(), nodeA.info.singleIdentity().owningKey))
+        addOutputState(stateA, DummyContract.PROGRAM_ID, notaryIdentity, encumbrance = 2) // Encumbered by stateB
+        addOutputState(stateC, DummyContract.PROGRAM_ID, notaryIdentity, encumbrance = 0) // Encumbered by stateA
+        addOutputState(stateB, DummyContract.PROGRAM_ID, notaryIdentity, encumbrance = 1) // Encumbered by stateC
+    }
+
+    val signedByA = nodeA.services.signInitialTransaction(tx)
+    val signedByAB = nodeB.services.addSignature(signedByA)
+    val stx = notaryNode.services.addSignature(signedByAB, notaryIdentity.owningKey)
+
+    nodeA.services.recordTransactions(stx)
+    nodeB.services.recordTransactions(stx)
+
+    return stx.tx
+}
+
+
+fun issueTwoStateTx( services: ServiceHub, participant: Party, notary: Party ) : WireTransaction {
+    val stateA = DummyContract.SingleOwnerState(Random().nextInt(), participant)
+    val stateB = DummyContract.SingleOwnerState(Random().nextInt(), participant)
+
+    val tx = TransactionBuilder(notary = notary).apply {
+        addCommand(Command(DummyContract.Commands.Create(), participant.owningKey))
+        addOutputState(stateA, DummyContract.PROGRAM_ID, notary)
+        addOutputState(stateB, DummyContract.PROGRAM_ID, notary)
+    }
+    val stx = services.signInitialTransaction(tx)
+    services.recordTransactions(stx)
+    return stx.tx
+}

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -3,7 +3,6 @@ package net.corda.node.services
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.MoveNotaryFlow
 import net.corda.core.flows.NotaryFlow
 import net.corda.core.flows.StateReplacementException
@@ -11,13 +10,9 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.getRequiredTransaction
 import net.corda.core.node.ServiceHub
-import net.corda.core.serialization.SerializedBytes
-import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.getOrThrow
-import net.corda.serialization.internal.amqp.DeserializationInput
-import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
@@ -33,7 +28,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
-import java.net.URI
 import java.util.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -205,93 +199,5 @@ class MoveNotaryTests {
     //       - Multiple states in a single "notary change" transaction
     //       - Transaction contains additional states and commands with business logic
     //       - The transaction type is not a notary change transaction at all.
-
-    /*
-    Change in NotaryChangeWireTransaction in 4.13 (https://r3-cev.atlassian.net/browse/ENT-13850)
-    The NotaryChangeWireTransaction gets an extra field `requiredSigningKeys` so collect signatures
-    and finality flow can be adapted to work with NotaryChangeWireTransactions as well as
-    normal WireTransactions.
-    These tests use pre-canned, serialized NotaryChangeWireTransactions from before the change
-    and from after the change to prove that the change is forwards and backwards compatible on
-    the wire.
-     */
-
-    // When regenerating the test files this needs to be set to the file system location of the resource files
-    @Suppress("UNUSED")
-    var localPath: URI = projectRootDir.toUri().resolve(
-            "node/src/test/resources/net/corda/node/services/")
-
-    // Read in a serialized NotaryChangeWireTransaction from 4.12 (or earlier)
-    // `requiredSigningKeys` did not exist as a field when serializing
-    @Test(timeout = 300_000)
-    fun deserializeNotaryChangeTransactionWithoutSigners(){
-        val resource = "NotaryChangeTest.transactionWithoutSigners"
-        val sf = testDefaultFactory()
-
-        val stateRef = StateRef(SecureHash.create("61A2ECDC1C54F31B7351F2C39F767D700A5658150C3E3C49F0458D487862A70D"), 0)
-
-        // uncomment to recreate the data.
-        // This has to be run on a version of Corda that does not have required signers on NotaryChangeWireTransaction
-        // val networkParamsHash = SecureHash.randomSHA256()
-        // val notaryChangeTx = NotaryChangeTransactionBuilder(listOf(stateRef), oldNotaryParty, newNotaryParty, networkParamsHash  ).build()
-        // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(notaryChangeTx, testSerializationContext).bytes)
-
-        val url = NotaryChangeTests::class.java.getResource(resource)!!
-        val sc2 = url.readBytes()
-        val deserializedTx = DeserializationInput(sf).deserialize(SerializedBytes<NotaryChangeWireTransaction>(sc2), testSerializationContext)
-
-        assertEquals(1, deserializedTx.inputs.size)
-        assertEquals(stateRef, deserializedTx.inputs.first())
-        assertTrue(deserializedTx.requiredSigningKeys.isEmpty())
-    }
-
-    // Read in a serialized NotaryChangeWireTransaction from 4.13+, with requiredSigningKeys
-    // populated from https://github.com/corda/corda/pull/7953
-    @Test(timeout = 300_000)
-    fun deserializeNotaryChangeTransactionWithSigners(){
-        val resource = "NotaryChangeTest.transactionWithSigners"
-        val sf = testDefaultFactory()
-
-        val stateRef = StateRef(SecureHash.create("36C3ECDC1C54F31B7351F2C39F767D700A5658150C3E3C49F0458D487862A70D"), 0)
-
-        // uncomment to recreate the data.
-        // This has to be run on a version of Corda that _has_ requiredSigningKeys on NotaryChangeWireTransaction
-        // val networkParamsHash = SecureHash.randomSHA256()
-        // val notaryChangeTx = NotaryChangeTransactionBuilder(listOf(stateRef), oldNotaryParty, newNotaryParty, networkParamsHash, setOf(clientA.owningKey)  ).build()
-        // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(notaryChangeTx, testSerializationContext).bytes)
-
-        val url = NotaryChangeTests::class.java.getResource(resource)!!
-        val sc2 = url.readBytes()
-        val deserializedTx = DeserializationInput(sf).deserialize(SerializedBytes<NotaryChangeWireTransaction>(sc2), testSerializationContext)
-
-        assertEquals(1, deserializedTx.inputs.size)
-        assertEquals(stateRef, deserializedTx.inputs.first())
-        assertEquals(1, deserializedTx.requiredSigningKeys.size)
-    }
-
-    // Read in a serialized NotaryChangeWireTransaction from 4.13+, with requiredSigningKeys
-    // present, but not populated.
-    @Test(timeout = 300_000)
-    fun deserializeNotaryChangeTransactionWithEmptySigners(){
-        val resource = "NotaryChangeTest.transactionWithEmptySigners"
-        val sf = testDefaultFactory()
-
-        val stateRef = StateRef(SecureHash.create("45D3ECDC1C54F3113351F2C39F767D700A5658150C3E3C49F0458D487862A70D"), 0)
-
-        // uncomment to recreate the data
-        // This has to be run on a version of Corda that _has_ requiredSigningKeys on NotaryChangeWireTransaction
-        // val networkParamsHash = SecureHash.randomSHA256()
-        // val notaryChangeTx = NotaryChangeTransactionBuilder(listOf(stateRef), oldNotaryParty, newNotaryParty, networkParamsHash, emptySet()).build()
-        // File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(notaryChangeTx, testSerializationContext).bytes)
-
-        val url = NotaryChangeTests::class.java.getResource(resource)!!
-        val sc2 = url.readBytes()
-        val deserializedTx = DeserializationInput(sf).deserialize(SerializedBytes<NotaryChangeWireTransaction>(sc2), testSerializationContext)
-
-        assertEquals(1, deserializedTx.inputs.size)
-        assertEquals(stateRef, deserializedTx.inputs.first())
-        assertTrue(deserializedTx.requiredSigningKeys.isEmpty())
-    }
-
 }
 

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -256,7 +256,7 @@ class NotaryChangeTests {
 
         assertEquals(1, deserializedTx.inputs.size)
         assertEquals(stateRef, deserializedTx.inputs.first())
-
+        assertTrue(deserializedTx.requiredSigningKeys.isEmpty())
     }
 
     // Read in a serialized NotaryChangeWireTransaction from 4.13+, with requiredSigningKeys
@@ -280,6 +280,7 @@ class NotaryChangeTests {
 
         assertEquals(1, deserializedTx.inputs.size)
         assertEquals(stateRef, deserializedTx.inputs.first())
+        assertEquals(1, deserializedTx.requiredSigningKeys.size)
     }
 
     // Read in a serialized NotaryChangeWireTransaction from 4.13+, with requiredSigningKeys
@@ -303,6 +304,7 @@ class NotaryChangeTests {
 
         assertEquals(1, deserializedTx.inputs.size)
         assertEquals(stateRef, deserializedTx.inputs.first())
+        assertTrue(deserializedTx.requiredSigningKeys.isEmpty())
     }
 
 }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -98,14 +98,14 @@ class NotaryServiceTests {
                                         numberOfInputs: Int = 10_005): SignedTransaction {
             val txHash = SecureHash.randomSHA256()
             val inputs = (1..numberOfInputs).map { StateRef(txHash, it) }
-            val tx = if (paramsHash != null) {
-                NotaryChangeTransactionBuilder(inputs, notary, party, paramsHash).build()
-            } else {
-                NotaryChangeWireTransaction(listOf(inputs, notary, party).map { it.serialize() })
-            }
 
             return node.services.run {
                 val myKey = myInfo.legalIdentities.first().owningKey
+                val tx = if (paramsHash != null) {
+                    NotaryChangeTransactionBuilder(inputs, notary, party, paramsHash, setOf(myKey)).build()
+                } else {
+                    NotaryChangeWireTransaction(listOf(inputs, notary, party).map { it.serialize() }, DigestService.sha2_256, setOf(myKey))
+                }
                 val signableData = SignableData(tx.id, SignatureMetadata(myInfo.platformVersion, Crypto.findSignatureScheme(myKey).schemeNumberID))
                 val mySignature = keyManagementService.sign(signableData, myKey)
                 SignedTransaction(tx, listOf(mySignature))

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
@@ -223,7 +223,8 @@ class NotaryWhitelistTests(
                 listOf(inputState.ref),
                 fakeNotaryParty,
                 oldNotary,
-                aliceNode.services.networkParametersService.currentHash
+                aliceNode.services.networkParametersService.currentHash,
+                inputState.state.data.participants.map{it.owningKey}.toSet()
         ).build()
 
         val notaryChangeAliceSig = getAliceSig(notaryChangeTx)

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -711,7 +711,12 @@ class NodeVaultServiceTest {
         // Change notary
         services.identityService.verifyAndRegisterIdentity(DUMMY_NOTARY_IDENTITY)
         val newNotary = DUMMY_NOTARY
-        val changeNotaryTx = NotaryChangeTransactionBuilder(listOf(initialCashState.ref), issueStx.notary!!, newNotary, services.networkParametersService.currentHash).build()
+        val changeNotaryTx = NotaryChangeTransactionBuilder(
+                listOf(initialCashState.ref),
+                issueStx.notary!!,
+                newNotary,
+                services.networkParametersService.currentHash,
+                initialCashState.state.data.participants.map { it.owningKey }.toSet()).build()
         val cashStateWithNewNotary = StateAndRef(initialCashState.state.copy(notary = newNotary), StateRef(changeNotaryTx.id, 0))
 
         database.transaction {


### PR DESCRIPTION
- Update collect signtatures and finality flow to work with NotaryChangeTransactions
- Fix up the transaction hierarchy to make the above work
- Implement required signing keys on NotaryChangeTransaction
- Add MoveNotaryFlow
- Extendended test coverage