### PR TITLE
ENT-13924 - Artemis upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,6 +233,8 @@ allprojects {
     apply plugin: 'org.owasp.dependencycheck'
     apply plugin: 'org.sonarqube'
 
+    tasks.register("allDependencies", DependencyReportTask) {}
+
     allOpen {
         annotations(
                 "javax.persistence.Entity",

--- a/constants.properties
+++ b/constants.properties
@@ -42,7 +42,7 @@ tcnativeVersion=2.0.48.Final
 # We must configure it manually to use the latest capsule version.
 capsuleVersion=1.0.4_r3
 asmVersion=9.5
-artemisVersion=2.36.0
+artemisVersion=2.42.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.17.2
 jacksonKotlinVersion=2.17.0

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/DeduplicationChecker.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/DeduplicationChecker.kt
@@ -25,7 +25,7 @@ class DeduplicationChecker(cacheExpiry: Duration, name: String = "DeduplicationC
      * @return true if the message is unique, false if it's a duplicate.
      */
     fun checkDuplicateMessageId(identity: Any, sequenceNumber: Long): Boolean {
-        return watermarkCache[identity]!!.getAndUpdate { maxOf(sequenceNumber, it) } >= sequenceNumber
+        return watermarkCache[identity].getAndUpdate { maxOf(sequenceNumber, it) } >= sequenceNumber
     }
 }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt
@@ -61,7 +61,10 @@ class HibernateConfiguration(
     }
 
     /** @param key must be immutable, not just read-only. */
-    fun sessionFactoryForSchemas(key: Set<MappedSchema>): SessionFactory = sessionFactories.get(key, ::makeSessionFactoryForSchemas)!!
+    fun sessionFactoryForSchemas(key: Set<MappedSchema>): SessionFactory {
+        return sessionFactories.get(key, ::makeSessionFactoryForSchemas)
+                ?: throw NullPointerException("No session factory found for key [$key]")
+    }
 
     private fun makeSessionFactoryForSchemas(schemas: Set<MappedSchema>): SessionFactory {
         val sessionFactory = sessionFactoryFactory.makeSessionFactoryForSchemas(schemas, customClassLoader, attributeConverters, allowHibernateToManageAppSchema)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/revocation/CertDistPointCrlSource.kt
@@ -106,7 +106,7 @@ class CertDistPointCrlSource(cacheSize: Long = DEFAULT_CACHE_SIZE,
     }
 
     private fun getPossibleCRL(uri: URI): X509CRL {
-        return cache[uri]!!
+        return cache[uri] ?: throw NullPointerException("No CRL found for uri [$uri]")
     }
 
     // DistributionPointFetcher.verifyCRL

--- a/node/src/main/kotlin/net/corda/node/internal/security/RPCPermissionResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/security/RPCPermissionResolver.kt
@@ -114,12 +114,12 @@ internal object RPCPermissionResolver : PermissionResolver {
             .build(InterfaceMethodMapCacheLoader())
 
     private class InterfaceMethodMapCacheLoader : CacheLoader<String, Map<String, Set<String>>> {
-        override fun load(interfaceName: String): Map<String, Set<String>>? {
+        override fun load(interfaceName: String): Map<String, Set<String>> {
             return try {
                 inspectInterface(interfaceName)
             } catch (ex: Exception) {
                 logger.error("Unexpected error when populating cache for $interfaceName", ex)
-                null
+                emptyMap()
             }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/migration/MigrationNamedCacheFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/MigrationNamedCacheFactory.kt
@@ -19,7 +19,7 @@ class MigrationNamedCacheFactory(private val metricRegistry: MetricRegistry?,
     override fun bindWithMetrics(metricRegistry: MetricRegistry) = MigrationNamedCacheFactory(metricRegistry, this.nodeConfiguration)
     override fun bindWithConfig(nodeConfiguration: NodeConfiguration) = MigrationNamedCacheFactory(this.metricRegistry, nodeConfiguration)
 
-    private fun <K, V> configuredForNamed(caffeine: Caffeine<K, V>, name: String): Caffeine<K, V> {
+    private fun <K : Any, V : Any> configuredForNamed(caffeine: Caffeine<K, V>, name: String): Caffeine<K, V> {
         return when(name) {
             "HibernateConfiguration_sessionFactories" -> caffeine.maximumSize(
                     nodeConfiguration?.database?.mappedSchemaCacheSize ?: DatabaseConfig.Defaults.mappedSchemaCacheSize

--- a/node/src/main/kotlin/net/corda/node/services/attachments/NodeAttachmentTrustCalculator.kt
+++ b/node/src/main/kotlin/net/corda/node/services/attachments/NodeAttachmentTrustCalculator.kt
@@ -61,7 +61,7 @@ class NodeAttachmentTrustCalculator(
                 )
                 (attachmentStorage.queryAttachments(queryCriteria).isNotEmpty() ||
                     calculateTrustUsingRotatedKeys(signer))
-            }!!
+            }
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -319,8 +319,8 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = database.transaction {
-        if (nameToParty[name]?.isPresent == true) {
-            nameToParty[name]?.get()
+        if (nameToParty[name].isPresent == true) {
+            nameToParty[name].get()
         }
         else {
             retrievePartyFromArchive(name)

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -152,7 +152,7 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
         return database.transaction { queryByLegalName(session, name) }.sortedByDescending { it.serial }
     }
 
-    override fun getNodesByLegalIdentityKey(identityKey: PublicKey): List<NodeInfo> = nodesByKeyCache[identityKey]!!
+    override fun getNodesByLegalIdentityKey(identityKey: PublicKey): List<NodeInfo> = nodesByKeyCache[identityKey]
 
     private val nodesByKeyCache = NonInvalidatingCache<PublicKey, List<NodeInfo>>(
             cacheFactory = cacheFactory,
@@ -171,7 +171,7 @@ open class PersistentNetworkMapCache(cacheFactory: NamedCacheFactory,
     }
 
     override fun getPeerCertificateByLegalName(name: CordaX500Name): PartyAndCertificate? {
-        return identityByLegalNameCache.get(name)!!.orElse(null)
+        return identityByLegalNameCache.get(name).orElse(null)
     }
 
     private val identityByLegalNameCache = NonInvalidatingCache<CordaX500Name, Optional<PartyAndCertificate>>(

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentPartyInfoCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentPartyInfoCache.kt
@@ -56,25 +56,37 @@ class PersistentPartyInfoCache(private val networkMapCache: PersistentNetworkMap
 
     private fun updateInfoDB(partyHashCode: SecureHash, partyName: CordaX500Name) {
         database.transaction {
-            if (queryByPartyId(session, partyHashCode) == null) {
+            try {
+                queryByPartyId(session, partyHashCode)
+            } catch (_ : IllegalStateException) {
                 session.save(DBTransactionStorageLedgerRecovery.DBRecoveryPartyInfo(partyHashCode.toString(), partyName.toString()))
             }
         }
     }
 
-    private fun queryByCordaX500Name(session: Session, key: CordaX500Name): SecureHash? {
+    private fun queryByCordaX500Name(session: Session, key: CordaX500Name): SecureHash {
         val query = session.createQuery(
                 "FROM ${DBTransactionStorageLedgerRecovery.DBRecoveryPartyInfo::class.java.name} WHERE partyName = :partyName",
                 DBTransactionStorageLedgerRecovery.DBRecoveryPartyInfo::class.java)
         query.setParameter("partyName", key.toString())
-        return query.resultList.singleOrNull()?.let { SecureHash.parse(it.partyId) }
+        if (query.resultList.count() == 1) {
+            return query.resultList.first().let { SecureHash.parse(it.partyId) }
+        } else {
+            // TBD - IDK how better to handle this
+            throw IllegalStateException("Database query by X500 name returned != 1 result")
+        }
     }
 
-    private fun queryByPartyId(session: Session, key: SecureHash): CordaX500Name? {
+    private fun queryByPartyId(session: Session, key: SecureHash): CordaX500Name {
         val query = session.createQuery(
                 "FROM ${DBTransactionStorageLedgerRecovery.DBRecoveryPartyInfo::class.java.name} WHERE partyId = :partyId",
                 DBTransactionStorageLedgerRecovery.DBRecoveryPartyInfo::class.java)
         query.setParameter("partyId", key.toString())
-        return query.resultList.singleOrNull()?.partyName?.let { CordaX500Name.parse(it) }
+        if (query.resultList.count() == 1) {
+            return query.resultList.first().partyName.let { CordaX500Name.parse(it) }
+        } else {
+            // TBD - IDK how better to handle this
+            throw IllegalStateException("Database query by party ID returned != 1 result")
+        }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -327,7 +327,7 @@ class NodeAttachmentService @JvmOverloads constructor(
     }
 
     override fun openAttachment(id: SecureHash): Attachment? {
-        val content = attachmentContentCache.get(id)!!
+        val content = attachmentContentCache.get(id)
         if (content.isPresent) {
             return content.get().first
         }

--- a/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
@@ -39,7 +39,7 @@ abstract class AppendOnlyPersistentMapBase<K : Any, V, E, out EK>(
     /**
      * Returns the value associated with the key, first loading that value from the storage if necessary.
      */
-    operator fun get(key: K): V? = cache.get(key)?.orElse(null)
+    operator fun get(key: K): V? = cache.get(key).orElse(null)
 
     val size: Long get() = allPersisted.use { it.count() }
 

--- a/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
@@ -82,13 +82,13 @@ open class DefaultNamedCacheFactory protected constructor(private val metricRegi
     @Suppress("UNCHECKED_CAST")
     override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         checkState(name)
-        return configuredForNamed(caffeine as Caffeine<K, V>, name).build<K, V>()
+        return configuredForNamed(caffeine as Caffeine<K, V>, name).build()
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         checkState(name)
-        return configuredForNamed(caffeine as Caffeine<K, V>, name).build<K, V>(loader)
+        return configuredForNamed(caffeine as Caffeine<K, V>, name).build(loader)
     }
 
     protected open val defaultCacheSize = 1024L

--- a/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NodeNamedCache.kt
@@ -34,7 +34,7 @@ open class DefaultNamedCacheFactory protected constructor(private val metricRegi
     override fun bindWithConfig(nodeConfiguration: NodeConfiguration): BindableNamedCacheFactory = DefaultNamedCacheFactory(this.metricRegistry, nodeConfiguration)
 
     @Suppress("ComplexMethod")
-    protected open fun <K, V> configuredForNamed(caffeine: Caffeine<K, V>, name: String): Caffeine<K, V> {
+    protected open fun <K : Any, V : Any> configuredForNamed(caffeine: Caffeine<K, V>, name: String): Caffeine<K, V> {
         return with(nodeConfiguration!!) {
             when {
                 name.startsWith("RPCSecurityManagerShiroCache_") -> with(security?.authService?.options?.cache!!) { caffeine.maximumSize(maxEntries).expireAfterWrite(expireAfterSecs, TimeUnit.SECONDS) }
@@ -79,14 +79,16 @@ open class DefaultNamedCacheFactory protected constructor(private val metricRegi
         checkNotNull(nodeConfiguration)
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String): Cache<K, V> {
         checkState(name)
-        return configuredForNamed(caffeine, name).build<K, V>()
+        return configuredForNamed(caffeine as Caffeine<K, V>, name).build<K, V>()
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun <K : Any, V : Any> buildNamed(caffeine: Caffeine<in K, in V>, name: String, loader: CacheLoader<K, V>): LoadingCache<K, V> {
         checkState(name)
-        return configuredForNamed(caffeine, name).build<K, V>(loader)
+        return configuredForNamed(caffeine as Caffeine<K, V>, name).build<K, V>(loader)
     }
 
     protected open val defaultCacheSize = 1024L

--- a/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingCache.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingCache.kt
@@ -7,16 +7,16 @@ import com.github.benmanes.caffeine.cache.Weigher
 import net.corda.core.internal.NamedCacheFactory
 
 class NonInvalidatingCache<K : Any, V : Any> private constructor(val cache: LoadingCache<K, V>) : LoadingCache<K, V> by cache {
-    constructor(cacheFactory: NamedCacheFactory, name: String, loadFunction: (K) -> V?) : this(buildCache(cacheFactory, name, loadFunction))
+    constructor(cacheFactory: NamedCacheFactory, name: String, loadFunction: (K) -> V) : this(buildCache(cacheFactory, name, loadFunction))
 
     private companion object {
-        private fun <K : Any, V : Any> buildCache(cacheFactory: NamedCacheFactory, name: String, loadFunction: (K) -> V?): LoadingCache<K, V> {
+        private fun <K : Any, V : Any> buildCache(cacheFactory: NamedCacheFactory, name: String, loadFunction: (K) -> V): LoadingCache<K, V> {
             return cacheFactory.buildNamed(name, NonInvalidatingCacheLoader(loadFunction))
         }
     }
 
     // TODO look into overriding loadAll() if we ever use it
-    class NonInvalidatingCacheLoader<K : Any, V : Any>(val loadFunction: (K) -> V?) : CacheLoader<K, V> {
+    class NonInvalidatingCacheLoader<K : Any, V : Any>(val loadFunction: (K) -> V) : CacheLoader<K, V> {
         override fun reload(key: K, oldValue: V): V {
             throw IllegalStateException("Non invalidating cache refreshed")
         }
@@ -26,14 +26,14 @@ class NonInvalidatingCache<K : Any, V : Any> private constructor(val cache: Load
 }
 
 class NonInvalidatingWeightBasedCache<K : Any, V : Any> private constructor(val cache: LoadingCache<K, V>) : LoadingCache<K, V> by cache {
-    constructor(cacheFactory: NamedCacheFactory, name: String, weigher: Weigher<K, V>, loadFunction: (K) -> V?) :
+    constructor(cacheFactory: NamedCacheFactory, name: String, weigher: Weigher<K, V>, loadFunction: (K) -> V) :
             this(buildCache(cacheFactory, name, weigher, loadFunction))
 
     private companion object {
         private fun <K : Any, V : Any> buildCache(cacheFactory: NamedCacheFactory,
                                                   name: String,
                                                   weigher: Weigher<K, V>,
-                                                  loadFunction: (K) -> V?): LoadingCache<K, V> {
+                                                  loadFunction: (K) -> V): LoadingCache<K, V> {
             val builder = Caffeine.newBuilder().weigher(weigher)
             return cacheFactory.buildNamed(builder, name, NonInvalidatingCache.NonInvalidatingCacheLoader(loadFunction))
         }

--- a/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingUnboundCache.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingUnboundCache.kt
@@ -10,7 +10,7 @@ import net.corda.core.internal.NamedCacheFactory
 class NonInvalidatingUnboundCache<K : Any, V : Any> private constructor(val cache: LoadingCache<K, V>) : LoadingCache<K, V> by cache {
     constructor(name: String,
                 cacheFactory: NamedCacheFactory,
-                loadFunction: (K) -> V?,
+                loadFunction: (K) -> V,
                 removalListener: RemovalListener<K, V> = RemovalListener { _, _, _ -> },
                 keysToPreload: () -> Iterable<K> = { emptyList() }) :
             this(buildCache(name, cacheFactory, loadFunction, removalListener, keysToPreload))
@@ -18,7 +18,7 @@ class NonInvalidatingUnboundCache<K : Any, V : Any> private constructor(val cach
     private companion object {
         private fun <K : Any, V : Any> buildCache(name: String,
                                                   cacheFactory: NamedCacheFactory,
-                                                  loadFunction: (K) -> V?,
+                                                  loadFunction: (K) -> V,
                                                   removalListener: RemovalListener<K, V>,
                                                   keysToPreload: () -> Iterable<K>): LoadingCache<K, V> {
             val builder = Caffeine.newBuilder().removalListener(removalListener).executor(SameThreadExecutor.getExecutor())
@@ -29,7 +29,7 @@ class NonInvalidatingUnboundCache<K : Any, V : Any> private constructor(val cach
     }
 
     // TODO look into overriding loadAll() if we ever use it
-    private class NonInvalidatingCacheLoader<K : Any, V : Any>(val loadFunction: (K) -> V?) : CacheLoader<K, V> {
+    private class NonInvalidatingCacheLoader<K : Any, V : Any>(val loadFunction: (K) -> V) : CacheLoader<K, V> {
         override fun reload(key: K, oldValue: V): V {
             throw IllegalStateException("Non invalidating cache refreshed")
         }

--- a/node/src/main/kotlin/net/corda/node/utilities/PersistentMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/PersistentMap.kt
@@ -38,7 +38,7 @@ class PersistentMap<K : Any, V : Any, E, out EK>(
         cache.getAll(session.createQuery(criteriaQuery).resultList.map { e -> fromPersistentEntity(e as E).first }.asIterable())
     }
 
-    class ExplicitRemoval<K, V, E, EK>(private val toPersistentEntityKey: (K) -> EK, private val persistentEntityClass: Class<E>) : RemovalListener<K, V> {
+    class ExplicitRemoval<K : Any, V : Any, E, EK>(private val toPersistentEntityKey: (K) -> EK, private val persistentEntityClass: Class<E>) : RemovalListener<K, V> {
         override fun onRemoval(key: K?, value: V?, cause: RemovalCause) {
             when (cause) {
                 RemovalCause.EXPLICIT -> {
@@ -58,7 +58,7 @@ class PersistentMap<K : Any, V : Any, E, out EK>(
     }
 
     override operator fun get(key: K): V? {
-        return cache.get(key)!!.orElse(null)
+        return cache.get(key).orElse(null)
     }
 
     fun all(): Sequence<Pair<K, V>> {
@@ -121,7 +121,7 @@ class PersistentMap<K : Any, V : Any, E, out EK>(
      * Removes the mapping for the specified key from this map and underlying storage if present.
      */
     override fun remove(key: K): V? {
-        val result = cache.get(key)!!.orElse(null)
+        val result = cache.get(key).orElse(null)
         cache.invalidate(key)
         return result
     }
@@ -213,7 +213,7 @@ class PersistentMap<K : Any, V : Any, E, out EK>(
     override fun put(key: K, value: V): V? {
         val old = cache.get(key)
         set(key, value)
-        return old!!.orElse(null)
+        return old.orElse(null)
     }
 
     fun load() {


### PR DESCRIPTION
Upgraded Artemis to get past numerous security issues.
A consequence of this is that Artemis upgrades the dependency on Caffeine from 3.1.8 to 3.2.1, which sees a change to the nullability of Caffeine's type-arguments - basically they were previously nullable, now they are not.
The bulk of these changes are for removing unnecessary null checks , and updating cache-related functions to manage without nullable type arguments. For the most part these changes followed the guidance of the Intelli-J IDE.
Draft PR to see how the tests fare.