### PR TITLE
ENT-13851 Make notary change work with confidential identities

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/MoveNotaryFlow.kt
@@ -76,10 +76,11 @@ class MoveNotaryFlow<out T : ContractState>(
     @Suspendable
     override fun call(): List<StateAndRef<T>> {
         progressTracker.currentStep = BUILDING
-        val (stx, participants) = assembleTx()
+        val (stx, participants, myKeys) = assembleTx()
         val sessions = getParticipantSessions(participants)
         progressTracker.currentStep = SIGNING
-        val fullySigned = subFlow(CollectSignaturesFlow(stx, sessions, SIGNING.childProgressTracker()))
+
+        val fullySigned = subFlow(CollectSignaturesFlow(stx, sessions, myKeys, SIGNING.childProgressTracker()))
         progressTracker.currentStep = FINALIZING
         val finalized = subFlow(FinalityFlow(fullySigned, sessions, FINALIZING.childProgressTracker()))
         return finalized.resolveBaseTransaction(serviceHub).outputs
@@ -91,7 +92,7 @@ class MoveNotaryFlow<out T : ContractState>(
      * This assembles the notary change transaction by resolving any encumbered states, adding all inputs and signing it.
      * The original n states are the first n inputs/outputs, states added due to encumbrances are added at the end
      */
-    private fun assembleTx(): Pair<SignedTransaction, Set<AbstractParty>> {
+    private fun assembleTx(): Triple<SignedTransaction, Set<AbstractParty>, Iterable<PublicKey>> {
         require(states.all {
             serviceHub.keyManagementService.filterMyKeys(it.state.data.participants.map { it.owningKey }).toList().isNotEmpty()
         }) { "Cannot request move for state we are not a participant in" }
@@ -108,7 +109,7 @@ class MoveNotaryFlow<out T : ContractState>(
         ).build()
 
         val myKeys = serviceHub.keyManagementService.filterMyKeys(participants.map { it.owningKey })
-        return SignedTransaction(tx, myKeys.map { signTransaction(tx.id, it) }) to participants
+        return Triple(SignedTransaction(tx, myKeys.map { signTransaction(tx.id, it) }), participants, myKeys)
     }
 
     private fun signTransaction(id: SecureHash, key: PublicKey): TransactionSignature {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -227,6 +227,7 @@ dependencies {
     testImplementation project(':client:jfx')
     testImplementation project(':finance:contracts')
     testImplementation project(':finance:workflows')
+    testImplementation project(':testing:cordapps:dummystateworkflows')
     // sample test schemas
     testImplementation project(path: ':finance:contracts', configuration: 'testArtifacts')
     testImplementation project(':testing:cordapps:dbfailure:dbfworkflows')

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -36,12 +36,14 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.singleIdentity
+import net.corda.testing.dummystatecreator.IssueDummyStateMultiparty
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetworkNotarySpec
 import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.MockNodeParameters
 import net.corda.testing.node.StartedMockNode
 import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.cordappWithPackages
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -72,7 +74,7 @@ class MoveNotaryTests {
     fun setUp() {
         mockNet = MockNetwork(MockNetworkParameters(
                 notarySpecs = listOf(MockNetworkNotarySpec(oldNotaryName), MockNetworkNotarySpec(newNotaryName)),
-                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP)
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, cordappWithPackages("net.corda.testing.dummystatecreator"))
         ))
         clientNodeA = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         clientNodeB = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))
@@ -628,6 +630,31 @@ class MoveNotaryTests {
         assertThatThrownBy { flow.call() }
                 .hasMessageContaining("Missing required encumbrance 2 in INPUT, transaction:")
     }
+
+    @Test( timeout = 300_00 )
+    fun `can move notary for states using confidential identities`(){
+        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty)
+        val flow = MoveNotaryFlow(listOf(state), newNotaryParty)
+        val future = clientNodeA.startFlow(flow)
+
+        mockNet.runNetwork()
+
+        val newState = future.getOrThrow().single()
+        assertEquals(newState.state.notary, newNotaryParty)
+        val loadedStateA = clientNodeA.services.loadState(newState.ref)
+        val loadedStateB = clientNodeB.services.loadState(newState.ref)
+        assertEquals(loadedStateA, loadedStateB)
+
+    }
+
+
+    fun issueMultiPartyConfidentialState(nodeA: StartedMockNode, nodeB: StartedMockNode, notaryIdentity: Party) : StateAndRef<DummyContract.MultiOwnerState> {
+        val future = nodeA.startFlow(IssueDummyStateMultiparty( nodeB.info.singleIdentity(), notaryIdentity, true))
+        mockNet.runNetwork()
+
+        return future.get()
+    }
+
 }
 
 fun issueMultiPartyEncumberedState(nodeA: StartedMockNode, nodeB: StartedMockNode, notaryNode: StartedMockNode, notaryIdentity: Party): WireTransaction {
@@ -652,3 +679,4 @@ fun issueMultiPartyEncumberedState(nodeA: StartedMockNode, nodeB: StartedMockNod
 
     return stx.tx
 }
+

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -633,7 +633,23 @@ class MoveNotaryTests {
 
     @Test( timeout = 300_00 )
     fun `can move notary for states using confidential identities`(){
-        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty)
+        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty, IssueDummyStateMultiparty.Confidenitality.OLD)
+        val flow = MoveNotaryFlow(listOf(state), newNotaryParty)
+        val future = clientNodeA.startFlow(flow)
+
+        mockNet.runNetwork()
+
+        val newState = future.getOrThrow().single()
+        assertEquals(newState.state.notary, newNotaryParty)
+        val loadedStateA = clientNodeA.services.loadState(newState.ref)
+        val loadedStateB = clientNodeB.services.loadState(newState.ref)
+        assertEquals(loadedStateA, loadedStateB)
+
+    }
+
+    @Test( timeout = 300_00 )
+    fun `can move notary for states using confidential identities without certs`(){
+        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty, IssueDummyStateMultiparty.Confidenitality.NEW)
         val flow = MoveNotaryFlow(listOf(state), newNotaryParty)
         val future = clientNodeA.startFlow(flow)
 
@@ -648,8 +664,12 @@ class MoveNotaryTests {
     }
 
 
-    fun issueMultiPartyConfidentialState(nodeA: StartedMockNode, nodeB: StartedMockNode, notaryIdentity: Party) : StateAndRef<DummyContract.MultiOwnerState> {
-        val future = nodeA.startFlow(IssueDummyStateMultiparty( nodeB.info.singleIdentity(), notaryIdentity, true))
+    fun issueMultiPartyConfidentialState(
+            nodeA: StartedMockNode,
+            nodeB: StartedMockNode,
+            notaryIdentity: Party,
+            condidentialIdentities: IssueDummyStateMultiparty.Confidenitality = IssueDummyStateMultiparty.Confidenitality.NONE): StateAndRef<DummyContract.MultiOwnerState> {
+        val future = nodeA.startFlow(IssueDummyStateMultiparty(nodeB.info.singleIdentity(), notaryIdentity, condidentialIdentities))
         mockNet.runNetwork()
 
         return future.get()

--- a/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MoveNotaryTests.kt
@@ -37,6 +37,7 @@ import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.dummystatecreator.IssueDummyStateMultiparty
+import net.corda.testing.dummystatecreator.IssueDummyStateMultiparty.Confidentiality
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetworkNotarySpec
 import net.corda.testing.node.MockNetworkParameters
@@ -633,7 +634,7 @@ class MoveNotaryTests {
 
     @Test( timeout = 300_00 )
     fun `can move notary for states using confidential identities`(){
-        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty, IssueDummyStateMultiparty.Confidenitality.OLD)
+        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty, Confidentiality.OLD)
         val flow = MoveNotaryFlow(listOf(state), newNotaryParty)
         val future = clientNodeA.startFlow(flow)
 
@@ -649,7 +650,7 @@ class MoveNotaryTests {
 
     @Test( timeout = 300_00 )
     fun `can move notary for states using confidential identities without certs`(){
-        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty, IssueDummyStateMultiparty.Confidenitality.NEW)
+        val state = issueMultiPartyConfidentialState(clientNodeA, clientNodeB, oldNotaryParty, Confidentiality.NEW)
         val flow = MoveNotaryFlow(listOf(state), newNotaryParty)
         val future = clientNodeA.startFlow(flow)
 
@@ -668,8 +669,8 @@ class MoveNotaryTests {
             nodeA: StartedMockNode,
             nodeB: StartedMockNode,
             notaryIdentity: Party,
-            condidentialIdentities: IssueDummyStateMultiparty.Confidenitality = IssueDummyStateMultiparty.Confidenitality.NONE): StateAndRef<DummyContract.MultiOwnerState> {
-        val future = nodeA.startFlow(IssueDummyStateMultiparty(nodeB.info.singleIdentity(), notaryIdentity, condidentialIdentities))
+            confidentialIdentities: Confidentiality = Confidentiality.NONE): StateAndRef<DummyContract.MultiOwnerState> {
+        val future = nodeA.startFlow(IssueDummyStateMultiparty(nodeB.info.singleIdentity(), notaryIdentity, confidentialIdentities))
         mockNet.runNetwork()
 
         return future.get()

--- a/settings.gradle
+++ b/settings.gradle
@@ -113,6 +113,7 @@ include 'testing:cordapps:missingmigration'
 include 'testing:cordapps:sleeping'
 include 'testing:cordapps:cashobservers'
 include 'testing:cordapps:4.11-workflows'
+include 'testing:cordapps:dummystateworkflows'
 
 // Common libraries - start
 include 'common-validation'

--- a/testing/cordapps/dummystateworkflows/build.gradle
+++ b/testing/cordapps/dummystateworkflows/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+dependencies {
+    implementation project(":core")
+    implementation project(":core-test-utils")
+    implementation project(":confidential-identities")
+    implementation "co.paralleluniverse:quasar-core:$quasar_version"
+}
+
+jar {
+    baseName "dummystate-creation-cordapp"
+}

--- a/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/AgreeConfidentialKeysFlow.kt
+++ b/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/AgreeConfidentialKeysFlow.kt
@@ -1,0 +1,57 @@
+package net.corda.testing.dummystatecreator
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.verify
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.identity.Party
+import net.corda.core.node.services.KeyManagementService
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.unwrap
+import net.corda.testing.core.singleIdentity
+import java.security.PublicKey
+
+/**
+ * This is a simplified mechanism to agree Confidential Identities for a test scenario using the newer mechanism not issuing a certificate
+ * for every key. This class is not safe for production use cases - use the confidential identities SDK if you need this in your CorDapp.
+ */
+class AgreeConfidentialKeysFlow(val counterPartySession: FlowSession) : FlowLogic<Map<Party, AnonymousParty>>() {
+
+    companion object {
+        @CordaSerializable
+        data class SignedKey(val keyBytes: OpaqueBytes, val signature: DigitalSignature)
+
+        fun SignedKey.checkSigAndGetKey(signingKey: PublicKey): PublicKey {
+            require(signingKey.verify(this.keyBytes.bytes, this.signature)) { "The keybytes for the new public key are not signed by the expected party" }
+            return this.keyBytes.deserialize()
+        }
+
+        fun signKey(newKey: PublicKey, signingKey: PublicKey, keyManagementService: KeyManagementService): SignedKey {
+            val serializedKey = newKey.serialize()
+            val sig = keyManagementService.sign(serializedKey.bytes, signingKey)
+            return SignedKey(serializedKey, sig)
+        }
+    }
+
+    @Suspendable
+    override fun call(): Map<Party, AnonymousParty> {
+        val myParty = serviceHub.myInfo.singleIdentity()
+        val counterParty = counterPartySession.counterparty
+
+        val myNewKey = serviceHub.keyManagementService.freshKey()
+
+        val counterPartyKey = counterPartySession.sendAndReceive<SignedKey>(
+                signKey(myNewKey, myParty.owningKey, serviceHub.keyManagementService))
+                .unwrap { it.checkSigAndGetKey(counterParty.owningKey) }
+
+        serviceHub.identityService.registerKey(counterPartyKey, counterParty)
+
+        return mapOf(myParty to AnonymousParty(myNewKey), counterParty to AnonymousParty(counterPartyKey))
+    }
+}
+

--- a/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/IssueDummyStateMultiparty.kt
+++ b/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/IssueDummyStateMultiparty.kt
@@ -22,10 +22,10 @@ import net.corda.testing.core.singleIdentity
 import kotlin.random.Random
 
 @InitiatingFlow
-class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val useConfidentialIdenities: Confidenitality) : FlowLogic<StateAndRef<DummyContract.MultiOwnerState>>() {
+class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val useConfidentialIdenities: Confidentiality) : FlowLogic<StateAndRef<DummyContract.MultiOwnerState>>() {
 
     @CordaSerializable
-    enum class Confidenitality {
+    enum class Confidentiality {
         NONE,
         OLD,
         NEW
@@ -40,8 +40,8 @@ class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val
         val myKeys = mutableListOf(serviceHub.myInfo.singleIdentity().owningKey)
 
         val participants = when (useConfidentialIdenities){
-            Confidenitality.OLD -> subFlow(SwapIdentitiesFlow(session))
-            Confidenitality.NEW -> subFlow(AgreeConfidentialKeysFlow(session))
+            Confidentiality.OLD -> subFlow(SwapIdentitiesFlow(session))
+            Confidentiality.NEW -> subFlow(AgreeConfidentialKeysFlow(session))
             else -> emptyMap<Party, AnonymousParty>()
         }.let {
             if (it.isEmpty())
@@ -67,10 +67,10 @@ class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val
 class IssueDummyStateResponder(val otherSideSession: FlowSession) : FlowLogic<Unit>(){
     @Suspendable
     override fun call() {
-        val useConfidentialIdenities = otherSideSession.receive<IssueDummyStateMultiparty.Confidenitality>().unwrap{it}
+        val useConfidentialIdenities = otherSideSession.receive<IssueDummyStateMultiparty.Confidentiality>().unwrap{it}
         when (useConfidentialIdenities){
-            IssueDummyStateMultiparty.Confidenitality.OLD -> subFlow(SwapIdentitiesFlow(otherSideSession))
-            IssueDummyStateMultiparty.Confidenitality.NEW -> subFlow(AgreeConfidentialKeysFlow(otherSideSession))
+            IssueDummyStateMultiparty.Confidentiality.OLD -> subFlow(SwapIdentitiesFlow(otherSideSession))
+            IssueDummyStateMultiparty.Confidentiality.NEW -> subFlow(AgreeConfidentialKeysFlow(otherSideSession))
             else -> {}
         }
         subFlow(object: SignTransactionFlow(otherSideSession){

--- a/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/IssueDummyStateMultiparty.kt
+++ b/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/IssueDummyStateMultiparty.kt
@@ -1,0 +1,63 @@
+package net.corda.testing.dummystatecreator
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.confidential.SwapIdentitiesFlow
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.CollectSignaturesFlow
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.ReceiveFinalityFlow
+import net.corda.core.flows.SignTransactionFlow
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.unwrap
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.singleIdentity
+import kotlin.random.Random
+
+@InitiatingFlow
+class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val useConfidentialIdenities: Boolean) : FlowLogic<StateAndRef<DummyContract.MultiOwnerState>>() {
+    @Suspendable
+    override fun call(): StateAndRef<DummyContract.MultiOwnerState> {
+        val session = initiateFlow(counterParty)
+
+        session.send(useConfidentialIdenities)
+
+        val myKeys = mutableListOf(serviceHub.myInfo.singleIdentity().owningKey)
+
+        val participants = if (useConfidentialIdenities){
+            val confidentialIdentities = subFlow(SwapIdentitiesFlow(session))
+            myKeys.add(confidentialIdentities[serviceHub.myInfo.singleIdentity()]!!.owningKey)
+            confidentialIdentities.values.toList()
+        } else listOf( serviceHub.myInfo.singleIdentity(), counterParty)
+
+        val tx = TransactionBuilder(notary)
+                .addOutputState(DummyContract.MultiOwnerState(Random.nextInt(), participants))
+                .addCommand(DummyContract.Commands.Create(), participants.map{it.owningKey})
+        val stx = serviceHub.signInitialTransaction(tx, myKeys.last())
+
+        val counterSigned = subFlow(CollectSignaturesFlow(stx, listOf(session), myKeys))
+        val final = subFlow(FinalityFlow(counterSigned, session ))
+        return final.tx.outRef(0)
+    }
+}
+
+@InitiatedBy(IssueDummyStateMultiparty::class)
+class IssueDummyStateResponder(val otherSideSession: FlowSession) : FlowLogic<Unit>(){
+    @Suspendable
+    override fun call() {
+        val useConfidentialIdenities = otherSideSession.receive<Boolean>().unwrap{it}
+        if (useConfidentialIdenities){
+            subFlow(SwapIdentitiesFlow(otherSideSession))
+        }
+        subFlow(object: SignTransactionFlow(otherSideSession){
+            override fun checkTransaction(stx: SignedTransaction) {
+            }
+        })
+        subFlow(ReceiveFinalityFlow(otherSideSession))
+    }
+}

--- a/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/IssueDummyStateMultiparty.kt
+++ b/testing/cordapps/dummystateworkflows/src/main/kotlin/net/corda/testing/dummystatecreator/IssueDummyStateMultiparty.kt
@@ -11,7 +11,9 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.flows.SignTransactionFlow
+import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.unwrap
@@ -20,7 +22,15 @@ import net.corda.testing.core.singleIdentity
 import kotlin.random.Random
 
 @InitiatingFlow
-class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val useConfidentialIdenities: Boolean) : FlowLogic<StateAndRef<DummyContract.MultiOwnerState>>() {
+class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val useConfidentialIdenities: Confidenitality) : FlowLogic<StateAndRef<DummyContract.MultiOwnerState>>() {
+
+    @CordaSerializable
+    enum class Confidenitality {
+        NONE,
+        OLD,
+        NEW
+    }
+
     @Suspendable
     override fun call(): StateAndRef<DummyContract.MultiOwnerState> {
         val session = initiateFlow(counterParty)
@@ -29,11 +39,18 @@ class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val
 
         val myKeys = mutableListOf(serviceHub.myInfo.singleIdentity().owningKey)
 
-        val participants = if (useConfidentialIdenities){
-            val confidentialIdentities = subFlow(SwapIdentitiesFlow(session))
-            myKeys.add(confidentialIdentities[serviceHub.myInfo.singleIdentity()]!!.owningKey)
-            confidentialIdentities.values.toList()
-        } else listOf( serviceHub.myInfo.singleIdentity(), counterParty)
+        val participants = when (useConfidentialIdenities){
+            Confidenitality.OLD -> subFlow(SwapIdentitiesFlow(session))
+            Confidenitality.NEW -> subFlow(AgreeConfidentialKeysFlow(session))
+            else -> emptyMap<Party, AnonymousParty>()
+        }.let {
+            if (it.isEmpty())
+                listOf(serviceHub.myInfo.singleIdentity(), counterParty)
+            else {
+                myKeys.add(it[serviceHub.myInfo.singleIdentity()]!!.owningKey)
+                it.values.toList()
+            }
+        }
 
         val tx = TransactionBuilder(notary)
                 .addOutputState(DummyContract.MultiOwnerState(Random.nextInt(), participants))
@@ -50,9 +67,11 @@ class IssueDummyStateMultiparty (val counterParty: Party, val notary: Party, val
 class IssueDummyStateResponder(val otherSideSession: FlowSession) : FlowLogic<Unit>(){
     @Suspendable
     override fun call() {
-        val useConfidentialIdenities = otherSideSession.receive<Boolean>().unwrap{it}
-        if (useConfidentialIdenities){
-            subFlow(SwapIdentitiesFlow(otherSideSession))
+        val useConfidentialIdenities = otherSideSession.receive<IssueDummyStateMultiparty.Confidenitality>().unwrap{it}
+        when (useConfidentialIdenities){
+            IssueDummyStateMultiparty.Confidenitality.OLD -> subFlow(SwapIdentitiesFlow(otherSideSession))
+            IssueDummyStateMultiparty.Confidenitality.NEW -> subFlow(AgreeConfidentialKeysFlow(otherSideSession))
+            else -> {}
         }
         subFlow(object: SignTransactionFlow(otherSideSession){
             override fun checkTransaction(stx: SignedTransaction) {


### PR DESCRIPTION
Add a test to move notary for a state using confidential identitied and fix the flow so it passes.
Sadly, issuing a state with confidential idenitities needs to be done in a CorDapp.
