### PR TITLE
ENT-13857: add missing await call into the test flow

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
@@ -92,8 +92,8 @@ class ServiceHubMetricsTest {
     class TestFlow(private val externalLatch: ExternalLatch, private val metric : String) : FlowLogic<String>() {
         @Suspendable
         override fun call(): String {
+            await(ExternalOperation(externalLatch))// Wait for the latch to be released
             registerMetricFromFlow(metric)
-            ExternalOperation(externalLatch)// Wait for the latch to be released
             return getMetricFromFlow()
         }
 

--- a/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
@@ -73,6 +73,7 @@ class ServiceHubMetricsTest {
             var registry: MetricRegistry? = null
             if(getMetricsRegistryDirectly) {
                 registry = serviceHub.getMetricsRegistry(MetricRegistry::class.java)
+                registry.gauges["TestFlow.TestMetric"]?.value as String
             }
             sleep(Duration.ZERO)
             return getMetricFromFlow()

--- a/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
@@ -7,7 +7,6 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.utilities.getOrThrow
 import com.codahale.metrics.Gauge
-import net.corda.core.flows.FlowExternalAsyncOperation
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.InternalMockNetwork
@@ -19,26 +18,15 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import java.time.Duration
-import java.time.Instant
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class ServiceHubMetricsTest {
     private lateinit var mockNet: InternalMockNetwork
     private lateinit var nodeA: TestStartedNode
 
-    interface ExternalLatch {
-        val latch: CountDownLatch
-    }
-
-    object Latch1 : ExternalLatch {
-        override val latch = CountDownLatch(0)
-    }
-    object Latch2 : ExternalLatch {
-        override val latch = CountDownLatch(1)
-    }
     @Before
     fun start() {
         mockNet = InternalMockNetwork(
@@ -57,8 +45,8 @@ class ServiceHubMetricsTest {
     }
 
     @Test(timeout=300_000)
-    fun `Can register metrics from a flow`() {
-        val result = nodeA.services.startFlow(TestFlow(Latch1, "Result")).resultFuture.getOrThrow()
+    fun `no metrics on stack can checkpoint`() {
+        val result = nodeA.services.startFlow(TestFlow(false, "Result")).resultFuture.getOrThrow()
         val metric = nodeA.internals.metricRegistry.gauges["TestFlow.TestMetric"]
 
         assertNotNull(result)
@@ -68,32 +56,25 @@ class ServiceHubMetricsTest {
     }
 
     @Test(timeout=300_000)
-    fun `Can checkpoint`() {
-        nodeA.services.startFlow(TestFlow(Latch2, "Result2"))
-        nodeA = mockNet.restartNode(nodeA, InternalMockNodeParameters(legalName = ALICE_NAME))
-        Latch2.latch.countDown()
-
-
-        eventuallyAssert {
-            val metric = nodeA.internals.metricRegistry.gauges["TestFlow.TestMetric"]
-            assertNotNull(metric)
-            assertEquals("Result2", metric.value)
+    fun `metrics on stack cannot checkpoint`() {
+        val exception = assertFailsWith<com.esotericsoftware.kryo.KryoException> {
+            nodeA.services.startFlow(TestFlow(true, "Result")).resultFuture.getOrThrow()
         }
-    }
+        assertTrue(exception.message!!.contains("com.codahale.metrics.MetricRegistry"))
 
-    class ExternalOperation(val externalLatch: ExternalLatch) : FlowExternalAsyncOperation<Unit> {
-        override fun execute(deduplicationId: String): CompletableFuture<Unit> {
-            return externalLatch.latch.asCompletableFuture()
-        }
     }
 
     @StartableByRPC
     @InitiatingFlow
-    class TestFlow(private val externalLatch: ExternalLatch, private val metric : String) : FlowLogic<String>() {
+    class TestFlow(private val getMetricsRegistryDirectly: Boolean, private val metric : String) : FlowLogic<String>() {
         @Suspendable
         override fun call(): String {
-            await(ExternalOperation(externalLatch))// Wait for the latch to be released
             registerMetricFromFlow(metric)
+            var registry: MetricRegistry? = null
+            if(getMetricsRegistryDirectly) {
+                registry = serviceHub.getMetricsRegistry(MetricRegistry::class.java)
+            }
+            sleep(Duration.ZERO)
             return getMetricFromFlow()
         }
 
@@ -108,39 +89,4 @@ class ServiceHubMetricsTest {
             return serviceHub.getMetricsRegistry(MetricRegistry::class.java).gauges["TestFlow.TestMetric"]?.value as String
         }
     }
-}
-
-private fun eventuallyAssert(
-        timeout: Duration = Duration.ofSeconds(30),
-        pollInterval: Duration = Duration.ofMillis(100),
-        assertions: () -> Unit,
-) {
-    val deadline = Instant.now().plus(timeout)
-    var lastError: Throwable? = null
-
-    while (Instant.now().isBefore(deadline)) {
-        try {
-            assertions()
-            return  // Success
-        } catch (e: Throwable) {
-            lastError = e
-            Thread.sleep(pollInterval.toMillis())
-        }
-    }
-
-    // If we get here, we've timed out - throw the last error
-    throw AssertionError("Assertions failed after ${timeout.seconds} seconds", lastError)
-}
-fun CountDownLatch.asCompletableFuture(): CompletableFuture<Unit> {
-    val future = CompletableFuture<Unit>()
-    Thread {
-        try {
-            this.await()
-            future.complete(Unit)
-        } catch (e: InterruptedException) {
-            future.completeExceptionally(e)
-            Thread.currentThread().interrupt()
-        }
-    }.start()
-    return future
 }

--- a/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/node/ServiceHubMetricsTest.kt
@@ -70,7 +70,7 @@ class ServiceHubMetricsTest {
         @Suspendable
         override fun call(): String {
             registerMetricFromFlow(metric)
-            var registry: MetricRegistry? = null
+            val registry: MetricRegistry?
             if(getMetricsRegistryDirectly) {
                 registry = serviceHub.getMetricsRegistry(MetricRegistry::class.java)
                 registry.gauges["TestFlow.TestMetric"]?.value as String


### PR DESCRIPTION
add missing await call into the test flow

# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs/kdocs?
- [x] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
