### PR TITLE
ENT-4952: Network Builder: Remove deprecated MS ADAL lib, fix startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,8 @@ buildscript {
     ext.snake_yaml_version = constants.getProperty("snakeYamlVersion")
     ext.json_smart_version = constants.getProperty("jsonSmartVersion")
     ext.azure_version = constants.getProperty("azureVersion")
+    ext.azure_resource_manager_version = constants.getProperty("azureResourceManagerVersion")
+    ext.azure_identity_version = constants.getProperty("azureIdentityVersion")
     if (JavaVersion.current().isJava8()) {
         ext.fontawesomefx_commons_version = constants.getProperty("fontawesomefxCommonsJava8Version")
         ext.fontawesomefx_fontawesome_version = constants.getProperty("fontawesomefxFontawesomeJava8Version")

--- a/constants.properties
+++ b/constants.properties
@@ -109,3 +109,5 @@ fontawesomefxFontawesomeJava8Version=4.7.0-5
 fontawesomefxCommonsVersion=11.0
 fontawesomefxFontawesomeVersion=4.7.0-11
 azureVersion=1.41.4
+azureResourceManagerVersion=2.52.0
+azureIdentityVersion=1.2.0

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -67,6 +67,7 @@
     <ID>ComplexCondition:CheckpointAgent.kt$CheckpointHook$!that.javaClass.name.endsWith("ObjectField") || arrayValue != null || that.field.type == java.lang.String::class.java || value == null</ID>
     <ID>ComplexCondition:CheckpointAgent.kt$CheckpointHook$(checkpointId != null) || ((clazz.name == instrumentClassname) &amp;&amp; (input.total() &gt;= minimumSize) &amp;&amp; (input.total() &lt;= maximumSize))</ID>
     <ID>ComplexCondition:CheckpointAgent.kt$CheckpointHook$(checkpointId != null) || ((obj.javaClass.name == instrumentClassname) &amp;&amp; (output.total() &gt;= minimumSize) &amp;&amp; (output.total() &lt;= maximumSize))</ID>
+    <ID>ComplexCondition:ConfigUtilities.kt$value is Temporal || value is NetworkHostAndPort || value is CordaX500Name || value is Path || value is URL || value is UUID || value is X500Principal</ID>
     <ID>ComplexCondition:CordaClassResolver.kt$CordaClassResolver$type.isPrimitive || type == Any::class.java || type == String::class.java || (!type.isEnum &amp;&amp; isAbstract(type.modifiers))</ID>
     <ID>ComplexCondition:DeserializationInput.kt$DeserializationInput$type != TypeIdentifier.UnknownType.getLocalType() &amp;&amp; serializer.type != type &amp;&amp; with(serializer.type) { !isSubClassOf(type) &amp;&amp; !materiallyEquivalentTo(type) }</ID>
     <ID>ComplexCondition:FlowMessaging.kt$FlowMessagingImpl$(exception is KryoException || exception is NotSerializableException) &amp;&amp; message is ExistingSessionMessage &amp;&amp; message.payload is ErrorSessionMessage</ID>
@@ -78,6 +79,8 @@
     <ID>ComplexMethod:AMQPBridgeManager.kt$AMQPBridgeManager.AMQPBridge$private fun clientArtemisMessageHandler(artemisMessage: ClientMessage)</ID>
     <ID>ComplexMethod:AMQPBridgeTest.kt$AMQPBridgeTest$@Test(timeout=300_000) fun `test acked and nacked messages`()</ID>
     <ID>ComplexMethod:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$// Make sure our inputs aren't designed to blow things up. private fun validate(typeString: String)</ID>
+    <ID>ComplexMethod:ANSIProgressRenderer.kt$ANSIProgressRenderer$// Returns number of lines rendered. private fun renderLevel(ansi: Ansi, error: Boolean): Int</ID>
+    <ID>ComplexMethod:ANSIProgressRenderer.kt$ANSIProgressRenderer$@Synchronized protected fun draw(moveUp: Boolean, error: Throwable? = null)</ID>
     <ID>ComplexMethod:AbstractConcatenatedList.kt$AbstractConcatenatedList$// This is where we create a listener for a *nested* list. Note that 'indexMap' doesn't need to be adjusted on any // of these changes as the indices of nested lists don't change, just their contents. private fun createListener(wrapped: WrappedObservableList&lt;A&gt;): ListChangeListener&lt;A&gt;</ID>
     <ID>ComplexMethod:AbstractConcatenatedList.kt$AbstractConcatenatedList$// This is where we handle changes to the *source* list. override fun sourceChanged(change: ListChangeListener.Change&lt;out ObservableList&lt;A&gt;&gt;)</ID>
     <ID>ComplexMethod:AbstractFlattenedList.kt$AbstractFlattenedList$override fun sourceChanged(c: ListChangeListener.Change&lt;out ObservableValue&lt;out A&gt;&gt;)</ID>
@@ -91,6 +94,7 @@
     <ID>ComplexMethod:AppendOnlyPersistentMap.kt$AppendOnlyPersistentMapBase$private fun set(key: K, value: V, logWarning: Boolean, store: (K, V) -&gt; V?): Boolean</ID>
     <ID>ComplexMethod:AppendOnlyPersistentMapTest.kt$AppendOnlyPersistentMapTest.TestThread$private fun doActivity()</ID>
     <ID>ComplexMethod:AttachmentVersionNumberMigration.kt$AttachmentVersionNumberMigration$override fun execute(database: Database?)</ID>
+    <ID>ComplexMethod:AttachmentsClassLoader.kt$AttachmentsClassLoader$private fun checkAttachments(attachments: List&lt;Attachment&gt;)</ID>
     <ID>ComplexMethod:BridgeControlListener.kt$BridgeControlListener$private fun processControlMessage(msg: ClientMessage)</ID>
     <ID>ComplexMethod:CashSelectionH2Impl.kt$CashSelectionH2Impl$// We are using an H2 specific means of selecting a minimum set of rows that match a request amount of coins: // 1) There is no standard SQL mechanism of calculating a cumulative total on a field and restricting row selection on the // running total of such an accumulator // 2) H2 uses session variables to perform this accumulator function: // http://www.h2database.com/html/functions.html#set // 3) H2 does not support JOIN's in FOR UPDATE (hence we are forced to execute 2 queries) override fun executeQuery(connection: Connection, amount: Amount&lt;Currency&gt;, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set&lt;AbstractParty&gt;, withIssuerRefs: Set&lt;OpaqueBytes&gt;, withResultSet: (ResultSet) -&gt; Boolean): Boolean</ID>
     <ID>ComplexMethod:CashSelectionPostgreSQLImpl.kt$CashSelectionPostgreSQLImpl$// This is using PostgreSQL window functions for selecting a minimum set of rows that match a request amount of coins: // 1) This may also be possible with user-defined functions (e.g. using PL/pgSQL) // 2) The window function accumulated column (`total`) does not include the current row (starts from 0) and cannot // appear in the WHERE clause, hence restricting row selection and adjusting the returned total in the outer query. // 3) Currently (version 9.6), FOR UPDATE cannot be specified with window functions override fun executeQuery(connection: Connection, amount: Amount&lt;Currency&gt;, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set&lt;AbstractParty&gt;, withIssuerRefs: Set&lt;OpaqueBytes&gt;, withResultSet: (ResultSet) -&gt; Boolean): Boolean</ID>
@@ -103,8 +107,12 @@
     <ID>ComplexMethod:CheckpointDumperImpl.kt$CheckpointDumperImpl$private fun FlowIORequest&lt;*&gt;.toSuspendedOn(suspendedTimestamp: Instant, now: Instant): SuspendedOn</ID>
     <ID>ComplexMethod:ClassCarpenter.kt$ClassCarpenterImpl$ private fun validateSchema(schema: Schema)</ID>
     <ID>ComplexMethod:CompatibleTransactionTests.kt$CompatibleTransactionTests$@Test(timeout=300_000) fun `Command visibility tests`()</ID>
+    <ID>ComplexMethod:ConfigUtilities.kt$// For Iterables figure out the type parameter and apply the same logic as above on the individual elements. private fun Iterable&lt;*&gt;.toConfigIterable(field: Field): Iterable&lt;Any?&gt;</ID>
+    <ID>ComplexMethod:ConfigUtilities.kt$@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") // Reflect over the fields of the receiver and generate a value Map that can use to create Config object. private fun Any.toConfigMap(): Map&lt;String, Any&gt;</ID>
+    <ID>ComplexMethod:ConfigUtilities.kt$private fun convertValue(value: Any): Any</ID>
     <ID>ComplexMethod:ConnectionStateMachine.kt$ConnectionStateMachine$override fun onConnectionFinal(event: Event)</ID>
     <ID>ComplexMethod:ConnectionStateMachine.kt$ConnectionStateMachine$override fun onDelivery(event: Event)</ID>
+    <ID>ComplexMethod:ConstraintsUtils.kt$ fun AttachmentConstraint.canBeTransitionedFrom(input: AttachmentConstraint, attachment: ContractAttachment): Boolean</ID>
     <ID>ComplexMethod:CordaPersistence.kt$CordaPersistence$private fun &lt;T&gt; inTopLevelTransaction(isolationLevel: TransactionIsolationLevel, recoverableFailureTolerance: Int, recoverAnyNestedSQLException: Boolean, statement: DatabaseTransaction.() -&gt; T): T</ID>
     <ID>ComplexMethod:CordaRPCClient.kt$CordaRPCClientConfiguration$override fun equals(other: Any?): Boolean</ID>
     <ID>ComplexMethod:CordaRPCClientTest.kt$CordaRPCClientTest$@Test(timeout=300_000) fun `shutdown command stops the node`()</ID>
@@ -125,6 +133,9 @@
     <ID>ComplexMethod:HibernateQueryCriteriaParser.kt$HibernateQueryCriteriaParser$private fun parse(sorting: Sort)</ID>
     <ID>ComplexMethod:IRS.kt$InterestRateSwap.CommonLeg$override fun equals(other: Any?): Boolean</ID>
     <ID>ComplexMethod:IRS.kt$InterestRateSwap.FloatingLeg$override fun equals(other: Any?): Boolean</ID>
+    <ID>ComplexMethod:InteractiveShell.kt$InteractiveShell$ @JvmStatic fun runFlowByNameFragment(nameFragment: String, inputData: String, output: RenderPrintWriter, rpcOps: CordaRPCOps, ansiProgressRenderer: ANSIProgressRenderer, inputObjectMapper: ObjectMapper = createYamlInputMapper(rpcOps))</ID>
+    <ID>ComplexMethod:InteractiveShell.kt$InteractiveShell$ private fun maybeAbbreviateGenericType(type: Type, extraRecognisedPackage: String): String</ID>
+    <ID>ComplexMethod:InteractiveShell.kt$InteractiveShell$@JvmStatic fun runRPCFromString(input: List&lt;String&gt;, out: RenderPrintWriter, context: InvocationContext&lt;out Any&gt;, cordaRPCOps: CordaRPCOps, inputObjectMapper: ObjectMapper): Any?</ID>
     <ID>ComplexMethod:Kryo.kt$ImmutableClassSerializer$override fun read(kryo: Kryo, input: Input, type: Class&lt;T&gt;): T</ID>
     <ID>ComplexMethod:Kryo.kt$ImmutableClassSerializer$override fun write(kryo: Kryo, output: Output, obj: T)</ID>
     <ID>ComplexMethod:LoadTest.kt$LoadTest$fun run(nodes: Nodes, parameters: RunParameters, random: SplittableRandom)</ID>
@@ -140,6 +151,8 @@
     <ID>ComplexMethod:NewTransaction.kt$NewTransaction$fun show(window: Window)</ID>
     <ID>ComplexMethod:NewTransaction.kt$NewTransaction$private fun newTransactionDialog(window: Window)</ID>
     <ID>ComplexMethod:Node.kt$Node$override fun startMessagingService(rpcOps: List&lt;RPCOps&gt;, nodeInfo: NodeInfo, myNotaryIdentity: PartyAndCertificate?, networkParameters: NetworkParameters)</ID>
+    <ID>ComplexMethod:NodeNamedCache.kt$DefaultNamedCacheFactory$open protected fun &lt;K, V&gt; configuredForNamed(caffeine: Caffeine&lt;K, V&gt;, name: String): Caffeine&lt;K, V&gt;</ID>
+    <ID>ComplexMethod:NodeVaultService.kt$NodeVaultService$@Throws(VaultQueryException::class) private fun &lt;T : ContractState&gt; _queryBy(criteria: QueryCriteria, paging_: PageSpecification, sorting: Sort, contractStateType: Class&lt;out T&gt;, skipPagingChecks: Boolean): Vault.Page&lt;T&gt;</ID>
     <ID>ComplexMethod:NodeVaultService.kt$NodeVaultService$private fun makeUpdates(batch: Iterable&lt;CoreTransaction&gt;, statesToRecord: StatesToRecord, previouslySeen: Boolean): List&lt;Vault.Update&lt;ContractState&gt;&gt;</ID>
     <ID>ComplexMethod:NodeVaultService.kt$NodeVaultService$private fun processAndNotify(updates: List&lt;Vault.Update&lt;ContractState&gt;&gt;)</ID>
     <ID>ComplexMethod:ObjectDiffer.kt$ObjectDiffer$fun diff(a: Any?, b: Any?): DiffTree?</ID>
@@ -152,6 +165,7 @@
     <ID>ComplexMethod:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ private tailrec fun establishConnectionWithRetry( retryInterval: Duration, roundRobinIndex: Int = 0, retries: Int = -1 ): CordaRPCConnection?</ID>
     <ID>ComplexMethod:RemoteTypeCarpenter.kt$SchemaBuildingRemoteTypeCarpenter$override fun carpent(typeInformation: RemoteTypeInformation): Type</ID>
     <ID>ComplexMethod:SendTransactionFlow.kt$DataVendingFlow$@Suspendable override fun call(): Void?</ID>
+    <ID>ComplexMethod:ShellCmdLineOptions.kt$ShellCmdLineOptions$private fun toConfigFile(): Config</ID>
     <ID>ComplexMethod:StartedFlowTransition.kt$StartedFlowTransition$override fun transition(): TransitionResult</ID>
     <ID>ComplexMethod:StatusTransitions.kt$StatusTransitions$ fun verify(tx: LedgerTransaction)</ID>
     <ID>ComplexMethod:StringToMethodCallParser.kt$StringToMethodCallParser$ @Throws(UnparseableCallException::class) fun parse(target: T?, command: String): ParsedMethodCall</ID>
@@ -192,6 +206,7 @@
     <ID>ForEachOnRange:BFTSmartConfigTests.kt$BFTSmartConfigTests$forEach { n -&gt; assertEquals(2, maxFaultyReplicas(n)) }</ID>
     <ID>ForEachOnRange:BFTSmartConfigTests.kt$BFTSmartConfigTests$forEach { n -&gt; assertEquals(n, maxFaultyReplicas(n) + minCorrectReplicas(n)) }</ID>
     <ID>ForEachOnRange:HibernateConfigurationTest.kt$HibernateConfigurationTest$forEach { consumeCash(it.DOLLARS) }</ID>
+    <ID>ForEachOnRange:VaultQueryTests.kt$VaultQueryTestsBase$forEach { val newAllStates = vaultService.queryBy&lt;DummyLinearContract.State&gt;(sorting = sorting, criteria = criteria).states assertThat(newAllStates.groupBy(StateAndRef&lt;*&gt;::ref)).hasSameSizeAs(allStates) assertThat(newAllStates).containsExactlyElementsOf(allStates) }</ID>
     <ID>ForEachOnRange:VaultQueryTests.kt$VaultQueryTestsBase$forEach { vaultFiller.fillWithSomeTestLinearStates(1, linearNumber = it.toLong(), linearString = it.toString()) }</ID>
     <ID>ForbiddenComment:AbstractAttachment.kt$AbstractAttachment$// TODO: read file size information from metadata instead of loading the data.</ID>
     <ID>ForbiddenComment:AbstractCashSelection.kt$AbstractCashSelection$// TODO: future implementation to retrieve contract states from a Vault BLOB store</ID>
@@ -214,6 +229,7 @@
     <ID>ForbiddenComment:ArtemisMessagingComponent.kt$ArtemisMessagingComponent.Companion$// TODO: we might want to make this value configurable.</ID>
     <ID>ForbiddenComment:ArtemisMessagingServer.kt$// TODO: Implement a discovery engine that can trigger builds of new connections when another node registers? (later)</ID>
     <ID>ForbiddenComment:ArtemisMessagingServer.kt$// TODO: Verify that nobody can connect to us and fiddle with our config over the socket due to the secman.</ID>
+    <ID>ForbiddenComment:ArtemisMessagingServer.kt$ArtemisMessagingServer$// TODO: Maybe wrap [IOException] on a key store load error so that it's clearly splitting key store loading from</ID>
     <ID>ForbiddenComment:BFTSmart.kt$BFTSmart$// TODO: Define and document the configuration of the bft-smart cluster.</ID>
     <ID>ForbiddenComment:BFTSmart.kt$BFTSmart$// TODO: Potentially update the bft-smart API for our use case or rebuild client and server from lower level building</ID>
     <ID>ForbiddenComment:BFTSmart.kt$BFTSmart$// TODO: Support cluster membership changes. This requires reading about reconfiguration of bft-smart clusters and</ID>
@@ -318,6 +334,17 @@
     <ID>ForbiddenComment:IdentitySyncFlow.kt$IdentitySyncFlow.Send$// TODO: Can this be triggered automatically from [SendTransactionFlow]?</ID>
     <ID>ForbiddenComment:IdentitySyncFlow.kt$IdentitySyncFlow.Send$// TODO: Consider if this too restrictive - we perhaps should be checking the name on the signing certificate in the certificate path instead</ID>
     <ID>ForbiddenComment:InMemoryIdentityServiceTests.kt$InMemoryIdentityServiceTests$// TODO: Generate certificate with an EdDSA key rather than ECDSA</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Add a command to view last N lines/tail/control log4j2 loggers.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Add command history.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Command completion.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Configure default renderers, send objects down the pipeline, add support for xml output format.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Do something sensible with commands that return a future.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Fix up the 'dashboard' command which has some rendering issues.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Get rid of the 'java' command, it's kind of worthless.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Make it notice new shell commands added after the node started.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Resurrect or reimplement the mail plugin.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Review or fix the JVM commands which have bitrotted and some are useless.</ID>
+    <ID>ForbiddenComment:InteractiveShell.kt$InteractiveShell$// TODO: A default renderer could be used, instead of an object mapper. See: http://www.crashub.org/1.3/reference.html#_renderers</ID>
     <ID>ForbiddenComment:InternalUtils.kt$// TODO: Add inline back when a new Kotlin version is released and check if the java.lang.VerifyError</ID>
     <ID>ForbiddenComment:InternalUtils.kt$// TODO: Currently the certificate revocation status is not handled here. Nowhere in the code the second parameter is used. Consider adding the support in the future.</ID>
     <ID>ForbiddenComment:IrsDemoClientApi.kt$IRSDemoClientApi$// TODO: Add uploading of files to the HTTP API</ID>
@@ -345,13 +372,17 @@
     <ID>ForbiddenComment:NodeTerminalView.kt$NodeTerminalView$// TODO: Remove this special case once Rick's serialisation work means we can deserialise states that weren't on our own classpath.</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: Optimise this.</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: Perhaps these can be stored in a batch?</ID>
+    <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: This is a catch-all solution. But why is the default pageNumber set to be -1 in the first place?</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: This is expensive - is there another way?</ID>
+    <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: improve typing of returned other results</ID>
+    <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: revisit (use single instance of parser for all queries)</ID>
     <ID>ForbiddenComment:NodeVaultServiceTest.kt$NodeVaultServiceTest$// TODO: Unit test linear state relevancy checks</ID>
     <ID>ForbiddenComment:NodeWebServer.kt$NodeWebServer$// TODO: Redesign</ID>
     <ID>ForbiddenComment:NotaryChangeFlow.kt$NotaryChangeFlow$// TODO: We need a much faster way of finding our key in the transaction</ID>
     <ID>ForbiddenComment:NotaryChangeTests.kt$NotaryChangeTests$// TODO: Add more test cases once we have a general flow/service exception handling mechanism:</ID>
     <ID>ForbiddenComment:NotaryChangeTests.kt$NotaryChangeTests$// TODO: Re-enable the test when parameter currentness checks are in place, ENT-2666.</ID>
     <ID>ForbiddenComment:NotaryError.kt$StateConsumptionDetails$// TODO: include notary timestamp?</ID>
+    <ID>ForbiddenComment:NotaryFlow.kt$NotaryFlow.Client$// TODO: This is not required any more once our AMQP serialization supports turning off object referencing.</ID>
     <ID>ForbiddenComment:NotaryServiceFlow.kt$NotaryServiceFlow.Companion$// TODO: Determine an appropriate limit and also enforce in the network parameters and the transaction builder.</ID>
     <ID>ForbiddenComment:NotaryUtils.kt$// TODO: if requestSignature was generated over an old version of NotarisationRequest, we need to be able to</ID>
     <ID>ForbiddenComment:OGUtils.kt$// TODO: Do this correctly</ID>
@@ -494,6 +525,7 @@
     <ID>FunctionNaming:LedgerDSLInterpreter.kt$LedgerDSLInterpreter$ fun _unverifiedTransaction(transactionLabel: String?, transactionBuilder: TransactionBuilder, dsl: T.() -&gt; Unit): WireTransaction</ID>
     <ID>FunctionNaming:NamedCacheTest.kt$NamedCacheTest$@Test(timeout=300_000) fun TestCheckCacheName()</ID>
     <ID>FunctionNaming:NodeHandleTests.kt$NodeHandleTests$@Test(timeout=300_000) fun object_defined_functions_are_static_for_node_rpc_ops()</ID>
+    <ID>FunctionNaming:NodeVaultService.kt$NodeVaultService$@Throws(VaultQueryException::class) private fun &lt;T : ContractState&gt; _queryBy(criteria: QueryCriteria, paging_: PageSpecification, sorting: Sort, contractStateType: Class&lt;out T&gt;, skipPagingChecks: Boolean): Vault.Page&lt;T&gt;</ID>
     <ID>FunctionNaming:PasswordTest.kt$PasswordTest$@Test(timeout=300_000) fun constructor_and_getters()</ID>
     <ID>FunctionNaming:PasswordTest.kt$PasswordTest$@Test(timeout=300_000) fun toString_is_masked()</ID>
     <ID>FunctionNaming:ProgressTracker.kt$ProgressTracker$private fun _allSteps(level: Int = 0): List&lt;Pair&lt;Int, Step&gt;&gt;</ID>
@@ -543,6 +575,10 @@
     <ID>FunctionNaming:SpecificationTest.kt$SpecificationTest$@Test(timeout=300_000) fun parse_list_aggregation()</ID>
     <ID>FunctionNaming:SpecificationTest.kt$SpecificationTest$@Test(timeout=300_000) fun validate_list_aggregation()</ID>
     <ID>FunctionNaming:SpecificationTest.kt$SpecificationTest$@Test(timeout=300_000) fun validate_with_domain_specific_errors()</ID>
+    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun args_to_config()</ID>
+    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun cmd_options_override_config_from_file()</ID>
+    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun cmd_options_to_config_from_file()</ID>
+    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun empty_args_to_cmd_options()</ID>
     <ID>FunctionNaming:TransactionDSLInterpreter.kt$TransactionDSLInterpreter$ fun _attachment(contractClassName: ContractClassName)</ID>
     <ID>FunctionNaming:TransactionDSLInterpreter.kt$TransactionDSLInterpreter$ fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List&lt;PublicKey&gt;)</ID>
     <ID>FunctionNaming:TransactionDSLInterpreter.kt$TransactionDSLInterpreter$ fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List&lt;PublicKey&gt;, jarManifestAttributes: Map&lt;String,String&gt;)</ID>
@@ -575,6 +611,8 @@
     <ID>LongParameterList:Cash.kt$Cash$(inputs: List&lt;State&gt;, outputs: List&lt;State&gt;, tx: LedgerTransaction, issueCommand: CommandWithParties&lt;Commands.Issue&gt;, currency: Currency, issuer: PartyAndReference)</ID>
     <ID>LongParameterList:CashUtils.kt$CashUtils$(services: ServiceHub, tx: TransactionBuilder, amount: Amount&lt;Currency&gt;, ourIdentity: PartyAndCertificate, to: AbstractParty, onlyFromParties: Set&lt;AbstractParty&gt; = emptySet(), anonymous: Boolean = true)</ID>
     <ID>LongParameterList:CashUtils.kt$CashUtils$(services: ServiceHub, tx: TransactionBuilder, payments: List&lt;PartyAndAmount&lt;Currency&gt;&gt;, ourIdentity: PartyAndCertificate, onlyFromParties: Set&lt;AbstractParty&gt; = emptySet(), anonymous: Boolean = true)</ID>
+    <ID>LongParameterList:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$(port: Int, name: CordaX500Name = ALICE_NAME, crlCheckSoftFail: Boolean, nodeCrlDistPoint: String = "http://${server.hostAndPort}/crl/node.crl", tlsCrlDistPoint: String? = "http://${server.hostAndPort}/crl/empty.crl", maxMessageSize: Int = MAX_MESSAGE_SIZE)</ID>
+    <ID>LongParameterList:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests.Companion$(clrServer: CrlServer, signatureAlgorithm: String, caCertificate: X509Certificate, caPrivateKey: PrivateKey, endpoint: String, indirect: Boolean, vararg serialNumbers: BigInteger)</ID>
     <ID>LongParameterList:CertificateStoreStubs.kt$CertificateStoreStubs.P2P.Companion$(baseDirectory: Path, certificatesDirectoryName: String = DEFAULT_CERTIFICATES_DIRECTORY_NAME, keyStoreFileName: String = KeyStore.DEFAULT_STORE_FILE_NAME, keyStorePassword: String = KeyStore.DEFAULT_STORE_PASSWORD, keyPassword: String = keyStorePassword, trustStoreFileName: String = TrustStore.DEFAULT_STORE_FILE_NAME, trustStorePassword: String = TrustStore.DEFAULT_STORE_PASSWORD)</ID>
     <ID>LongParameterList:ContractAttachment.kt$ContractAttachment.Companion$(attachment: Attachment, contract: ContractClassName, additionalContracts: Set&lt;ContractClassName&gt; = emptySet(), uploader: String? = null, signerKeys: List&lt;PublicKey&gt; = emptyList(), version: Int = DEFAULT_CORDAPP_VERSION)</ID>
     <ID>LongParameterList:ContractFunctions.kt$(expiry: String, notional: BigDecimal, strike: BigDecimal, foreignCurrency: Currency, domesticCurrency: Currency, partyA: Party, partyB: Party)</ID>
@@ -604,6 +642,7 @@
     <ID>LongParameterList:IRS.kt$InterestRateSwap.FloatingLeg$(floatingRatePayer: AbstractParty = this.floatingRatePayer, notional: Amount&lt;Currency&gt; = this.notional, paymentFrequency: Frequency = this.paymentFrequency, effectiveDate: LocalDate = this.effectiveDate, effectiveDateAdjustment: DateRollConvention? = this.effectiveDateAdjustment, terminationDate: LocalDate = this.terminationDate, terminationDateAdjustment: DateRollConvention? = this.terminationDateAdjustment, dayCountBasisDay: DayCountBasisDay = this.dayCountBasisDay, dayCountBasisYear: DayCountBasisYear = this.dayCountBasisYear, dayInMonth: Int = this.dayInMonth, paymentRule: PaymentRule = this.paymentRule, paymentDelay: Int = this.paymentDelay, paymentCalendar: BusinessCalendar = this.paymentCalendar, interestPeriodAdjustment: AccrualAdjustment = this.interestPeriodAdjustment, rollConvention: DateRollConvention = this.rollConvention, fixingRollConvention: DateRollConvention = this.fixingRollConvention, resetDayInMonth: Int = this.resetDayInMonth, fixingPeriod: Int = this.fixingPeriodOffset, resetRule: PaymentRule = this.resetRule, fixingsPerPayment: Frequency = this.fixingsPerPayment, fixingCalendar: BusinessCalendar = this.fixingCalendar, index: String = this.index, indexSource: String = this.indexSource, indexTenor: Tenor = this.indexTenor )</ID>
     <ID>LongParameterList:IdenticonRenderer.kt$IdenticonRenderer$(g: GraphicsContext, x: Double, y: Double, patchIndex: Int, turn: Int, patchSize: Double, _invert: Boolean, color: PatchColor)</ID>
     <ID>LongParameterList:Injectors.kt$( metricRegistry: MetricRegistry, parallelism: Int, overallDuration: Duration, injectionRate: Rate, queueSizeMetricName: String = "QueueSize", workDurationMetricName: String = "WorkDuration", work: () -&gt; Unit )</ID>
+    <ID>LongParameterList:InteractiveShell.kt$InteractiveShell$(nameFragment: String, inputData: String, output: RenderPrintWriter, rpcOps: CordaRPCOps, ansiProgressRenderer: ANSIProgressRenderer, inputObjectMapper: ObjectMapper = createYamlInputMapper(rpcOps))</ID>
     <ID>LongParameterList:JarSignatureTestUtils.kt$JarSignatureTestUtils$(alias: String = "Test", storePassword: String = "secret!", name: String = CODE_SIGNER.toString(), keyalg: String = "RSA", keyPassword: String = storePassword, storeName: String = "_teststore")</ID>
     <ID>LongParameterList:MockServices.kt$MockServices.Companion$( cordappLoader: CordappLoader, identityService: IdentityService, networkParameters: NetworkParameters, initialIdentity: TestIdentity, moreKeys: Set&lt;KeyPair&gt;, keyManagementService: KeyManagementService, schemaService: SchemaService, persistence: CordaPersistence )</ID>
     <ID>LongParameterList:MockServices.kt$MockServices.Companion$( cordappPackages: List&lt;String&gt;, initialIdentity: TestIdentity, networkParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN), moreKeys: Set&lt;KeyPair&gt;, moreIdentities: Set&lt;PartyAndCertificate&gt;, cacheFactory: TestingNamedCacheFactory = TestingNamedCacheFactory() )</ID>
@@ -655,6 +694,12 @@
     <ID>LongParameterList:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$( withError: Boolean, issuer: PartyAndReference, owner: AbstractParty, amount: Amount&lt;Issued&lt;Currency&gt;&gt;, attachmentID: SecureHash?, notary: Party)</ID>
     <ID>LongParameterList:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$( withError: Boolean, issuer: PartyAndReference, owner: AbstractParty, notary: Party, node: TestStartedNode, identity: Party, notaryNode: TestStartedNode, vararg extraSigningNodes: TestStartedNode )</ID>
     <ID>LongParameterList:UniquenessProvider.kt$UniquenessProvider$( states: List&lt;StateRef&gt;, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature, timeWindow: TimeWindow? = null, references: List&lt;StateRef&gt; = emptyList() )</ID>
+    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(howMuch: Amount&lt;Currency&gt;, issuerServices: ServiceHub, atLeastThisManyStates: Int, atMostThisManyStates: Int, issuedBy: PartyAndReference, owner: AbstractParty? = null, rng: Random? = null, statesToRecord: StatesToRecord = StatesToRecord.ONLY_RELEVANT)</ID>
+    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(howMuch: Amount&lt;Currency&gt;, issuerServices: ServiceHub, thisManyStates: Int, issuedBy: PartyAndReference, owner: AbstractParty? = null, rng: Random? = null, statesToRecord: StatesToRecord = StatesToRecord.ONLY_RELEVANT)</ID>
+    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(numberToCreate: Int, externalId: String? = null, participants: List&lt;AbstractParty&gt; = emptyList(), linearString: String = "", linearNumber: Long = 0L, linearBoolean: Boolean = false, linearTimestamp: Instant = now())</ID>
+    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(numberToCreate: Int, externalId: String? = null, participants: List&lt;AbstractParty&gt; = emptyList(), uniqueIdentifier: UniqueIdentifier? = null, linearString: String = "", linearNumber: Long = 0L, linearBoolean: Boolean = false, linearTimestamp: Instant = now(), constraint: AttachmentConstraint = AutomaticPlaceholderConstraint, includeMe: Boolean = true)</ID>
+    <ID>LongParameterList:VaultService.kt$Vault.StateMetadata$( ref: StateRef = this.ref, contractStateClassName: String = this.contractStateClassName, recordedTime: Instant = this.recordedTime, consumedTime: Instant? = this.consumedTime, status: Vault.StateStatus = this.status, notary: AbstractParty? = this.notary, lockId: String? = this.lockId, lockUpdateTime: Instant? = this.lockUpdateTime )</ID>
+    <ID>LongParameterList:VaultService.kt$Vault.StateMetadata$( ref: StateRef = this.ref, contractStateClassName: String = this.contractStateClassName, recordedTime: Instant = this.recordedTime, consumedTime: Instant? = this.consumedTime, status: Vault.StateStatus = this.status, notary: AbstractParty? = this.notary, lockId: String? = this.lockId, lockUpdateTime: Instant? = this.lockUpdateTime, relevancyStatus: Vault.RelevancyStatus? )</ID>
     <ID>LongParameterList:WireTransaction.kt$WireTransaction.Companion$(inputs: List&lt;StateRef&gt;, outputs: List&lt;TransactionState&lt;ContractState&gt;&gt;, commands: List&lt;Command&lt;*&gt;&gt;, attachments: List&lt;SecureHash&gt;, notary: Party?, timeWindow: TimeWindow?)</ID>
     <ID>LongParameterList:X509Utilities.kt$X509Utilities$(certificateType: CertificateType, issuer: X500Principal, issuerKeyPair: KeyPair, subject: X500Principal, subjectPublicKey: PublicKey, validityWindow: Pair&lt;Date, Date&gt;, nameConstraints: NameConstraints? = null, crlDistPoint: String? = null, crlIssuer: X500Name? = null)</ID>
     <ID>LongParameterList:X509Utilities.kt$X509Utilities$(certificateType: CertificateType, issuer: X500Principal, issuerPublicKey: PublicKey, issuerSigner: ContentSigner, subject: X500Principal, subjectPublicKey: PublicKey, validityWindow: Pair&lt;Date, Date&gt;, nameConstraints: NameConstraints? = null, crlDistPoint: String? = null, crlIssuer: X500Name? = null)</ID>
@@ -679,10 +724,7 @@
     <ID>MagicNumber:AttachmentDemo.kt$10006</ID>
     <ID>MagicNumber:AttachmentDemo.kt$10009</ID>
     <ID>MagicNumber:AttachmentDemo.kt$10010</ID>
-    <ID>MagicNumber:AzureBackend.kt$AzureBackend.Companion$404</ID>
-    <ID>MagicNumber:AzureInstantiator.kt$AzureInstantiator$404</ID>
-    <ID>MagicNumber:AzureRegistryLocator.kt$RegistryLocator$404</ID>
-    <ID>MagicNumber:AzureSmbVolume.kt$AzureSmbVolume$404</ID>
+    <ID>MagicNumber:AttachmentTrustTable.kt$AttachmentTrustTable$3</ID>
     <ID>MagicNumber:AzureSmbVolume.kt$AzureSmbVolume$5000</ID>
     <ID>MagicNumber:BFTSmart.kt$BFTSmart.Client$100</ID>
     <ID>MagicNumber:BFTSmart.kt$BFTSmart.Replica.&lt;no name provided&gt;$20000</ID>
@@ -714,6 +756,7 @@
     <ID>MagicNumber:CordaPersistence.kt$DatabaseConfig.Defaults$100L</ID>
     <ID>MagicNumber:CordaRPCClient.kt$CordaRPCClientConfiguration$3</ID>
     <ID>MagicNumber:CordaRPCClient.kt$CordaRPCClientConfiguration$5</ID>
+    <ID>MagicNumber:CordaSSHAuthInfo.kt$CordaSSHAuthInfo$10</ID>
     <ID>MagicNumber:CordaSecurityProvider.kt$CordaSecurityProvider$0.1</ID>
     <ID>MagicNumber:Crypto.kt$Crypto$2048</ID>
     <ID>MagicNumber:Crypto.kt$Crypto$256</ID>
@@ -990,6 +1033,8 @@
     <ID>MagicNumber:OracleUtils.kt$24</ID>
     <ID>MagicNumber:OracleUtils.kt$45</ID>
     <ID>MagicNumber:OrdinalIO.kt$OrdinalBits$128</ID>
+    <ID>MagicNumber:P2PMessagingClient.kt$P2PMessagingClient$30000</ID>
+    <ID>MagicNumber:P2PMessagingClient.kt$P2PMessagingClient$60000</ID>
     <ID>MagicNumber:P2PMessagingClient.kt$P2PMessagingConsumer$10</ID>
     <ID>MagicNumber:Parameters.kt$Parameters$0.02</ID>
     <ID>MagicNumber:Parameters.kt$Parameters$0.8</ID>
@@ -1054,8 +1099,11 @@
     <ID>MagicNumber:SimmFlow.kt$1e-9</ID>
     <ID>MagicNumber:StaffedFlowHospital.kt$StaffedFlowHospital$1.5</ID>
     <ID>MagicNumber:StaffedFlowHospital.kt$StaffedFlowHospital$10</ID>
+    <ID>MagicNumber:StandaloneShell.kt$StandaloneShell$7</ID>
     <ID>MagicNumber:StateRevisionFlow.kt$StateRevisionFlow.Requester$30</ID>
     <ID>MagicNumber:TestNodeInfoBuilder.kt$TestNodeInfoBuilder$1234</ID>
+    <ID>MagicNumber:TestUtils.kt$10000</ID>
+    <ID>MagicNumber:TestUtils.kt$30000</ID>
     <ID>MagicNumber:TraderDemo.kt$TraderDemo$1_000_000_000_000</ID>
     <ID>MagicNumber:TraderDemo.kt$TraderDemo$1_100_000_000_000</ID>
     <ID>MagicNumber:TraderDemoClientApi.kt$TraderDemoClientApi$10</ID>
@@ -1087,6 +1135,7 @@
     <ID>MagicNumber:WebServer.kt$100.0</ID>
     <ID>MagicNumber:WebServer.kt$WebServer$500</ID>
     <ID>MagicNumber:WireTransaction.kt$WireTransaction$4</ID>
+    <ID>MagicNumber:X509Utilities.kt$X509Utilities$3650</ID>
     <ID>MagicNumber:errorAndTerminate.kt$10</ID>
     <ID>MatchingDeclarationName:AMQPSerializerFactories.kt$net.corda.serialization.internal.amqp.AMQPSerializerFactories.kt</ID>
     <ID>MatchingDeclarationName:AMQPTestSerialiationScheme.kt$net.corda.nodeapi.internal.serialization.testutils.AMQPTestSerialiationScheme.kt</ID>
@@ -1133,6 +1182,8 @@
     <ID>MatchingDeclarationName:TransactionTypes.kt$net.corda.explorer.model.TransactionTypes.kt</ID>
     <ID>MatchingDeclarationName:Utils.kt$io.cryptoblk.core.Utils.kt</ID>
     <ID>MatchingDeclarationName:VirtualCordapps.kt$net.corda.node.internal.cordapp.VirtualCordapps.kt</ID>
+    <ID>ModifierOrder:NodeNamedCache.kt$DefaultNamedCacheFactory$open protected</ID>
+    <ID>NestedBlockDepth:ANSIProgressRenderer.kt$ANSIProgressRenderer$// Returns number of lines rendered. private fun renderLevel(ansi: Ansi, error: Boolean): Int</ID>
     <ID>NestedBlockDepth:AbstractAggregatedList.kt$AbstractAggregatedList$override fun sourceChanged(c: ListChangeListener.Change&lt;out E&gt;)</ID>
     <ID>NestedBlockDepth:AbstractConcatenatedList.kt$AbstractConcatenatedList$// This is where we handle changes to the *source* list. override fun sourceChanged(change: ListChangeListener.Change&lt;out ObservableList&lt;A&gt;&gt;)</ID>
     <ID>NestedBlockDepth:AbstractNode.kt$AbstractNode$private fun installCordaServices()</ID>
@@ -1141,6 +1192,7 @@
     <ID>NestedBlockDepth:Amount.kt$Amount.Companion$ @JvmStatic fun parseCurrency(input: String): Amount&lt;Currency&gt;</ID>
     <ID>NestedBlockDepth:AttachmentDemo.kt$@Suppress("DEPRECATION") // DOCSTART 1 fun recipient(rpc: CordaRPCOps, webPort: Int)</ID>
     <ID>NestedBlockDepth:AttachmentVersionNumberMigration.kt$AttachmentVersionNumberMigration$override fun execute(database: Database?)</ID>
+    <ID>NestedBlockDepth:AttachmentsClassLoader.kt$AttachmentsClassLoader$private fun checkAttachments(attachments: List&lt;Attachment&gt;)</ID>
     <ID>NestedBlockDepth:CheckpointAgent.kt$CheckpointAgent.Companion$fun parseArguments(argumentsString: String?)</ID>
     <ID>NestedBlockDepth:CheckpointAgent.kt$CheckpointHook$private fun instrumentClass(clazz: CtClass): CtClass?</ID>
     <ID>NestedBlockDepth:CheckpointVerifier.kt$CheckpointVerifier$ fun verifyCheckpointsCompatible( checkpointStorage: CheckpointStorage, currentCordapps: List&lt;Cordapp&gt;, platformVersion: Int, serviceHub: ServiceHub, tokenizableServices: List&lt;Any&gt; )</ID>
@@ -1151,6 +1203,7 @@
     <ID>NestedBlockDepth:DeserializationInput.kt$DeserializationInput$fun readObject(obj: Any, schemas: SerializationSchemas, type: Type, context: SerializationContext): Any</ID>
     <ID>NestedBlockDepth:FetchDataFlow.kt$FetchAttachmentsFlow$override fun maybeWriteToDisk(downloaded: List&lt;Attachment&gt;)</ID>
     <ID>NestedBlockDepth:HibernateQueryCriteriaParser.kt$HibernateQueryCriteriaParser$override fun parseCriteria(criteria: CommonQueryCriteria): Collection&lt;Predicate&gt;</ID>
+    <ID>NestedBlockDepth:InteractiveShell.kt$InteractiveShell$ @JvmStatic fun runFlowByNameFragment(nameFragment: String, inputData: String, output: RenderPrintWriter, rpcOps: CordaRPCOps, ansiProgressRenderer: ANSIProgressRenderer, inputObjectMapper: ObjectMapper = createYamlInputMapper(rpcOps))</ID>
     <ID>NestedBlockDepth:InternalUtils.kt$ inline fun &lt;T&gt; Iterable&lt;T&gt;.noneOrSingle(predicate: (T) -&gt; Boolean): T?</ID>
     <ID>NestedBlockDepth:JarSignatureTestUtils.kt$JarSignatureTestUtils$fun Path.addManifest(fileName: String, vararg entries: Pair&lt;Attributes.Name, String&gt;)</ID>
     <ID>NestedBlockDepth:Main.kt$Node$fun avalancheLoop()</ID>
@@ -1171,6 +1224,7 @@
     <ID>NestedBlockDepth:SpringDriver.kt$SpringBootDriverDSL$private fun queryWebserver(handle: NodeHandle, process: Process, checkUrl: String): WebserverHandle</ID>
     <ID>NestedBlockDepth:StatusTransitions.kt$StatusTransitions$ fun verify(tx: LedgerTransaction)</ID>
     <ID>NestedBlockDepth:ThrowableSerializer.kt$ThrowableSerializer$override fun fromProxy(proxy: ThrowableProxy): Throwable</ID>
+    <ID>NestedBlockDepth:TransactionVerifierServiceInternal.kt$Verifier$ private fun verifyConstraintsValidity(contractAttachmentsByContract: Map&lt;ContractClassName, ContractAttachment&gt;)</ID>
     <ID>SpreadOperator:AbstractNode.kt$FlowStarterImpl$(logicType, *args)</ID>
     <ID>SpreadOperator:AbstractParty.kt$AbstractParty$(*bytes)</ID>
     <ID>SpreadOperator:AbstractRPCTest.kt$AbstractRPCTest.Companion$(*modes)</ID>
@@ -1180,6 +1234,10 @@
     <ID>SpreadOperator:AuthenticatedRpcOpsProxy.kt$AuthenticatedRpcOpsProxy.PermissionsEnforcingInvocationHandler$(methodFullName(method), *(args.map(Class&lt;*&gt;::getName).toTypedArray()))</ID>
     <ID>SpreadOperator:AzureInstantiator.kt$AzureInstantiator$(*portsToOpen.toIntArray())</ID>
     <ID>SpreadOperator:ByteArrays.kt$OpaqueBytes.Companion$(*b)</ID>
+    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$(newNodeCert, INTERMEDIATE_CA.certificate, *nodeKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_CA) }.drop(2).toTypedArray())</ID>
+    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$(newTlsCert, newNodeCert, INTERMEDIATE_CA.certificate, *sslKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_TLS) }.drop(3).toTypedArray())</ID>
+    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests.CrlServlet$( server, SIGNATURE_ALGORITHM, INTERMEDIATE_CA.certificate, INTERMEDIATE_CA.keyPair.private, NODE_CRL, false, *revokedNodeCerts.toTypedArray())</ID>
+    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests.CrlServlet$( server, SIGNATURE_ALGORITHM, ROOT_CA.certificate, ROOT_CA.keyPair.private, INTEMEDIATE_CRL, false, *revokedIntermediateCerts.toTypedArray())</ID>
     <ID>SpreadOperator:CertificateStore.kt$CertificateStore$(*options)</ID>
     <ID>SpreadOperator:ClassCarpenterTestUtils.kt$AmqpCarpenterBase$(*constructorParams)</ID>
     <ID>SpreadOperator:ClassCarpentingTypeLoaderTests.kt$ClassCarpentingTypeLoaderTests$(*params)</ID>
@@ -1220,6 +1278,9 @@
     <ID>SpreadOperator:HibernateQueryCriteriaParser.kt$HibernateAttachmentQueryCriteriaParser$(*predicateSet.toTypedArray())</ID>
     <ID>SpreadOperator:IRSDemo.kt$(*args)</ID>
     <ID>SpreadOperator:InstallShellExtensionsParser.kt$ShellExtensionsGenerator$(*commandAndArgs)</ID>
+    <ID>SpreadOperator:InteractiveShell.kt$InteractiveShell$(clazz, *args)</ID>
+    <ID>SpreadOperator:InteractiveShellTest.kt$InteractiveShellTest$(*args)</ID>
+    <ID>SpreadOperator:InteractiveShellTest.kt$InteractiveShellTest$(*args.map { it!!::class.java }.toTypedArray())</ID>
     <ID>SpreadOperator:InternalUtils.kt$(this, target, *options)</ID>
     <ID>SpreadOperator:InvocationHandlerTemplate.kt$InvocationHandlerTemplate$(delegate, *args)</ID>
     <ID>SpreadOperator:IrsDemoWebApplication.kt$IrsDemoWebApplication.Companion$(IrsDemoWebApplication::class.java, *args)</ID>
@@ -1279,6 +1340,7 @@
     <ID>SpreadOperator:ReactiveArtemisConsumer.kt$ReactiveArtemisConsumer.Companion$(queueName, *queueNames)</ID>
     <ID>SpreadOperator:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ErrorInterceptingHandler$(reconnectingRPCConnection.proxy, *(args ?: emptyArray()))</ID>
     <ID>SpreadOperator:ServiceHub.kt$ServiceHub$(first, *remaining)</ID>
+    <ID>SpreadOperator:StandaloneShell.kt$StandaloneShell$(format, *args)</ID>
     <ID>SpreadOperator:StringToMethodCallParser.kt$StringToMethodCallParser.ParsedMethodCall$(target, *args)</ID>
     <ID>SpreadOperator:TestNodeInfoBuilder.kt$TestNodeInfoBuilder$(*certs, intermediateAndRoot.first.certificate, intermediateAndRoot.second)</ID>
     <ID>SpreadOperator:TestUtils.kt$TestIdentity$(*bytes)</ID>
@@ -1290,6 +1352,7 @@
     <ID>SpreadOperator:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$(listOf(bc1), node, identity, notaryNode, *extraSigningNodes)</ID>
     <ID>SpreadOperator:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$(listOf(bc2), node, identity, notaryNode, *extraSigningNodes)</ID>
     <ID>SpreadOperator:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$(listOf(eb1), node, identity, notaryNode, *extraSigningNodes)</ID>
+    <ID>SpreadOperator:VaultQueryTests.kt$VaultQueryTestRule$( cordappPackages, makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity), megaCorp, moreKeys = *arrayOf(DUMMY_NOTARY_KEY))</ID>
     <ID>SpreadOperator:VaultQueryTests.kt$VaultQueryTestsBase$(*states.toList().toTypedArray())</ID>
     <ID>SpreadOperator:VaultWithCashTest.kt$VaultWithCashTest$( cordappPackages, makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity), TestIdentity(MEGA_CORP.name, servicesKey), networkParameters, moreKeys = *arrayOf(dummyNotary.keyPair))</ID>
     <ID>SpreadOperator:WaitForStateConsumption.kt$WaitForStateConsumption$(*futures.toTypedArray())</ID>
@@ -1300,6 +1363,7 @@
     <ID>SpreadOperator:X509Utilities.kt$X509Utilities$(*certificates)</ID>
     <ID>ThrowsCount:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$// Make sure our inputs aren't designed to blow things up. private fun validate(typeString: String)</ID>
     <ID>ThrowsCount:AbstractNode.kt$AbstractNode$private fun installCordaServices()</ID>
+    <ID>ThrowsCount:ArtemisMessagingServer.kt$ArtemisMessagingServer$// TODO: Maybe wrap [IOException] on a key store load error so that it's clearly splitting key store loading from // Artemis IO errors @Throws(IOException::class, AddressBindingException::class, KeyStoreException::class) private fun configureAndStartServer()</ID>
     <ID>ThrowsCount:CheckpointVerifier.kt$CheckpointVerifier$ fun verifyCheckpointsCompatible( checkpointStorage: CheckpointStorage, currentCordapps: List&lt;Cordapp&gt;, platformVersion: Int, serviceHub: ServiceHub, tokenizableServices: List&lt;Any&gt; )</ID>
     <ID>ThrowsCount:CheckpointVerifier.kt$CheckpointVerifier$// Throws exception when the flow is incompatible private fun checkFlowCompatible(subFlow: SubFlow, currentCordappsByHash: Map&lt;SecureHash.SHA256, Cordapp&gt;, platformVersion: Int)</ID>
     <ID>ThrowsCount:ClassCarpenter.kt$ClassCarpenterImpl$ private fun validateSchema(schema: Schema)</ID>
@@ -1316,6 +1380,7 @@
     <ID>ThrowsCount:MockServices.kt$ fun &lt;T : SerializeAsToken&gt; createMockCordaService(serviceHub: MockServices, serviceConstructor: (AppServiceHub) -&gt; T): T</ID>
     <ID>ThrowsCount:NetworkRegistrationHelper.kt$NetworkRegistrationHelper$private fun validateCertificates( registeringPublicKey: PublicKey, registeringLegalName: CordaX500Name, expectedCertRole: CertRole, certificates: List&lt;X509Certificate&gt; )</ID>
     <ID>ThrowsCount:NodeInfoFilesCopier.kt$NodeInfoFilesCopier$private fun atomicCopy(source: Path, destination: Path)</ID>
+    <ID>ThrowsCount:NodeVaultService.kt$NodeVaultService$@Throws(VaultQueryException::class) private fun &lt;T : ContractState&gt; _queryBy(criteria: QueryCriteria, paging_: PageSpecification, sorting: Sort, contractStateType: Class&lt;out T&gt;, skipPagingChecks: Boolean): Vault.Page&lt;T&gt;</ID>
     <ID>ThrowsCount:NodeVaultService.kt$NodeVaultService$private fun makeUpdates(batch: Iterable&lt;CoreTransaction&gt;, statesToRecord: StatesToRecord, previouslySeen: Boolean): List&lt;Vault.Update&lt;ContractState&gt;&gt;</ID>
     <ID>ThrowsCount:NonValidatingNotaryFlow.kt$NonValidatingNotaryFlow$ private fun checkNotaryWhitelisted(notary: Party, attachedParameterHash: SecureHash?)</ID>
     <ID>ThrowsCount:PropertyDescriptor.kt$PropertyDescriptor$ fun validate()</ID>
@@ -1328,6 +1393,8 @@
     <ID>ThrowsCount:StringToMethodCallParser.kt$StringToMethodCallParser$ @Throws(UnparseableCallException::class) fun parse(target: T?, command: String): ParsedMethodCall</ID>
     <ID>ThrowsCount:StringToMethodCallParser.kt$StringToMethodCallParser$ @Throws(UnparseableCallException::class) fun parseArguments(methodNameHint: String, parameters: List&lt;Pair&lt;String, Type&gt;&gt;, args: String): Array&lt;Any?&gt;</ID>
     <ID>ThrowsCount:StructuresTests.kt$AttachmentTest$@Test(timeout=300_000) fun `openAsJAR does not leak file handle if attachment has corrupted manifest`()</ID>
+    <ID>ThrowsCount:TransactionVerifierServiceInternal.kt$Verifier$ private fun getUniqueContractAttachmentsByContract(): Map&lt;ContractClassName, ContractAttachment&gt;</ID>
+    <ID>ThrowsCount:TransactionVerifierServiceInternal.kt$Verifier$// Using basic graph theory, a full cycle of encumbered (co-dependent) states should exist to achieve bi-directional // encumbrances. This property is important to ensure that no states involved in an encumbrance-relationship // can be spent on their own. Briefly, if any of the states is having more than one encumbrance references by // other states, a full cycle detection will fail. As a result, all of the encumbered states must be present // as "from" and "to" only once (or zero times if no encumbrance takes place). For instance, // a -&gt; b // c -&gt; b and a -&gt; b // b -&gt; a b -&gt; c // do not satisfy the bi-directionality (full cycle) property. // // In the first example "b" appears twice in encumbrance ("to") list and "c" exists in the encumbered ("from") list only. // Due the above, one could consume "a" and "b" in the same transaction and then, because "b" is already consumed, "c" cannot be spent. // // Similarly, the second example does not form a full cycle because "a" and "c" exist in one of the lists only. // As a result, one can consume "b" and "c" in the same transactions, which will make "a" impossible to be spent. // // On other hand the following are valid constructions: // a -&gt; b a -&gt; c // b -&gt; c and c -&gt; b // c -&gt; a b -&gt; a // and form a full cycle, meaning that the bi-directionality property is satisfied. private fun checkBidirectionalOutputEncumbrances(statesAndEncumbrance: List&lt;Pair&lt;Int, Int&gt;&gt;)</ID>
     <ID>ThrowsCount:WireTransaction.kt$WireTransaction.Companion$ @CordaInternal fun resolveStateRefBinaryComponent(stateRef: StateRef, services: ServicesForResolution): SerializedBytes&lt;TransactionState&lt;ContractState&gt;&gt;?</ID>
     <ID>TooGenericExceptionCaught:AMQPChannelHandler.kt$AMQPChannelHandler$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:AMQPExceptions.kt$th: Throwable</ID>
@@ -1337,6 +1404,7 @@
     <ID>TooGenericExceptionCaught:AbstractNode.kt$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:AbstractNodeTests.kt$ColdJVM.Companion$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:Amount.kt$Amount.Companion$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ArtemisRpcBroker.kt$ArtemisRpcBroker$th: Throwable</ID>
     <ID>TooGenericExceptionCaught:AttachmentDemo.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AttachmentLoadingTests.kt$AttachmentLoadingTests.ConsumeAndBroadcastResponderFlow$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AttachmentVersionNumberMigration.kt$AttachmentVersionNumberMigration$e: Exception</ID>
@@ -1357,6 +1425,7 @@
     <ID>TooGenericExceptionCaught:ConnectionStateMachine.kt$ConnectionStateMachine$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ContractAttachmentSerializer.kt$ContractAttachmentSerializer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContractUpgradeTransactions.kt$ContractUpgradeWireTransaction$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CordaAuthenticationPlugin.kt$CordaAuthenticationPlugin$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CordaClassResolver.kt$LoggingWhitelist.Companion$ioEx: Exception</ID>
     <ID>TooGenericExceptionCaught:CordaPersistence.kt$CordaPersistence$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CordaRPCClientTest.kt$CordaRPCClientTest$e: Exception</ID>
@@ -1396,6 +1465,7 @@
     <ID>TooGenericExceptionCaught:Injectors.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:InstallShellExtensionsParser.kt$ShellExtensionsGenerator$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:InteractiveShell.kt$InteractiveShell$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:InteractiveShell.kt$InteractiveShell$e: IndexOutOfBoundsException</ID>
     <ID>TooGenericExceptionCaught:InterestSwapRestAPI.kt$InterestRateSwapAPI$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:InternalMockNetwork.kt$InternalMockNetwork$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:InternalTestUtils.kt$&lt;no name provided&gt;$e: Exception</ID>
@@ -1435,6 +1505,7 @@
     <ID>TooGenericExceptionCaught:NodeRPC.kt$NodeRPC$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeRPC.kt$NodeRPC.&lt;no name provided&gt;$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeSchedulerService.kt$NodeSchedulerService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:NodeStartup.kt$NodeStartup$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeTerminalView.kt$NodeTerminalView$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeVaultService.kt$NodeVaultService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeVaultServiceTest.kt$NodeVaultServiceTest$e: Exception</ID>
@@ -1463,6 +1534,7 @@
     <ID>TooGenericExceptionCaught:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ReconnectingObservable.kt$ReconnectingObservable.ReconnectingSubscriber$e: Exception</ID>
     <ID>TooGenericExceptionCaught:RpcServerObservableSerializerTests.kt$RpcServerObservableSerializerTests$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SSLHelper.kt$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:SerializationOutputTests.kt$SerializationOutputTests$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:ShutdownManager.kt$ShutdownManager$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:SimpleAMQPClient.kt$SimpleAMQPClient$e: Exception</ID>
@@ -1471,6 +1543,7 @@
     <ID>TooGenericExceptionCaught:SingleThreadedStateMachineManager.kt$SingleThreadedStateMachineManager$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:SingleThreadedStateMachineManager.kt$SingleThreadedStateMachineManager$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:SingleThreadedStateMachineManager.kt$SingleThreadedStateMachineManager$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:StandaloneShell.kt$StandaloneShell$e: Exception</ID>
     <ID>TooGenericExceptionCaught:StandardConfigValueParsers.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:StringToMethodCallParser.kt$StringToMethodCallParser$e: Exception</ID>
     <ID>TooGenericExceptionCaught:TLSAuthenticationTests.kt$TLSAuthenticationTests$ex: Exception</ID>
@@ -1497,6 +1570,7 @@
     <ID>TooGenericExceptionCaught:X509EdDSAEngine.kt$X509EdDSAEngine$e: Exception</ID>
     <ID>TooGenericExceptionCaught:X509UtilitiesTest.kt$X509UtilitiesTest$ex: Exception</ID>
     <ID>TooGenericExceptionThrown:AMQPExceptionsTests.kt$AMQPExceptionsTests$throw Exception("FAILED")</ID>
+    <ID>TooGenericExceptionThrown:AzureBackend.kt$AzureBackend.Companion$throw RuntimeException(e)</ID>
     <ID>TooGenericExceptionThrown:ClassLoadingUtilsTest.kt$ClassLoadingUtilsTest$throw RuntimeException()</ID>
     <ID>TooGenericExceptionThrown:CommandParsers.kt$AzureParser.RegionConverter$throw Error("Unknown azure region: $value")</ID>
     <ID>TooGenericExceptionThrown:ContractHierarchyTest.kt$ContractHierarchyTest.IndirectContractParent$throw RuntimeException("Boom!")</ID>
@@ -1527,6 +1601,7 @@
     <ID>TooManyFunctions:AbstractNode.kt$AbstractNode&lt;S&gt; : SingletonSerializeAsToken</ID>
     <ID>TooManyFunctions:ActionExecutorImpl.kt$ActionExecutorImpl : ActionExecutor</ID>
     <ID>TooManyFunctions:AppendOnlyPersistentMap.kt$AppendOnlyPersistentMapBase&lt;K, V, E, out EK&gt;</ID>
+    <ID>TooManyFunctions:ArtemisTcpTransport.kt$ArtemisTcpTransport$Companion</ID>
     <ID>TooManyFunctions:BCCryptoService.kt$BCCryptoService : CryptoService</ID>
     <ID>TooManyFunctions:BFTSmart.kt$BFTSmart$Replica : DefaultRecoverable</ID>
     <ID>TooManyFunctions:BaseTransaction.kt$BaseTransaction : NamedByHash</ID>
@@ -1548,6 +1623,7 @@
     <ID>TooManyFunctions:Generator.kt$Generator$Companion</ID>
     <ID>TooManyFunctions:HibernateQueryCriteriaParser.kt$HibernateQueryCriteriaParser : AbstractQueryCriteriaParserIQueryCriteriaParser</ID>
     <ID>TooManyFunctions:HibernateStatistics.kt$DelegatingStatisticsService : StatisticsService</ID>
+    <ID>TooManyFunctions:InteractiveShell.kt$InteractiveShell</ID>
     <ID>TooManyFunctions:InternalMockNetwork.kt$InternalMockNetwork : AutoCloseable</ID>
     <ID>TooManyFunctions:InternalMockNetwork.kt$InternalMockNetwork$MockNode : AbstractNode</ID>
     <ID>TooManyFunctions:InternalTestUtils.kt$net.corda.testing.internal.InternalTestUtils.kt</ID>
@@ -1616,6 +1692,9 @@
     <ID>VariableNaming:ByteArraysTest.kt$ByteArraysTest$val HEX_REGEX = "^[0-9A-F]+\$".toRegex()</ID>
     <ID>VariableNaming:Cap.kt$Cap$val TEST_TX_TIME_1: Instant get() = Instant.parse("2017-09-02T12:00:00.00Z")</ID>
     <ID>VariableNaming:Caplet.kt$Caplet$val TEST_TX_TIME_1: Instant get() = Instant.parse("2017-09-02T12:00:00.00Z")</ID>
+    <ID>VariableNaming:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$val ECDSA_ALGORITHM = "SHA256withECDSA"</ID>
+    <ID>VariableNaming:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$val EC_ALGORITHM = "EC"</ID>
+    <ID>VariableNaming:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$val EMPTY_CRL = "empty.crl"</ID>
     <ID>VariableNaming:CompositeKeyTests.kt$CompositeKeyTests$val EdSignature = keyPairEd.sign(SignableData(secureHash, SignatureMetadata(1, Crypto.findSignatureScheme(keyPairEd.public).schemeNumberID)))</ID>
     <ID>VariableNaming:CompositeKeyTests.kt$CompositeKeyTests$val K1Signature = keyPairK1.sign(SignableData(secureHash, SignatureMetadata(1, Crypto.findSignatureScheme(keyPairK1.public).schemeNumberID)))</ID>
     <ID>VariableNaming:CompositeKeyTests.kt$CompositeKeyTests$val R1Signature = keyPairR1.sign(SignableData(secureHash, SignatureMetadata(1, Crypto.findSignatureScheme(keyPairR1.public).schemeNumberID)))</ID>
@@ -1730,6 +1809,7 @@
     <ID>VariableNaming:VaultQueryTests.kt$VaultQueryParties$val MINI_CORP_IDENTITY get() = miniCorp.identity</ID>
     <ID>VariableNaming:VaultQueryTests.kt$VaultQueryTestsBase$// Beware: do not use `MyContractClass::class.qualifiedName` as this returns a fully qualified name using "dot" notation for enclosed class val MYCONTRACT_ID = "net.corda.node.services.vault.VaultQueryTestsBase\$MyContractClass"</ID>
     <ID>VariableNaming:ZeroCouponBond.kt$ZeroCouponBond$val TEST_TX_TIME_1: Instant get() = Instant.parse("2017-09-02T12:00:00.00Z")</ID>
+    <ID>WildcardImport:AMQPClient.kt$import io.netty.channel.*</ID>
     <ID>WildcardImport:AMQPRemoteTypeModel.kt$import net.corda.serialization.internal.model.*</ID>
     <ID>WildcardImport:AMQPSerializationScheme.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:AMQPServerSerializationScheme.kt$import net.corda.serialization.internal.amqp.*</ID>
@@ -1738,6 +1818,7 @@
     <ID>WildcardImport:AMQPTestUtils.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:AMQPTypeIdentifierParser.kt$import org.apache.qpid.proton.amqp.*</ID>
     <ID>WildcardImport:AMQPTypeIdentifiers.kt$import org.apache.qpid.proton.amqp.*</ID>
+    <ID>WildcardImport:ANSIProgressRendererTest.kt$import com.nhaarman.mockito_kotlin.*</ID>
     <ID>WildcardImport:AbstractCashFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:AbstractCashSelection.kt$import net.corda.core.utilities.*</ID>
     <ID>WildcardImport:AdvancedExceptionDialog.kt$import javafx.scene.control.*</ID>
@@ -1749,6 +1830,7 @@
     <ID>WildcardImport:AnotherDummyContract.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:AppendOnlyPersistentMapTest.kt$import org.junit.Assert.*</ID>
     <ID>WildcardImport:ArtemisMessagingClient.kt$import org.apache.activemq.artemis.api.core.client.*</ID>
+    <ID>WildcardImport:ArtemisMessagingServer.kt$import net.corda.node.internal.artemis.*</ID>
     <ID>WildcardImport:ArtemisRpcBroker.kt$import net.corda.node.internal.artemis.*</ID>
     <ID>WildcardImport:AttachmentDemoFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:AttachmentLoadingTests.kt$import net.corda.core.contracts.*</ID>
@@ -1757,6 +1839,9 @@
     <ID>WildcardImport:AttachmentTest.kt$import org.junit.Assert.*</ID>
     <ID>WildcardImport:AttachmentTests.kt$import com.natpryce.hamkrest.*</ID>
     <ID>WildcardImport:AttachmentTrustCalculatorTest.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:AttachmentsClassLoader.kt$import java.net.*</ID>
+    <ID>WildcardImport:AttachmentsClassLoader.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:AttachmentsClassLoader.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:AttachmentsClassLoaderStaticContractTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:AutoOfferFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:BCCryptoService.kt$import java.security.*</ID>
@@ -1795,6 +1880,8 @@
     <ID>WildcardImport:CashViewer.kt$import net.corda.explorer.views.*</ID>
     <ID>WildcardImport:CashViewer.kt$import tornadofx.*</ID>
     <ID>WildcardImport:CertRoleTests.kt$import kotlin.test.*</ID>
+    <ID>WildcardImport:CertificateRevocationListNodeTests.kt$import net.corda.nodeapi.internal.crypto.*</ID>
+    <ID>WildcardImport:CertificateRevocationListNodeTests.kt$import org.bouncycastle.asn1.x509.*</ID>
     <ID>WildcardImport:CertificatesUtils.kt$import net.corda.nodeapi.internal.crypto.*</ID>
     <ID>WildcardImport:CheckpointSerializationAPI.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:ClassCarpenter.kt$import org.objectweb.asm.Opcodes.*</ID>
@@ -1818,12 +1905,15 @@
     <ID>WildcardImport:CompositeKey.kt$import org.bouncycastle.asn1.*</ID>
     <ID>WildcardImport:CompositeKeyFactory.kt$import java.security.*</ID>
     <ID>WildcardImport:CompositeKeyTests.kt$import net.corda.core.crypto.*</ID>
+    <ID>WildcardImport:CompositeSignature.kt$import java.security.*</ID>
     <ID>WildcardImport:ConcurrencyUtilsTest.kt$import com.nhaarman.mockito_kotlin.*</ID>
     <ID>WildcardImport:ConfigParsingTest.kt$import org.assertj.core.api.Assertions.*</ID>
+    <ID>WildcardImport:ConfigUtilities.kt$import com.typesafe.config.*</ID>
     <ID>WildcardImport:Configuration.kt$import com.typesafe.config.*</ID>
     <ID>WildcardImport:ConnectionStateMachine.kt$import org.apache.qpid.proton.amqp.messaging.*</ID>
     <ID>WildcardImport:ConnectionStateMachine.kt$import org.apache.qpid.proton.engine.*</ID>
     <ID>WildcardImport:Constants.kt$import com.fasterxml.jackson.databind.*</ID>
+    <ID>WildcardImport:ConstraintsPropagationTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ConstraintsPropagationTests.kt$import org.junit.*</ID>
     <ID>WildcardImport:ConstraintsUtils.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ContractAttachmentSerializerTest.kt$import net.corda.core.serialization.*</ID>
@@ -1841,12 +1931,20 @@
     <ID>WildcardImport:ContractsScanning.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:CorDappInfoServlet.kt$import kotlinx.html.*</ID>
     <ID>WildcardImport:CorDappSerializerTests.kt$import net.corda.serialization.internal.amqp.testutils.*</ID>
+    <ID>WildcardImport:CordaClassResolver.kt$import com.esotericsoftware.kryo.*</ID>
+    <ID>WildcardImport:CordaClassResolver.kt$import java.nio.file.StandardOpenOption.*</ID>
     <ID>WildcardImport:CordaClassResolverTests.kt$import com.esotericsoftware.kryo.*</ID>
     <ID>WildcardImport:CordaCliWrapper.kt$import picocli.CommandLine.*</ID>
     <ID>WildcardImport:CordaExceptionTest.kt$import net.corda.core.contracts.TransactionVerificationException.*</ID>
     <ID>WildcardImport:CordaExceptionTest.kt$import org.junit.Assert.*</ID>
     <ID>WildcardImport:CordaFutureImplTest.kt$import com.nhaarman.mockito_kotlin.*</ID>
     <ID>WildcardImport:CordaInternal.kt$import kotlin.annotation.AnnotationTarget.*</ID>
+    <ID>WildcardImport:CordaModule.kt$import com.fasterxml.jackson.annotation.*</ID>
+    <ID>WildcardImport:CordaModule.kt$import com.fasterxml.jackson.databind.*</ID>
+    <ID>WildcardImport:CordaModule.kt$import net.corda.core.contracts.*</ID>
+    <ID>WildcardImport:CordaModule.kt$import net.corda.core.crypto.*</ID>
+    <ID>WildcardImport:CordaModule.kt$import net.corda.core.identity.*</ID>
+    <ID>WildcardImport:CordaModule.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:CordaRPCOps.kt$import net.corda.core.node.services.vault.*</ID>
     <ID>WildcardImport:CordaServiceTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:CordaViewModel.kt$import tornadofx.*</ID>
@@ -1874,6 +1972,7 @@
     <ID>WildcardImport:DemoBench.kt$import tornadofx.*</ID>
     <ID>WildcardImport:DemoBenchNodeInfoFilesCopier.kt$import tornadofx.*</ID>
     <ID>WildcardImport:DemoBenchView.kt$import tornadofx.*</ID>
+    <ID>WildcardImport:DeserializationInput.kt$import net.corda.serialization.internal.*</ID>
     <ID>WildcardImport:DeserializeNeedingCarpentryOfEnumsTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:DeserializeNeedingCarpentryOfEnumsTest.kt$import net.corda.serialization.internal.amqp.testutils.*</ID>
     <ID>WildcardImport:DeserializeNeedingCarpentryOfEnumsTest.kt$import net.corda.serialization.internal.carpenter.*</ID>
@@ -1953,11 +2052,18 @@
     <ID>WildcardImport:InputStreamSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:InstallFactory.kt$import tornadofx.*</ID>
     <ID>WildcardImport:InstallShellExtensionsParser.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:InteractiveShellIntegrationTest.kt$import net.corda.core.contracts.*</ID>
+    <ID>WildcardImport:InteractiveShellIntegrationTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:InterestRatesSwapDemoAPI.kt$import org.springframework.web.bind.annotation.*</ID>
     <ID>WildcardImport:InterestSwapRestAPI.kt$import org.springframework.web.bind.annotation.*</ID>
     <ID>WildcardImport:InternalAccessTestHelpers.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:IssuerModel.kt$import tornadofx.*</ID>
     <ID>WildcardImport:JVMConfig.kt$import tornadofx.*</ID>
+    <ID>WildcardImport:JacksonSupport.kt$import com.fasterxml.jackson.core.*</ID>
+    <ID>WildcardImport:JacksonSupport.kt$import com.fasterxml.jackson.databind.*</ID>
+    <ID>WildcardImport:JacksonSupport.kt$import net.corda.core.crypto.*</ID>
+    <ID>WildcardImport:JacksonSupport.kt$import net.corda.core.identity.*</ID>
+    <ID>WildcardImport:JacksonSupport.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:JacksonSupportTest.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:JacksonSupportTest.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:JacksonSupportTest.kt$import net.corda.core.identity.*</ID>
@@ -1973,6 +2079,11 @@
     <ID>WildcardImport:Kryo.kt$import com.esotericsoftware.kryo.*</ID>
     <ID>WildcardImport:Kryo.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:KryoStreamsTest.kt$import java.io.*</ID>
+    <ID>WildcardImport:KryoTests.kt$import kotlin.test.*</ID>
+    <ID>WildcardImport:KryoTests.kt$import net.corda.core.crypto.*</ID>
+    <ID>WildcardImport:KryoTests.kt$import net.corda.core.serialization.*</ID>
+    <ID>WildcardImport:KryoTests.kt$import net.corda.serialization.internal.*</ID>
+    <ID>WildcardImport:KryoTests.kt$import org.assertj.core.api.Assertions.*</ID>
     <ID>WildcardImport:LargeTransactionsTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:LazyMappedListTest.kt$import net.corda.core.contracts.ComponentGroupEnum.*</ID>
     <ID>WildcardImport:LedgerTransactionQueryTests.kt$import net.corda.core.contracts.*</ID>
@@ -2036,6 +2147,9 @@
     <ID>WildcardImport:NewTransaction.kt$import net.corda.client.jfx.model.*</ID>
     <ID>WildcardImport:NewTransaction.kt$import net.corda.client.jfx.utils.*</ID>
     <ID>WildcardImport:NewTransaction.kt$import tornadofx.*</ID>
+    <ID>WildcardImport:NodeAttachmentService.kt$import javax.persistence.*</ID>
+    <ID>WildcardImport:NodeAttachmentService.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:NodeAttachmentService.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:NodeAttachmentServiceTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:NodeAttachmentServiceTest.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NodeAttachmentServiceTest.kt$import org.assertj.core.api.Assertions.*</ID>
@@ -2057,12 +2171,22 @@
     <ID>WildcardImport:NodeSchedulerServiceTest.kt$import org.junit.*</ID>
     <ID>WildcardImport:NodeSchemaService.kt$import net.corda.core.schemas.*</ID>
     <ID>WildcardImport:NodeSchemaServiceTest.kt$import javax.persistence.*</ID>
+    <ID>WildcardImport:NodeStartup.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:NodeStartup.kt$import net.corda.node.*</ID>
+    <ID>WildcardImport:NodeStartup.kt$import net.corda.node.internal.subcommands.*</ID>
     <ID>WildcardImport:NodeTabView.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NodeTabView.kt$import net.corda.demobench.model.*</ID>
     <ID>WildcardImport:NodeTabView.kt$import tornadofx.*</ID>
     <ID>WildcardImport:NodeTerminalView.kt$import tornadofx.*</ID>
     <ID>WildcardImport:NodeTest.kt$import net.corda.node.services.config.*</ID>
     <ID>WildcardImport:NodeTestUtils.kt$import net.corda.testing.dsl.*</ID>
+    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.contracts.*</ID>
+    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.node.services.*</ID>
+    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.node.services.vault.*</ID>
+    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.transactions.*</ID>
+    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.utilities.*</ID>
+    <ID>WildcardImport:NodeVaultService.kt$import net.corda.nodeapi.internal.persistence.*</ID>
     <ID>WildcardImport:NodeVaultServiceTest.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:NodeVaultServiceTest.kt$import net.corda.core.identity.*</ID>
     <ID>WildcardImport:NodeVaultServiceTest.kt$import net.corda.core.node.services.*</ID>
@@ -2074,6 +2198,9 @@
     <ID>WildcardImport:NodeVersioningTest.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NodeWebServer.kt$import net.corda.webserver.servlets.*</ID>
     <ID>WildcardImport:NodeWebServer.kt$import org.eclipse.jetty.server.*</ID>
+    <ID>WildcardImport:NonValidatingNotaryServiceTests.kt$import net.corda.core.crypto.*</ID>
+    <ID>WildcardImport:NonValidatingNotaryServiceTests.kt$import net.corda.core.flows.*</ID>
+    <ID>WildcardImport:NonValidatingNotaryServiceTests.kt$import net.corda.testing.node.internal.*</ID>
     <ID>WildcardImport:NotaryChangeTests.kt$import net.corda.testing.node.*</ID>
     <ID>WildcardImport:NotaryChangeTransactions.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:NotaryChangeTransactions.kt$import net.corda.core.transactions.NotaryChangeWireTransaction.Component.*</ID>
@@ -2096,10 +2223,14 @@
     <ID>WildcardImport:OnLedgerAsset.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:OracleNodeTearOffTests.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:P2PFlowsDrainingModeTest.kt$import net.corda.core.flows.*</ID>
+    <ID>WildcardImport:P2PMessagingClient.kt$import net.corda.core.utilities.*</ID>
+    <ID>WildcardImport:P2PMessagingClient.kt$import net.corda.nodeapi.internal.ArtemisMessagingComponent.*</ID>
+    <ID>WildcardImport:P2PMessagingClient.kt$import org.apache.activemq.artemis.api.core.client.*</ID>
     <ID>WildcardImport:PackageOwnershipVerificationTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:PartialMerkleTreeTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:PartialMerkleTreeTest.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:PartialMerkleTreeTest.kt$import net.corda.core.crypto.*</ID>
+    <ID>WildcardImport:PartyAndCertificate.kt$import java.security.cert.*</ID>
     <ID>WildcardImport:PathUtils.kt$import java.io.*</ID>
     <ID>WildcardImport:PathUtils.kt$import java.nio.file.*</ID>
     <ID>WildcardImport:PersistentIdentityMigrationNewTableTest.kt$import net.corda.testing.core.*</ID>
@@ -2117,6 +2248,7 @@
     <ID>WildcardImport:ProfileController.kt$import tornadofx.*</ID>
     <ID>WildcardImport:Properties.kt$import com.typesafe.config.*</ID>
     <ID>WildcardImport:PropertyDescriptor.kt$import net.corda.serialization.internal.amqp.MethodClassifier.*</ID>
+    <ID>WildcardImport:ProtonWrapperTests.kt$import javax.net.ssl.*</ID>
     <ID>WildcardImport:PublicKeyHashToExternalId.kt$import javax.persistence.*</ID>
     <ID>WildcardImport:PublicKeySerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:QueryCriteriaUtils.kt$import net.corda.core.node.services.vault.CollectionOperator.*</ID>
@@ -2127,6 +2259,7 @@
     <ID>WildcardImport:RPCSecurityManagerImpl.kt$import org.apache.shiro.authc.*</ID>
     <ID>WildcardImport:ReceiveFinalityFlowTest.kt$import net.corda.node.services.statemachine.StaffedFlowHospital.*</ID>
     <ID>WildcardImport:ReceiveFinalityFlowTest.kt$import net.corda.testing.node.internal.*</ID>
+    <ID>WildcardImport:ReceiveTransactionFlow.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ReferenceInputStateTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ReferencedStatesFlowTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ReferencedStatesFlowTests.kt$import net.corda.core.flows.*</ID>
@@ -2143,6 +2276,8 @@
     <ID>WildcardImport:RpcExceptionHandlingTest.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:RpcExceptionHandlingTest.kt$import net.corda.testing.driver.*</ID>
     <ID>WildcardImport:RpcServerObservableSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
+    <ID>WildcardImport:SSLHelper.kt$import java.security.cert.*</ID>
+    <ID>WildcardImport:SSLHelper.kt$import javax.net.ssl.*</ID>
     <ID>WildcardImport:SampleCashSchemaV2.kt$import javax.persistence.*</ID>
     <ID>WildcardImport:ScheduledFlowIntegrationTests.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:ScheduledFlowTests.kt$import net.corda.core.contracts.*</ID>
@@ -2179,6 +2314,7 @@
     <ID>WildcardImport:ServiceHub.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ServiceHub.kt$import net.corda.core.node.services.*</ID>
     <ID>WildcardImport:ServiceHubInternal.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:ServicesForResolutionImpl.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:SettingsModel.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:SettingsModel.kt$import tornadofx.*</ID>
     <ID>WildcardImport:SharedContexts.kt$import net.corda.core.serialization.*</ID>
@@ -2203,6 +2339,7 @@
     <ID>WildcardImport:TestDSL.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TestDSL.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:TestResponseFlowInIsolation.kt$import net.corda.core.flows.*</ID>
+    <ID>WildcardImport:TestUtils.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:ThrowableSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:TimedFlowTests.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:TimedFlowTests.kt$import net.corda.testing.node.internal.*</ID>
@@ -2211,6 +2348,8 @@
     <ID>WildcardImport:TraderDemoTest.kt$import net.corda.testing.driver.*</ID>
     <ID>WildcardImport:TransactionBuilder.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionBuilder.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:TransactionBuilderTest.kt$import net.corda.core.contracts.*</ID>
+    <ID>WildcardImport:TransactionBuilderTest.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:TransactionDSLInterpreter.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionDataModel.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionEncumbranceTests.kt$import net.corda.core.contracts.*</ID>
@@ -2226,6 +2365,7 @@
     <ID>WildcardImport:TransactionUtils.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionUtils.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:TransactionUtils.kt$import net.corda.core.transactions.*</ID>
+    <ID>WildcardImport:TransactionVerifierServiceInternal.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.client.jfx.model.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.client.jfx.utils.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.core.contracts.*</ID>
@@ -2256,6 +2396,7 @@
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.testing.node.internal.*</ID>
+    <ID>WildcardImport:VaultFiller.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.vault.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.vault.QueryCriteria.*</ID>
@@ -2294,12 +2435,20 @@
     <ID>WildcardImport:WhitelistBasedTypeModelConfiguration.kt$import org.apache.qpid.proton.amqp.*</ID>
     <ID>WildcardImport:WhitelistGenerator.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:WireTransaction.kt$import net.corda.core.contracts.*</ID>
+    <ID>WildcardImport:WireTransaction.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:WireTransaction.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:WithFinality.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:WithMockNet.kt$import com.natpryce.hamkrest.*</ID>
     <ID>WildcardImport:X509CRLSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:X509CertificateSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:X509EdDSAEngine.kt$import java.security.*</ID>
+    <ID>WildcardImport:X509Utilities.kt$import java.security.cert.*</ID>
+    <ID>WildcardImport:X509Utilities.kt$import net.corda.core.internal.*</ID>
+    <ID>WildcardImport:X509Utilities.kt$import org.bouncycastle.asn1.*</ID>
+    <ID>WildcardImport:X509Utilities.kt$import org.bouncycastle.asn1.x509.*</ID>
+    <ID>WildcardImport:X509UtilitiesTest.kt$import javax.net.ssl.*</ID>
+    <ID>WildcardImport:X509UtilitiesTest.kt$import kotlin.test.*</ID>
+    <ID>WildcardImport:X509UtilitiesTest.kt$import org.bouncycastle.asn1.x509.*</ID>
     <ID>WildcardImport:internalAccessTestHelpers.kt$import net.corda.core.contracts.*</ID>
   </Whitelist>
 </SmellBaseline>

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -67,7 +67,6 @@
     <ID>ComplexCondition:CheckpointAgent.kt$CheckpointHook$!that.javaClass.name.endsWith("ObjectField") || arrayValue != null || that.field.type == java.lang.String::class.java || value == null</ID>
     <ID>ComplexCondition:CheckpointAgent.kt$CheckpointHook$(checkpointId != null) || ((clazz.name == instrumentClassname) &amp;&amp; (input.total() &gt;= minimumSize) &amp;&amp; (input.total() &lt;= maximumSize))</ID>
     <ID>ComplexCondition:CheckpointAgent.kt$CheckpointHook$(checkpointId != null) || ((obj.javaClass.name == instrumentClassname) &amp;&amp; (output.total() &gt;= minimumSize) &amp;&amp; (output.total() &lt;= maximumSize))</ID>
-    <ID>ComplexCondition:ConfigUtilities.kt$value is Temporal || value is NetworkHostAndPort || value is CordaX500Name || value is Path || value is URL || value is UUID || value is X500Principal</ID>
     <ID>ComplexCondition:CordaClassResolver.kt$CordaClassResolver$type.isPrimitive || type == Any::class.java || type == String::class.java || (!type.isEnum &amp;&amp; isAbstract(type.modifiers))</ID>
     <ID>ComplexCondition:DeserializationInput.kt$DeserializationInput$type != TypeIdentifier.UnknownType.getLocalType() &amp;&amp; serializer.type != type &amp;&amp; with(serializer.type) { !isSubClassOf(type) &amp;&amp; !materiallyEquivalentTo(type) }</ID>
     <ID>ComplexCondition:FlowMessaging.kt$FlowMessagingImpl$(exception is KryoException || exception is NotSerializableException) &amp;&amp; message is ExistingSessionMessage &amp;&amp; message.payload is ErrorSessionMessage</ID>
@@ -79,8 +78,6 @@
     <ID>ComplexMethod:AMQPBridgeManager.kt$AMQPBridgeManager.AMQPBridge$private fun clientArtemisMessageHandler(artemisMessage: ClientMessage)</ID>
     <ID>ComplexMethod:AMQPBridgeTest.kt$AMQPBridgeTest$@Test(timeout=300_000) fun `test acked and nacked messages`()</ID>
     <ID>ComplexMethod:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$// Make sure our inputs aren't designed to blow things up. private fun validate(typeString: String)</ID>
-    <ID>ComplexMethod:ANSIProgressRenderer.kt$ANSIProgressRenderer$// Returns number of lines rendered. private fun renderLevel(ansi: Ansi, error: Boolean): Int</ID>
-    <ID>ComplexMethod:ANSIProgressRenderer.kt$ANSIProgressRenderer$@Synchronized protected fun draw(moveUp: Boolean, error: Throwable? = null)</ID>
     <ID>ComplexMethod:AbstractConcatenatedList.kt$AbstractConcatenatedList$// This is where we create a listener for a *nested* list. Note that 'indexMap' doesn't need to be adjusted on any // of these changes as the indices of nested lists don't change, just their contents. private fun createListener(wrapped: WrappedObservableList&lt;A&gt;): ListChangeListener&lt;A&gt;</ID>
     <ID>ComplexMethod:AbstractConcatenatedList.kt$AbstractConcatenatedList$// This is where we handle changes to the *source* list. override fun sourceChanged(change: ListChangeListener.Change&lt;out ObservableList&lt;A&gt;&gt;)</ID>
     <ID>ComplexMethod:AbstractFlattenedList.kt$AbstractFlattenedList$override fun sourceChanged(c: ListChangeListener.Change&lt;out ObservableValue&lt;out A&gt;&gt;)</ID>
@@ -94,7 +91,6 @@
     <ID>ComplexMethod:AppendOnlyPersistentMap.kt$AppendOnlyPersistentMapBase$private fun set(key: K, value: V, logWarning: Boolean, store: (K, V) -&gt; V?): Boolean</ID>
     <ID>ComplexMethod:AppendOnlyPersistentMapTest.kt$AppendOnlyPersistentMapTest.TestThread$private fun doActivity()</ID>
     <ID>ComplexMethod:AttachmentVersionNumberMigration.kt$AttachmentVersionNumberMigration$override fun execute(database: Database?)</ID>
-    <ID>ComplexMethod:AttachmentsClassLoader.kt$AttachmentsClassLoader$private fun checkAttachments(attachments: List&lt;Attachment&gt;)</ID>
     <ID>ComplexMethod:BridgeControlListener.kt$BridgeControlListener$private fun processControlMessage(msg: ClientMessage)</ID>
     <ID>ComplexMethod:CashSelectionH2Impl.kt$CashSelectionH2Impl$// We are using an H2 specific means of selecting a minimum set of rows that match a request amount of coins: // 1) There is no standard SQL mechanism of calculating a cumulative total on a field and restricting row selection on the // running total of such an accumulator // 2) H2 uses session variables to perform this accumulator function: // http://www.h2database.com/html/functions.html#set // 3) H2 does not support JOIN's in FOR UPDATE (hence we are forced to execute 2 queries) override fun executeQuery(connection: Connection, amount: Amount&lt;Currency&gt;, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set&lt;AbstractParty&gt;, withIssuerRefs: Set&lt;OpaqueBytes&gt;, withResultSet: (ResultSet) -&gt; Boolean): Boolean</ID>
     <ID>ComplexMethod:CashSelectionPostgreSQLImpl.kt$CashSelectionPostgreSQLImpl$// This is using PostgreSQL window functions for selecting a minimum set of rows that match a request amount of coins: // 1) This may also be possible with user-defined functions (e.g. using PL/pgSQL) // 2) The window function accumulated column (`total`) does not include the current row (starts from 0) and cannot // appear in the WHERE clause, hence restricting row selection and adjusting the returned total in the outer query. // 3) Currently (version 9.6), FOR UPDATE cannot be specified with window functions override fun executeQuery(connection: Connection, amount: Amount&lt;Currency&gt;, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set&lt;AbstractParty&gt;, withIssuerRefs: Set&lt;OpaqueBytes&gt;, withResultSet: (ResultSet) -&gt; Boolean): Boolean</ID>
@@ -107,12 +103,8 @@
     <ID>ComplexMethod:CheckpointDumperImpl.kt$CheckpointDumperImpl$private fun FlowIORequest&lt;*&gt;.toSuspendedOn(suspendedTimestamp: Instant, now: Instant): SuspendedOn</ID>
     <ID>ComplexMethod:ClassCarpenter.kt$ClassCarpenterImpl$ private fun validateSchema(schema: Schema)</ID>
     <ID>ComplexMethod:CompatibleTransactionTests.kt$CompatibleTransactionTests$@Test(timeout=300_000) fun `Command visibility tests`()</ID>
-    <ID>ComplexMethod:ConfigUtilities.kt$// For Iterables figure out the type parameter and apply the same logic as above on the individual elements. private fun Iterable&lt;*&gt;.toConfigIterable(field: Field): Iterable&lt;Any?&gt;</ID>
-    <ID>ComplexMethod:ConfigUtilities.kt$@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") // Reflect over the fields of the receiver and generate a value Map that can use to create Config object. private fun Any.toConfigMap(): Map&lt;String, Any&gt;</ID>
-    <ID>ComplexMethod:ConfigUtilities.kt$private fun convertValue(value: Any): Any</ID>
     <ID>ComplexMethod:ConnectionStateMachine.kt$ConnectionStateMachine$override fun onConnectionFinal(event: Event)</ID>
     <ID>ComplexMethod:ConnectionStateMachine.kt$ConnectionStateMachine$override fun onDelivery(event: Event)</ID>
-    <ID>ComplexMethod:ConstraintsUtils.kt$ fun AttachmentConstraint.canBeTransitionedFrom(input: AttachmentConstraint, attachment: ContractAttachment): Boolean</ID>
     <ID>ComplexMethod:CordaPersistence.kt$CordaPersistence$private fun &lt;T&gt; inTopLevelTransaction(isolationLevel: TransactionIsolationLevel, recoverableFailureTolerance: Int, recoverAnyNestedSQLException: Boolean, statement: DatabaseTransaction.() -&gt; T): T</ID>
     <ID>ComplexMethod:CordaRPCClient.kt$CordaRPCClientConfiguration$override fun equals(other: Any?): Boolean</ID>
     <ID>ComplexMethod:CordaRPCClientTest.kt$CordaRPCClientTest$@Test(timeout=300_000) fun `shutdown command stops the node`()</ID>
@@ -133,9 +125,6 @@
     <ID>ComplexMethod:HibernateQueryCriteriaParser.kt$HibernateQueryCriteriaParser$private fun parse(sorting: Sort)</ID>
     <ID>ComplexMethod:IRS.kt$InterestRateSwap.CommonLeg$override fun equals(other: Any?): Boolean</ID>
     <ID>ComplexMethod:IRS.kt$InterestRateSwap.FloatingLeg$override fun equals(other: Any?): Boolean</ID>
-    <ID>ComplexMethod:InteractiveShell.kt$InteractiveShell$ @JvmStatic fun runFlowByNameFragment(nameFragment: String, inputData: String, output: RenderPrintWriter, rpcOps: CordaRPCOps, ansiProgressRenderer: ANSIProgressRenderer, inputObjectMapper: ObjectMapper = createYamlInputMapper(rpcOps))</ID>
-    <ID>ComplexMethod:InteractiveShell.kt$InteractiveShell$ private fun maybeAbbreviateGenericType(type: Type, extraRecognisedPackage: String): String</ID>
-    <ID>ComplexMethod:InteractiveShell.kt$InteractiveShell$@JvmStatic fun runRPCFromString(input: List&lt;String&gt;, out: RenderPrintWriter, context: InvocationContext&lt;out Any&gt;, cordaRPCOps: CordaRPCOps, inputObjectMapper: ObjectMapper): Any?</ID>
     <ID>ComplexMethod:Kryo.kt$ImmutableClassSerializer$override fun read(kryo: Kryo, input: Input, type: Class&lt;T&gt;): T</ID>
     <ID>ComplexMethod:Kryo.kt$ImmutableClassSerializer$override fun write(kryo: Kryo, output: Output, obj: T)</ID>
     <ID>ComplexMethod:LoadTest.kt$LoadTest$fun run(nodes: Nodes, parameters: RunParameters, random: SplittableRandom)</ID>
@@ -151,8 +140,6 @@
     <ID>ComplexMethod:NewTransaction.kt$NewTransaction$fun show(window: Window)</ID>
     <ID>ComplexMethod:NewTransaction.kt$NewTransaction$private fun newTransactionDialog(window: Window)</ID>
     <ID>ComplexMethod:Node.kt$Node$override fun startMessagingService(rpcOps: List&lt;RPCOps&gt;, nodeInfo: NodeInfo, myNotaryIdentity: PartyAndCertificate?, networkParameters: NetworkParameters)</ID>
-    <ID>ComplexMethod:NodeNamedCache.kt$DefaultNamedCacheFactory$open protected fun &lt;K, V&gt; configuredForNamed(caffeine: Caffeine&lt;K, V&gt;, name: String): Caffeine&lt;K, V&gt;</ID>
-    <ID>ComplexMethod:NodeVaultService.kt$NodeVaultService$@Throws(VaultQueryException::class) private fun &lt;T : ContractState&gt; _queryBy(criteria: QueryCriteria, paging_: PageSpecification, sorting: Sort, contractStateType: Class&lt;out T&gt;, skipPagingChecks: Boolean): Vault.Page&lt;T&gt;</ID>
     <ID>ComplexMethod:NodeVaultService.kt$NodeVaultService$private fun makeUpdates(batch: Iterable&lt;CoreTransaction&gt;, statesToRecord: StatesToRecord, previouslySeen: Boolean): List&lt;Vault.Update&lt;ContractState&gt;&gt;</ID>
     <ID>ComplexMethod:NodeVaultService.kt$NodeVaultService$private fun processAndNotify(updates: List&lt;Vault.Update&lt;ContractState&gt;&gt;)</ID>
     <ID>ComplexMethod:ObjectDiffer.kt$ObjectDiffer$fun diff(a: Any?, b: Any?): DiffTree?</ID>
@@ -165,7 +152,6 @@
     <ID>ComplexMethod:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ private tailrec fun establishConnectionWithRetry( retryInterval: Duration, roundRobinIndex: Int = 0, retries: Int = -1 ): CordaRPCConnection?</ID>
     <ID>ComplexMethod:RemoteTypeCarpenter.kt$SchemaBuildingRemoteTypeCarpenter$override fun carpent(typeInformation: RemoteTypeInformation): Type</ID>
     <ID>ComplexMethod:SendTransactionFlow.kt$DataVendingFlow$@Suspendable override fun call(): Void?</ID>
-    <ID>ComplexMethod:ShellCmdLineOptions.kt$ShellCmdLineOptions$private fun toConfigFile(): Config</ID>
     <ID>ComplexMethod:StartedFlowTransition.kt$StartedFlowTransition$override fun transition(): TransitionResult</ID>
     <ID>ComplexMethod:StatusTransitions.kt$StatusTransitions$ fun verify(tx: LedgerTransaction)</ID>
     <ID>ComplexMethod:StringToMethodCallParser.kt$StringToMethodCallParser$ @Throws(UnparseableCallException::class) fun parse(target: T?, command: String): ParsedMethodCall</ID>
@@ -206,7 +192,6 @@
     <ID>ForEachOnRange:BFTSmartConfigTests.kt$BFTSmartConfigTests$forEach { n -&gt; assertEquals(2, maxFaultyReplicas(n)) }</ID>
     <ID>ForEachOnRange:BFTSmartConfigTests.kt$BFTSmartConfigTests$forEach { n -&gt; assertEquals(n, maxFaultyReplicas(n) + minCorrectReplicas(n)) }</ID>
     <ID>ForEachOnRange:HibernateConfigurationTest.kt$HibernateConfigurationTest$forEach { consumeCash(it.DOLLARS) }</ID>
-    <ID>ForEachOnRange:VaultQueryTests.kt$VaultQueryTestsBase$forEach { val newAllStates = vaultService.queryBy&lt;DummyLinearContract.State&gt;(sorting = sorting, criteria = criteria).states assertThat(newAllStates.groupBy(StateAndRef&lt;*&gt;::ref)).hasSameSizeAs(allStates) assertThat(newAllStates).containsExactlyElementsOf(allStates) }</ID>
     <ID>ForEachOnRange:VaultQueryTests.kt$VaultQueryTestsBase$forEach { vaultFiller.fillWithSomeTestLinearStates(1, linearNumber = it.toLong(), linearString = it.toString()) }</ID>
     <ID>ForbiddenComment:AbstractAttachment.kt$AbstractAttachment$// TODO: read file size information from metadata instead of loading the data.</ID>
     <ID>ForbiddenComment:AbstractCashSelection.kt$AbstractCashSelection$// TODO: future implementation to retrieve contract states from a Vault BLOB store</ID>
@@ -229,7 +214,6 @@
     <ID>ForbiddenComment:ArtemisMessagingComponent.kt$ArtemisMessagingComponent.Companion$// TODO: we might want to make this value configurable.</ID>
     <ID>ForbiddenComment:ArtemisMessagingServer.kt$// TODO: Implement a discovery engine that can trigger builds of new connections when another node registers? (later)</ID>
     <ID>ForbiddenComment:ArtemisMessagingServer.kt$// TODO: Verify that nobody can connect to us and fiddle with our config over the socket due to the secman.</ID>
-    <ID>ForbiddenComment:ArtemisMessagingServer.kt$ArtemisMessagingServer$// TODO: Maybe wrap [IOException] on a key store load error so that it's clearly splitting key store loading from</ID>
     <ID>ForbiddenComment:BFTSmart.kt$BFTSmart$// TODO: Define and document the configuration of the bft-smart cluster.</ID>
     <ID>ForbiddenComment:BFTSmart.kt$BFTSmart$// TODO: Potentially update the bft-smart API for our use case or rebuild client and server from lower level building</ID>
     <ID>ForbiddenComment:BFTSmart.kt$BFTSmart$// TODO: Support cluster membership changes. This requires reading about reconfiguration of bft-smart clusters and</ID>
@@ -334,17 +318,6 @@
     <ID>ForbiddenComment:IdentitySyncFlow.kt$IdentitySyncFlow.Send$// TODO: Can this be triggered automatically from [SendTransactionFlow]?</ID>
     <ID>ForbiddenComment:IdentitySyncFlow.kt$IdentitySyncFlow.Send$// TODO: Consider if this too restrictive - we perhaps should be checking the name on the signing certificate in the certificate path instead</ID>
     <ID>ForbiddenComment:InMemoryIdentityServiceTests.kt$InMemoryIdentityServiceTests$// TODO: Generate certificate with an EdDSA key rather than ECDSA</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Add a command to view last N lines/tail/control log4j2 loggers.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Add command history.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Command completion.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Configure default renderers, send objects down the pipeline, add support for xml output format.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Do something sensible with commands that return a future.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Fix up the 'dashboard' command which has some rendering issues.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Get rid of the 'java' command, it's kind of worthless.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Make it notice new shell commands added after the node started.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Resurrect or reimplement the mail plugin.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$// TODO: Review or fix the JVM commands which have bitrotted and some are useless.</ID>
-    <ID>ForbiddenComment:InteractiveShell.kt$InteractiveShell$// TODO: A default renderer could be used, instead of an object mapper. See: http://www.crashub.org/1.3/reference.html#_renderers</ID>
     <ID>ForbiddenComment:InternalUtils.kt$// TODO: Add inline back when a new Kotlin version is released and check if the java.lang.VerifyError</ID>
     <ID>ForbiddenComment:InternalUtils.kt$// TODO: Currently the certificate revocation status is not handled here. Nowhere in the code the second parameter is used. Consider adding the support in the future.</ID>
     <ID>ForbiddenComment:IrsDemoClientApi.kt$IRSDemoClientApi$// TODO: Add uploading of files to the HTTP API</ID>
@@ -372,17 +345,13 @@
     <ID>ForbiddenComment:NodeTerminalView.kt$NodeTerminalView$// TODO: Remove this special case once Rick's serialisation work means we can deserialise states that weren't on our own classpath.</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: Optimise this.</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: Perhaps these can be stored in a batch?</ID>
-    <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: This is a catch-all solution. But why is the default pageNumber set to be -1 in the first place?</ID>
     <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: This is expensive - is there another way?</ID>
-    <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: improve typing of returned other results</ID>
-    <ID>ForbiddenComment:NodeVaultService.kt$NodeVaultService$// TODO: revisit (use single instance of parser for all queries)</ID>
     <ID>ForbiddenComment:NodeVaultServiceTest.kt$NodeVaultServiceTest$// TODO: Unit test linear state relevancy checks</ID>
     <ID>ForbiddenComment:NodeWebServer.kt$NodeWebServer$// TODO: Redesign</ID>
     <ID>ForbiddenComment:NotaryChangeFlow.kt$NotaryChangeFlow$// TODO: We need a much faster way of finding our key in the transaction</ID>
     <ID>ForbiddenComment:NotaryChangeTests.kt$NotaryChangeTests$// TODO: Add more test cases once we have a general flow/service exception handling mechanism:</ID>
     <ID>ForbiddenComment:NotaryChangeTests.kt$NotaryChangeTests$// TODO: Re-enable the test when parameter currentness checks are in place, ENT-2666.</ID>
     <ID>ForbiddenComment:NotaryError.kt$StateConsumptionDetails$// TODO: include notary timestamp?</ID>
-    <ID>ForbiddenComment:NotaryFlow.kt$NotaryFlow.Client$// TODO: This is not required any more once our AMQP serialization supports turning off object referencing.</ID>
     <ID>ForbiddenComment:NotaryServiceFlow.kt$NotaryServiceFlow.Companion$// TODO: Determine an appropriate limit and also enforce in the network parameters and the transaction builder.</ID>
     <ID>ForbiddenComment:NotaryUtils.kt$// TODO: if requestSignature was generated over an old version of NotarisationRequest, we need to be able to</ID>
     <ID>ForbiddenComment:OGUtils.kt$// TODO: Do this correctly</ID>
@@ -525,7 +494,6 @@
     <ID>FunctionNaming:LedgerDSLInterpreter.kt$LedgerDSLInterpreter$ fun _unverifiedTransaction(transactionLabel: String?, transactionBuilder: TransactionBuilder, dsl: T.() -&gt; Unit): WireTransaction</ID>
     <ID>FunctionNaming:NamedCacheTest.kt$NamedCacheTest$@Test(timeout=300_000) fun TestCheckCacheName()</ID>
     <ID>FunctionNaming:NodeHandleTests.kt$NodeHandleTests$@Test(timeout=300_000) fun object_defined_functions_are_static_for_node_rpc_ops()</ID>
-    <ID>FunctionNaming:NodeVaultService.kt$NodeVaultService$@Throws(VaultQueryException::class) private fun &lt;T : ContractState&gt; _queryBy(criteria: QueryCriteria, paging_: PageSpecification, sorting: Sort, contractStateType: Class&lt;out T&gt;, skipPagingChecks: Boolean): Vault.Page&lt;T&gt;</ID>
     <ID>FunctionNaming:PasswordTest.kt$PasswordTest$@Test(timeout=300_000) fun constructor_and_getters()</ID>
     <ID>FunctionNaming:PasswordTest.kt$PasswordTest$@Test(timeout=300_000) fun toString_is_masked()</ID>
     <ID>FunctionNaming:ProgressTracker.kt$ProgressTracker$private fun _allSteps(level: Int = 0): List&lt;Pair&lt;Int, Step&gt;&gt;</ID>
@@ -575,10 +543,6 @@
     <ID>FunctionNaming:SpecificationTest.kt$SpecificationTest$@Test(timeout=300_000) fun parse_list_aggregation()</ID>
     <ID>FunctionNaming:SpecificationTest.kt$SpecificationTest$@Test(timeout=300_000) fun validate_list_aggregation()</ID>
     <ID>FunctionNaming:SpecificationTest.kt$SpecificationTest$@Test(timeout=300_000) fun validate_with_domain_specific_errors()</ID>
-    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun args_to_config()</ID>
-    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun cmd_options_override_config_from_file()</ID>
-    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun cmd_options_to_config_from_file()</ID>
-    <ID>FunctionNaming:StandaloneShellArgsParserTest.kt$StandaloneShellArgsParserTest$@Test(timeout=300_000) fun empty_args_to_cmd_options()</ID>
     <ID>FunctionNaming:TransactionDSLInterpreter.kt$TransactionDSLInterpreter$ fun _attachment(contractClassName: ContractClassName)</ID>
     <ID>FunctionNaming:TransactionDSLInterpreter.kt$TransactionDSLInterpreter$ fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List&lt;PublicKey&gt;)</ID>
     <ID>FunctionNaming:TransactionDSLInterpreter.kt$TransactionDSLInterpreter$ fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List&lt;PublicKey&gt;, jarManifestAttributes: Map&lt;String,String&gt;)</ID>
@@ -611,8 +575,6 @@
     <ID>LongParameterList:Cash.kt$Cash$(inputs: List&lt;State&gt;, outputs: List&lt;State&gt;, tx: LedgerTransaction, issueCommand: CommandWithParties&lt;Commands.Issue&gt;, currency: Currency, issuer: PartyAndReference)</ID>
     <ID>LongParameterList:CashUtils.kt$CashUtils$(services: ServiceHub, tx: TransactionBuilder, amount: Amount&lt;Currency&gt;, ourIdentity: PartyAndCertificate, to: AbstractParty, onlyFromParties: Set&lt;AbstractParty&gt; = emptySet(), anonymous: Boolean = true)</ID>
     <ID>LongParameterList:CashUtils.kt$CashUtils$(services: ServiceHub, tx: TransactionBuilder, payments: List&lt;PartyAndAmount&lt;Currency&gt;&gt;, ourIdentity: PartyAndCertificate, onlyFromParties: Set&lt;AbstractParty&gt; = emptySet(), anonymous: Boolean = true)</ID>
-    <ID>LongParameterList:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$(port: Int, name: CordaX500Name = ALICE_NAME, crlCheckSoftFail: Boolean, nodeCrlDistPoint: String = "http://${server.hostAndPort}/crl/node.crl", tlsCrlDistPoint: String? = "http://${server.hostAndPort}/crl/empty.crl", maxMessageSize: Int = MAX_MESSAGE_SIZE)</ID>
-    <ID>LongParameterList:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests.Companion$(clrServer: CrlServer, signatureAlgorithm: String, caCertificate: X509Certificate, caPrivateKey: PrivateKey, endpoint: String, indirect: Boolean, vararg serialNumbers: BigInteger)</ID>
     <ID>LongParameterList:CertificateStoreStubs.kt$CertificateStoreStubs.P2P.Companion$(baseDirectory: Path, certificatesDirectoryName: String = DEFAULT_CERTIFICATES_DIRECTORY_NAME, keyStoreFileName: String = KeyStore.DEFAULT_STORE_FILE_NAME, keyStorePassword: String = KeyStore.DEFAULT_STORE_PASSWORD, keyPassword: String = keyStorePassword, trustStoreFileName: String = TrustStore.DEFAULT_STORE_FILE_NAME, trustStorePassword: String = TrustStore.DEFAULT_STORE_PASSWORD)</ID>
     <ID>LongParameterList:ContractAttachment.kt$ContractAttachment.Companion$(attachment: Attachment, contract: ContractClassName, additionalContracts: Set&lt;ContractClassName&gt; = emptySet(), uploader: String? = null, signerKeys: List&lt;PublicKey&gt; = emptyList(), version: Int = DEFAULT_CORDAPP_VERSION)</ID>
     <ID>LongParameterList:ContractFunctions.kt$(expiry: String, notional: BigDecimal, strike: BigDecimal, foreignCurrency: Currency, domesticCurrency: Currency, partyA: Party, partyB: Party)</ID>
@@ -642,7 +604,6 @@
     <ID>LongParameterList:IRS.kt$InterestRateSwap.FloatingLeg$(floatingRatePayer: AbstractParty = this.floatingRatePayer, notional: Amount&lt;Currency&gt; = this.notional, paymentFrequency: Frequency = this.paymentFrequency, effectiveDate: LocalDate = this.effectiveDate, effectiveDateAdjustment: DateRollConvention? = this.effectiveDateAdjustment, terminationDate: LocalDate = this.terminationDate, terminationDateAdjustment: DateRollConvention? = this.terminationDateAdjustment, dayCountBasisDay: DayCountBasisDay = this.dayCountBasisDay, dayCountBasisYear: DayCountBasisYear = this.dayCountBasisYear, dayInMonth: Int = this.dayInMonth, paymentRule: PaymentRule = this.paymentRule, paymentDelay: Int = this.paymentDelay, paymentCalendar: BusinessCalendar = this.paymentCalendar, interestPeriodAdjustment: AccrualAdjustment = this.interestPeriodAdjustment, rollConvention: DateRollConvention = this.rollConvention, fixingRollConvention: DateRollConvention = this.fixingRollConvention, resetDayInMonth: Int = this.resetDayInMonth, fixingPeriod: Int = this.fixingPeriodOffset, resetRule: PaymentRule = this.resetRule, fixingsPerPayment: Frequency = this.fixingsPerPayment, fixingCalendar: BusinessCalendar = this.fixingCalendar, index: String = this.index, indexSource: String = this.indexSource, indexTenor: Tenor = this.indexTenor )</ID>
     <ID>LongParameterList:IdenticonRenderer.kt$IdenticonRenderer$(g: GraphicsContext, x: Double, y: Double, patchIndex: Int, turn: Int, patchSize: Double, _invert: Boolean, color: PatchColor)</ID>
     <ID>LongParameterList:Injectors.kt$( metricRegistry: MetricRegistry, parallelism: Int, overallDuration: Duration, injectionRate: Rate, queueSizeMetricName: String = "QueueSize", workDurationMetricName: String = "WorkDuration", work: () -&gt; Unit )</ID>
-    <ID>LongParameterList:InteractiveShell.kt$InteractiveShell$(nameFragment: String, inputData: String, output: RenderPrintWriter, rpcOps: CordaRPCOps, ansiProgressRenderer: ANSIProgressRenderer, inputObjectMapper: ObjectMapper = createYamlInputMapper(rpcOps))</ID>
     <ID>LongParameterList:JarSignatureTestUtils.kt$JarSignatureTestUtils$(alias: String = "Test", storePassword: String = "secret!", name: String = CODE_SIGNER.toString(), keyalg: String = "RSA", keyPassword: String = storePassword, storeName: String = "_teststore")</ID>
     <ID>LongParameterList:MockServices.kt$MockServices.Companion$( cordappLoader: CordappLoader, identityService: IdentityService, networkParameters: NetworkParameters, initialIdentity: TestIdentity, moreKeys: Set&lt;KeyPair&gt;, keyManagementService: KeyManagementService, schemaService: SchemaService, persistence: CordaPersistence )</ID>
     <ID>LongParameterList:MockServices.kt$MockServices.Companion$( cordappPackages: List&lt;String&gt;, initialIdentity: TestIdentity, networkParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN), moreKeys: Set&lt;KeyPair&gt;, moreIdentities: Set&lt;PartyAndCertificate&gt;, cacheFactory: TestingNamedCacheFactory = TestingNamedCacheFactory() )</ID>
@@ -694,12 +655,6 @@
     <ID>LongParameterList:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$( withError: Boolean, issuer: PartyAndReference, owner: AbstractParty, amount: Amount&lt;Issued&lt;Currency&gt;&gt;, attachmentID: SecureHash?, notary: Party)</ID>
     <ID>LongParameterList:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$( withError: Boolean, issuer: PartyAndReference, owner: AbstractParty, notary: Party, node: TestStartedNode, identity: Party, notaryNode: TestStartedNode, vararg extraSigningNodes: TestStartedNode )</ID>
     <ID>LongParameterList:UniquenessProvider.kt$UniquenessProvider$( states: List&lt;StateRef&gt;, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature, timeWindow: TimeWindow? = null, references: List&lt;StateRef&gt; = emptyList() )</ID>
-    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(howMuch: Amount&lt;Currency&gt;, issuerServices: ServiceHub, atLeastThisManyStates: Int, atMostThisManyStates: Int, issuedBy: PartyAndReference, owner: AbstractParty? = null, rng: Random? = null, statesToRecord: StatesToRecord = StatesToRecord.ONLY_RELEVANT)</ID>
-    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(howMuch: Amount&lt;Currency&gt;, issuerServices: ServiceHub, thisManyStates: Int, issuedBy: PartyAndReference, owner: AbstractParty? = null, rng: Random? = null, statesToRecord: StatesToRecord = StatesToRecord.ONLY_RELEVANT)</ID>
-    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(numberToCreate: Int, externalId: String? = null, participants: List&lt;AbstractParty&gt; = emptyList(), linearString: String = "", linearNumber: Long = 0L, linearBoolean: Boolean = false, linearTimestamp: Instant = now())</ID>
-    <ID>LongParameterList:VaultFiller.kt$VaultFiller$(numberToCreate: Int, externalId: String? = null, participants: List&lt;AbstractParty&gt; = emptyList(), uniqueIdentifier: UniqueIdentifier? = null, linearString: String = "", linearNumber: Long = 0L, linearBoolean: Boolean = false, linearTimestamp: Instant = now(), constraint: AttachmentConstraint = AutomaticPlaceholderConstraint, includeMe: Boolean = true)</ID>
-    <ID>LongParameterList:VaultService.kt$Vault.StateMetadata$( ref: StateRef = this.ref, contractStateClassName: String = this.contractStateClassName, recordedTime: Instant = this.recordedTime, consumedTime: Instant? = this.consumedTime, status: Vault.StateStatus = this.status, notary: AbstractParty? = this.notary, lockId: String? = this.lockId, lockUpdateTime: Instant? = this.lockUpdateTime )</ID>
-    <ID>LongParameterList:VaultService.kt$Vault.StateMetadata$( ref: StateRef = this.ref, contractStateClassName: String = this.contractStateClassName, recordedTime: Instant = this.recordedTime, consumedTime: Instant? = this.consumedTime, status: Vault.StateStatus = this.status, notary: AbstractParty? = this.notary, lockId: String? = this.lockId, lockUpdateTime: Instant? = this.lockUpdateTime, relevancyStatus: Vault.RelevancyStatus? )</ID>
     <ID>LongParameterList:WireTransaction.kt$WireTransaction.Companion$(inputs: List&lt;StateRef&gt;, outputs: List&lt;TransactionState&lt;ContractState&gt;&gt;, commands: List&lt;Command&lt;*&gt;&gt;, attachments: List&lt;SecureHash&gt;, notary: Party?, timeWindow: TimeWindow?)</ID>
     <ID>LongParameterList:X509Utilities.kt$X509Utilities$(certificateType: CertificateType, issuer: X500Principal, issuerKeyPair: KeyPair, subject: X500Principal, subjectPublicKey: PublicKey, validityWindow: Pair&lt;Date, Date&gt;, nameConstraints: NameConstraints? = null, crlDistPoint: String? = null, crlIssuer: X500Name? = null)</ID>
     <ID>LongParameterList:X509Utilities.kt$X509Utilities$(certificateType: CertificateType, issuer: X500Principal, issuerPublicKey: PublicKey, issuerSigner: ContentSigner, subject: X500Principal, subjectPublicKey: PublicKey, validityWindow: Pair&lt;Date, Date&gt;, nameConstraints: NameConstraints? = null, crlDistPoint: String? = null, crlIssuer: X500Name? = null)</ID>
@@ -724,7 +679,10 @@
     <ID>MagicNumber:AttachmentDemo.kt$10006</ID>
     <ID>MagicNumber:AttachmentDemo.kt$10009</ID>
     <ID>MagicNumber:AttachmentDemo.kt$10010</ID>
-    <ID>MagicNumber:AttachmentTrustTable.kt$AttachmentTrustTable$3</ID>
+    <ID>MagicNumber:AzureBackend.kt$AzureBackend.Companion$404</ID>
+    <ID>MagicNumber:AzureInstantiator.kt$AzureInstantiator$404</ID>
+    <ID>MagicNumber:AzureRegistryLocator.kt$RegistryLocator$404</ID>
+    <ID>MagicNumber:AzureSmbVolume.kt$AzureSmbVolume$404</ID>
     <ID>MagicNumber:AzureSmbVolume.kt$AzureSmbVolume$5000</ID>
     <ID>MagicNumber:BFTSmart.kt$BFTSmart.Client$100</ID>
     <ID>MagicNumber:BFTSmart.kt$BFTSmart.Replica.&lt;no name provided&gt;$20000</ID>
@@ -756,7 +714,6 @@
     <ID>MagicNumber:CordaPersistence.kt$DatabaseConfig.Defaults$100L</ID>
     <ID>MagicNumber:CordaRPCClient.kt$CordaRPCClientConfiguration$3</ID>
     <ID>MagicNumber:CordaRPCClient.kt$CordaRPCClientConfiguration$5</ID>
-    <ID>MagicNumber:CordaSSHAuthInfo.kt$CordaSSHAuthInfo$10</ID>
     <ID>MagicNumber:CordaSecurityProvider.kt$CordaSecurityProvider$0.1</ID>
     <ID>MagicNumber:Crypto.kt$Crypto$2048</ID>
     <ID>MagicNumber:Crypto.kt$Crypto$256</ID>
@@ -1033,8 +990,6 @@
     <ID>MagicNumber:OracleUtils.kt$24</ID>
     <ID>MagicNumber:OracleUtils.kt$45</ID>
     <ID>MagicNumber:OrdinalIO.kt$OrdinalBits$128</ID>
-    <ID>MagicNumber:P2PMessagingClient.kt$P2PMessagingClient$30000</ID>
-    <ID>MagicNumber:P2PMessagingClient.kt$P2PMessagingClient$60000</ID>
     <ID>MagicNumber:P2PMessagingClient.kt$P2PMessagingConsumer$10</ID>
     <ID>MagicNumber:Parameters.kt$Parameters$0.02</ID>
     <ID>MagicNumber:Parameters.kt$Parameters$0.8</ID>
@@ -1099,11 +1054,8 @@
     <ID>MagicNumber:SimmFlow.kt$1e-9</ID>
     <ID>MagicNumber:StaffedFlowHospital.kt$StaffedFlowHospital$1.5</ID>
     <ID>MagicNumber:StaffedFlowHospital.kt$StaffedFlowHospital$10</ID>
-    <ID>MagicNumber:StandaloneShell.kt$StandaloneShell$7</ID>
     <ID>MagicNumber:StateRevisionFlow.kt$StateRevisionFlow.Requester$30</ID>
     <ID>MagicNumber:TestNodeInfoBuilder.kt$TestNodeInfoBuilder$1234</ID>
-    <ID>MagicNumber:TestUtils.kt$10000</ID>
-    <ID>MagicNumber:TestUtils.kt$30000</ID>
     <ID>MagicNumber:TraderDemo.kt$TraderDemo$1_000_000_000_000</ID>
     <ID>MagicNumber:TraderDemo.kt$TraderDemo$1_100_000_000_000</ID>
     <ID>MagicNumber:TraderDemoClientApi.kt$TraderDemoClientApi$10</ID>
@@ -1135,7 +1087,6 @@
     <ID>MagicNumber:WebServer.kt$100.0</ID>
     <ID>MagicNumber:WebServer.kt$WebServer$500</ID>
     <ID>MagicNumber:WireTransaction.kt$WireTransaction$4</ID>
-    <ID>MagicNumber:X509Utilities.kt$X509Utilities$3650</ID>
     <ID>MagicNumber:errorAndTerminate.kt$10</ID>
     <ID>MatchingDeclarationName:AMQPSerializerFactories.kt$net.corda.serialization.internal.amqp.AMQPSerializerFactories.kt</ID>
     <ID>MatchingDeclarationName:AMQPTestSerialiationScheme.kt$net.corda.nodeapi.internal.serialization.testutils.AMQPTestSerialiationScheme.kt</ID>
@@ -1182,8 +1133,6 @@
     <ID>MatchingDeclarationName:TransactionTypes.kt$net.corda.explorer.model.TransactionTypes.kt</ID>
     <ID>MatchingDeclarationName:Utils.kt$io.cryptoblk.core.Utils.kt</ID>
     <ID>MatchingDeclarationName:VirtualCordapps.kt$net.corda.node.internal.cordapp.VirtualCordapps.kt</ID>
-    <ID>ModifierOrder:NodeNamedCache.kt$DefaultNamedCacheFactory$open protected</ID>
-    <ID>NestedBlockDepth:ANSIProgressRenderer.kt$ANSIProgressRenderer$// Returns number of lines rendered. private fun renderLevel(ansi: Ansi, error: Boolean): Int</ID>
     <ID>NestedBlockDepth:AbstractAggregatedList.kt$AbstractAggregatedList$override fun sourceChanged(c: ListChangeListener.Change&lt;out E&gt;)</ID>
     <ID>NestedBlockDepth:AbstractConcatenatedList.kt$AbstractConcatenatedList$// This is where we handle changes to the *source* list. override fun sourceChanged(change: ListChangeListener.Change&lt;out ObservableList&lt;A&gt;&gt;)</ID>
     <ID>NestedBlockDepth:AbstractNode.kt$AbstractNode$private fun installCordaServices()</ID>
@@ -1192,7 +1141,6 @@
     <ID>NestedBlockDepth:Amount.kt$Amount.Companion$ @JvmStatic fun parseCurrency(input: String): Amount&lt;Currency&gt;</ID>
     <ID>NestedBlockDepth:AttachmentDemo.kt$@Suppress("DEPRECATION") // DOCSTART 1 fun recipient(rpc: CordaRPCOps, webPort: Int)</ID>
     <ID>NestedBlockDepth:AttachmentVersionNumberMigration.kt$AttachmentVersionNumberMigration$override fun execute(database: Database?)</ID>
-    <ID>NestedBlockDepth:AttachmentsClassLoader.kt$AttachmentsClassLoader$private fun checkAttachments(attachments: List&lt;Attachment&gt;)</ID>
     <ID>NestedBlockDepth:CheckpointAgent.kt$CheckpointAgent.Companion$fun parseArguments(argumentsString: String?)</ID>
     <ID>NestedBlockDepth:CheckpointAgent.kt$CheckpointHook$private fun instrumentClass(clazz: CtClass): CtClass?</ID>
     <ID>NestedBlockDepth:CheckpointVerifier.kt$CheckpointVerifier$ fun verifyCheckpointsCompatible( checkpointStorage: CheckpointStorage, currentCordapps: List&lt;Cordapp&gt;, platformVersion: Int, serviceHub: ServiceHub, tokenizableServices: List&lt;Any&gt; )</ID>
@@ -1203,7 +1151,6 @@
     <ID>NestedBlockDepth:DeserializationInput.kt$DeserializationInput$fun readObject(obj: Any, schemas: SerializationSchemas, type: Type, context: SerializationContext): Any</ID>
     <ID>NestedBlockDepth:FetchDataFlow.kt$FetchAttachmentsFlow$override fun maybeWriteToDisk(downloaded: List&lt;Attachment&gt;)</ID>
     <ID>NestedBlockDepth:HibernateQueryCriteriaParser.kt$HibernateQueryCriteriaParser$override fun parseCriteria(criteria: CommonQueryCriteria): Collection&lt;Predicate&gt;</ID>
-    <ID>NestedBlockDepth:InteractiveShell.kt$InteractiveShell$ @JvmStatic fun runFlowByNameFragment(nameFragment: String, inputData: String, output: RenderPrintWriter, rpcOps: CordaRPCOps, ansiProgressRenderer: ANSIProgressRenderer, inputObjectMapper: ObjectMapper = createYamlInputMapper(rpcOps))</ID>
     <ID>NestedBlockDepth:InternalUtils.kt$ inline fun &lt;T&gt; Iterable&lt;T&gt;.noneOrSingle(predicate: (T) -&gt; Boolean): T?</ID>
     <ID>NestedBlockDepth:JarSignatureTestUtils.kt$JarSignatureTestUtils$fun Path.addManifest(fileName: String, vararg entries: Pair&lt;Attributes.Name, String&gt;)</ID>
     <ID>NestedBlockDepth:Main.kt$Node$fun avalancheLoop()</ID>
@@ -1224,7 +1171,6 @@
     <ID>NestedBlockDepth:SpringDriver.kt$SpringBootDriverDSL$private fun queryWebserver(handle: NodeHandle, process: Process, checkUrl: String): WebserverHandle</ID>
     <ID>NestedBlockDepth:StatusTransitions.kt$StatusTransitions$ fun verify(tx: LedgerTransaction)</ID>
     <ID>NestedBlockDepth:ThrowableSerializer.kt$ThrowableSerializer$override fun fromProxy(proxy: ThrowableProxy): Throwable</ID>
-    <ID>NestedBlockDepth:TransactionVerifierServiceInternal.kt$Verifier$ private fun verifyConstraintsValidity(contractAttachmentsByContract: Map&lt;ContractClassName, ContractAttachment&gt;)</ID>
     <ID>SpreadOperator:AbstractNode.kt$FlowStarterImpl$(logicType, *args)</ID>
     <ID>SpreadOperator:AbstractParty.kt$AbstractParty$(*bytes)</ID>
     <ID>SpreadOperator:AbstractRPCTest.kt$AbstractRPCTest.Companion$(*modes)</ID>
@@ -1234,10 +1180,6 @@
     <ID>SpreadOperator:AuthenticatedRpcOpsProxy.kt$AuthenticatedRpcOpsProxy.PermissionsEnforcingInvocationHandler$(methodFullName(method), *(args.map(Class&lt;*&gt;::getName).toTypedArray()))</ID>
     <ID>SpreadOperator:AzureInstantiator.kt$AzureInstantiator$(*portsToOpen.toIntArray())</ID>
     <ID>SpreadOperator:ByteArrays.kt$OpaqueBytes.Companion$(*b)</ID>
-    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$(newNodeCert, INTERMEDIATE_CA.certificate, *nodeKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_CA) }.drop(2).toTypedArray())</ID>
-    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$(newTlsCert, newNodeCert, INTERMEDIATE_CA.certificate, *sslKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_TLS) }.drop(3).toTypedArray())</ID>
-    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests.CrlServlet$( server, SIGNATURE_ALGORITHM, INTERMEDIATE_CA.certificate, INTERMEDIATE_CA.keyPair.private, NODE_CRL, false, *revokedNodeCerts.toTypedArray())</ID>
-    <ID>SpreadOperator:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests.CrlServlet$( server, SIGNATURE_ALGORITHM, ROOT_CA.certificate, ROOT_CA.keyPair.private, INTEMEDIATE_CRL, false, *revokedIntermediateCerts.toTypedArray())</ID>
     <ID>SpreadOperator:CertificateStore.kt$CertificateStore$(*options)</ID>
     <ID>SpreadOperator:ClassCarpenterTestUtils.kt$AmqpCarpenterBase$(*constructorParams)</ID>
     <ID>SpreadOperator:ClassCarpentingTypeLoaderTests.kt$ClassCarpentingTypeLoaderTests$(*params)</ID>
@@ -1278,9 +1220,6 @@
     <ID>SpreadOperator:HibernateQueryCriteriaParser.kt$HibernateAttachmentQueryCriteriaParser$(*predicateSet.toTypedArray())</ID>
     <ID>SpreadOperator:IRSDemo.kt$(*args)</ID>
     <ID>SpreadOperator:InstallShellExtensionsParser.kt$ShellExtensionsGenerator$(*commandAndArgs)</ID>
-    <ID>SpreadOperator:InteractiveShell.kt$InteractiveShell$(clazz, *args)</ID>
-    <ID>SpreadOperator:InteractiveShellTest.kt$InteractiveShellTest$(*args)</ID>
-    <ID>SpreadOperator:InteractiveShellTest.kt$InteractiveShellTest$(*args.map { it!!::class.java }.toTypedArray())</ID>
     <ID>SpreadOperator:InternalUtils.kt$(this, target, *options)</ID>
     <ID>SpreadOperator:InvocationHandlerTemplate.kt$InvocationHandlerTemplate$(delegate, *args)</ID>
     <ID>SpreadOperator:IrsDemoWebApplication.kt$IrsDemoWebApplication.Companion$(IrsDemoWebApplication::class.java, *args)</ID>
@@ -1340,7 +1279,6 @@
     <ID>SpreadOperator:ReactiveArtemisConsumer.kt$ReactiveArtemisConsumer.Companion$(queueName, *queueNames)</ID>
     <ID>SpreadOperator:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ErrorInterceptingHandler$(reconnectingRPCConnection.proxy, *(args ?: emptyArray()))</ID>
     <ID>SpreadOperator:ServiceHub.kt$ServiceHub$(first, *remaining)</ID>
-    <ID>SpreadOperator:StandaloneShell.kt$StandaloneShell$(format, *args)</ID>
     <ID>SpreadOperator:StringToMethodCallParser.kt$StringToMethodCallParser.ParsedMethodCall$(target, *args)</ID>
     <ID>SpreadOperator:TestNodeInfoBuilder.kt$TestNodeInfoBuilder$(*certs, intermediateAndRoot.first.certificate, intermediateAndRoot.second)</ID>
     <ID>SpreadOperator:TestUtils.kt$TestIdentity$(*bytes)</ID>
@@ -1352,7 +1290,6 @@
     <ID>SpreadOperator:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$(listOf(bc1), node, identity, notaryNode, *extraSigningNodes)</ID>
     <ID>SpreadOperator:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$(listOf(bc2), node, identity, notaryNode, *extraSigningNodes)</ID>
     <ID>SpreadOperator:TwoPartyTradeFlowTests.kt$TwoPartyTradeFlowTests$(listOf(eb1), node, identity, notaryNode, *extraSigningNodes)</ID>
-    <ID>SpreadOperator:VaultQueryTests.kt$VaultQueryTestRule$( cordappPackages, makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity), megaCorp, moreKeys = *arrayOf(DUMMY_NOTARY_KEY))</ID>
     <ID>SpreadOperator:VaultQueryTests.kt$VaultQueryTestsBase$(*states.toList().toTypedArray())</ID>
     <ID>SpreadOperator:VaultWithCashTest.kt$VaultWithCashTest$( cordappPackages, makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity), TestIdentity(MEGA_CORP.name, servicesKey), networkParameters, moreKeys = *arrayOf(dummyNotary.keyPair))</ID>
     <ID>SpreadOperator:WaitForStateConsumption.kt$WaitForStateConsumption$(*futures.toTypedArray())</ID>
@@ -1363,7 +1300,6 @@
     <ID>SpreadOperator:X509Utilities.kt$X509Utilities$(*certificates)</ID>
     <ID>ThrowsCount:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$// Make sure our inputs aren't designed to blow things up. private fun validate(typeString: String)</ID>
     <ID>ThrowsCount:AbstractNode.kt$AbstractNode$private fun installCordaServices()</ID>
-    <ID>ThrowsCount:ArtemisMessagingServer.kt$ArtemisMessagingServer$// TODO: Maybe wrap [IOException] on a key store load error so that it's clearly splitting key store loading from // Artemis IO errors @Throws(IOException::class, AddressBindingException::class, KeyStoreException::class) private fun configureAndStartServer()</ID>
     <ID>ThrowsCount:CheckpointVerifier.kt$CheckpointVerifier$ fun verifyCheckpointsCompatible( checkpointStorage: CheckpointStorage, currentCordapps: List&lt;Cordapp&gt;, platformVersion: Int, serviceHub: ServiceHub, tokenizableServices: List&lt;Any&gt; )</ID>
     <ID>ThrowsCount:CheckpointVerifier.kt$CheckpointVerifier$// Throws exception when the flow is incompatible private fun checkFlowCompatible(subFlow: SubFlow, currentCordappsByHash: Map&lt;SecureHash.SHA256, Cordapp&gt;, platformVersion: Int)</ID>
     <ID>ThrowsCount:ClassCarpenter.kt$ClassCarpenterImpl$ private fun validateSchema(schema: Schema)</ID>
@@ -1380,7 +1316,6 @@
     <ID>ThrowsCount:MockServices.kt$ fun &lt;T : SerializeAsToken&gt; createMockCordaService(serviceHub: MockServices, serviceConstructor: (AppServiceHub) -&gt; T): T</ID>
     <ID>ThrowsCount:NetworkRegistrationHelper.kt$NetworkRegistrationHelper$private fun validateCertificates( registeringPublicKey: PublicKey, registeringLegalName: CordaX500Name, expectedCertRole: CertRole, certificates: List&lt;X509Certificate&gt; )</ID>
     <ID>ThrowsCount:NodeInfoFilesCopier.kt$NodeInfoFilesCopier$private fun atomicCopy(source: Path, destination: Path)</ID>
-    <ID>ThrowsCount:NodeVaultService.kt$NodeVaultService$@Throws(VaultQueryException::class) private fun &lt;T : ContractState&gt; _queryBy(criteria: QueryCriteria, paging_: PageSpecification, sorting: Sort, contractStateType: Class&lt;out T&gt;, skipPagingChecks: Boolean): Vault.Page&lt;T&gt;</ID>
     <ID>ThrowsCount:NodeVaultService.kt$NodeVaultService$private fun makeUpdates(batch: Iterable&lt;CoreTransaction&gt;, statesToRecord: StatesToRecord, previouslySeen: Boolean): List&lt;Vault.Update&lt;ContractState&gt;&gt;</ID>
     <ID>ThrowsCount:NonValidatingNotaryFlow.kt$NonValidatingNotaryFlow$ private fun checkNotaryWhitelisted(notary: Party, attachedParameterHash: SecureHash?)</ID>
     <ID>ThrowsCount:PropertyDescriptor.kt$PropertyDescriptor$ fun validate()</ID>
@@ -1393,8 +1328,6 @@
     <ID>ThrowsCount:StringToMethodCallParser.kt$StringToMethodCallParser$ @Throws(UnparseableCallException::class) fun parse(target: T?, command: String): ParsedMethodCall</ID>
     <ID>ThrowsCount:StringToMethodCallParser.kt$StringToMethodCallParser$ @Throws(UnparseableCallException::class) fun parseArguments(methodNameHint: String, parameters: List&lt;Pair&lt;String, Type&gt;&gt;, args: String): Array&lt;Any?&gt;</ID>
     <ID>ThrowsCount:StructuresTests.kt$AttachmentTest$@Test(timeout=300_000) fun `openAsJAR does not leak file handle if attachment has corrupted manifest`()</ID>
-    <ID>ThrowsCount:TransactionVerifierServiceInternal.kt$Verifier$ private fun getUniqueContractAttachmentsByContract(): Map&lt;ContractClassName, ContractAttachment&gt;</ID>
-    <ID>ThrowsCount:TransactionVerifierServiceInternal.kt$Verifier$// Using basic graph theory, a full cycle of encumbered (co-dependent) states should exist to achieve bi-directional // encumbrances. This property is important to ensure that no states involved in an encumbrance-relationship // can be spent on their own. Briefly, if any of the states is having more than one encumbrance references by // other states, a full cycle detection will fail. As a result, all of the encumbered states must be present // as "from" and "to" only once (or zero times if no encumbrance takes place). For instance, // a -&gt; b // c -&gt; b and a -&gt; b // b -&gt; a b -&gt; c // do not satisfy the bi-directionality (full cycle) property. // // In the first example "b" appears twice in encumbrance ("to") list and "c" exists in the encumbered ("from") list only. // Due the above, one could consume "a" and "b" in the same transaction and then, because "b" is already consumed, "c" cannot be spent. // // Similarly, the second example does not form a full cycle because "a" and "c" exist in one of the lists only. // As a result, one can consume "b" and "c" in the same transactions, which will make "a" impossible to be spent. // // On other hand the following are valid constructions: // a -&gt; b a -&gt; c // b -&gt; c and c -&gt; b // c -&gt; a b -&gt; a // and form a full cycle, meaning that the bi-directionality property is satisfied. private fun checkBidirectionalOutputEncumbrances(statesAndEncumbrance: List&lt;Pair&lt;Int, Int&gt;&gt;)</ID>
     <ID>ThrowsCount:WireTransaction.kt$WireTransaction.Companion$ @CordaInternal fun resolveStateRefBinaryComponent(stateRef: StateRef, services: ServicesForResolution): SerializedBytes&lt;TransactionState&lt;ContractState&gt;&gt;?</ID>
     <ID>TooGenericExceptionCaught:AMQPChannelHandler.kt$AMQPChannelHandler$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:AMQPExceptions.kt$th: Throwable</ID>
@@ -1404,7 +1337,6 @@
     <ID>TooGenericExceptionCaught:AbstractNode.kt$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:AbstractNodeTests.kt$ColdJVM.Companion$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:Amount.kt$Amount.Companion$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:ArtemisRpcBroker.kt$ArtemisRpcBroker$th: Throwable</ID>
     <ID>TooGenericExceptionCaught:AttachmentDemo.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AttachmentLoadingTests.kt$AttachmentLoadingTests.ConsumeAndBroadcastResponderFlow$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AttachmentVersionNumberMigration.kt$AttachmentVersionNumberMigration$e: Exception</ID>
@@ -1425,7 +1357,6 @@
     <ID>TooGenericExceptionCaught:ConnectionStateMachine.kt$ConnectionStateMachine$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ContractAttachmentSerializer.kt$ContractAttachmentSerializer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContractUpgradeTransactions.kt$ContractUpgradeWireTransaction$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:CordaAuthenticationPlugin.kt$CordaAuthenticationPlugin$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CordaClassResolver.kt$LoggingWhitelist.Companion$ioEx: Exception</ID>
     <ID>TooGenericExceptionCaught:CordaPersistence.kt$CordaPersistence$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CordaRPCClientTest.kt$CordaRPCClientTest$e: Exception</ID>
@@ -1465,7 +1396,6 @@
     <ID>TooGenericExceptionCaught:Injectors.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:InstallShellExtensionsParser.kt$ShellExtensionsGenerator$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:InteractiveShell.kt$InteractiveShell$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:InteractiveShell.kt$InteractiveShell$e: IndexOutOfBoundsException</ID>
     <ID>TooGenericExceptionCaught:InterestSwapRestAPI.kt$InterestRateSwapAPI$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:InternalMockNetwork.kt$InternalMockNetwork$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:InternalTestUtils.kt$&lt;no name provided&gt;$e: Exception</ID>
@@ -1505,7 +1435,6 @@
     <ID>TooGenericExceptionCaught:NodeRPC.kt$NodeRPC$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeRPC.kt$NodeRPC.&lt;no name provided&gt;$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeSchedulerService.kt$NodeSchedulerService$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:NodeStartup.kt$NodeStartup$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeTerminalView.kt$NodeTerminalView$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeVaultService.kt$NodeVaultService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NodeVaultServiceTest.kt$NodeVaultServiceTest$e: Exception</ID>
@@ -1534,7 +1463,6 @@
     <ID>TooGenericExceptionCaught:ReconnectingCordaRPCOps.kt$ReconnectingCordaRPCOps.ReconnectingRPCConnection$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ReconnectingObservable.kt$ReconnectingObservable.ReconnectingSubscriber$e: Exception</ID>
     <ID>TooGenericExceptionCaught:RpcServerObservableSerializerTests.kt$RpcServerObservableSerializerTests$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:SSLHelper.kt$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:SerializationOutputTests.kt$SerializationOutputTests$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:ShutdownManager.kt$ShutdownManager$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:SimpleAMQPClient.kt$SimpleAMQPClient$e: Exception</ID>
@@ -1543,7 +1471,6 @@
     <ID>TooGenericExceptionCaught:SingleThreadedStateMachineManager.kt$SingleThreadedStateMachineManager$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:SingleThreadedStateMachineManager.kt$SingleThreadedStateMachineManager$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:SingleThreadedStateMachineManager.kt$SingleThreadedStateMachineManager$t: Throwable</ID>
-    <ID>TooGenericExceptionCaught:StandaloneShell.kt$StandaloneShell$e: Exception</ID>
     <ID>TooGenericExceptionCaught:StandardConfigValueParsers.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:StringToMethodCallParser.kt$StringToMethodCallParser$e: Exception</ID>
     <ID>TooGenericExceptionCaught:TLSAuthenticationTests.kt$TLSAuthenticationTests$ex: Exception</ID>
@@ -1570,7 +1497,6 @@
     <ID>TooGenericExceptionCaught:X509EdDSAEngine.kt$X509EdDSAEngine$e: Exception</ID>
     <ID>TooGenericExceptionCaught:X509UtilitiesTest.kt$X509UtilitiesTest$ex: Exception</ID>
     <ID>TooGenericExceptionThrown:AMQPExceptionsTests.kt$AMQPExceptionsTests$throw Exception("FAILED")</ID>
-    <ID>TooGenericExceptionThrown:AzureBackend.kt$AzureBackend.Companion$throw RuntimeException(e)</ID>
     <ID>TooGenericExceptionThrown:ClassLoadingUtilsTest.kt$ClassLoadingUtilsTest$throw RuntimeException()</ID>
     <ID>TooGenericExceptionThrown:CommandParsers.kt$AzureParser.RegionConverter$throw Error("Unknown azure region: $value")</ID>
     <ID>TooGenericExceptionThrown:ContractHierarchyTest.kt$ContractHierarchyTest.IndirectContractParent$throw RuntimeException("Boom!")</ID>
@@ -1601,7 +1527,6 @@
     <ID>TooManyFunctions:AbstractNode.kt$AbstractNode&lt;S&gt; : SingletonSerializeAsToken</ID>
     <ID>TooManyFunctions:ActionExecutorImpl.kt$ActionExecutorImpl : ActionExecutor</ID>
     <ID>TooManyFunctions:AppendOnlyPersistentMap.kt$AppendOnlyPersistentMapBase&lt;K, V, E, out EK&gt;</ID>
-    <ID>TooManyFunctions:ArtemisTcpTransport.kt$ArtemisTcpTransport$Companion</ID>
     <ID>TooManyFunctions:BCCryptoService.kt$BCCryptoService : CryptoService</ID>
     <ID>TooManyFunctions:BFTSmart.kt$BFTSmart$Replica : DefaultRecoverable</ID>
     <ID>TooManyFunctions:BaseTransaction.kt$BaseTransaction : NamedByHash</ID>
@@ -1623,7 +1548,6 @@
     <ID>TooManyFunctions:Generator.kt$Generator$Companion</ID>
     <ID>TooManyFunctions:HibernateQueryCriteriaParser.kt$HibernateQueryCriteriaParser : AbstractQueryCriteriaParserIQueryCriteriaParser</ID>
     <ID>TooManyFunctions:HibernateStatistics.kt$DelegatingStatisticsService : StatisticsService</ID>
-    <ID>TooManyFunctions:InteractiveShell.kt$InteractiveShell</ID>
     <ID>TooManyFunctions:InternalMockNetwork.kt$InternalMockNetwork : AutoCloseable</ID>
     <ID>TooManyFunctions:InternalMockNetwork.kt$InternalMockNetwork$MockNode : AbstractNode</ID>
     <ID>TooManyFunctions:InternalTestUtils.kt$net.corda.testing.internal.InternalTestUtils.kt</ID>
@@ -1692,9 +1616,6 @@
     <ID>VariableNaming:ByteArraysTest.kt$ByteArraysTest$val HEX_REGEX = "^[0-9A-F]+\$".toRegex()</ID>
     <ID>VariableNaming:Cap.kt$Cap$val TEST_TX_TIME_1: Instant get() = Instant.parse("2017-09-02T12:00:00.00Z")</ID>
     <ID>VariableNaming:Caplet.kt$Caplet$val TEST_TX_TIME_1: Instant get() = Instant.parse("2017-09-02T12:00:00.00Z")</ID>
-    <ID>VariableNaming:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$val ECDSA_ALGORITHM = "SHA256withECDSA"</ID>
-    <ID>VariableNaming:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$val EC_ALGORITHM = "EC"</ID>
-    <ID>VariableNaming:CertificateRevocationListNodeTests.kt$CertificateRevocationListNodeTests$val EMPTY_CRL = "empty.crl"</ID>
     <ID>VariableNaming:CompositeKeyTests.kt$CompositeKeyTests$val EdSignature = keyPairEd.sign(SignableData(secureHash, SignatureMetadata(1, Crypto.findSignatureScheme(keyPairEd.public).schemeNumberID)))</ID>
     <ID>VariableNaming:CompositeKeyTests.kt$CompositeKeyTests$val K1Signature = keyPairK1.sign(SignableData(secureHash, SignatureMetadata(1, Crypto.findSignatureScheme(keyPairK1.public).schemeNumberID)))</ID>
     <ID>VariableNaming:CompositeKeyTests.kt$CompositeKeyTests$val R1Signature = keyPairR1.sign(SignableData(secureHash, SignatureMetadata(1, Crypto.findSignatureScheme(keyPairR1.public).schemeNumberID)))</ID>
@@ -1809,7 +1730,6 @@
     <ID>VariableNaming:VaultQueryTests.kt$VaultQueryParties$val MINI_CORP_IDENTITY get() = miniCorp.identity</ID>
     <ID>VariableNaming:VaultQueryTests.kt$VaultQueryTestsBase$// Beware: do not use `MyContractClass::class.qualifiedName` as this returns a fully qualified name using "dot" notation for enclosed class val MYCONTRACT_ID = "net.corda.node.services.vault.VaultQueryTestsBase\$MyContractClass"</ID>
     <ID>VariableNaming:ZeroCouponBond.kt$ZeroCouponBond$val TEST_TX_TIME_1: Instant get() = Instant.parse("2017-09-02T12:00:00.00Z")</ID>
-    <ID>WildcardImport:AMQPClient.kt$import io.netty.channel.*</ID>
     <ID>WildcardImport:AMQPRemoteTypeModel.kt$import net.corda.serialization.internal.model.*</ID>
     <ID>WildcardImport:AMQPSerializationScheme.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:AMQPServerSerializationScheme.kt$import net.corda.serialization.internal.amqp.*</ID>
@@ -1818,7 +1738,6 @@
     <ID>WildcardImport:AMQPTestUtils.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:AMQPTypeIdentifierParser.kt$import org.apache.qpid.proton.amqp.*</ID>
     <ID>WildcardImport:AMQPTypeIdentifiers.kt$import org.apache.qpid.proton.amqp.*</ID>
-    <ID>WildcardImport:ANSIProgressRendererTest.kt$import com.nhaarman.mockito_kotlin.*</ID>
     <ID>WildcardImport:AbstractCashFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:AbstractCashSelection.kt$import net.corda.core.utilities.*</ID>
     <ID>WildcardImport:AdvancedExceptionDialog.kt$import javafx.scene.control.*</ID>
@@ -1830,7 +1749,6 @@
     <ID>WildcardImport:AnotherDummyContract.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:AppendOnlyPersistentMapTest.kt$import org.junit.Assert.*</ID>
     <ID>WildcardImport:ArtemisMessagingClient.kt$import org.apache.activemq.artemis.api.core.client.*</ID>
-    <ID>WildcardImport:ArtemisMessagingServer.kt$import net.corda.node.internal.artemis.*</ID>
     <ID>WildcardImport:ArtemisRpcBroker.kt$import net.corda.node.internal.artemis.*</ID>
     <ID>WildcardImport:AttachmentDemoFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:AttachmentLoadingTests.kt$import net.corda.core.contracts.*</ID>
@@ -1839,9 +1757,6 @@
     <ID>WildcardImport:AttachmentTest.kt$import org.junit.Assert.*</ID>
     <ID>WildcardImport:AttachmentTests.kt$import com.natpryce.hamkrest.*</ID>
     <ID>WildcardImport:AttachmentTrustCalculatorTest.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:AttachmentsClassLoader.kt$import java.net.*</ID>
-    <ID>WildcardImport:AttachmentsClassLoader.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:AttachmentsClassLoader.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:AttachmentsClassLoaderStaticContractTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:AutoOfferFlow.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:BCCryptoService.kt$import java.security.*</ID>
@@ -1880,8 +1795,6 @@
     <ID>WildcardImport:CashViewer.kt$import net.corda.explorer.views.*</ID>
     <ID>WildcardImport:CashViewer.kt$import tornadofx.*</ID>
     <ID>WildcardImport:CertRoleTests.kt$import kotlin.test.*</ID>
-    <ID>WildcardImport:CertificateRevocationListNodeTests.kt$import net.corda.nodeapi.internal.crypto.*</ID>
-    <ID>WildcardImport:CertificateRevocationListNodeTests.kt$import org.bouncycastle.asn1.x509.*</ID>
     <ID>WildcardImport:CertificatesUtils.kt$import net.corda.nodeapi.internal.crypto.*</ID>
     <ID>WildcardImport:CheckpointSerializationAPI.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:ClassCarpenter.kt$import org.objectweb.asm.Opcodes.*</ID>
@@ -1905,15 +1818,12 @@
     <ID>WildcardImport:CompositeKey.kt$import org.bouncycastle.asn1.*</ID>
     <ID>WildcardImport:CompositeKeyFactory.kt$import java.security.*</ID>
     <ID>WildcardImport:CompositeKeyTests.kt$import net.corda.core.crypto.*</ID>
-    <ID>WildcardImport:CompositeSignature.kt$import java.security.*</ID>
     <ID>WildcardImport:ConcurrencyUtilsTest.kt$import com.nhaarman.mockito_kotlin.*</ID>
     <ID>WildcardImport:ConfigParsingTest.kt$import org.assertj.core.api.Assertions.*</ID>
-    <ID>WildcardImport:ConfigUtilities.kt$import com.typesafe.config.*</ID>
     <ID>WildcardImport:Configuration.kt$import com.typesafe.config.*</ID>
     <ID>WildcardImport:ConnectionStateMachine.kt$import org.apache.qpid.proton.amqp.messaging.*</ID>
     <ID>WildcardImport:ConnectionStateMachine.kt$import org.apache.qpid.proton.engine.*</ID>
     <ID>WildcardImport:Constants.kt$import com.fasterxml.jackson.databind.*</ID>
-    <ID>WildcardImport:ConstraintsPropagationTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ConstraintsPropagationTests.kt$import org.junit.*</ID>
     <ID>WildcardImport:ConstraintsUtils.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ContractAttachmentSerializerTest.kt$import net.corda.core.serialization.*</ID>
@@ -1931,20 +1841,12 @@
     <ID>WildcardImport:ContractsScanning.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:CorDappInfoServlet.kt$import kotlinx.html.*</ID>
     <ID>WildcardImport:CorDappSerializerTests.kt$import net.corda.serialization.internal.amqp.testutils.*</ID>
-    <ID>WildcardImport:CordaClassResolver.kt$import com.esotericsoftware.kryo.*</ID>
-    <ID>WildcardImport:CordaClassResolver.kt$import java.nio.file.StandardOpenOption.*</ID>
     <ID>WildcardImport:CordaClassResolverTests.kt$import com.esotericsoftware.kryo.*</ID>
     <ID>WildcardImport:CordaCliWrapper.kt$import picocli.CommandLine.*</ID>
     <ID>WildcardImport:CordaExceptionTest.kt$import net.corda.core.contracts.TransactionVerificationException.*</ID>
     <ID>WildcardImport:CordaExceptionTest.kt$import org.junit.Assert.*</ID>
     <ID>WildcardImport:CordaFutureImplTest.kt$import com.nhaarman.mockito_kotlin.*</ID>
     <ID>WildcardImport:CordaInternal.kt$import kotlin.annotation.AnnotationTarget.*</ID>
-    <ID>WildcardImport:CordaModule.kt$import com.fasterxml.jackson.annotation.*</ID>
-    <ID>WildcardImport:CordaModule.kt$import com.fasterxml.jackson.databind.*</ID>
-    <ID>WildcardImport:CordaModule.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:CordaModule.kt$import net.corda.core.crypto.*</ID>
-    <ID>WildcardImport:CordaModule.kt$import net.corda.core.identity.*</ID>
-    <ID>WildcardImport:CordaModule.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:CordaRPCOps.kt$import net.corda.core.node.services.vault.*</ID>
     <ID>WildcardImport:CordaServiceTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:CordaViewModel.kt$import tornadofx.*</ID>
@@ -1972,7 +1874,6 @@
     <ID>WildcardImport:DemoBench.kt$import tornadofx.*</ID>
     <ID>WildcardImport:DemoBenchNodeInfoFilesCopier.kt$import tornadofx.*</ID>
     <ID>WildcardImport:DemoBenchView.kt$import tornadofx.*</ID>
-    <ID>WildcardImport:DeserializationInput.kt$import net.corda.serialization.internal.*</ID>
     <ID>WildcardImport:DeserializeNeedingCarpentryOfEnumsTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:DeserializeNeedingCarpentryOfEnumsTest.kt$import net.corda.serialization.internal.amqp.testutils.*</ID>
     <ID>WildcardImport:DeserializeNeedingCarpentryOfEnumsTest.kt$import net.corda.serialization.internal.carpenter.*</ID>
@@ -2052,18 +1953,11 @@
     <ID>WildcardImport:InputStreamSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:InstallFactory.kt$import tornadofx.*</ID>
     <ID>WildcardImport:InstallShellExtensionsParser.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:InteractiveShellIntegrationTest.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:InteractiveShellIntegrationTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:InterestRatesSwapDemoAPI.kt$import org.springframework.web.bind.annotation.*</ID>
     <ID>WildcardImport:InterestSwapRestAPI.kt$import org.springframework.web.bind.annotation.*</ID>
     <ID>WildcardImport:InternalAccessTestHelpers.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:IssuerModel.kt$import tornadofx.*</ID>
     <ID>WildcardImport:JVMConfig.kt$import tornadofx.*</ID>
-    <ID>WildcardImport:JacksonSupport.kt$import com.fasterxml.jackson.core.*</ID>
-    <ID>WildcardImport:JacksonSupport.kt$import com.fasterxml.jackson.databind.*</ID>
-    <ID>WildcardImport:JacksonSupport.kt$import net.corda.core.crypto.*</ID>
-    <ID>WildcardImport:JacksonSupport.kt$import net.corda.core.identity.*</ID>
-    <ID>WildcardImport:JacksonSupport.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:JacksonSupportTest.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:JacksonSupportTest.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:JacksonSupportTest.kt$import net.corda.core.identity.*</ID>
@@ -2079,11 +1973,6 @@
     <ID>WildcardImport:Kryo.kt$import com.esotericsoftware.kryo.*</ID>
     <ID>WildcardImport:Kryo.kt$import net.corda.core.transactions.*</ID>
     <ID>WildcardImport:KryoStreamsTest.kt$import java.io.*</ID>
-    <ID>WildcardImport:KryoTests.kt$import kotlin.test.*</ID>
-    <ID>WildcardImport:KryoTests.kt$import net.corda.core.crypto.*</ID>
-    <ID>WildcardImport:KryoTests.kt$import net.corda.core.serialization.*</ID>
-    <ID>WildcardImport:KryoTests.kt$import net.corda.serialization.internal.*</ID>
-    <ID>WildcardImport:KryoTests.kt$import org.assertj.core.api.Assertions.*</ID>
     <ID>WildcardImport:LargeTransactionsTest.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:LazyMappedListTest.kt$import net.corda.core.contracts.ComponentGroupEnum.*</ID>
     <ID>WildcardImport:LedgerTransactionQueryTests.kt$import net.corda.core.contracts.*</ID>
@@ -2147,9 +2036,6 @@
     <ID>WildcardImport:NewTransaction.kt$import net.corda.client.jfx.model.*</ID>
     <ID>WildcardImport:NewTransaction.kt$import net.corda.client.jfx.utils.*</ID>
     <ID>WildcardImport:NewTransaction.kt$import tornadofx.*</ID>
-    <ID>WildcardImport:NodeAttachmentService.kt$import javax.persistence.*</ID>
-    <ID>WildcardImport:NodeAttachmentService.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:NodeAttachmentService.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:NodeAttachmentServiceTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:NodeAttachmentServiceTest.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NodeAttachmentServiceTest.kt$import org.assertj.core.api.Assertions.*</ID>
@@ -2171,22 +2057,12 @@
     <ID>WildcardImport:NodeSchedulerServiceTest.kt$import org.junit.*</ID>
     <ID>WildcardImport:NodeSchemaService.kt$import net.corda.core.schemas.*</ID>
     <ID>WildcardImport:NodeSchemaServiceTest.kt$import javax.persistence.*</ID>
-    <ID>WildcardImport:NodeStartup.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:NodeStartup.kt$import net.corda.node.*</ID>
-    <ID>WildcardImport:NodeStartup.kt$import net.corda.node.internal.subcommands.*</ID>
     <ID>WildcardImport:NodeTabView.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NodeTabView.kt$import net.corda.demobench.model.*</ID>
     <ID>WildcardImport:NodeTabView.kt$import tornadofx.*</ID>
     <ID>WildcardImport:NodeTerminalView.kt$import tornadofx.*</ID>
     <ID>WildcardImport:NodeTest.kt$import net.corda.node.services.config.*</ID>
     <ID>WildcardImport:NodeTestUtils.kt$import net.corda.testing.dsl.*</ID>
-    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.node.services.*</ID>
-    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.node.services.vault.*</ID>
-    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.transactions.*</ID>
-    <ID>WildcardImport:NodeVaultService.kt$import net.corda.core.utilities.*</ID>
-    <ID>WildcardImport:NodeVaultService.kt$import net.corda.nodeapi.internal.persistence.*</ID>
     <ID>WildcardImport:NodeVaultServiceTest.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:NodeVaultServiceTest.kt$import net.corda.core.identity.*</ID>
     <ID>WildcardImport:NodeVaultServiceTest.kt$import net.corda.core.node.services.*</ID>
@@ -2198,9 +2074,6 @@
     <ID>WildcardImport:NodeVersioningTest.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:NodeWebServer.kt$import net.corda.webserver.servlets.*</ID>
     <ID>WildcardImport:NodeWebServer.kt$import org.eclipse.jetty.server.*</ID>
-    <ID>WildcardImport:NonValidatingNotaryServiceTests.kt$import net.corda.core.crypto.*</ID>
-    <ID>WildcardImport:NonValidatingNotaryServiceTests.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:NonValidatingNotaryServiceTests.kt$import net.corda.testing.node.internal.*</ID>
     <ID>WildcardImport:NotaryChangeTests.kt$import net.corda.testing.node.*</ID>
     <ID>WildcardImport:NotaryChangeTransactions.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:NotaryChangeTransactions.kt$import net.corda.core.transactions.NotaryChangeWireTransaction.Component.*</ID>
@@ -2223,14 +2096,10 @@
     <ID>WildcardImport:OnLedgerAsset.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:OracleNodeTearOffTests.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:P2PFlowsDrainingModeTest.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:P2PMessagingClient.kt$import net.corda.core.utilities.*</ID>
-    <ID>WildcardImport:P2PMessagingClient.kt$import net.corda.nodeapi.internal.ArtemisMessagingComponent.*</ID>
-    <ID>WildcardImport:P2PMessagingClient.kt$import org.apache.activemq.artemis.api.core.client.*</ID>
     <ID>WildcardImport:PackageOwnershipVerificationTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:PartialMerkleTreeTest.kt$import kotlin.test.*</ID>
     <ID>WildcardImport:PartialMerkleTreeTest.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:PartialMerkleTreeTest.kt$import net.corda.core.crypto.*</ID>
-    <ID>WildcardImport:PartyAndCertificate.kt$import java.security.cert.*</ID>
     <ID>WildcardImport:PathUtils.kt$import java.io.*</ID>
     <ID>WildcardImport:PathUtils.kt$import java.nio.file.*</ID>
     <ID>WildcardImport:PersistentIdentityMigrationNewTableTest.kt$import net.corda.testing.core.*</ID>
@@ -2248,7 +2117,6 @@
     <ID>WildcardImport:ProfileController.kt$import tornadofx.*</ID>
     <ID>WildcardImport:Properties.kt$import com.typesafe.config.*</ID>
     <ID>WildcardImport:PropertyDescriptor.kt$import net.corda.serialization.internal.amqp.MethodClassifier.*</ID>
-    <ID>WildcardImport:ProtonWrapperTests.kt$import javax.net.ssl.*</ID>
     <ID>WildcardImport:PublicKeyHashToExternalId.kt$import javax.persistence.*</ID>
     <ID>WildcardImport:PublicKeySerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:QueryCriteriaUtils.kt$import net.corda.core.node.services.vault.CollectionOperator.*</ID>
@@ -2259,7 +2127,6 @@
     <ID>WildcardImport:RPCSecurityManagerImpl.kt$import org.apache.shiro.authc.*</ID>
     <ID>WildcardImport:ReceiveFinalityFlowTest.kt$import net.corda.node.services.statemachine.StaffedFlowHospital.*</ID>
     <ID>WildcardImport:ReceiveFinalityFlowTest.kt$import net.corda.testing.node.internal.*</ID>
-    <ID>WildcardImport:ReceiveTransactionFlow.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ReferenceInputStateTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ReferencedStatesFlowTests.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ReferencedStatesFlowTests.kt$import net.corda.core.flows.*</ID>
@@ -2276,8 +2143,6 @@
     <ID>WildcardImport:RpcExceptionHandlingTest.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:RpcExceptionHandlingTest.kt$import net.corda.testing.driver.*</ID>
     <ID>WildcardImport:RpcServerObservableSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
-    <ID>WildcardImport:SSLHelper.kt$import java.security.cert.*</ID>
-    <ID>WildcardImport:SSLHelper.kt$import javax.net.ssl.*</ID>
     <ID>WildcardImport:SampleCashSchemaV2.kt$import javax.persistence.*</ID>
     <ID>WildcardImport:ScheduledFlowIntegrationTests.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:ScheduledFlowTests.kt$import net.corda.core.contracts.*</ID>
@@ -2314,7 +2179,6 @@
     <ID>WildcardImport:ServiceHub.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:ServiceHub.kt$import net.corda.core.node.services.*</ID>
     <ID>WildcardImport:ServiceHubInternal.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:ServicesForResolutionImpl.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:SettingsModel.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:SettingsModel.kt$import tornadofx.*</ID>
     <ID>WildcardImport:SharedContexts.kt$import net.corda.core.serialization.*</ID>
@@ -2339,7 +2203,6 @@
     <ID>WildcardImport:TestDSL.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TestDSL.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:TestResponseFlowInIsolation.kt$import net.corda.core.flows.*</ID>
-    <ID>WildcardImport:TestUtils.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:ThrowableSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:TimedFlowTests.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:TimedFlowTests.kt$import net.corda.testing.node.internal.*</ID>
@@ -2348,8 +2211,6 @@
     <ID>WildcardImport:TraderDemoTest.kt$import net.corda.testing.driver.*</ID>
     <ID>WildcardImport:TransactionBuilder.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionBuilder.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:TransactionBuilderTest.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:TransactionBuilderTest.kt$import net.corda.testing.core.*</ID>
     <ID>WildcardImport:TransactionDSLInterpreter.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionDataModel.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionEncumbranceTests.kt$import net.corda.core.contracts.*</ID>
@@ -2365,7 +2226,6 @@
     <ID>WildcardImport:TransactionUtils.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionUtils.kt$import net.corda.core.serialization.*</ID>
     <ID>WildcardImport:TransactionUtils.kt$import net.corda.core.transactions.*</ID>
-    <ID>WildcardImport:TransactionVerifierServiceInternal.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.client.jfx.model.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.client.jfx.utils.*</ID>
     <ID>WildcardImport:TransactionViewer.kt$import net.corda.core.contracts.*</ID>
@@ -2396,7 +2256,6 @@
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:ValidatingNotaryServiceTests.kt$import net.corda.testing.node.internal.*</ID>
-    <ID>WildcardImport:VaultFiller.kt$import net.corda.core.contracts.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.vault.*</ID>
     <ID>WildcardImport:VaultQueryExceptionsTests.kt$import net.corda.core.node.services.vault.QueryCriteria.*</ID>
@@ -2435,20 +2294,12 @@
     <ID>WildcardImport:WhitelistBasedTypeModelConfiguration.kt$import org.apache.qpid.proton.amqp.*</ID>
     <ID>WildcardImport:WhitelistGenerator.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:WireTransaction.kt$import net.corda.core.contracts.*</ID>
-    <ID>WildcardImport:WireTransaction.kt$import net.corda.core.crypto.*</ID>
     <ID>WildcardImport:WireTransaction.kt$import net.corda.core.internal.*</ID>
     <ID>WildcardImport:WithFinality.kt$import net.corda.core.flows.*</ID>
     <ID>WildcardImport:WithMockNet.kt$import com.natpryce.hamkrest.*</ID>
     <ID>WildcardImport:X509CRLSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:X509CertificateSerializer.kt$import net.corda.serialization.internal.amqp.*</ID>
     <ID>WildcardImport:X509EdDSAEngine.kt$import java.security.*</ID>
-    <ID>WildcardImport:X509Utilities.kt$import java.security.cert.*</ID>
-    <ID>WildcardImport:X509Utilities.kt$import net.corda.core.internal.*</ID>
-    <ID>WildcardImport:X509Utilities.kt$import org.bouncycastle.asn1.*</ID>
-    <ID>WildcardImport:X509Utilities.kt$import org.bouncycastle.asn1.x509.*</ID>
-    <ID>WildcardImport:X509UtilitiesTest.kt$import javax.net.ssl.*</ID>
-    <ID>WildcardImport:X509UtilitiesTest.kt$import kotlin.test.*</ID>
-    <ID>WildcardImport:X509UtilitiesTest.kt$import org.bouncycastle.asn1.x509.*</ID>
     <ID>WildcardImport:internalAccessTestHelpers.kt$import net.corda.core.contracts.*</ID>
   </Whitelist>
 </SmellBaseline>

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -32,8 +32,6 @@ apply plugin: 'com.jfrog.artifactory'
 configurations {
     compile {
         exclude group: "log4j", module: "log4j"
-        exclude group: "org.apache.logging.log4j"
-
         // The Node only needs this for binary compatibility with Cordapps written in Kotlin 1.1.
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jre8'
     }
@@ -73,10 +71,11 @@ processResources {
 }
 
 shadowJar {
-    baseName = 'network-builder'
+    archiveBaseName = 'network-builder'
     archiveClassifier = jdkClassifier
-    version = null
+    archiveVersion = null
     zip64 true
+    exclude '**/Log4j2Plugins.dat'
 }
 
 tasks.register('buildNetworkBuilder') {

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -40,7 +40,8 @@ configurations {
 }
 
 dependencies {
-    compile "com.microsoft.azure:azure:$azure_version"
+    compile "com.azure.resourcemanager:azure-resourcemanager:$azure_resource_manager_version"
+    compile "com.azure:azure-identity:$azure_identity_version"
     compile "com.github.docker-java:docker-java:$docker_java_version"
 
     testCompile "org.jetbrains.kotlin:kotlin-test"

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Constants.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/Constants.kt
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import com.microsoft.azure.management.resources.ResourceGroup
-import com.microsoft.azure.management.resources.fluentcore.arm.Region
+import com.azure.resourcemanager.resources.models.ResourceGroup
+import com.azure.core.management.Region
 
 class Constants {
 
@@ -30,7 +30,7 @@ class Constants {
                 })
                 it.addDeserializer(Region::class.java, object : JsonDeserializer<Region>() {
                     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Region {
-                        return Region.findByLabelOrName(p.valueAsString)
+                        return Region.fromName(p.valueAsString)
                     }
                 })
             })

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/backends/AzureBackend.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/backends/AzureBackend.kt
@@ -31,6 +31,7 @@ data class AzureBackend(override val containerPusher: AzureContainerPusher,
                 .authenticate(credential, profile)
                 .withDefaultSubscription()
 
+        @Suppress("MagicNumber")
         fun fromContext(context: Context): AzureBackend {
             val resourceGroupName = context.networkName.replace(Constants.ALPHA_NUMERIC_DOT_AND_UNDERSCORE_ONLY_REGEX, "")
             val resourceGroup = try {

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/backends/AzureBackend.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/backends/AzureBackend.kt
@@ -1,9 +1,11 @@
 package net.corda.networkbuilder.backends
 
-import com.microsoft.azure.CloudException
-import com.microsoft.azure.credentials.AzureCliCredentials
-import com.microsoft.azure.management.Azure
-import com.microsoft.rest.LogLevel
+import com.azure.core.credential.TokenCredential
+import com.azure.core.management.profile.AzureProfile
+import com.azure.resourcemanager.AzureResourceManager
+import com.azure.core.management.AzureEnvironment
+import com.azure.core.management.exception.ManagementException
+import com.azure.identity.AzureCliCredentialBuilder
 import net.corda.networkbuilder.Constants
 import net.corda.networkbuilder.containers.instance.azure.AzureInstantiator
 import net.corda.networkbuilder.containers.push.azure.AzureContainerPusher
@@ -11,6 +13,8 @@ import net.corda.networkbuilder.containers.push.azure.RegistryLocator
 import net.corda.networkbuilder.context.Context
 import net.corda.networkbuilder.volumes.azure.AzureSmbVolume
 import org.slf4j.LoggerFactory
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.concurrent.CompletableFuture
 
 data class AzureBackend(override val containerPusher: AzureContainerPusher,
@@ -21,28 +25,32 @@ data class AzureBackend(override val containerPusher: AzureContainerPusher,
 
         val LOG = LoggerFactory.getLogger(AzureBackend::class.java)
 
-        private val azure: Azure = kotlin.run {
-            Azure.configure()
-                    .withLogLevel(LogLevel.NONE)
-                    .authenticate(AzureCliCredentials.create())
-                    .withDefaultSubscription()
-        }
+        private val credential: TokenCredential = AzureCliCredentialBuilder().build()
+        private val profile = AzureProfile(AzureEnvironment.AZURE)
+        private val azure: AzureResourceManager = AzureResourceManager.configure()
+                .authenticate(credential, profile)
+                .withDefaultSubscription()
 
         fun fromContext(context: Context): AzureBackend {
             val resourceGroupName = context.networkName.replace(Constants.ALPHA_NUMERIC_DOT_AND_UNDERSCORE_ONLY_REGEX, "")
             val resourceGroup = try {
-                LOG.info("Attempting to find existing resourceGroup with name: $resourceGroupName")
-                val foundResourceGroup = azure.resourceGroups().getByName(resourceGroupName)
-
-                if (foundResourceGroup == null) {
-                    LOG.info("No existing resourceGroup found creating new resourceGroup with name: $resourceGroupName")
-                    azure.resourceGroups().define(resourceGroupName).withRegion(context.extraParams[Constants.REGION_ARG_NAME]).create()
+                LOG.info("Attempting to find existing resource group with name: $resourceGroupName")
+                val existingGroup = azure.resourceGroups().getByName(resourceGroupName)
+                LOG.info("Found existing resource group with name $resourceGroupName, reusing")
+                existingGroup
+            } catch (ex: ManagementException) {
+                if (ex.response.statusCode == 404) {
+                    LOG.info("No existing resource group with name $resourceGroupName found. Creating new one.")
+                    val now = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                    azure.resourceGroups().define(resourceGroupName)
+                            .withRegion(context.extraParams[Constants.REGION_ARG_NAME])
+                            .withTag("CreatedBy", "Corda Network Builder")
+                            .withTag("CreatedOn", now)
+                            .withTag("NetworkName", context.networkName)
+                            .create()
                 } else {
-                    LOG.info("Found existing resourceGroup, reusing")
-                    foundResourceGroup
+                    throw ex
                 }
-            } catch (e: CloudException) {
-                throw RuntimeException(e)
             }
 
             val registryLocatorFuture = CompletableFuture.supplyAsync {

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/cli/CommandParsers.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/cli/CommandParsers.kt
@@ -1,6 +1,6 @@
 package net.corda.networkbuilder.cli
 
-import com.microsoft.azure.management.resources.fluentcore.arm.Region
+import com.azure.core.management.Region
 import net.corda.networkbuilder.Constants
 import net.corda.networkbuilder.backends.Backend
 import picocli.CommandLine

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/instance/azure/AzureInstantiator.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/instance/azure/AzureInstantiator.kt
@@ -1,11 +1,11 @@
 package net.corda.networkbuilder.containers.instance.azure
 
-import com.microsoft.azure.management.Azure
-import com.microsoft.azure.management.containerinstance.ContainerGroup
-import com.microsoft.azure.management.containerinstance.ContainerGroupRestartPolicy
-import com.microsoft.azure.management.containerregistry.Registry
-import com.microsoft.azure.management.resources.ResourceGroup
-import com.microsoft.rest.ServiceCallback
+import com.azure.core.management.exception.ManagementException
+import com.azure.resourcemanager.AzureResourceManager
+import com.azure.resourcemanager.containerinstance.models.ContainerGroup
+import com.azure.resourcemanager.containerinstance.models.ContainerGroupRestartPolicy
+import com.azure.resourcemanager.containerregistry.models.Registry
+import com.azure.resourcemanager.resources.models.ResourceGroup
 import net.corda.networkbuilder.Constants.Companion.restFriendlyName
 import net.corda.networkbuilder.containers.instance.Instantiator
 import net.corda.networkbuilder.containers.instance.Instantiator.Companion.ADDITIONAL_NODE_INFOS_PATH
@@ -13,12 +13,16 @@ import net.corda.networkbuilder.containers.push.azure.RegistryLocator.Companion.
 import net.corda.networkbuilder.volumes.azure.AzureSmbVolume
 import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.function.Supplier
 
-class AzureInstantiator(private val azure: Azure,
+class AzureInstantiator(private val azure: AzureResourceManager,
                         private val registry: Registry,
                         private val azureSmbVolume: AzureSmbVolume,
                         private val resourceGroup: ResourceGroup
 ) : Instantiator {
+    private val executor = Executors.newSingleThreadExecutor()
+
     override fun instantiateContainer(imageId: String,
                                       portsToOpen: List<Int>,
                                       instanceName: String,
@@ -30,9 +34,9 @@ class AzureInstantiator(private val azure: Azure,
         val registryAddress = registry.loginServerUrl()
         val (username, password) = registry.parseCredentials()
         val mountName = "node-setup"
-        return CompletableFuture<Pair<String, Map<Int, Int>>>().also {
-            azure.containerGroups().define(buildIdent(instanceName))
-                    .withRegion(resourceGroup.region())
+        return CompletableFuture.supplyAsync(Supplier {
+            val containerGroup = azure.containerGroups().define(buildIdent(instanceName))
+                    .withRegion(resourceGroup.regionName())
                     .withExistingResourceGroup(resourceGroup)
                     .withLinux()
                     .withPrivateImageRegistry(registryAddress, username, password)
@@ -46,20 +50,14 @@ class AzureInstantiator(private val azure: Azure,
                     .withExternalTcpPorts(*portsToOpen.toIntArray())
                     .withVolumeMountSetting(mountName, ADDITIONAL_NODE_INFOS_PATH)
                     .withEnvironmentVariables(env ?: emptyMap())
-                    .attach().withRestartPolicy(ContainerGroupRestartPolicy.ON_FAILURE)
+                    .attach()
+                    .withRestartPolicy(ContainerGroupRestartPolicy.ON_FAILURE)
                     .withDnsPrefix(buildIdent(instanceName))
-                    .createAsync(object : ServiceCallback<ContainerGroup> {
-                        override fun failure(t: Throwable?) {
-                            it.completeExceptionally(t)
-                        }
-
-                        override fun success(result: ContainerGroup) {
-                            val fqdn = result.fqdn()
-                            LOG.info("Completed instantiation: $instanceName is running at $fqdn with port(s) $portsToOpen exposed")
-                            it.complete(result.fqdn() to portsToOpen.map { port -> port to port }.toMap())
-                        }
-                    })
-        }
+                    .create()
+            val fqdn = containerGroup.fqdn()
+            LOG.info("Completed instantiation: $instanceName is running at $fqdn with port(s) $portsToOpen exposed")
+            fqdn to portsToOpen.associate { it to it }
+        }, executor)
     }
 
     private fun buildIdent(instanceName: String) = "$instanceName-${resourceGroup.restFriendlyName()}"
@@ -69,12 +67,21 @@ class AzureInstantiator(private val azure: Azure,
     }
 
     fun findAndKillExistingContainerGroup(resourceGroup: ResourceGroup, containerName: String): ContainerGroup? {
-        val existingContainer = azure.containerGroups().getByResourceGroup(resourceGroup.name(), containerName)
-        if (existingContainer != null) {
-            LOG.info("Found an existing instance of: $containerName destroying ContainerGroup")
-            azure.containerGroups().deleteByResourceGroup(resourceGroup.name(), containerName)
+        return try {
+            val existingContainer = azure.containerGroups().getByResourceGroup(resourceGroup.name(), containerName)
+            if (existingContainer != null) {
+                LOG.info("Found an existing instance of: $containerName, destroying ContainerGroup")
+                azure.containerGroups().deleteByResourceGroup(resourceGroup.name(), containerName)
+            }
+            existingContainer
+        } catch (e: ManagementException) {
+            if (e.response.statusCode == 404) {
+                LOG.info("No existing container group found for: $containerName")
+                null
+            } else {
+                throw e
+            }
         }
-        return existingContainer
     }
 
     companion object {

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/instance/azure/AzureInstantiator.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/instance/azure/AzureInstantiator.kt
@@ -66,6 +66,7 @@ class AzureInstantiator(private val azure: AzureResourceManager,
         return "${buildIdent(instanceName)}.${resourceGroup.region().name()}.azurecontainer.io"
     }
 
+    @Suppress("MagicNumber")
     fun findAndKillExistingContainerGroup(resourceGroup: ResourceGroup, containerName: String): ContainerGroup? {
         return try {
             val existingContainer = azure.containerGroups().getByResourceGroup(resourceGroup.name(), containerName)

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/push/azure/AzureContainerPusher.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/push/azure/AzureContainerPusher.kt
@@ -2,7 +2,7 @@ package net.corda.networkbuilder.containers.push.azure
 
 import com.github.dockerjava.api.async.ResultCallback
 import com.github.dockerjava.api.model.PushResponseItem
-import com.microsoft.azure.management.containerregistry.Registry
+import com.azure.resourcemanager.containerregistry.models.Registry
 import net.corda.networkbuilder.containers.push.ContainerPusher
 import net.corda.networkbuilder.containers.push.azure.RegistryLocator.Companion.parseCredentials
 import net.corda.networkbuilder.docker.DockerUtils

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/push/azure/AzureRegistryLocator.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/push/azure/AzureRegistryLocator.kt
@@ -14,6 +14,7 @@ class RegistryLocator(private val azure: AzureResourceManager,
 
     val registry: Registry = locateRegistry()
 
+    @Suppress("MagicNumber")
     private fun locateRegistry(): Registry {
         LOG.info("Attempting to find existing registry with name: ${resourceGroup.restFriendlyName()}")
         val found = try {

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/push/azure/AzureRegistryLocator.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/containers/push/azure/AzureRegistryLocator.kt
@@ -1,21 +1,30 @@
 package net.corda.networkbuilder.containers.push.azure
 
-import com.microsoft.azure.management.Azure
-import com.microsoft.azure.management.containerregistry.AccessKeyType
-import com.microsoft.azure.management.containerregistry.Registry
-import com.microsoft.azure.management.resources.ResourceGroup
+import com.azure.core.management.exception.ManagementException
+import com.azure.resourcemanager.AzureResourceManager
+import com.azure.resourcemanager.containerregistry.models.AccessKeyType
+import com.azure.resourcemanager.containerregistry.models.Registry
+import com.azure.resourcemanager.resources.models.ResourceGroup
 import net.corda.networkbuilder.Constants.Companion.restFriendlyName
 import net.corda.networkbuilder.containers.instance.azure.AzureInstantiator
 import org.slf4j.LoggerFactory
 
-class RegistryLocator(private val azure: Azure,
+class RegistryLocator(private val azure: AzureResourceManager,
                       private val resourceGroup: ResourceGroup) {
 
     val registry: Registry = locateRegistry()
 
     private fun locateRegistry(): Registry {
         LOG.info("Attempting to find existing registry with name: ${resourceGroup.restFriendlyName()}")
-        val found = azure.containerRegistries().getByResourceGroup(resourceGroup.name(), resourceGroup.restFriendlyName())
+        val found = try {
+            azure.containerRegistries().getByResourceGroup(resourceGroup.name(), resourceGroup.restFriendlyName())
+        } catch (ex: ManagementException) {
+            if (ex.response.statusCode == 404) {
+                null
+            } else {
+                throw ex
+            }
+        }
 
         return if (found == null) {
             LOG.info("Did not find existing container registry - creating new registry with name ${resourceGroup.restFriendlyName()}")

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/gui/BootstrapperView.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/gui/BootstrapperView.kt
@@ -1,6 +1,6 @@
 package net.corda.networkbuilder.gui
 
-import com.microsoft.azure.management.resources.fluentcore.arm.Region
+import com.azure.core.management.Region
 import java.util.Random
 import javafx.beans.binding.Bindings
 import javafx.beans.property.SimpleObjectProperty

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/volumes/Volume.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/volumes/Volume.kt
@@ -1,6 +1,7 @@
 package net.corda.networkbuilder.volumes
 
-import com.microsoft.azure.storage.file.CloudFile
+import com.azure.storage.file.share.ShareFileClient
+import com.azure.storage.file.share.models.ShareFileUploadOptions
 import com.typesafe.config.ConfigFactory
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
@@ -11,6 +12,7 @@ import net.corda.nodeapi.internal.DEV_ROOT_CA
 import net.corda.nodeapi.internal.SignedNodeInfo
 import net.corda.nodeapi.internal.config.getBooleanCaseInsensitive
 import net.corda.nodeapi.internal.createDevNetworkMapCa
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.security.cert.X509Certificate
 import java.time.Instant
@@ -28,8 +30,10 @@ interface Volume {
         internal val keyPair = networkMapCa.keyPair
     }
 
-    fun CloudFile.uploadFromByteArray(array: ByteArray) {
-        this.uploadFromByteArray(array, 0, array.size)
+    fun ShareFileClient.uploadFromByteArray(array: ByteArray) {
+        val inputStream = ByteArrayInputStream(array)
+        this.create(array.size.toLong())
+        this.uploadWithResponse(ShareFileUploadOptions(inputStream), null, null)
     }
 
     fun convertNodeIntoToNetworkParams(notaryFiles: List<Pair<File, File>>): NetworkParameters {

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/volumes/azure/AzureSmbVolume.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/volumes/azure/AzureSmbVolume.kt
@@ -58,6 +58,7 @@ class AzureSmbVolume(private val azure: AzureResourceManager, private val resour
         }
     }
 
+    @Suppress("MagicNumber")
     private fun getStorageAccount(): StorageAccount {
         val existing = try {
             azure.storageAccounts().getByResourceGroup(

--- a/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/volumes/azure/AzureSmbVolume.kt
+++ b/tools/network-builder/src/main/kotlin/net/corda/networkbuilder/volumes/azure/AzureSmbVolume.kt
@@ -1,9 +1,12 @@
 package net.corda.networkbuilder.volumes.azure
 
-import com.microsoft.azure.management.Azure
-import com.microsoft.azure.management.resources.ResourceGroup
-import com.microsoft.azure.management.storage.StorageAccount
-import com.microsoft.azure.storage.CloudStorageAccount
+import com.azure.core.management.exception.ManagementException
+import com.azure.resourcemanager.AzureResourceManager
+import com.azure.resourcemanager.resources.models.ResourceGroup
+import com.azure.resourcemanager.storage.models.StorageAccount
+import com.azure.storage.common.StorageSharedKeyCredential
+import com.azure.storage.file.share.ShareDirectoryClient
+import com.azure.storage.file.share.ShareServiceClientBuilder
 import net.corda.core.internal.signWithCert
 import net.corda.core.serialization.serialize
 import net.corda.networkbuilder.Constants.Companion.restFriendlyName
@@ -13,55 +16,80 @@ import net.corda.networkbuilder.volumes.Volume.Companion.keyPair
 import net.corda.networkbuilder.volumes.Volume.Companion.networkMapCert
 import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 import org.slf4j.LoggerFactory
+import java.time.Instant
 
-class AzureSmbVolume(private val azure: Azure, private val resourceGroup: ResourceGroup) : Volume {
+class AzureSmbVolume(private val azure: AzureResourceManager, private val resourceGroup: ResourceGroup) : Volume {
 
     private val storageAccount = getStorageAccount()
 
     private val accKeys = storageAccount.keys[0]
+    private val credential = StorageSharedKeyCredential(storageAccount.name(), storageAccountKey)
+    private val shareClient = ShareServiceClientBuilder()
+            .endpoint("https://${storageAccount.name()}.file.core.windows.net")
+            .credential(credential)
+            .buildClient()
+            .getShareClient("nodeinfos")
+            .apply { createIfNotExists() }
 
-    private val cloudFileShare = CloudStorageAccount.parse(
-            "DefaultEndpointsProtocol=https;" +
-                    "AccountName=${storageAccount.name()};" +
-                    "AccountKey=${accKeys.value()};" +
-                    "EndpointSuffix=core.windows.net"
-    )
-            .createCloudFileClient()
-            .getShareReference("nodeinfos")
-
-    val networkParamsFolder = cloudFileShare.rootDirectoryReference.getDirectoryReference("network-params")
-    val shareName: String = cloudFileShare.name
+    var networkParamsFolder: ShareDirectoryClient
+    val shareName: String = shareClient.shareName
     val storageAccountName: String
-        get() = resourceGroup.restFriendlyName()
+        get() = resourceGroup.restFriendlyName() + "storageacc"
     val storageAccountKey: String
         get() = accKeys.value()
 
     init {
         while (true) {
             try {
-                cloudFileShare.createIfNotExists()
-                networkParamsFolder.createIfNotExists()
-                break
+                shareClient.createIfNotExists()
+                val folder = shareClient.rootDirectoryClient
+                        .getSubdirectoryClient("network-params")
+                folder.createIfNotExists()
+                if (folder.exists()) {
+                    networkParamsFolder = folder
+                    break
+                } else {
+                    LOG.debug("'network-params' folder does not yet exist, retrying...")
+                }
             } catch (e: Exception) {
-                LOG.debug("storage account not ready, waiting")
+                LOG.debug("Storage account or file share not ready, waiting: ${e.message}")
                 Thread.sleep(5000)
             }
         }
     }
 
     private fun getStorageAccount(): StorageAccount {
-        return azure.storageAccounts().getByResourceGroup(resourceGroup.name(), resourceGroup.restFriendlyName())
-                ?: azure.storageAccounts().define(resourceGroup.restFriendlyName())
-                        .withRegion(resourceGroup.region())
-                        .withExistingResourceGroup(resourceGroup)
-                        .withAccessFromAllNetworks()
-                        .create()
+        val existing = try {
+            azure.storageAccounts().getByResourceGroup(
+                    resourceGroup.name(),
+                    resourceGroup.restFriendlyName()
+            )
+        } catch (ex: ManagementException) {
+            if (ex.response.statusCode == 404) {
+                null
+            } else {
+                throw ex
+            }
+        }
+
+        return existing ?: run {
+            azure.storageAccounts()
+                    .define(storageAccountName)
+                    .withRegion(resourceGroup.region())
+                    .withExistingResourceGroup(resourceGroup)
+                    .withAccessFromAllNetworks()
+                    .withTags(mapOf(
+                            "createdBy" to "Corda Network Builder",
+                            "createdAt" to Instant.now().toString()
+                    ))
+                    .create()
+        }
     }
 
     override fun notariesForNetworkParams(notaries: List<CopiedNotary>) {
-        val networkParamsFile = networkParamsFolder.getFileReference(NETWORK_PARAMS_FILE_NAME)
+        val networkParamsFile = networkParamsFolder.getFileClient(NETWORK_PARAMS_FILE_NAME)
         networkParamsFile.deleteIfExists()
-        LOG.info("Storing network-params in AzureFile location: ${networkParamsFile.uri}")
+        LOG.info("Storing network-params in AzureFile location: ${networkParamsFile.fileUrl}")
         val networkParameters = convertNodeIntoToNetworkParams(notaries.map { it.configFile to it.nodeInfoFile })
         networkParamsFile.uploadFromByteArray(networkParameters.signWithCert(keyPair.private, networkMapCert).serialize().bytes)
     }

--- a/tools/network-builder/src/main/resources/node-Dockerfile
+++ b/tools/network-builder/src/main/resources/node-Dockerfile
@@ -1,4 +1,4 @@
-FROM corda/community:4.10.5-zulu-openjdk
+FROM corda/community:4.10.6-zulu-openjdk8
 
 # Copy corda files
 ADD --chown=corda:corda node.conf               /opt/corda/node.conf

--- a/tools/network-builder/src/main/resources/node-Dockerfile
+++ b/tools/network-builder/src/main/resources/node-Dockerfile
@@ -1,8 +1,15 @@
-FROM corda/corda-zulu-java1.8-4.4
+FROM corda/community:4.10.5-zulu-openjdk
 
 # Copy corda files
 ADD --chown=corda:corda node.conf               /opt/corda/node.conf
 ADD --chown=corda:corda cordapps/               /opt/corda/cordapps
+ADD --chown=corda:corda nodeInfo-*              /opt/corda/
+ADD --chown=corda:corda network-parameters      /opt/corda/
+ADD --chown=corda:corda certificates/           /opt/corda/certificates/
+ADD --chown=corda:corda drivers/                /opt/corda/drivers/
+ADD --chown=corda:corda corda.jar               /opt/corda/
+ADD --chown=corda:corda persistence.mv.db       /opt/corda/
+ADD --chown=corda:corda persistence.trace.db    /opt/corda/
 
 # Copy node info watcher script
 ADD --chown=corda:corda node_info_watcher.sh    /opt/corda/

--- a/tools/network-builder/src/main/resources/node_info_watcher.sh
+++ b/tools/network-builder/src/main/resources/node_info_watcher.sh
@@ -2,11 +2,11 @@
 while [ 1 -lt 2 ]; do
     NODE_INFO=$(ls | grep nodeInfo)
     if [ ${#NODE_INFO} -ge 5 ]; then
-        echo "found nodeInfo copying to additional node node info folder"
+        echo "Found nodeInfo file, copying to additional-node-infos folder."
         cp ${NODE_INFO} additional-node-infos/
         exit 0
     else
-        echo "no node info found waiting"
+        echo "No nodeInfo file found, waiting..."
         fi
     sleep 5
 done

--- a/tools/network-builder/src/main/resources/notary-Dockerfile
+++ b/tools/network-builder/src/main/resources/notary-Dockerfile
@@ -1,4 +1,4 @@
-FROM corda/community:4.10.5-zulu-openjdk
+FROM corda/community:4.10.6-zulu-openjdk8
 
 # Copy corda files
 ADD --chown=corda:corda node.conf               /opt/corda/node.conf

--- a/tools/network-builder/src/main/resources/notary-Dockerfile
+++ b/tools/network-builder/src/main/resources/notary-Dockerfile
@@ -1,9 +1,11 @@
-FROM corda/corda-zulu-4.1
+FROM corda/community:4.10.5-zulu-openjdk
 
 # Copy corda files
 ADD --chown=corda:corda node.conf               /opt/corda/node.conf
 ADD --chown=corda:corda cordapps/               /opt/corda/cordapps
 ADD --chown=corda:corda certificates/           /opt/corda/certificates
+ADD --chown=corda:corda persistence.mv.db       /opt/corda/
+ADD --chown=corda:corda persistence.trace.db    /opt/corda/
 
 # Copy node info watcher script
 ADD --chown=corda:corda node_info_watcher.sh    /opt/corda/


### PR DESCRIPTION
The same changes as in https://github.com/corda/corda/pull/7954 apart from a few Log4j bits in build.gradle .
1. Removed deprecated com.microsoft.azure:azure dependency which contained deprecated MS ADAL library in network-builder.
2. Fixed various issues related to the network builder being obsolete and not working.
[Building a network via the command line](https://docs.r3.com/en/platform/corda/4.12/enterprise/network-builder.html#building-a-network-via-the-command-line) was tested both on Docker and Azure workflows - nodes started up correctly, ran some flows, checked the vault and verified correct output.

GUI seems to be working:
<img width="2021" height="1575" alt="image" src="https://github.com/user-attachments/assets/ca66b180-d4ad-4c2a-a011-79bd10c05db1" />


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
