### PR TITLE
ENT-13924 - Artemis upgrade, preserve Caffeine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,8 @@ logger.lifecycle("Quasar classifier: {}", quasar_classifier.toString())
 logger.lifecycle("Building Corda version: {}", corda_release_version)
 logger.lifecycle("User home: {}", System.getProperty('user.home'))
 
+def projectsToExcludeFromCaffeineForcing = ['legacy411','legacy412']
+
 allprojects {
     apply plugin: 'java'
     apply plugin: 'kotlin-allopen'
@@ -451,6 +453,16 @@ allprojects {
                     // force-upgrade to latest json-smart@2.5.2
                     if (details.requested.group == 'net.minidev' && details.requested.name == 'json-smart') {
                         details.useVersion json_smart_version
+                    }
+
+                    // Artemis was upgraded to 2.42.0 to address numerous security issues. However, this pulls in and upgrade
+                    // to Caffeine 3.1.8 to 3.2.1, which causes a plethora of compiler warnings.
+                    // For simplicity, force the caffeine version back to 3.1.8.
+                    // Remove this when it's decided to embrace the newer version of Caffeine.
+                    if (details.requested.group == 'com.github.ben-manes.caffeine' && details.requested.name == 'caffeine') {
+                        if (!projectsToExcludeFromCaffeineForcing.contains(project.name)) {
+                            details.useVersion caffeine_version
+                        }
                     }
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -455,10 +455,11 @@ allprojects {
                         details.useVersion json_smart_version
                     }
 
-                    // Artemis was upgraded to 2.42.0 to address numerous security issues. However, this pulls in and upgrade
+                    // Artemis was upgraded to 2.42.0 to address numerous security issues. However, this pulls in an upgrade
                     // to Caffeine 3.1.8 to 3.2.1, which causes a plethora of compiler warnings.
-                    // For simplicity, force the caffeine version back to 3.1.8.
-                    // Remove this when it's decided to embrace the newer version of Caffeine.
+                    // For simplicity, force the caffeine version back to 3.1.8, but exclude the legacy projects that
+                    // require a JDK8-compatible version of Caffeine.
+                    // Remove this when it's decided to fully embrace the newer version of Caffeine.
                     if (details.requested.group == 'com.github.ben-manes.caffeine' && details.requested.name == 'caffeine') {
                         if (!projectsToExcludeFromCaffeineForcing.contains(project.name)) {
                             details.useVersion caffeine_version

--- a/constants.properties
+++ b/constants.properties
@@ -42,7 +42,7 @@ tcnativeVersion=2.0.48.Final
 # We must configure it manually to use the latest capsule version.
 capsuleVersion=1.0.4_r3
 asmVersion=9.5
-artemisVersion=2.36.0
+artemisVersion=2.42.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.17.2
 jacksonKotlinVersion=2.17.0

--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentRule.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentRule.kt
@@ -28,7 +28,7 @@ class SerializationEnvironmentRule(private val inheritable: Boolean = false) : T
     companion object {
         init {
             // Can't turn it off, and it creates threads that do serialization, so hack it:
-            InVMConnector::class.staticField<ExecutorService>("threadPoolExecutor").value = rigorousMock<ExecutorService>()
+            InVMConnector::class.staticField<ExecutorService>("executorService").value = rigorousMock<ExecutorService>()
                     .also {
                 doAnswer {
                     inVMExecutors.computeIfAbsent(effectiveSerializationEnv) {

--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/internal/CheckpointSerializationTestHelpers.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/internal/CheckpointSerializationTestHelpers.kt
@@ -28,7 +28,7 @@ class CheckpointSerializationEnvironmentRule(private val inheritable: Boolean = 
     companion object {
         init {
             // Can't turn it off, and it creates threads that do serialization, so hack it:
-            InVMConnector::class.staticField<ExecutorService>("threadPoolExecutor").value = rigorousMock<ExecutorService>()
+            InVMConnector::class.staticField<ExecutorService>("executorService").value = rigorousMock<ExecutorService>()
                     .also {
                 doAnswer {
                     inVMExecutors.computeIfAbsent(effectiveSerializationEnv) {


### PR DESCRIPTION
Upgraded Artemis to get past numerous security issues.
A consequence of this is that Artemis upgrades the dependency on Caffeine from 3.1.8 to 3.2.1, which causes a plethora of compiler warnings.
The changes presented here forcibly keep Caffeine at 3.1.8, except for the legacy sub-projects which require a JDK8-compatible version of Caffeine.