### PR TITLE
ENT-13857: Fix ServiceHubMetricsTest

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
@@ -73,8 +73,9 @@ class ServiceHubMetricsTest {
         nodeA = mockNet.restartNode(nodeA, InternalMockNodeParameters(legalName = ALICE_NAME))
         Latch2.latch.countDown()
 
-        val metric = nodeA.internals.metricRegistry.gauges["TestFlow.TestMetric"]
+
         eventuallyAssert {
+            val metric = nodeA.internals.metricRegistry.gauges["TestFlow.TestMetric"]
             assertNotNull(metric)
             assertEquals("Result2", metric.value)
         }


### PR DESCRIPTION
Fix ServiceHubMetricsTest by ensuring the metrics variable is populated every time it tries to reassert
# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs/kdocs?
- [x] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
