### PR TITLE
ENT-13929: Notary instruction component group

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -7575,7 +7575,6 @@ public abstract class net.corda.core.transactions.FullTransaction extends net.co
 public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
   public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
   public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
-  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters, java.util.List, java.util.List, java.util.List, java.util.List, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function2, net.corda.core.serialization.internal.AttachmentsClassLoaderCache, net.corda.core.crypto.DigestService, kotlin.jvm.internal.DefaultConstructorMarker)
   public final java.util.List commandsOfType()
   @NotNull
   public final java.util.List commandsOfType(Class)

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION", "unused")
 
 package net.corda.client.jackson.internal
 
@@ -51,6 +51,7 @@ import net.corda.core.contracts.AttachmentConstraint
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
@@ -132,6 +133,7 @@ class CordaModule : SimpleModule("corda-core") {
         context.setMixInAnnotations(TransactionState::class.java, TransactionStateMixin::class.java)
         context.setMixInAnnotations(Command::class.java, CommandMixin::class.java)
         context.setMixInAnnotations(TimeWindow::class.java, TimeWindowMixin::class.java)
+        context.setMixInAnnotations(NotaryInstruction::class.java, NotaryInstructionMixin::class.java)
         context.setMixInAnnotations(PrivacySalt::class.java, PrivacySaltMixin::class.java)
         context.setMixInAnnotations(SignatureScheme::class.java, SignatureSchemeMixin::class.java)
         context.setMixInAnnotations(SignatureMetadata::class.java, SignatureMetadataMixin::class.java)
@@ -143,6 +145,7 @@ class CordaModule : SimpleModule("corda-core") {
 }
 
 private class CordaSerializableClassIntrospector(private val context: Module.SetupContext) : BasicClassIntrospector() {
+    @Deprecated("Deprecated in Java")
     override fun constructPropertyCollector(
             config: MapperConfig<*>?,
             ac: AnnotatedClass?,
@@ -270,7 +273,8 @@ private class WireTransactionSerializer : JsonSerializer<WireTransaction>() {
                 value.legacyAttachments.map { "$it-legacy" } + value.nonLegacyAttachments.map { it.toString() },
                 value.references,
                 value.privacySalt,
-                value.networkParametersHash
+                value.networkParametersHash,
+                value.notaryInstructions
         ))
     }
 }
@@ -289,24 +293,27 @@ private class WireTransactionDeserializer : JsonDeserializer<WireTransaction>() 
                 wrapper.timeWindow,
                 wrapper.references,
                 wrapper.networkParametersHash,
-                legacyAttachments.map { SecureHash.parse(it.removeSuffix("-legacy")) }
+                legacyAttachments.map { SecureHash.parse(it.removeSuffix("-legacy")) },
+                wrapper.notaryInstructions
         )
         return WireTransaction(componentGroups, wrapper.privacySalt, wrapper.digestService ?: DigestService.sha2_256)
     }
 }
 
-private class WireTransactionJson(@get:JsonInclude(Include.NON_NULL) val digestService: DigestService?,
-                                  val id: SecureHash,
-                                  val notary: Party?,
-                                  val inputs: List<StateRef>,
-                                  val outputs: List<TransactionState<*>>,
-                                  val commands: List<Command<*>>,
-                                  val timeWindow: TimeWindow?,
-                                  val attachments: List<String>,
-                                  val references: List<StateRef>,
-                                  val privacySalt: PrivacySalt,
-                                  val networkParametersHash: SecureHash?
-)
+private class WireTransactionJson(
+        @get:JsonInclude(Include.NON_NULL) val digestService: DigestService?,
+        val id: SecureHash,
+        val notary: Party?,
+        val inputs: List<StateRef>,
+        val outputs: List<TransactionState<*>>,
+        val commands: List<Command<*>>,
+        val timeWindow: TimeWindow?,
+        val attachments: List<String>,
+        val references: List<StateRef>,
+        val privacySalt: PrivacySalt,
+        val networkParametersHash: SecureHash?,
+        val notaryInstructions: List<NotaryInstruction>
+ )
 
 private interface TransactionStateMixin {
     @get:JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
@@ -337,6 +344,9 @@ private class TimeWindowDeserializer : JsonDeserializer<TimeWindow>() {
 }
 
 private data class TimeWindowJson(val fromTime: Instant?, val untilTime: Instant?)
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+private interface NotaryInstructionMixin
 
 @JsonSerialize(using = PrivacySaltSerializer::class)
 @JsonDeserialize(using = PrivacySaltDeserializer::class)
@@ -393,7 +403,6 @@ private class PartialTreeSerializer : JsonSerializer<PartialTree>() {
             is PartialTree.IncludedLeaf -> PartialTreeJson(includedLeaf = tree.hash)
             is PartialTree.Leaf -> PartialTreeJson(leaf = tree.hash)
             is PartialTree.Node -> PartialTreeJson(left = convert(tree.left), right = convert(tree.right), hashAlgorithm = tree.hashAlgorithm)
-            else -> throw IllegalArgumentException("Don't know how to serialize $tree")
         }
     }
 }

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -13,6 +13,7 @@ import net.corda.client.jackson.internal.valueAs
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
@@ -193,7 +194,7 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         // The contents of the file were written out as follows:
 //        ClassNotOnClasspath(BOB_NAME, 54321).serialize().open().copyTo("build" / "class-not-on-classpath-data")
 
-        val serializedBytes = SerializedBytes<Any>(javaClass.getResource("class-not-on-classpath-data").readBytes())
+        val serializedBytes = SerializedBytes<Any>(javaClass.getResource("class-not-on-classpath-data")!!.readBytes())
         val json = mapper.valueToTree<ObjectNode>(serializedBytes)
         println(mapper.writeValueAsString(json))
         assertThat(json["class"].textValue()).isEqualTo("net.corda.client.jackson.JacksonSupportTest\$ClassNotOnClasspath")
@@ -280,6 +281,8 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
 
     @Test(timeout=300_000)
 	fun `SignedTransaction (WireTransaction)`() {
+        data class FakeNotaryInstruction(val instr: String) : NotaryInstruction
+
         val attachmentId = SecureHash.randomSHA256()
 
         val wtx = TransactionBuilder(
@@ -291,14 +294,27 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
                 window = TimeWindow.fromStartAndDuration(Instant.now(), 1.hours),
                 references = mutableListOf(StateRef(SecureHash.randomSHA256(), 0)),
                 privacySalt = net.corda.core.contracts.PrivacySalt()
-        ).toWireTransaction(services)
+        ).addNotaryInstruction(FakeNotaryInstruction("notary-instruct")).toWireTransaction(services)
         val stx = sign(wtx)
         partyObjectMapper.identities += listOf(MINI_CORP.party, DUMMY_NOTARY)
         val json = mapper.valueToTree<ObjectNode>(stx)
         println(mapper.writeValueAsString(json))
         val (wtxJson, signaturesJson) = json.assertHasOnlyFields("wire", "signatures")
         assertThat(signaturesJson.childrenAs<TransactionSignature>(mapper)).isEqualTo(stx.sigs)
-        val wtxFields = wtxJson.assertHasOnlyFields("id", "notary", "inputs", "attachments", "outputs", "commands", "timeWindow", "references", "privacySalt", "networkParametersHash", "digestService")
+        val wtxFields = wtxJson.assertHasOnlyFields(
+                "id",
+                "notary",
+                "inputs",
+                "attachments",
+                "outputs",
+                "commands",
+                "timeWindow",
+                "references",
+                "privacySalt",
+                "networkParametersHash",
+                "notaryInstructions",
+                "digestService"
+        )
         assertThat(wtxFields[0].valueAs<SecureHash>(mapper)).isEqualTo(wtx.id)
         assertThat(wtxFields[1].valueAs<Party>(mapper)).isEqualTo(wtx.notary)
         assertThat(wtxFields[2].childrenAs<StateRef>(mapper)).isEqualTo(wtx.inputs)
@@ -308,7 +324,8 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         assertThat(wtxFields[6].valueAs<TimeWindow>(mapper)).isEqualTo(wtx.timeWindow)
         assertThat(wtxFields[7].childrenAs<StateRef>(mapper)).isEqualTo(wtx.references)
         assertThat(wtxFields[8].valueAs<PrivacySalt>(mapper)).isEqualTo(wtx.privacySalt)
-        assertThat(wtxFields[10].valueAs<DigestService>(mapper)).isEqualTo(wtx.digestService)
+        assertThat(wtxFields[10].childrenAs<NotaryInstruction>(mapper)).isEqualTo(wtx.notaryInstructions)
+        assertThat(wtxFields[11].valueAs<DigestService>(mapper)).isEqualTo(wtx.digestService)
         assertThat(mapper.convertValue<WireTransaction>(wtxJson)).isEqualTo(wtx)
         assertThat(mapper.convertValue<SignedTransaction>(json)).isEqualTo(stx)
     }

--- a/core-tests/src/test/kotlin/net/corda/coretests/internal/NetworkParametersResolutionTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/internal/NetworkParametersResolutionTest.kt
@@ -78,7 +78,10 @@ class NetworkParametersResolutionTest {
                         wtx.notary,
                         wtx.timeWindow,
                         wtx.references,
-                        parameters?.serialize()?.hash),
+                        parameters?.serialize()?.hash,
+                        emptyList(),
+                        emptyList()
+                ),
                 wtx.privacySalt
         )
         val publicKey = services.myInfo.singleIdentity().owningKey

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/AttachmentsClassLoaderTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/AttachmentsClassLoaderTests.kt
@@ -396,6 +396,7 @@ class AttachmentsClassLoaderTests {
                     privacySalt,
                     testNetworkParameters(),
                     emptyList(),
+                    emptyList(),
                     isAttachmentTrusted = { true },
                     attachmentsClassLoaderCache = attachmentsClassLoaderCache
             )
@@ -432,6 +433,7 @@ class AttachmentsClassLoaderTests {
                         timeWindow,
                         privacySalt,
                         testNetworkParameters(),
+                        emptyList(),
                         emptyList(),
                         isAttachmentTrusted = { true },
                         attachmentsClassLoaderCache = attachmentsClassLoaderCache

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/CompatibleTransactionTests.kt
@@ -6,10 +6,12 @@ import net.corda.core.contracts.ComponentGroupEnum.ATTACHMENTS_V2_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.COMMANDS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.INPUTS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.NOTARY_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.NOTARY_INSTRUCTIONS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.OUTPUTS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.PARAMETERS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.SIGNERS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.TIMEWINDOW_GROUP
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
@@ -41,6 +43,7 @@ import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.core.dummyCommand
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import java.time.Instant
@@ -60,9 +63,12 @@ class CompatibleTransactionTests {
         val DUMMY_NOTARY = TestIdentity(DUMMY_NOTARY_NAME, 20).party
     }
 
+    private data class DummyNotaryInstruction(val id: Int) : NotaryInstruction
+
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
+
     private val dummyOutState = TransactionState(DummyState(0), DummyContract.PROGRAM_ID, DUMMY_NOTARY)
     private val stateRef1 = StateRef(SecureHash.randomSHA256(), 0)
     private val stateRef2 = StateRef(SecureHash.randomSHA256(), 1)
@@ -76,6 +82,7 @@ class CompatibleTransactionTests {
     private val timeWindow = TimeWindow.fromOnly(Instant.now())
     private val privacySalt: PrivacySalt = PrivacySalt()
     private val paramsHash = SecureHash.randomSHA256()
+    private val notaryInstructions = listOf(DummyNotaryInstruction(1), DummyNotaryInstruction(2))
 
     private val inputGroup by lazy { ComponentGroup(INPUTS_GROUP.ordinal, inputs.map { it.serialize() }) }
     private val outputGroup by lazy { ComponentGroup(OUTPUTS_GROUP.ordinal, outputs.map { it.serialize() }) }
@@ -85,6 +92,7 @@ class CompatibleTransactionTests {
     private val timeWindowGroup by lazy { ComponentGroup(TIMEWINDOW_GROUP.ordinal, listOf(timeWindow.serialize())) }
     private val signersGroup by lazy { ComponentGroup(SIGNERS_GROUP.ordinal, commands.map { it.signers.serialize() }) }
     private val networkParamsGroup by lazy { ComponentGroup(PARAMETERS_GROUP.ordinal, listOf(paramsHash.serialize())) }
+    private val notaryInstructionsGroup by lazy { ComponentGroup(NOTARY_INSTRUCTIONS_GROUP.ordinal, notaryInstructions.map { it.serialize() }) }
 
     private val newUnknownComponentGroup = ComponentGroup(100, listOf(OpaqueBytes(secureRandomBytes(4)), OpaqueBytes(secureRandomBytes(8))))
     private val newUnknownComponentEmptyGroup = ComponentGroup(101, emptyList())
@@ -164,7 +172,7 @@ class CompatibleTransactionTests {
 
     @Test(timeout=300_000)
 	fun `WireTransaction constructors and compatibility`() {
-        val groups = createComponentGroups(inputs, outputs, commands, attachments, notary, timeWindow, emptyList(), null)
+        val groups = createComponentGroups(inputs, outputs, commands, attachments, notary, timeWindow, emptyList(), null, emptyList(), emptyList())
         val wireTransactionOldConstructor = WireTransaction(groups, privacySalt)
         assertEquals(wireTransactionA, wireTransactionOldConstructor)
 
@@ -246,14 +254,9 @@ class CompatibleTransactionTests {
         ComponentGroupEnum.entries.forEach(ftxAll::checkAllComponentsVisible)
 
         // Filter inputs only.
-        fun filtering(elem: Any): Boolean {
-            return when (elem) {
-                is StateRef -> true
-                else -> false
-            }
-        }
+        val inputsOnly = Predicate<Any> { it is StateRef }
 
-        val ftxInputs = wireTransactionA.buildFilteredTransaction(Predicate(::filtering)) // Inputs only filtered.
+        val ftxInputs = wireTransactionA.buildFilteredTransaction(inputsOnly) // Inputs only filtered.
         ftxInputs.verify()
         ftxInputs.checkAllComponentsVisible(INPUTS_GROUP)
 
@@ -282,13 +285,15 @@ class CompatibleTransactionTests {
                 notaryGroup,
                 timeWindowGroup,
                 signersGroup,
+                notaryInstructionsGroup,
                 newUnknownComponentGroup // A new unknown component with ordinal 100 that we cannot process.
         )
         val wireTransactionCompatibleA = WireTransaction(componentGroupsCompatibleA, privacySalt)
-        val ftxCompatible = wireTransactionCompatibleA.buildFilteredTransaction(Predicate(::filtering))
+        val ftxCompatible = wireTransactionCompatibleA.buildFilteredTransaction(inputsOnly)
         ftxCompatible.verify()
         assertEquals(ftxInputs.inputs, ftxCompatible.inputs)
         assertEquals(wireTransactionCompatibleA.id, ftxCompatible.id)
+        assertThat(wireTransactionCompatibleA.notaryInstructions).isEqualTo(notaryInstructions)
 
         assertEquals(1, ftxCompatible.filteredComponentGroups.size)
         assertEquals(3, ftxCompatible.filteredComponentGroups.getRequiredGroup(INPUTS_GROUP).components.size)
@@ -296,6 +301,7 @@ class CompatibleTransactionTests {
         assertNotNull(ftxCompatible.filteredComponentGroups.getRequiredGroup(INPUTS_GROUP).partialMerkleTree)
         assertNull(wireTransactionCompatibleA.networkParametersHash)
         assertNull(ftxCompatible.networkParametersHash)
+        assertThat(ftxCompatible.notaryInstructions).isEmpty()
 
         // Now, let's allow everything, including the new component type that we cannot process.
         val ftxCompatibleAll = wireTransactionCompatibleA.buildFilteredTransaction { true } // All filtered, including the unknown component.
@@ -306,25 +312,27 @@ class CompatibleTransactionTests {
         assertEquals(wireTransactionCompatibleA.componentGroups.size, ftxCompatibleAll.filteredComponentGroups.size)
 
         // Hide one component group only.
-        // Filter inputs only.
-        fun filterOutInputs(elem: Any): Boolean {
-            return when (elem) {
-                is StateRef -> false
-                else -> true
-            }
-        }
+        val filterOutInputs = Predicate<Any> { it !is StateRef }
 
-        val ftxCompatibleNoInputs = wireTransactionCompatibleA.buildFilteredTransaction(Predicate(::filterOutInputs))
+        val ftxCompatibleNoInputs = wireTransactionCompatibleA.buildFilteredTransaction(filterOutInputs)
         ftxCompatibleNoInputs.verify()
         assertFailsWith<ComponentVisibilityException> { ftxCompatibleNoInputs.checkAllComponentsVisible(INPUTS_GROUP) }
         assertEquals(wireTransactionCompatibleA.componentGroups.size - 1, ftxCompatibleNoInputs.filteredComponentGroups.size)
         assertEquals(wireTransactionCompatibleA.componentGroups.maxOfOrNull { it.groupIndex }, ftxCompatibleNoInputs.groupHashes.size - 1)
+
+        val ftxCompatibleNotaryInstructions = wireTransactionCompatibleA.buildFilteredTransaction { it is NotaryInstruction }
+        ftxCompatibleNotaryInstructions.verify()
+        assertThat(ftxCompatibleNotaryInstructions.notaryInstructions).isEqualTo(notaryInstructions)
     }
 
     @Test(timeout=300_000)
 	fun `Command visibility tests`() {
         // 1st and 3rd commands require a signature from KEY_1.
-        val twoCommandsforKey1 = listOf(dummyCommand(DUMMY_KEY_1.public, DUMMY_KEY_2.public), dummyCommand(DUMMY_KEY_2.public), dummyCommand(DUMMY_KEY_1.public))
+        val twoCommandsforKey1 = listOf(
+                dummyCommand(DUMMY_KEY_1.public, DUMMY_KEY_2.public),
+                dummyCommand(DUMMY_KEY_2.public),
+                dummyCommand(DUMMY_KEY_1.public)
+        )
         val componentGroups = listOf(
                 inputGroup,
                 outputGroup,
@@ -553,7 +561,8 @@ class CompatibleTransactionTests {
         // Modify last signer (we have a pointer from commandData).
         // Update partial Merkle tree for signers.
         val alterSignerComponents = signerComponents.subList(0, 2) + signerComponents[1] // Third one is removed and the 2nd command is added twice.
-        val alterSignersHashes = wtx.accessAvailableComponentHashes()[SIGNERS_GROUP.ordinal]!!.subList(0, 2) + wtx.digestService.componentHash(key1CommandsFtx.filteredComponentGroups[1].nonces[2], alterSignerComponents[2])
+        val alterSignersHashes = wtx.accessAvailableComponentHashes()[SIGNERS_GROUP.ordinal]!!.subList(0, 2) +
+                wtx.digestService.componentHash(key1CommandsFtx.filteredComponentGroups[1].nonces[2], alterSignerComponents[2])
         val alterMTree = MerkleTree.getMerkleTree(alterSignersHashes, wtx.digestService)
         val alterSignerPMTK = PartialMerkleTree.build(
                 alterMTree,
@@ -612,4 +621,3 @@ class CompatibleTransactionTests {
         assertFailsWith<ComponentVisibilityException> { ftx2.checkAllComponentsVisible(PARAMETERS_GROUP) }
     }
 }
-

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/LedgerTransactionQueryTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/LedgerTransactionQueryTests.kt
@@ -1,9 +1,14 @@
 package net.corda.coretests.transactions
 
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import net.corda.core.contracts.*
+import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.FungibleAsset
+import net.corda.core.contracts.NotaryInstruction
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
@@ -14,12 +19,18 @@ import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
-import net.corda.testing.core.*
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.SerializationEnvironmentRule
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.core.dummyCommand
+import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.MockServices
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.function.Predicate
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -65,6 +76,11 @@ class LedgerTransactionQueryTests {
         override val participants: List<AbstractParty> = emptyList()
     }
 
+    interface NotaryInstructions {
+        data class Instr1(val id: Int) : NotaryInstruction
+        data class Instr2(val id: Int) : NotaryInstruction
+    }
+
     private fun makeDummyState(data: Any): ContractState {
         return when (data) {
             is String -> StringTypeDummyState(data)
@@ -94,6 +110,8 @@ class LedgerTransactionQueryTests {
             tx.addOutputState(makeDummyState(i.toString()), DummyContract.PROGRAM_ID)
             tx.addCommand(Commands.Cmd1(i), listOf(identity.owningKey))
             tx.addCommand(Commands.Cmd2(i), listOf(identity.owningKey))
+            tx.addNotaryInstruction(NotaryInstructions.Instr1(i))
+            tx.addNotaryInstruction(NotaryInstructions.Instr2(i))
         }
         return tx.toLedgerTransaction(services)
     }
@@ -218,7 +236,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Filtered Input Tests`() {
         val ltx = makeDummyTransaction()
-        val intStates = ltx.filterInputs(IntTypeDummyState::class.java, Predicate { it.data.rem(2) == 0 })
+        val intStates = ltx.filterInputs(IntTypeDummyState::class.java) { it.data.rem(2) == 0 }
         assertEquals(3, intStates.size)
         assertEquals(listOf(0, 2, 4), intStates.map { it.data })
         val stringStates: List<StringTypeDummyState> = ltx.filterInputs { it.data == "3" }
@@ -228,7 +246,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Filtered InRef Tests`() {
         val ltx = makeDummyTransaction()
-        val intStates = ltx.filterInRefs(IntTypeDummyState::class.java, Predicate { it.data.rem(2) == 0 })
+        val intStates = ltx.filterInRefs(IntTypeDummyState::class.java) { it.data.rem(2) == 0 }
         assertEquals(3, intStates.size)
         assertEquals(listOf(0, 2, 4), intStates.map { it.state.data.data })
         assertEquals(listOf(ltx.inputs[0], ltx.inputs[4], ltx.inputs[8]), intStates)
@@ -240,7 +258,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Filtered Output Tests`() {
         val ltx = makeDummyTransaction()
-        val intStates = ltx.filterOutputs(IntTypeDummyState::class.java, Predicate { it.data.rem(2) == 0 })
+        val intStates = ltx.filterOutputs(IntTypeDummyState::class.java) { it.data.rem(2) == 0 }
         assertEquals(3, intStates.size)
         assertEquals(listOf(0, 2, 4), intStates.map { it.data })
         val stringStates: List<StringTypeDummyState> = ltx.filterOutputs { it.data == "3" }
@@ -250,7 +268,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Filtered OutRef Tests`() {
         val ltx = makeDummyTransaction()
-        val intStates = ltx.filterOutRefs(IntTypeDummyState::class.java, Predicate { it.data.rem(2) == 0 })
+        val intStates = ltx.filterOutRefs(IntTypeDummyState::class.java) { it.data.rem(2) == 0 }
         assertEquals(3, intStates.size)
         assertEquals(listOf(0, 2, 4), intStates.map { it.state.data.data })
         assertEquals(listOf(0, 4, 8), intStates.map { it.ref.index })
@@ -264,7 +282,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Filtered Commands Tests`() {
         val ltx = makeDummyTransaction()
-        val intCmds1 = ltx.filterCommands(Commands.Cmd1::class.java, Predicate { it.id.rem(2) == 0 })
+        val intCmds1 = ltx.filterCommands(Commands.Cmd1::class.java) { it.id.rem(2) == 0 }
         assertEquals(3, intCmds1.size)
         assertEquals(listOf(0, 2, 4), intCmds1.map { it.value.id })
         val intCmds2 = ltx.filterCommands<Commands.Cmd2> { it.id == 3 }
@@ -274,7 +292,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Find Input Tests`() {
         val ltx = makeDummyTransaction()
-        val intState = ltx.findInput(IntTypeDummyState::class.java, Predicate { it.data == 4 })
+        val intState = ltx.findInput(IntTypeDummyState::class.java) { it.data == 4 }
         assertEquals(ltx.getInput(8), intState)
         val stringState: StringTypeDummyState = ltx.findInput { it.data == "3" }
         assertEquals(ltx.getInput(7), stringState)
@@ -283,7 +301,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Find InRef Tests`() {
         val ltx = makeDummyTransaction()
-        val intState = ltx.findInRef(IntTypeDummyState::class.java, Predicate { it.data == 4 })
+        val intState = ltx.findInRef(IntTypeDummyState::class.java) { it.data == 4 }
         assertEquals(ltx.inRef(8), intState)
         val stringState: StateAndRef<StringTypeDummyState> = ltx.findInRef { it.data == "3" }
         assertEquals(ltx.inRef(7), stringState)
@@ -292,7 +310,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Find Output Tests`() {
         val ltx = makeDummyTransaction()
-        val intState = ltx.findOutput(IntTypeDummyState::class.java, Predicate { it.data == 4 })
+        val intState = ltx.findOutput(IntTypeDummyState::class.java) { it.data == 4 }
         assertEquals(ltx.getOutput(8), intState)
         val stringState: StringTypeDummyState = ltx.findOutput { it.data == "3" }
         assertEquals(ltx.getOutput(7), stringState)
@@ -301,7 +319,7 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Find OutRef Tests`() {
         val ltx = makeDummyTransaction()
-        val intState = ltx.findOutRef(IntTypeDummyState::class.java, Predicate { it.data == 4 })
+        val intState = ltx.findOutRef(IntTypeDummyState::class.java) { it.data == 4 }
         assertEquals(ltx.outRef(8), intState)
         val stringState: StateAndRef<StringTypeDummyState> = ltx.findOutRef { it.data == "3" }
         assertEquals(ltx.outRef(7), stringState)
@@ -310,9 +328,28 @@ class LedgerTransactionQueryTests {
     @Test(timeout=300_000)
 	fun `Find Commands Tests`() {
         val ltx = makeDummyTransaction()
-        val intCmd1 = ltx.findCommand(Commands.Cmd1::class.java, Predicate { it.id == 2 })
+        val intCmd1 = ltx.findCommand(Commands.Cmd1::class.java) { it.id == 2 }
         assertEquals(ltx.getCommand(4), intCmd1)
         val intCmd2 = ltx.findCommand<Commands.Cmd2> { it.id == 3 }
         assertEquals(ltx.getCommand(7), intCmd2)
+    }
+
+    @Test(timeout=300_000)
+    fun `find notary instructions`() {
+        val ltx = makeDummyTransaction()
+        val instr1 = ltx.findNotaryInstruction(NotaryInstructions.Instr1::class.java) { it.id == 2 }
+        assertEquals(ltx.getNotaryInstruction(4), instr1)
+        val instr2 = ltx.findNotaryInstruction<NotaryInstructions.Instr2> { it.id == 3 }
+        assertEquals(ltx.getNotaryInstruction(7), instr2)
+    }
+
+    @Test(timeout=300_000)
+    fun `filtered notary instructions`() {
+        val ltx = makeDummyTransaction()
+        val instrs1 = ltx.filterNotaryInstructions(NotaryInstructions.Instr1::class.java) { it.id.rem(2) == 0 }
+        assertEquals(3, instrs1.size)
+        assertEquals(listOf(0, 2, 4), instrs1.map { it.id })
+        val instrs2 = ltx.filterNotaryInstructions<NotaryInstructions.Instr2> { it.id == 3 }
+        assertEquals(3, instrs2.single().id)
     }
 }

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
@@ -2,6 +2,7 @@ package net.corda.coretests.transactions
 
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.HashAttachmentConstraint
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
@@ -37,6 +38,7 @@ import java.time.Instant
 import kotlin.io.path.inputStream
 import kotlin.test.assertFailsWith
 
+@Suppress("INVISIBLE_MEMBER")
 class TransactionBuilderTest {
     @Rule
     @JvmField
@@ -51,7 +53,6 @@ class TransactionBuilderTest {
     private val contractAttachmentId = services.attachments.getLatestContractAttachments(DummyContract.PROGRAM_ID)[0]
 
     @Test(timeout=300_000)
-    @Suppress("INVISIBLE_MEMBER")
 	fun `bare minimum issuance tx`() {
         val outputState = TransactionState(
                 data = DummyState(),
@@ -69,6 +70,7 @@ class TransactionBuilderTest {
         // From 4.12 attachments are added to the new component group by default
         assertThat(wtx.nonLegacyAttachments).isNotEmpty
         assertThat(wtx.legacyAttachments).isEmpty()
+        assertThat(wtx.notaryInstructions).isEmpty()
     }
 
     @Test(timeout=300_000)
@@ -105,17 +107,31 @@ class TransactionBuilderTest {
     }
 
     @Test(timeout=300_000)
+    fun `notary instructions`() {
+        val notaryInstuction = FakeNotaryInstuction("1")
+        val builder = TransactionBuilder(notary)
+                .addOutputState(TransactionState(DummyState(), DummyContract.PROGRAM_ID, notary))
+                .addCommand(DummyCommandData, notary.owningKey)
+                .addNotaryInstruction(notaryInstuction)
+        val wtx = builder.toWireTransaction(services)
+        assertThat(wtx.notaryInstructions).containsOnly(notaryInstuction)
+    }
+
+    @Test(timeout=300_000)
     fun `list accessors are mutable copies`() {
         val inputState1 = TransactionState(DummyState(), DummyContract.PROGRAM_ID, notary)
         val inputStateRef1 = StateRef(SecureHash.randomSHA256(), 0)
         val referenceState1 = TransactionState(DummyState(), DummyContract.PROGRAM_ID, notary)
         val referenceStateRef1 = StateRef(SecureHash.randomSHA256(), 1)
+        val notaryInstruction1 = FakeNotaryInstuction("1")
+        val notaryInstruction2 = FakeNotaryInstuction("2")
         val builder = TransactionBuilder(notary)
                 .addInputState(StateAndRef(inputState1, inputStateRef1))
                 .addAttachment(SecureHash.allOnesHash)
                 .addOutputState(TransactionState(DummyState(), DummyContract.PROGRAM_ID, notary))
                 .addCommand(DummyCommandData, notary.owningKey)
                 .addReferenceState(StateAndRef(referenceState1, referenceStateRef1).referenced())
+                .addNotaryInstruction(notaryInstruction1)
         val inputStateRef2 = StateRef(SecureHash.randomSHA256(), 0)
         val referenceStateRef2 = StateRef(SecureHash.randomSHA256(), 1)
 
@@ -125,6 +141,7 @@ class TransactionBuilderTest {
         assertThat((builder.outputStates() as ArrayList).also { it.add(TransactionState(DummyState(), DummyContract.PROGRAM_ID, notary)) }).hasSize(2)
         assertThat((builder.commands() as ArrayList).also { it.add(Command(DummyCommandData, notary.owningKey)) }).hasSize(2)
         assertThat((builder.referenceStates() as ArrayList).also { it.add(referenceStateRef2) }).hasSize(2)
+        assertThat((builder.notaryInstructions() as ArrayList).also { it.add(notaryInstruction2) }).hasSize(2)
 
         // List accessors are copies.
         assertThat(builder.inputStates()).hasSize(1)
@@ -132,6 +149,7 @@ class TransactionBuilderTest {
         assertThat(builder.outputStates()).hasSize(1)
         assertThat(builder.commands()).hasSize(1)
         assertThat(builder.referenceStates()).hasSize(1)
+        assertThat(builder.notaryInstructions()).hasSize(1)
     }
 
     @Test(timeout=300_000)
@@ -149,6 +167,7 @@ class TransactionBuilderTest {
                 .setTimeWindow(timeWindow)
                 .setPrivacySalt(PrivacySalt())
                 .addReferenceState(StateAndRef(referenceState, referenceStateRef).referenced())
+                .addNotaryInstruction(FakeNotaryInstuction("1"))
         val copy = builder.copy()
 
         assertThat(builder.notary).isEqualTo(copy.notary)
@@ -160,6 +179,7 @@ class TransactionBuilderTest {
 //        assertThat(builder.timeWindow()).isEqualTo(copy.timeWindow())
 //        assertThat(builder.privacySalt()).isEqualTo(copy.privacySalt())
         assertThat(builder.referenceStates()).isEqualTo(copy.referenceStates())
+        assertThat(builder.notaryInstructions()).isEqualTo(copy.notaryInstructions())
     }
 
     @Test(timeout=300_000)
@@ -286,4 +306,6 @@ class TransactionBuilderTest {
                 .isThrownBy { builder.toWireTransaction(services) }
                 .withMessageContaining("Multiple attachments specified for the same contract net.corda.testing.contracts.DummyContract")
     }
+
+    private data class FakeNotaryInstuction(val instruct: String) : NotaryInstruction
 }

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionTests.kt
@@ -170,6 +170,7 @@ class TransactionTests(private val digestService : DigestService) {
                 privacySalt,
                 testNetworkParameters(),
                 emptyList(),
+                emptyList(),
                 isAttachmentTrusted = { true },
                 attachmentsClassLoaderCache = attachmentsClassLoaderCache,
                 digestService = digestService
@@ -226,6 +227,7 @@ class TransactionTests(private val digestService : DigestService) {
                 timeWindow,
                 privacySalt,
                 testNetworkParameters(notaries = listOf(NotaryInfo(DUMMY_NOTARY, true))),
+                emptyList(),
                 emptyList(),
                 isAttachmentTrusted = { true },
                 attachmentsClassLoaderCache = attachmentsClassLoaderCache,

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -135,6 +135,14 @@ scanApi {
         // Kotlin should probably have declared this class as "synthetic".
         "net.corda.core.Utils\$toFuture\$1\$subscription\$1"
     ]
+
+    excludeMethods = [
+            "net.corda.core.transactions.LedgerTransaction": [
+                    // This is a private c'tor but is exposed as public by the Kotlin compiler. Further, it's got the DefaultConstructorMarker
+                    // parameter even though there are no default values.
+                    "<init>(Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lnet/corda/core/crypto/SecureHash;Lnet/corda/core/identity/Party;Lnet/corda/core/contracts/TimeWindow;Lnet/corda/core/contracts/PrivacySalt;Lnet/corda/core/node/NetworkParameters;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lnet/corda/core/serialization/internal/AttachmentsClassLoaderCache;Lnet/corda/core/crypto/DigestService;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+            ]
+    ]
 }
 
 tasks.register("writeTestResources", JavaExec) {

--- a/core/src/main/kotlin/net/corda/core/contracts/ComponentGroupEnum.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ComponentGroupEnum.kt
@@ -14,5 +14,6 @@ enum class ComponentGroupEnum {
     SIGNERS_GROUP, // ordinal = 6.
     REFERENCES_GROUP, // ordinal = 7.
     PARAMETERS_GROUP, // ordinal = 8.
-    ATTACHMENTS_V2_GROUP // ordinal = 9. From 4.12+ this group is used for attachments.
+    ATTACHMENTS_V2_GROUP, // ordinal = 9. From 4.12+ this group is used for attachments.
+    NOTARY_INSTRUCTIONS_GROUP, // ordinal = 10.
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/NotaryInstruction.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/NotaryInstruction.kt
@@ -1,0 +1,18 @@
+package net.corda.core.contracts
+
+import net.corda.core.DoNotImplement
+import net.corda.core.serialization.CordaSerializable
+
+/**
+ * An additional instruction or directive for the notary to perform when it notarises the transaction. Each instruction implementation will
+ * be understood by one or more notary types, and they are trusted to faithfully action them.
+ *
+ * For security and backwards compatibility, the default notary behaviour is to reject transactions with _any_ notary instruction. Therefore
+ * only specialised notaries will support them. It's also possible for these notaries to reject transactions which have mixed instructions
+ * and demand only their instructions be present.
+ *
+ * Note, notary instructions are not a notary plugin mechanism. All R3 notaries will reject any transaction with an unknown instruction.
+ */
+@DoNotImplement
+@CordaSerializable
+interface NotaryInstruction

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -3,6 +3,7 @@ package net.corda.core.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.CordaInternal
 import net.corda.core.DoNotImplement
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.TransactionSignature
@@ -120,28 +121,41 @@ class NotaryFlow {
                     and can't be used for regular transactions.
                 */
                 check(stx.coreTransaction is NotaryChangeWireTransaction) {
-                    "Notary ${notaryParty.description()} is not on the network parameter whitelist. A non-whitelisted notary can only be used for notary change transactions"
+                    "Notary ${notaryParty.description()} is not on the network parameter whitelist. A non-whitelisted notary can only be " +
+                            "used for notary change transactions"
                 }
                 val historicNotary = (serviceHub.networkParametersService as NetworkParametersStorage).getHistoricNotary(notaryParty)
-                        ?: throw IllegalStateException("The notary party ${notaryParty.description()} specified by transaction ${stx.id}, is not recognised as a current or historic notary.")
+                        ?: throw IllegalStateException("The notary party ${notaryParty.description()} specified by transaction " +
+                                "${stx.id}, is not recognised as a current or historic notary.")
                 historicNotary.validating
-            } else serviceHub.networkMapCache.isValidatingNotary(notaryParty)
+            } else {
+                serviceHub.networkMapCache.isValidatingNotary(notaryParty)
+            }
         }
 
         @Suspendable
-        private fun sendAndReceiveValidating(session: FlowSession, signature: NotarisationRequestSignature): UntrustworthyData<NotarisationResponse> {
+        private fun sendAndReceiveValidating(session: FlowSession,
+                                             signature: NotarisationRequestSignature): UntrustworthyData<NotarisationResponse> {
             val payload = NotarisationPayload(stx, signature)
             subFlow(NotarySendTransactionFlow(session, payload))
             return receiveResultOrTiming(session)
         }
 
+        @Suppress("RedundantSamConstructor")  // Because the external verifier uses Kotlin 1.2
         @Suspendable
-        private fun sendAndReceiveNonValidating(notaryParty: Party, session: FlowSession, signature: NotarisationRequestSignature): UntrustworthyData<NotarisationResponse> {
+        private fun sendAndReceiveNonValidating(notaryParty: Party,
+                                                session: FlowSession,
+                                                signature: NotarisationRequestSignature): UntrustworthyData<NotarisationResponse> {
             val ctx = stx.coreTransaction
             val tx = when (ctx) {
                 is ContractUpgradeWireTransaction -> ctx.buildFilteredTransaction()
                 is WireTransaction -> ctx.buildFilteredTransaction(Predicate {
-                    it is StateRef || it is ReferenceStateRef || it is TimeWindow || it == notaryParty || it is NetworkParametersHash
+                    it is StateRef
+                            || it is ReferenceStateRef
+                            || it is TimeWindow
+                            || it == notaryParty
+                            || it is NetworkParametersHash
+                            || it is NotaryInstruction
                 })
                 else -> ctx
             }

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -8,6 +8,7 @@ import net.corda.core.contracts.ComponentGroupEnum.ATTACHMENTS_V2_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.COMMANDS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.INPUTS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.NOTARY_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.NOTARY_INSTRUCTIONS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.OUTPUTS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.PARAMETERS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.REFERENCES_GROUP
@@ -16,6 +17,7 @@ import net.corda.core.contracts.ComponentGroupEnum.TIMEWINDOW_GROUP
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.NamedByHash
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
@@ -48,6 +50,9 @@ import java.io.ByteArrayOutputStream
 import java.security.PublicKey
 import kotlin.reflect.KClass
 
+@Suppress("EnumValuesSoftDeprecate")  // Because the external verifier uses Kotlin 1.2
+val MAX_COMPONENT_GROUP_INDEX = ComponentGroupEnum.values().size - 1
+
 /** Constructs a [NotaryChangeWireTransaction]. */
 class NotaryChangeTransactionBuilder(val inputs: List<StateRef>,
                                      val notary: Party,
@@ -76,7 +81,14 @@ class ContractUpgradeTransactionBuilder(
         private set
 
     fun build(): ContractUpgradeWireTransaction {
-        val components = listOf(inputs, notary, legacyContractAttachmentId, upgradedContractClassName, upgradedContractAttachmentId, networkParametersHash).map { it.serialize() }
+        val components = listOf(
+                inputs,
+                notary,
+                legacyContractAttachmentId,
+                upgradedContractClassName,
+                upgradedContractAttachmentId,
+                networkParametersHash
+        ).map { it.serialize() }
         return ContractUpgradeWireTransaction(components, privacySalt, digestService)
     }
 }
@@ -93,8 +105,9 @@ fun combinedHash(components: Iterable<SecureHash>, digestService: DigestService)
 /**
  * This function knows how to deserialize a transaction component group.
  *
- * In case the [componentGroups] is an instance of [LazyMappedList], this function will just use the original deserialized version, and avoid an unnecessary deserialization.
- * The [forceDeserialize] will force deserialization. In can be used in case the SerializationContext changes.
+ * In case the [componentGroups] is an instance of [LazyMappedList], this function will just use the original deserialized version, and
+ * avoid an unnecessary deserialization. The [forceDeserialize] will force deserialization. In can be used in case the SerializationContext
+ * changes.
  */
 fun <T : Any> deserialiseComponentGroup(componentGroups: List<ComponentGroup>,
                                         clazz: KClass<T>,
@@ -192,7 +205,8 @@ fun createComponentGroups(inputs: List<StateRef>,
                           references: List<StateRef>,
                           networkParametersHash: SecureHash?,
                           // The old attachments group is now only used to create transaction compatible with 4.11 (or earlier) nodes
-                          legacyAttachments: List<SecureHash> = emptyList()): List<ComponentGroup> {
+                          legacyAttachments: List<SecureHash>,
+                          notaryInstructions: List<NotaryInstruction>): List<ComponentGroup> {
     val serializationFactory = SerializationFactory.defaultFactory
     val serializationContext = serializationFactory.defaultContext
     val serialize = { value: Any, _: Int -> value.serialize(serializationFactory, serializationContext) }
@@ -211,11 +225,16 @@ fun createComponentGroups(inputs: List<StateRef>,
     // Adding signers to their own group. This is required for command visibility purposes: a party receiving
     // a FilteredTransaction can now verify it sees all the commands it should sign.
     componentGroupMap.addListGroup(SIGNERS_GROUP, commands.map { it.signers }, serialize)
-    if (networkParametersHash != null) componentGroupMap.add(ComponentGroup(PARAMETERS_GROUP.ordinal, listOf(networkParametersHash.serialize())))
+    if (networkParametersHash != null) {
+        componentGroupMap.add(ComponentGroup(PARAMETERS_GROUP.ordinal, listOf(networkParametersHash.serialize())))
+    }
+    componentGroupMap.addListGroup(NOTARY_INSTRUCTIONS_GROUP, notaryInstructions, serialize)
     return componentGroupMap
 }
 
-private fun MutableList<ComponentGroup>.addListGroup(type: ComponentGroupEnum, list: List<Any>, serialize: (Any, Int) -> SerializedBytes<Any>) {
+private fun MutableList<ComponentGroup>.addListGroup(type: ComponentGroupEnum,
+                                                     list: List<Any>,
+                                                     serialize: (Any, Int) -> SerializedBytes<Any>) {
     if (list.isNotEmpty()) {
         add(ComponentGroup(type.ordinal, list.lazyMapped(serialize)))
     }
@@ -228,7 +247,10 @@ typealias SerializedTransactionState = SerializedBytes<TransactionState<Contract
  * The [serializedState] is the actual component from the original wire transaction.
  */
 data class SerializedStateAndRef(val serializedState: SerializedTransactionState, val ref: StateRef) {
-    fun toStateAndRef(factory: SerializationFactory, context: SerializationContext) = StateAndRef(serializedState.deserialize(factory, context), ref)
+    fun toStateAndRef(factory: SerializationFactory, context: SerializationContext): StateAndRef<ContractState> {
+        return StateAndRef(serializedState.deserialize(factory, context), ref)
+    }
+
     fun toStateAndRef(): StateAndRef<ContractState> {
         val factory = SerializationFactory.defaultFactory
         return toStateAndRef(factory, factory.defaultContext)
@@ -243,7 +265,9 @@ fun FlowLogic<*>.checkParameterHash(networkParametersHash: SecureHash?) {
         if (serviceHub.networkParameters.minimumPlatformVersion < PlatformVersionSwitches.NETWORK_PARAMETERS_COMPONENT_GROUP) return
         else throw IllegalArgumentException("Transaction for notarisation doesn't contain network parameters hash.")
     } else {
-        serviceHub.networkParametersService.lookup(networkParametersHash) ?: throw IllegalArgumentException("Transaction for notarisation contains unknown parameters hash: $networkParametersHash")
+        requireNotNull(serviceHub.networkParametersService.lookup(networkParametersHash)) {
+            "Transaction for notarisation contains unknown parameters hash: $networkParametersHash"
+        }
     }
 
     // TODO: [ENT-2666] Implement network parameters fuzzy checking. By design in Corda network we have propagation time delay.

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -50,9 +50,6 @@ import java.io.ByteArrayOutputStream
 import java.security.PublicKey
 import kotlin.reflect.KClass
 
-@Suppress("EnumValuesSoftDeprecate")  // Because the external verifier uses Kotlin 1.2
-val MAX_COMPONENT_GROUP_INDEX = ComponentGroupEnum.values().size - 1
-
 /** Constructs a [NotaryChangeWireTransaction]. */
 class NotaryChangeTransactionBuilder(val inputs: List<StateRef>,
                                      val notary: Party,

--- a/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
@@ -1,19 +1,29 @@
 package net.corda.core.internal.notary
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.toStringShort
-import net.corda.core.flows.*
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.NotarisationPayload
+import net.corda.core.flows.NotarisationRequest
+import net.corda.core.flows.NotarisationRequestSignature
+import net.corda.core.flows.NotarisationResponse
+import net.corda.core.flows.NotaryError
+import net.corda.core.flows.NotaryException
+import net.corda.core.flows.NotaryFlow
+import net.corda.core.flows.WaitTimeUpdate
 import net.corda.core.identity.Party
 import net.corda.core.internal.PlatformVersionSwitches
 import net.corda.core.internal.checkParameterHash
 import net.corda.core.internal.telemetry.telemetryServiceInternal
 import net.corda.core.utilities.seconds
 import net.corda.core.utilities.unwrap
-import java.lang.IllegalStateException
 import java.time.Duration
 
 /**
@@ -82,7 +92,9 @@ abstract class NotaryServiceFlow(
                         otherSideSession.counterparty,
                         requestPayload.requestSignature,
                         tx.timeWindow,
-                        tx.references)
+                        tx.references,
+                        tx.notaryInstructions
+                )
             }
         } catch (e: NotaryInternalException) {
             logError(e.error)
@@ -106,6 +118,7 @@ abstract class NotaryServiceFlow(
             val transaction = extractParts(requestPayload)
             transactionId = transaction.id
             logger.info("Received a notarisation request for Tx [$transactionId] from [${otherSideSession.counterparty.name}]")
+            checkNotaryInstructions(transaction.notaryInstructions)
             checkNotary(transaction.notary)
             checkParameterHash(transaction.networkParametersHash)
             checkInputs(transaction.inputs + transaction.references)
@@ -118,6 +131,12 @@ abstract class NotaryServiceFlow(
 
     /** Extract the common transaction components required for notarisation. */
     protected abstract fun extractParts(requestPayload: NotarisationPayload): TransactionParts
+
+    private fun checkNotaryInstructions(notaryInstructions: List<NotaryInstruction>) {
+        require(service.uniquenessProvider.isNotaryInstructionsValid(notaryInstructions)) {
+            "Notary instructions not supported"
+        }
+    }
 
     /** Check if transaction is intended to be signed by this notary. */
     @Suspendable
@@ -163,7 +182,8 @@ abstract class NotaryServiceFlow(
             val inputs: List<StateRef>,
             val timeWindow: TimeWindow?,
             val notary: Party?,
-            val references: List<StateRef> = emptyList(),
+            val references: List<StateRef>,
+            val notaryInstructions: List<NotaryInstruction>,
             val networkParametersHash: SecureHash?
     )
 

--- a/core/src/main/kotlin/net/corda/core/internal/notary/SinglePartyNotaryService.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/SinglePartyNotaryService.kt
@@ -1,6 +1,7 @@
 package net.corda.core.internal.notary
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.Crypto
@@ -28,9 +29,10 @@ abstract class SinglePartyNotaryService : NotaryService() {
     protected open val log: Logger get() = staticLog
 
     /** Handles input state uniqueness checks. */
-    protected abstract val uniquenessProvider: UniquenessProvider
+    abstract val uniquenessProvider: UniquenessProvider
 
     /** Attempts to commit the specified transaction [txId]. */
+    @Suppress("LongParameterList")
     @Suspendable
     open fun commitInputStates(
             inputs: List<StateRef>,
@@ -38,14 +40,13 @@ abstract class SinglePartyNotaryService : NotaryService() {
             caller: Party,
             requestSignature: NotarisationRequestSignature,
             timeWindow: TimeWindow?,
-            references: List<StateRef>
+            references: List<StateRef>,
+            notaryInstructions: List<NotaryInstruction>
     ): Result {
         // TODO: Log the request here. Benchmarking shows that logging is expensive and we might get better performance
         // when we concurrently log requests here as part of the flows, instead of logging sequentially in the
         // `UniquenessProvider`.
-
-        val callingFlow = FlowLogic.currentTopLevel
-                ?: throw IllegalStateException("This method should be invoked in a flow context.")
+        val callingFlow = checkNotNull(FlowLogic.currentTopLevel) { "This method should be invoked in a flow context." }
 
         val result = callingFlow.await(
                 CommitOperation(
@@ -55,7 +56,8 @@ abstract class SinglePartyNotaryService : NotaryService() {
                         caller,
                         requestSignature,
                         timeWindow,
-                        references
+                        references,
+                        notaryInstructions
                 )
         )
 
@@ -85,18 +87,29 @@ abstract class SinglePartyNotaryService : NotaryService() {
             val caller: Party,
             val requestSignature: NotarisationRequestSignature,
             val timeWindow: TimeWindow?,
-            val references: List<StateRef>
+            val references: List<StateRef>,
+            val notaryInstructions: List<NotaryInstruction>
     ) : FlowExternalAsyncOperation<Result> {
 
         override fun execute(deduplicationId: String): CompletableFuture<Result> {
-            return service.uniquenessProvider.commit(inputs, txId, caller, requestSignature, timeWindow, references).toCompletableFuture()
+            return service.uniquenessProvider.commit(
+                    inputs,
+                    txId,
+                    caller,
+                    requestSignature,
+                    timeWindow,
+                    references,
+                    notaryInstructions
+            ).toCompletableFuture()
         }
     }
 
     /** Sign a single transaction. */
     fun signTransaction(txId: SecureHash): TransactionSignature {
-        val signableData = SignableData(txId, SignatureMetadata(services.myInfo.platformVersion, Crypto.findSignatureScheme(notaryIdentityKey).schemeNumberID))
+        val signableData = SignableData(
+                txId,
+                SignatureMetadata(services.myInfo.platformVersion, Crypto.findSignatureScheme(notaryIdentityKey).schemeNumberID)
+        )
         return services.keyManagementService.sign(signableData, notaryIdentityKey)
     }
-
 }

--- a/core/src/main/kotlin/net/corda/core/internal/notary/UniquenessProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/UniquenessProvider.kt
@@ -1,6 +1,7 @@
 package net.corda.core.internal.notary
 
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
@@ -17,14 +18,22 @@ typealias SigningFunction = (SecureHash) -> TransactionSignature
  * if any of the inputs have already been used in another transaction.
  */
 interface UniquenessProvider {
+    /**
+     * Check if the notary instructions are valid and can be processed by this uniqueness provider. By default notary instructions are not
+     * supported.
+     */
+    fun isNotaryInstructionsValid(notaryInstructions: List<NotaryInstruction>): Boolean = notaryInstructions.isEmpty()
+
     /** Commits all input states of the given transaction. */
+    @Suppress("LongParameterList")
     fun commit(
             states: List<StateRef>,
             txId: SecureHash,
             callerIdentity: Party,
             requestSignature: NotarisationRequestSignature,
-            timeWindow: TimeWindow? = null,
-            references: List<StateRef> = emptyList()
+            timeWindow: TimeWindow?,
+            references: List<StateRef>,
+            notaryInstructions: List<NotaryInstruction>
     ): CordaFuture<Result>
 
     /**

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -8,6 +8,7 @@ import net.corda.core.contracts.CommandWithParties
 import net.corda.core.contracts.ComponentGroupEnum
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.CordaRotatedKeys
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.RotatedKeys
 import net.corda.core.contracts.StateAndRef
@@ -88,6 +89,10 @@ private constructor(
         override val networkParameters: NetworkParameters?,
         /** Referenced states, which are like inputs but won't be consumed. */
         override val references: List<StateAndRef<ContractState>>,
+        /**
+         * List of notary instructions which provide additional directives to the notary when it notarises this transaction.
+         */
+        val notaryInstructions: List<NotaryInstruction>,
         //DOCEND 1
 
         private val componentGroups: List<ComponentGroup>?,
@@ -124,7 +129,7 @@ private constructor(
         attachmentsClassLoaderCache: AttachmentsClassLoaderCache?
     ) : this(
             inputs, outputs, commands, attachments, id, notary, timeWindow, privacySalt,
-            networkParameters, references, componentGroups, serializedInputs, serializedReferences,
+            networkParameters, references, emptyList(), componentGroups, serializedInputs, serializedReferences,
             isAttachmentTrusted, verifierFactory, attachmentsClassLoaderCache, DigestService.sha2_256)
 
     companion object {
@@ -154,6 +159,7 @@ private constructor(
                 privacySalt: PrivacySalt,
                 networkParameters: NetworkParameters,
                 references: List<StateAndRef<ContractState>>,
+                notaryInstructions: List<NotaryInstruction>,
                 componentGroups: List<ComponentGroup>? = null,
                 serializedInputs: List<SerializedStateAndRef>? = null,
                 serializedReferences: List<SerializedStateAndRef>? = null,
@@ -173,6 +179,7 @@ private constructor(
                     privacySalt = privacySalt,
                     networkParameters = networkParameters,
                     references = references,
+                    notaryInstructions = notaryInstructions,
                     componentGroups = protectOrNull(componentGroups),
                     serializedInputs = protectOrNull(serializedInputs),
                     serializedReferences = protectOrNull(serializedReferences),
@@ -200,29 +207,31 @@ private constructor(
                 privacySalt: PrivacySalt,
                 networkParameters: NetworkParameters?,
                 references: List<StateAndRef<ContractState>>,
+                notaryInstructions: List<NotaryInstruction>,
                 digestService: DigestService,
                 rotatedKeys: RotatedKeys): LedgerTransaction {
             return LedgerTransaction(
-                inputs = protect(inputs),
-                outputs = protect(outputs),
-                commands = protect(commands),
-                attachments = protect(attachments),
-                id = id,
-                notary = notary,
-                timeWindow = timeWindow,
-                privacySalt = privacySalt,
-                networkParameters = networkParameters,
-                references = protect(references),
-                componentGroups = null,
-                serializedInputs = null,
-                serializedReferences = null,
-                isAttachmentTrusted = { true },
-                verifierFactory = ::NoOpVerifier,
-                attachmentsClassLoaderCache = AttachmentsClassLoaderForRotatedKeysOnlyImpl(rotatedKeys),
-                digestService = digestService
-                // This check accesses input states and must run on the LedgerTransaction
-                // instance that is verified, not on the outer LedgerTransaction shell.
-                // All states must also deserialize using the correct SerializationContext.
+                    inputs = protect(inputs),
+                    outputs = protect(outputs),
+                    commands = protect(commands),
+                    attachments = protect(attachments),
+                    id = id,
+                    notary = notary,
+                    timeWindow = timeWindow,
+                    privacySalt = privacySalt,
+                    networkParameters = networkParameters,
+                    references = protect(references),
+                    notaryInstructions = protect(notaryInstructions),
+                    componentGroups = null,
+                    serializedInputs = null,
+                    serializedReferences = null,
+                    isAttachmentTrusted = { true },
+                    verifierFactory = ::NoOpVerifier,
+                    attachmentsClassLoaderCache = AttachmentsClassLoaderForRotatedKeysOnlyImpl(rotatedKeys),
+                    digestService = digestService
+                    // This check accesses input states and must run on the LedgerTransaction
+                    // instance that is verified, not on the outer LedgerTransaction shell.
+                    // All states must also deserialize using the correct SerializationContext.
             ).also(LedgerTransaction::checkBaseInvariants)
         }
     }
@@ -297,29 +306,32 @@ private constructor(
      * Node without changing either the wire format or any public APIs.
      */
     @CordaInternal
-    fun specialise(alternateVerifier: (LedgerTransaction, SerializationContext) -> Verifier): LedgerTransaction = LedgerTransaction(
-        inputs = inputs,
-        outputs = outputs,
-        commands = commands,
-        attachments = attachments,
-        id = id,
-        notary = notary,
-        timeWindow = timeWindow,
-        privacySalt = privacySalt,
-        networkParameters = networkParameters,
-        references = references,
-        componentGroups = componentGroups,
-        serializedInputs = serializedInputs,
-        serializedReferences = serializedReferences,
-        isAttachmentTrusted = isAttachmentTrusted,
-        verifierFactory = if (verifierFactory == ::NoOpVerifier) {
-            throw IllegalStateException("Cannot specialise transaction while verifying contracts")
-        } else {
-            alternateVerifier
-        },
-        attachmentsClassLoaderCache = attachmentsClassLoaderCache,
-        digestService = digestService
-    )
+    fun specialise(alternateVerifier: (LedgerTransaction, SerializationContext) -> Verifier): LedgerTransaction {
+        return LedgerTransaction(
+                inputs = inputs,
+                outputs = outputs,
+                commands = commands,
+                attachments = attachments,
+                id = id,
+                notary = notary,
+                timeWindow = timeWindow,
+                privacySalt = privacySalt,
+                networkParameters = networkParameters,
+                references = references,
+                notaryInstructions = notaryInstructions,
+                componentGroups = componentGroups,
+                serializedInputs = serializedInputs,
+                serializedReferences = serializedReferences,
+                isAttachmentTrusted = isAttachmentTrusted,
+                verifierFactory = if (verifierFactory == ::NoOpVerifier) {
+                    throw IllegalStateException("Cannot specialise transaction while verifying contracts")
+                } else {
+                    alternateVerifier
+                },
+                attachmentsClassLoaderCache = attachmentsClassLoaderCache,
+                digestService = digestService
+        )
+    }
 
     // Read network parameters with backwards compatibility goo.
     private fun getParamsWithGoo(): NetworkParameters {
@@ -661,6 +673,47 @@ private constructor(
      */
     fun getAttachment(id: SecureHash): Attachment = attachments.first { it.id == id }
 
+    /**
+     * Return the [NotaryInstruction] at the given index of the notary instructions list.
+     * @see notaryInstructions
+     */
+    fun getNotaryInstruction(index: Int): NotaryInstruction = notaryInstructions[index]
+
+    /**
+     * Return all the [NotaryInstruction]s of the given type.
+     * @see notaryInstructions
+     */
+    fun <T : NotaryInstruction> notaryInstructionsOfType(clazz: Class<T>): List<T> {
+        return notaryInstructions.mapNotNull { clazz.castIfPossible(it) }
+    }
+
+    inline fun <reified T : NotaryInstruction> notaryInstructionsOfType(): List<T> = notaryInstructionsOfType(T::class.java)
+
+    /**
+     * Return all the [NotaryInstruction]s of the given type and which statisfy the given predicate.
+     * @see notaryInstructions
+     */
+    fun <T : NotaryInstruction> filterNotaryInstructions(clazz: Class<T>, predicate: Predicate<T>): List<T> {
+        return notaryInstructionsOfType(clazz).filter(predicate::test)
+    }
+
+    inline fun <reified T : NotaryInstruction> filterNotaryInstructions(crossinline predicate: (T) -> Boolean): List<T> {
+        return filterNotaryInstructions(T::class.java, Predicate { predicate(it) })
+    }
+
+    /**
+     * Find the single matching [NotaryInstruction] of the given type and which satisfies the given predicate.
+     * @throws IllegalArgumentException If there are no matches or more than one match.
+     * @see notaryInstructions
+     */
+    fun <T : NotaryInstruction> findNotaryInstruction(clazz: Class<T>, predicate: Predicate<T>): T {
+        return notaryInstructionsOfType(clazz).single(predicate::test)
+    }
+
+    inline fun <reified T : NotaryInstruction> findNotaryInstruction(crossinline predicate: (T) -> Boolean): T {
+        return findNotaryInstruction(T::class.java, Predicate { predicate(it) })
+    }
+
     operator fun component1(): List<StateAndRef<ContractState>> = inputs
     operator fun component2(): List<TransactionState<ContractState>> = outputs
     operator fun component3(): List<CommandWithParties<CommandData>> = commands
@@ -773,6 +826,7 @@ private constructor(
                 privacySalt = privacySalt,
                 networkParameters = networkParameters,
                 references = references,
+                notaryInstructions = notaryInstructions,
                 componentGroups = componentGroups,
                 serializedInputs = serializedInputs,
                 serializedReferences = serializedReferences,
@@ -805,6 +859,7 @@ private constructor(
                 privacySalt = privacySalt,
                 networkParameters = networkParameters,
                 references = references,
+                notaryInstructions = notaryInstructions,
                 componentGroups = componentGroups,
                 serializedInputs = serializedInputs,
                 serializedReferences = serializedReferences,
@@ -868,18 +923,19 @@ private class DefaultVerifier(
                 }
 
                 LedgerTransaction.createForContractVerify(
-                    inputs = deserializedInputs,
-                    outputs = deserializedOutputs,
-                    commands = authenticatedDeserializedCommands,
-                    attachments = ltx.attachments,
-                    id = ltx.id,
-                    notary = ltx.notary,
-                    timeWindow = ltx.timeWindow,
-                    privacySalt = ltx.privacySalt,
-                    networkParameters = ltx.networkParameters,
-                    references = deserializedReferences,
-                    digestService = ltx.digestService,
-                    rotatedKeys = ltx.rotatedKeys
+                        inputs = deserializedInputs,
+                        outputs = deserializedOutputs,
+                        commands = authenticatedDeserializedCommands,
+                        attachments = ltx.attachments,
+                        id = ltx.id,
+                        notary = ltx.notary,
+                        timeWindow = ltx.timeWindow,
+                        privacySalt = ltx.privacySalt,
+                        networkParameters = ltx.networkParameters,
+                        references = deserializedReferences,
+                        notaryInstructions = ltx.notaryInstructions,
+                        digestService = ltx.digestService,
+                        rotatedKeys = ltx.rotatedKeys
                 )
             }
         }

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -88,6 +88,7 @@ open class TransactionBuilder(
         )
     }
 
+    private val notaryInstructions = arrayListOf<NotaryInstruction>()
     private val inputsWithTransactionState = arrayListOf<StateAndRef<ContractState>>()
     private val referencesWithTransactionState = arrayListOf<TransactionState<ContractState>>()
     private var excludedAttachments: Set<AttachmentId> = emptySet()
@@ -108,6 +109,7 @@ open class TransactionBuilder(
                 references = ArrayList(references),
                 serviceHub = serviceHub
         )
+        t.notaryInstructions.addAll(this.notaryInstructions)
         t.inputsWithTransactionState.addAll(this.inputsWithTransactionState)
         t.referencesWithTransactionState.addAll(this.referencesWithTransactionState)
         return t
@@ -115,7 +117,7 @@ open class TransactionBuilder(
 
     // DOCSTART 1
     /** A more convenient way to add items to this transaction that calls the add* methods for you based on type */
-    fun withItems(vararg items: Any) = apply {
+    fun withItems(vararg items: Any): TransactionBuilder = apply {
         for (t in items) {
             when (t) {
                 is StateAndRef<*> -> addInputState(t)
@@ -128,6 +130,7 @@ open class TransactionBuilder(
                 is CommandData -> throw IllegalArgumentException("You passed an instance of CommandData, but that lacks the pubkey. You need to wrap it in a Command object first.")
                 is TimeWindow -> setTimeWindow(t)
                 is PrivacySalt -> setPrivacySalt(t)
+                is NotaryInstruction -> addNotaryInstruction(t)
                 else -> throw IllegalArgumentException("Wrong argument type: ${t.javaClass}")
             }
         }
@@ -218,7 +221,8 @@ open class TransactionBuilder(
                             window,
                             referenceStates,
                             serviceHub.networkParametersService.currentHash,
-                            legacyAttachments
+                            legacyAttachments,
+                            notaryInstructions
                     ),
                     privacySalt,
                     serviceHub.digestService
@@ -351,7 +355,7 @@ open class TransactionBuilder(
         val attachment = if (isLegacy) {
             // Any (legacy) missing attachments must also be present in the legacy-contracts folder to be attached to a transaction
             val legacyContractCordapps = serviceHub.cordappProvider.legacyContractCordapps.mapToSet { it.jarHash }
-            attachments.firstOrNull { it.id in legacyContractCordapps } 
+            attachments.firstOrNull { it.id in legacyContractCordapps }
         } else {
             attachments.firstOrNull()
         }
@@ -804,7 +808,7 @@ open class TransactionBuilder(
      * Note: Reference states are only supported on Corda networks running a minimum platform version of 4.
      * [toWireTransaction] will throw an [IllegalStateException] if called in such an environment.
      */
-    open fun addReferenceState(referencedStateAndRef: ReferencedStateAndRef<*>) = apply {
+    open fun addReferenceState(referencedStateAndRef: ReferencedStateAndRef<*>): TransactionBuilder = apply {
         val stateAndRef = referencedStateAndRef.stateAndRef
         referencesWithTransactionState.add(stateAndRef.state)
 
@@ -834,24 +838,22 @@ open class TransactionBuilder(
     }
 
     /** Adds an input [StateRef] to the transaction. */
-    open fun addInputState(stateAndRef: StateAndRef<*>) = apply {
+    open fun addInputState(stateAndRef: StateAndRef<*>): TransactionBuilder = apply {
         checkNotary(stateAndRef)
         inputs.add(stateAndRef.ref)
         inputsWithTransactionState.add(stateAndRef)
         resolveStatePointers(stateAndRef.state)
-        return this
     }
 
     /** Adds an attachment with the specified hash to the TransactionBuilder. */
-    fun addAttachment(attachmentId: AttachmentId) = apply {
+    fun addAttachment(attachmentId: AttachmentId): TransactionBuilder = apply {
         attachments.add(attachmentId)
     }
 
     /** Adds an output state to the transaction. */
-    fun addOutputState(state: TransactionState<*>) = apply {
+    fun addOutputState(state: TransactionState<*>): TransactionBuilder = apply {
         outputs.add(state)
         resolveStatePointers(state)
-        return this
     }
 
     /** Adds an output state, with associated contract code (and constraints), and notary, to the transaction. */
@@ -892,7 +894,7 @@ open class TransactionBuilder(
     }
 
     /** Adds a [Command] to the transaction. */
-    fun addCommand(arg: Command<*>) = apply {
+    fun addCommand(arg: Command<*>): TransactionBuilder = apply {
         commands.add(arg)
     }
 
@@ -900,16 +902,16 @@ open class TransactionBuilder(
      * Adds a [Command] to the transaction, specified by the encapsulated [CommandData] object and required list of
      * signing [PublicKey]s.
      */
-    fun addCommand(data: CommandData, vararg keys: PublicKey) = addCommand(Command(data, listOf(*keys)))
+    fun addCommand(data: CommandData, vararg keys: PublicKey): TransactionBuilder = addCommand(Command(data, listOf(*keys)))
 
-    fun addCommand(data: CommandData, keys: List<PublicKey>) = addCommand(Command(data, keys))
+    fun addCommand(data: CommandData, keys: List<PublicKey>): TransactionBuilder = addCommand(Command(data, keys))
 
     /**
      * Sets the [TimeWindow] for this transaction, replacing the existing [TimeWindow] if there is one. To be valid, the
      * transaction must then be signed by the notary service within this window of time. In this way, the notary acts as
      * the Timestamp Authority.
      */
-    fun setTimeWindow(timeWindow: TimeWindow) = apply {
+    fun setTimeWindow(timeWindow: TimeWindow): TransactionBuilder = apply {
         check(notary != null) { "Only notarised transactions can have a time-window" }
         window = timeWindow
     }
@@ -923,24 +925,31 @@ open class TransactionBuilder(
      */
     fun setTimeWindow(time: Instant, timeTolerance: Duration) = setTimeWindow(TimeWindow.withTolerance(time, timeTolerance))
 
-    fun setPrivacySalt(privacySalt: PrivacySalt) = apply {
+    fun setPrivacySalt(privacySalt: PrivacySalt): TransactionBuilder = apply {
         this.privacySalt = privacySalt
     }
 
-    /** Returns an immutable list of input [StateRef]s. */
+    fun addNotaryInstruction(instruction: NotaryInstruction): TransactionBuilder = apply {
+        notaryInstructions.add(instruction)
+    }
+
+    /** Returns a copy of the input [StateRef]s. */
     fun inputStates(): List<StateRef> = ArrayList(inputs)
 
-    /** Returns an immutable list of reference input [StateRef]s. */
+    /** Returns a copy of the reference input [StateRef]s. */
     fun referenceStates(): List<StateRef> = ArrayList(references)
 
-    /** Returns an immutable list of attachment hashes. */
+    /** Returns a copy of attachment hashes. */
     fun attachments(): List<AttachmentId> = ArrayList(attachments)
 
-    /** Returns an immutable list of output [TransactionState]s. */
+    /** Returns a copy of the output [TransactionState]s. */
     fun outputStates(): List<TransactionState<*>> = ArrayList(outputs)
 
-    /** Returns an immutable list of [Command]s. */
+    /** Returns a copy of the [Command]s. */
     fun commands(): List<Command<*>> = ArrayList(commands)
+
+    /** Returns a copy of the [NotaryInstruction]s */
+    fun notaryInstructions(): List<NotaryInstruction> = ArrayList(notaryInstructions)
 
     /**
      * Sign the built transaction and return it. This is an internal function for use by the service hub, please use

--- a/core/src/main/kotlin/net/corda/core/transactions/TraversableTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TraversableTransaction.kt
@@ -16,6 +16,7 @@ import net.corda.core.contracts.ComponentGroupEnum.PARAMETERS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.REFERENCES_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.SIGNERS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.TIMEWINDOW_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.values
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
@@ -27,7 +28,6 @@ import net.corda.core.crypto.PartialMerkleTree
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.algorithm
 import net.corda.core.identity.Party
-import net.corda.core.internal.MAX_COMPONENT_GROUP_INDEX
 import net.corda.core.internal.deserialiseCommands
 import net.corda.core.internal.deserialiseComponentGroup
 import net.corda.core.internal.getGroup
@@ -246,7 +246,7 @@ class FilteredTransaction internal constructor(
                 // including the unknown new components.
                 wtx.componentGroups
                         .asSequence()
-                        .filter { it.groupIndex > MAX_COMPONENT_GROUP_INDEX }
+                        .filter { it.groupIndex >= values().size }
                         .forEach {
                             it.components.forEachIndexed { internalIndex, component -> filter(component, it.groupIndex, internalIndex) }
                         }

--- a/core/src/main/kotlin/net/corda/core/transactions/TraversableTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TraversableTransaction.kt
@@ -2,10 +2,32 @@ package net.corda.core.transactions
 
 import net.corda.core.CordaException
 import net.corda.core.CordaInternal
-import net.corda.core.contracts.*
-import net.corda.core.contracts.ComponentGroupEnum.*
-import net.corda.core.crypto.*
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.ComponentGroupEnum
+import net.corda.core.contracts.ComponentGroupEnum.ATTACHMENTS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.ATTACHMENTS_V2_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.COMMANDS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.INPUTS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.NOTARY_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.NOTARY_INSTRUCTIONS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.OUTPUTS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.PARAMETERS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.REFERENCES_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.SIGNERS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.TIMEWINDOW_GROUP
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.NotaryInstruction
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TimeWindow
+import net.corda.core.contracts.TransactionState
+import net.corda.core.crypto.DigestService
+import net.corda.core.crypto.MerkleTree
+import net.corda.core.crypto.PartialMerkleTree
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.algorithm
 import net.corda.core.identity.Party
+import net.corda.core.internal.MAX_COMPONENT_GROUP_INDEX
 import net.corda.core.internal.deserialiseCommands
 import net.corda.core.internal.deserialiseComponentGroup
 import net.corda.core.internal.getGroup
@@ -91,6 +113,11 @@ abstract class TraversableTransaction(open val componentGroups: List<ComponentGr
     }
 
     /**
+     * Returns the list of [NotaryInstruction]s for the notary.
+     */
+    val notaryInstructions: List<NotaryInstruction> = deserialiseComponentGroup(componentGroups, NotaryInstruction::class, NOTARY_INSTRUCTIONS_GROUP)
+
+    /**
      * Returns a list of all the component groups that are present in the transaction, excluding the privacySalt,
      * in the following order (which is the same with the order in [ComponentGroupEnum]:
      * - list of each input that is present
@@ -102,6 +129,7 @@ abstract class TraversableTransaction(open val componentGroups: List<ComponentGr
      * - list of each reference input that is present
      * - network parameters hash if present
      * - list of each attachment that is present
+     * - list of each notary instruction that is present
      */
     val availableComponentGroups: List<List<Any>>
         get() {
@@ -110,6 +138,7 @@ abstract class TraversableTransaction(open val componentGroups: List<ComponentGr
             timeWindow?.let { result += listOf(it) }
             networkParametersHash?.let { result += listOf(it) }
             result += nonLegacyAttachments
+            result += notaryInstructions
             return result
         }
 }
@@ -153,6 +182,7 @@ class FilteredTransaction internal constructor(
          * @param filtering filtering over the whole WireTransaction.
          * @return a list of [FilteredComponentGroup] used in PartialMerkleTree calculation and verification.
          */
+        @Suppress("ComplexMethod")
         private fun filterWithFun(wtx: WireTransaction, filtering: Predicate<Any>): List<FilteredComponentGroup> {
             val filteredSerialisedComponents: MutableMap<Int, MutableList<OpaqueBytes>> = hashMapOf()
             val filteredComponentNonces: MutableMap<Int, MutableList<SecureHash>> = hashMapOf()
@@ -204,6 +234,7 @@ class FilteredTransaction internal constructor(
                 // Similar situation is for network parameters hash and attachments, one should use wrapper [NetworkParametersHash] and not [SecureHash].
                 wtx.references.forEachIndexed { internalIndex, it -> filter(ReferenceStateRef(it), REFERENCES_GROUP.ordinal, internalIndex) }
                 wtx.networkParametersHash?.let { filter(NetworkParametersHash(it), PARAMETERS_GROUP.ordinal, 0) }
+                wtx.notaryInstructions.forEachIndexed { internalIndex, it -> filter(it, NOTARY_INSTRUCTIONS_GROUP.ordinal, internalIndex) }
                 // It is highlighted that because there is no a signers property in TraversableTransaction,
                 // one cannot specifically filter them in or out.
                 // The above is very important to ensure someone won't filter out the signers component group if at least one
@@ -214,8 +245,11 @@ class FilteredTransaction internal constructor(
                 // An example would be to redact certain contract state types, but otherwise leave a transaction alone,
                 // including the unknown new components.
                 wtx.componentGroups
-                        .filter { it.groupIndex >= values().size }
-                        .forEach { componentGroup -> componentGroup.components.forEachIndexed { internalIndex, component -> filter(component, componentGroup.groupIndex, internalIndex) } }
+                        .asSequence()
+                        .filter { it.groupIndex > MAX_COMPONENT_GROUP_INDEX }
+                        .forEach {
+                            it.components.forEachIndexed { internalIndex, component -> filter(component, it.groupIndex, internalIndex) }
+                        }
             }
 
             fun createPartialMerkleTree(componentGroupIndex: Int): PartialMerkleTree {
@@ -310,7 +344,10 @@ class FilteredTransaction internal constructor(
         } else {
             visibilityCheck(group.groupIndex < groupHashes.size) { "There is no matching component group hash for group ${group.groupIndex}" }
             val groupPartialRoot = groupHashes[group.groupIndex]
-            val groupFullRoot = MerkleTree.getMerkleTree(group.components.mapIndexed { index, component -> digestService.componentHash(group.nonces[index], component) }, digestService).hash
+            val groupFullRoot = MerkleTree.getMerkleTree(
+                    group.components.mapIndexed { index, component -> digestService.componentHash(group.nonces[index], component) },
+                    digestService
+            ).hash
             visibilityCheck(groupPartialRoot == groupFullRoot) { "Some components for group ${group.groupIndex} are not visible" }
             // Verify the top level Merkle tree from groupHashes.
             visibilityCheck(MerkleTree.getMerkleTree(groupHashes, digestService).hash == id) {
@@ -346,7 +383,7 @@ class FilteredTransaction internal constructor(
             try {
                 return SerializedBytes<List<PublicKey>>(opaqueBytes.bytes).deserialize()
             } catch (e: Exception) {
-                throw Exception("Malformed transaction, signers at index $internalIndex cannot be deserialised", e)
+                throw IllegalStateException("Malformed transaction, signers at index $internalIndex cannot be deserialised", e)
             }
         }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -7,9 +7,11 @@ import net.corda.core.contracts.Command
 import net.corda.core.contracts.CommandWithParties
 import net.corda.core.contracts.ComponentGroupEnum
 import net.corda.core.contracts.ComponentGroupEnum.COMMANDS_GROUP
+import net.corda.core.contracts.ComponentGroupEnum.NOTARY_INSTRUCTIONS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.OUTPUTS_GROUP
 import net.corda.core.contracts.ComponentGroupEnum.SIGNERS_GROUP
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.RotatedKeys
 import net.corda.core.contracts.StateRef
@@ -108,7 +110,11 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
             notary: Party?,
             timeWindow: TimeWindow?,
             privacySalt: PrivacySalt = PrivacySalt()
-    ) : this(createComponentGroups(inputs, outputs, commands, attachments, notary, timeWindow, emptyList(), null), privacySalt, DigestService.sha2_256)
+    ) : this(
+            createComponentGroups(inputs, outputs, commands, attachments, notary, timeWindow, emptyList(), null, emptyList(), emptyList()),
+            privacySalt,
+            DigestService.sha2_256
+    )
 
     init {
         check(componentGroups.all { it.components.isNotEmpty() }) { "Empty component groups are not allowed" }
@@ -239,6 +245,14 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         val resolvedNetworkParameters = verificationSupport.getNetworkParameters(networkParametersHash)
                 ?: throw TransactionResolutionException.UnknownParametersException(id, networkParametersHash!!)
 
+        val notaryInstructions = deserialiseComponentGroup(
+                componentGroups,
+                NotaryInstruction::class,
+                NOTARY_INSTRUCTIONS_GROUP,
+                factory = serializationFactory,
+                context = serializationContext
+        )
+
         val ltx = LedgerTransaction.create(
                 resolvedInputs,
                 outputs,
@@ -250,6 +264,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
                 privacySalt,
                 resolvedNetworkParameters.toImmutable(),
                 resolvedReferences,
+                notaryInstructions,
                 componentGroups,
                 serializedResolvedInputs,
                 serializedResolvedReferences,

--- a/core/src/test/kotlin/net/corda/core/internal/InternalAccessTestHelpers.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/InternalAccessTestHelpers.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.CommandWithParties
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.TimeWindow
@@ -44,6 +45,7 @@ fun createLedgerTransaction(
         privacySalt: PrivacySalt,
         networkParameters: NetworkParameters,
         references: List<StateAndRef<ContractState>>,
+        notaryInstructions: List<NotaryInstruction>,
         componentGroups: List<ComponentGroup>? = null,
         serializedInputs: List<SerializedStateAndRef>? = null,
         serializedReferences: List<SerializedStateAndRef>? = null,
@@ -62,6 +64,7 @@ fun createLedgerTransaction(
             privacySalt,
             networkParameters,
             references,
+            notaryInstructions,
             componentGroups,
             serializedInputs,
             serializedReferences,

--- a/node/src/integration-test2/kotlin/net/corda/flows/serialization/missing/MissingSerializerFlow.kt
+++ b/node/src/integration-test2/kotlin/net/corda/flows/serialization/missing/MissingSerializerFlow.kt
@@ -27,18 +27,20 @@ class MissingSerializerFlow(private val value: Long) : FlowLogic<SecureHash>() {
 
         val customDataState = CustomDataState(ourIdentity, CustomData(value))
         val wtx = WireTransaction(createComponentGroups(
-            inputs = emptyList(),
-            outputs = listOf(TransactionState(
-                data = customDataState,
+                inputs = emptyList(),
+                outputs = listOf(TransactionState(
+                        data = customDataState,
+                        notary = notary,
+                        constraint = AlwaysAcceptAttachmentConstraint
+                )),
                 notary = notary,
-                constraint = AlwaysAcceptAttachmentConstraint
-            )),
-            notary = notary,
-            commands = listOf(Command(Operate(), ourIdentity.owningKey)),
-            attachments = serviceHub.attachments.getLatestContractAttachments(customDataState.requiredContractClassName!!),
-            timeWindow = null,
-            references = emptyList(),
-            networkParametersHash = null
+                commands = listOf(Command(Operate(), ourIdentity.owningKey)),
+                attachments = serviceHub.attachments.getLatestContractAttachments(customDataState.requiredContractClassName!!),
+                timeWindow = null,
+                references = emptyList(),
+                networkParametersHash = null,
+                legacyAttachments = emptyList(),
+                notaryInstructions = emptyList()
         ))
         val signatureMetadata = SignatureMetadata(
             platformVersion = serviceHub.myInfo.platformVersion,

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -1,6 +1,8 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.contracts.ComponentGroupEnum
+import net.corda.core.contracts.NotaryInstruction
+import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.NotarisationPayload
@@ -34,12 +36,15 @@ class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePart
 
     override fun extractParts(requestPayload: NotarisationPayload): TransactionParts {
         val tx = requestPayload.coreTransaction
-        return when (tx) {
-            is FilteredTransaction -> TransactionParts(tx.id, tx.inputs, tx.timeWindow, tx.notary, tx.references, networkParametersHash = tx.networkParametersHash)
-            is ContractUpgradeFilteredTransaction,
-            is NotaryChangeWireTransaction -> TransactionParts(tx.id, tx.inputs, null, tx.notary, networkParametersHash = tx.networkParametersHash)
-            else -> throw unexpectedTransactionType(tx)
+        var timeWindow: TimeWindow? = null
+        var notaryInstructions: List<NotaryInstruction> = emptyList()
+        if (tx is FilteredTransaction) {
+            timeWindow = tx.timeWindow
+            notaryInstructions = tx.notaryInstructions
+        } else if (tx !is ContractUpgradeFilteredTransaction && tx !is NotaryChangeWireTransaction) {
+            throw unexpectedTransactionType(tx)
         }
+        return TransactionParts(tx.id, tx.inputs, timeWindow, tx.notary, tx.references, notaryInstructions, tx.networkParametersHash)
     }
 
     override fun verifyTransaction(requestPayload: NotarisationPayload) {
@@ -101,7 +106,7 @@ class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePart
     }
 
     private fun unexpectedTransactionType(tx: CoreTransaction): IllegalArgumentException {
-        return IllegalArgumentException("Received unexpected transaction type: ${tx::class.java.simpleName}," +
+        return IllegalArgumentException("Received unexpected transaction type: ${tx.javaClass.simpleName}," +
                 "expected either ${FilteredTransaction::class.java.simpleName} or ${NotaryChangeWireTransaction::class.java.simpleName}")
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.transactions
 
 import com.codahale.metrics.SlidingWindowReservoir
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
@@ -182,7 +183,8 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
             callerIdentity: Party,
             requestSignature: NotarisationRequestSignature,
             timeWindow: TimeWindow?,
-            references: List<StateRef>
+            references: List<StateRef>,
+            notaryInstructions: List<NotaryInstruction>
     ): CordaFuture<UniquenessProvider.Result> {
         val future = openFuture<UniquenessProvider.Result>()
         val request = CommitRequest(states, txId, callerIdentity, requestSignature, timeWindow, references, future)

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services.transactions
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.NotarisationPayload
@@ -20,11 +21,20 @@ import java.time.Duration
  * has its input states "blocked" by a transaction from another party, and needs to establish whether that transaction was
  * indeed valid.
  */
-open class ValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePartyNotaryService, etaThreshold: Duration = defaultEstimatedWaitTime) : NotaryServiceFlow(otherSideSession, service, etaThreshold) {
+open class ValidatingNotaryFlow(
+        otherSideSession: FlowSession,
+        service: SinglePartyNotaryService,
+        etaThreshold: Duration = defaultEstimatedWaitTime
+) : NotaryServiceFlow(otherSideSession, service, etaThreshold) {
     override fun extractParts(requestPayload: NotarisationPayload): TransactionParts {
         val stx = requestPayload.signedTransaction
-        val timeWindow: TimeWindow? = if (stx.coreTransaction is WireTransaction) stx.tx.timeWindow else null
-        return TransactionParts(stx.id, stx.inputs, timeWindow, stx.notary, stx.references, stx.networkParametersHash)
+        var timeWindow: TimeWindow? = null
+        var notaryInstructions: List<NotaryInstruction> = emptyList()
+        if (stx.coreTransaction is WireTransaction) {
+            timeWindow = stx.tx.timeWindow
+            notaryInstructions = stx.tx.notaryInstructions
+        }
+        return TransactionParts(stx.id, stx.inputs, timeWindow, stx.notary, stx.references, notaryInstructions, stx.networkParametersHash)
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/notary/experimental/raft/RaftUniquenessProvider.kt
@@ -14,6 +14,7 @@ import io.atomix.copycat.server.cluster.Member
 import io.atomix.copycat.server.storage.Storage
 import io.atomix.copycat.server.storage.StorageLevel
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
@@ -197,21 +198,21 @@ class RaftUniquenessProvider(
     }
 
     private fun registerMonitoring() {
-        metrics.register("RaftCluster.ThisServerStatus", Gauge<String> {
+        metrics.register("RaftCluster.ThisServerStatus", Gauge {
             server.state().name
         })
-        metrics.register("RaftCluster.MembersCount", Gauge<Int> {
+        metrics.register("RaftCluster.MembersCount", Gauge {
             server.cluster().members().size
         })
-        metrics.register("RaftCluster.Members", Gauge<List<String>> {
+        metrics.register("RaftCluster.Members", Gauge {
             server.cluster().members().map { it.address().toString() }
         })
 
-        metrics.register("RaftCluster.AvailableMembers", Gauge<List<String>> {
+        metrics.register("RaftCluster.AvailableMembers", Gauge {
             server.cluster().members().filter { it.status() == Member.Status.AVAILABLE }.map { it.address().toString() }
         })
 
-        metrics.register("RaftCluster.AvailableMembersCount", Gauge<Int> {
+        metrics.register("RaftCluster.AvailableMembersCount", Gauge {
             server.cluster().members().filter { it.status() == Member.Status.AVAILABLE }.size
         })
     }
@@ -222,7 +223,8 @@ class RaftUniquenessProvider(
             callerIdentity: Party,
             requestSignature: NotarisationRequestSignature,
             timeWindow: TimeWindow?,
-            references: List<StateRef>
+            references: List<StateRef>,
+            notaryInstructions: List<NotaryInstruction>
     ): CordaFuture<UniquenessProvider.Result> {
         log.debug { "Attempting to commit input states: ${states.joinToString()} for txId: $txId" }
         val commitCommand = CommitTransaction(

--- a/node/src/main/kotlin/net/corda/notary/jpa/JPAUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/notary/jpa/JPAUniquenessProvider.kt
@@ -2,6 +2,7 @@ package net.corda.notary.jpa
 
 import com.google.common.collect.Queues
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
@@ -159,7 +160,8 @@ class JPAUniquenessProvider(
             callerIdentity: Party,
             requestSignature: NotarisationRequestSignature,
             timeWindow: TimeWindow?,
-            references: List<StateRef>
+            references: List<StateRef>,
+            notaryInstructions: List<NotaryInstruction>
     ): CordaFuture<UniquenessProvider.Result> {
         val future = openFuture<UniquenessProvider.Result>()
         val requestEntities = Request(consumingTxHash = txId.toString(),

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -1,15 +1,18 @@
 package net.corda.node.services
 
 import co.paralleluniverse.fibers.Suspendable
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.*
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.NotarisationRequestSignature
+import net.corda.core.flows.NotaryError
+import net.corda.core.flows.NotaryFlow
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowIORequest
@@ -38,11 +41,20 @@ import net.corda.testing.core.singleIdentity
 import net.corda.testing.internal.LogHelper
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.MockNetworkParameters
-import net.corda.testing.node.internal.*
+import net.corda.testing.node.internal.CustomCordapp
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.InternalMockNetwork
+import net.corda.testing.node.internal.InternalMockNodeParameters
+import net.corda.testing.node.internal.TestStartedNode
+import net.corda.testing.node.internal.enclosedCordapp
+import net.corda.testing.node.internal.startFlow
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.time.Duration
 import java.util.concurrent.Future
@@ -203,7 +215,7 @@ class TimedFlowTests {
                 var exceptionThrown = false
                 try {
                     resultFuture.get(3, TimeUnit.SECONDS)
-                } catch (e: TimeoutException) {
+                } catch (_: TimeoutException) {
                     exceptionThrown = true
                 }
                 assertTrue(exceptionThrown)
@@ -236,7 +248,7 @@ class TimedFlowTests {
                 var exceptionThrown = false
                 try {
                     resultFuture.get(3, TimeUnit.SECONDS)
-                } catch (e: TimeoutException) {
+                } catch (_: TimeoutException) {
                     exceptionThrown = true
                 }
                 assertTrue(exceptionThrown)
@@ -269,10 +281,17 @@ class TimedFlowTests {
      * A test notary service that will just stop forever the first time you invoke its commitInputStates method and will succeed the
      * second time around.
      */
-    private class TestNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : SinglePartyNotaryService() {
+    private class TestNotaryService(override val services: ServiceHubInternal,
+                                    override val notaryIdentityKey: PublicKey) : SinglePartyNotaryService() {
         override val uniquenessProvider = object : UniquenessProvider {
             /** A dummy commit method that immediately returns a success message. */
-            override fun commit(states: List<StateRef>, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature, timeWindow: TimeWindow?, references: List<StateRef>): CordaFuture<UniquenessProvider.Result> {
+            override fun commit(states: List<StateRef>,
+                                txId: SecureHash,
+                                callerIdentity: Party,
+                                requestSignature: NotarisationRequestSignature,
+                                timeWindow: TimeWindow?,
+                                references: List<StateRef>,
+                                notaryInstructions: List<NotaryInstruction>): CordaFuture<UniquenessProvider.Result> {
                 return openFuture<UniquenessProvider.Result>().apply {
                     val signature = services.database.transaction {
                         signTransaction(txId)
@@ -291,7 +310,8 @@ class TimedFlowTests {
                 caller: Party,
                 requestSignature: NotarisationRequestSignature,
                 timeWindow: TimeWindow?,
-                references: List<StateRef>
+                references: List<StateRef>,
+                notaryInstructions: List<NotaryInstruction>
         ) : UniquenessProvider.Result {
             val callingFlow = FlowLogic.currentTopLevel
                     ?: throw IllegalStateException("This method should be invoked in a flow context.")
@@ -302,7 +322,7 @@ class TimedFlowTests {
                 callingFlow.stateMachine.suspend(FlowIORequest.WaitForLedgerCommit(SecureHash.randomSHA256()), false)
             } else {
                 log.info("Processing")
-                return super.commitInputStates(inputs, txId, caller, requestSignature, timeWindow, references)
+                return super.commitInputStates(inputs, txId, caller, requestSignature, timeWindow, references, notaryInstructions)
             }
             return UniquenessProvider.Result.Failure(NotaryError.General(Throwable("leave me alone")))
         }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NonValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NonValidatingNotaryServiceTests.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.Crypto
@@ -11,6 +12,7 @@ import net.corda.core.flows.NotarisationPayload
 import net.corda.core.flows.NotarisationRequest
 import net.corda.core.flows.NotarisationRequestSignature
 import net.corda.core.flows.NotaryError
+import net.corda.core.flows.NotaryError.TransactionInvalid
 import net.corda.core.flows.NotaryException
 import net.corda.core.flows.NotaryFlow
 import net.corda.core.identity.Party
@@ -44,6 +46,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Duration
 import java.time.Instant
 import java.util.Random
@@ -62,7 +65,7 @@ class NonValidatingNotaryServiceTests {
     fun setup() {
         mockNet = InternalMockNetwork(
                 cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
-                notarySpecs = listOf(MockNetworkNotarySpec(DUMMY_NOTARY_NAME, false))
+                notarySpecs = listOf(MockNetworkNotarySpec(DUMMY_NOTARY_NAME, validating = false))
         )
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         notaryNode = mockNet.defaultNotaryNode
@@ -78,7 +81,7 @@ class NonValidatingNotaryServiceTests {
     @Test(timeout=300_000)
 	fun `should sign a unique transaction with a valid time-window`() {
         val stx = run {
-            val input = issueState(aliceNode.services, alice)
+            val (input) = issueStates(aliceNode.services, alice)
             val tx = TransactionBuilder(notary)
                     .addInputState(input)
                     .addCommand(dummyCommand(alice.owningKey))
@@ -110,7 +113,7 @@ class NonValidatingNotaryServiceTests {
     @Test(timeout=300_000)
 	fun `should re-sign a transaction with an expired time-window`() {
         val stx = run {
-            val inputState = issueState(aliceNode.services, alice)
+            val (inputState) = issueStates(aliceNode.services, alice)
             val tx = TransactionBuilder(notary)
                     .addInputState(inputState)
                     .addCommand(dummyCommand(alice.owningKey))
@@ -134,7 +137,7 @@ class NonValidatingNotaryServiceTests {
     @Test(timeout=300_000)
 	fun `should report error for transaction with an invalid time-window`() {
         val stx = run {
-            val inputState = issueState(aliceNode.services, alice)
+            val (inputState) = issueStates(aliceNode.services, alice)
             val tx = TransactionBuilder(notary)
                     .addInputState(inputState)
                     .addCommand(dummyCommand(alice.owningKey))
@@ -163,7 +166,7 @@ class NonValidatingNotaryServiceTests {
     @Test(timeout=300_000)
 	fun `should sign identical transaction multiple times (notarisation is idempotent)`() {
         val stx = run {
-            val inputState = issueState(aliceNode.services, alice)
+            val (inputState) = issueStates(aliceNode.services, alice)
             val tx = TransactionBuilder(notary)
                     .addInputState(inputState)
                     .addCommand(dummyCommand(alice.owningKey))
@@ -191,8 +194,8 @@ class NonValidatingNotaryServiceTests {
 
     @Test(timeout=300_000)
 	fun `should report conflict when inputs are reused across transactions`() {
-        val firstState = issueState(aliceNode.services, alice)
-        val secondState = issueState(aliceNode.services, alice)
+        val (firstState) = issueStates(aliceNode.services, alice)
+        val (secondState) = issueStates(aliceNode.services, alice)
 
         fun spendState(state: StateAndRef<*>): SignedTransaction {
             val stx = run {
@@ -211,7 +214,7 @@ class NonValidatingNotaryServiceTests {
 
         val doubleSpendTx = run {
             val tx = TransactionBuilder(notary)
-                    .addInputState(issueState(aliceNode.services, alice))
+                    .addInputState(issueStates(aliceNode.services, alice).first())
                     .addInputState(firstState)
                     .addInputState(secondState)
                     .addCommand(dummyCommand(alice.owningKey))
@@ -270,6 +273,24 @@ class NonValidatingNotaryServiceTests {
         NotaryServiceTests.notariseWithTooManyInputs(aliceNode, alice, notary, mockNet)
     }
 
+    @Test(timeout=300_000)
+    fun `by default notary instructions are not supported`() {
+        data class DummyNotaryInstruction(val id: Int) : NotaryInstruction
+
+        val stx = run {
+            val (input) = issueStates(aliceNode.services, alice)
+            val tx = TransactionBuilder(notary)
+                    .addInputState(input)
+                    .addCommand(dummyCommand(alice.owningKey))
+                    .addNotaryInstruction(DummyNotaryInstruction(1))
+            aliceNode.services.signInitialTransaction(tx)
+        }
+
+        val notaryException = assertThrows<NotaryException> { runNotaryClient(stx).getOrThrow() }
+        assertThat(notaryException.error).isInstanceOf(TransactionInvalid::class.java)
+        assertThat((notaryException.error as TransactionInvalid).cause).hasMessageContaining("Notary instructions not supported")
+    }
+
     private fun runNotarisationAndInterceptClientPayload(payloadModifier: (NotarisationPayload) -> NotarisationPayload) {
         aliceNode.setMessagingServiceSpy(object : MessagingServiceSpy() {
             override fun send(message: Message, target: MessageRecipients, sequenceKey: Any) {
@@ -288,7 +309,7 @@ class NonValidatingNotaryServiceTests {
         })
 
         val stx = run {
-            val inputState = issueState(aliceNode.services, alice)
+            val (inputState) = issueStates(aliceNode.services, alice)
             val tx = TransactionBuilder(notary)
                     .addInputState(inputState)
                     .addCommand(dummyCommand(alice.owningKey))
@@ -305,14 +326,6 @@ class NonValidatingNotaryServiceTests {
         val future = aliceNode.services.startFlow(flow).resultFuture
         mockNet.runNetwork()
         return future
-    }
-
-    private fun issueState(serviceHub: ServiceHub, identity: Party): StateAndRef<*> {
-        val tx = DummyContract.generateInitial(Random().nextInt(), notary, identity.ref(0))
-        val signedByNode = serviceHub.signInitialTransaction(tx)
-        val stx = notaryNode.services.addSignature(signedByNode, notary.owningKey)
-        serviceHub.recordTransactions(stx)
-        return StateAndRef(stx.coreTransaction.outputs.first(), StateRef(stx.id, 0))
     }
 
     private fun issueStates(serviceHub: ServiceHub, identity: Party): List<StateAndRef<*>> {

--- a/node/src/test/kotlin/net/corda/node/services/transactions/UniquenessProviderTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/UniquenessProviderTests.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.transactions
 
 import com.codahale.metrics.MetricRegistry
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.Crypto
@@ -15,7 +16,7 @@ import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.crypto.randomHash
 import net.corda.core.flows.NotarisationRequestSignature
 import net.corda.core.flows.NotaryError
-import net.corda.core.flows.StateConsumptionDetails
+import net.corda.core.flows.StateConsumptionDetails.ConsumedStateType
 import net.corda.core.flows.StateConsumptionDetails.ConsumedStateType.INPUT_STATE
 import net.corda.core.flows.StateConsumptionDetails.ConsumedStateType.REFERENCE_INPUT_STATE
 import net.corda.core.identity.CordaX500Name
@@ -47,23 +48,25 @@ import net.corda.testing.node.TestClock
 import net.corda.testing.node.internal.MockKeyManagementService
 import net.corda.testing.node.makeTestIdentityService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assumptions.assumeThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
 import java.security.KeyPair
 import java.time.Clock
 
 @RunWith(Parameterized::class)
 class UniquenessProviderTests(
         private val uniquenessProviderFactory: UniquenessProviderFactory,
-        private val digestService: DigestService
+        private val digestService: DigestService,
 ) {
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "{0} {1}")
+        @Parameters(name = "{0} {1}")
         fun data(): Collection<Array<Any>> {
             return listOf(
                     arrayOf(JPAUniquenessProviderFactory(DigestService.sha2_256), DigestService.sha2_256),
@@ -95,8 +98,10 @@ class UniquenessProviderTests(
     @After
     fun tearDown() {
         HashAgility.init()
-        uniquenessProviderFactory.cleanUp()
-        LogHelper.reset(uniquenessProvider::class)
+        uniquenessProviderFactory.close()
+        if (::uniquenessProvider.isInitialized) {
+            LogHelper.reset(uniquenessProvider::class)
+        }
         LogHelper.reset("log4j.logger.org.hibernate.type")
         LogHelper.reset("log4j.logger.org.hibernate.SQL")
     }
@@ -116,7 +121,7 @@ class UniquenessProviderTests(
 
     /* Group A: only time window */
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction before time window is valid`() {
         val firstTxId = digestService.randomHash()
         val timeWindow = TimeWindow.between(
@@ -133,7 +138,7 @@ class UniquenessProviderTests(
         expectInvalidTimeWindow(emptyList(), firstTxId, timeWindow)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction within time window`() {
         val firstTxId = digestService.randomHash()
         val timeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().plus(30.minutes))
@@ -149,7 +154,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(emptyList(), firstTxId, timeWindow)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction after time window has expired`() {
         val firstTxId = digestService.randomHash()
         val timeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().minus(30.minutes))
@@ -160,7 +165,7 @@ class UniquenessProviderTests(
         expectInvalidTimeWindow(emptyList(), firstTxId, timeWindow)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `time window only transactions are processed correctly when duplicate requests occur in succession`() {
         val firstTxId = digestService.randomHash()
         val secondTxId = digestService.randomHash()
@@ -181,7 +186,7 @@ class UniquenessProviderTests(
 
     /* Group B: only reference states */
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction with unused reference states`() {
         val firstTxId = digestService.randomHash()
         val referenceState = generateStateRef()
@@ -192,7 +197,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(emptyList(), firstTxId, references = listOf(referenceState))
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with previously used reference states`() {
         val firstTxId = digestService.randomHash()
         val referenceState = generateStateRef()
@@ -201,14 +206,14 @@ class UniquenessProviderTests(
 
         // Transaction referencing the spent sate fails.
         val secondTxId = digestService.randomHash()
-        val consumedStates = expectConflict(emptyList(), secondTxId, references = listOf(referenceState))
-        assertThat(consumedStates[referenceState]).isEqualTo(StateConsumptionDetails(firstTxId.reHash(), REFERENCE_INPUT_STATE))
+        val conflict = expectConflict(emptyList(), secondTxId, references = listOf(referenceState))
+                .assertStateConsumed(referenceState, firstTxId, REFERENCE_INPUT_STATE)
 
         // Idempotency
-        assertThat(expectConflict(emptyList(), secondTxId, references = listOf(referenceState))).isEqualTo(consumedStates)
+        assertThat(expectConflict(emptyList(), secondTxId, references = listOf(referenceState))).isEqualTo(conflict)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits retry transaction when reference states were spent since initial transaction`() {
         val firstTxId = digestService.randomHash()
         val referenceState = generateStateRef()
@@ -223,7 +228,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(emptyList(), firstTxId, references = listOf(referenceState))
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `reference state only transactions are processed correctly when duplicate requests occur in succession`() {
         val firstTxId = digestService.randomHash()
         val secondTxId = digestService.randomHash()
@@ -243,7 +248,7 @@ class UniquenessProviderTests(
 
     /* Group C: reference states & time window */
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction with unused reference states and valid time window`() {
         val firstTxId = digestService.randomHash()
         val referenceState = generateStateRef()
@@ -259,7 +264,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(emptyList(), firstTxId, timeWindow, references = listOf(referenceState))
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with unused reference states and invalid time window`() {
         val firstTxId = digestService.randomHash()
         val referenceState = generateStateRef()
@@ -271,7 +276,7 @@ class UniquenessProviderTests(
         expectInvalidTimeWindow(emptyList(), firstTxId, invalidTimeWindow, references = listOf(referenceState))
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with previously used reference states and valid time window`() {
         val firstTxId = digestService.randomHash()
         val referenceState = generateStateRef()
@@ -281,14 +286,14 @@ class UniquenessProviderTests(
         // Transaction referencing the spent sate fails.
         val secondTxId = digestService.randomHash()
         val timeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().plus(30.minutes))
-        val consumedStates = expectConflict(emptyList(), secondTxId, timeWindow, references = listOf(referenceState))
-        assertThat(consumedStates[referenceState]).isEqualTo(StateConsumptionDetails(firstTxId.reHash(), REFERENCE_INPUT_STATE))
+        val conflict = expectConflict(emptyList(), secondTxId, timeWindow, references = listOf(referenceState))
+                .assertStateConsumed(referenceState, firstTxId, REFERENCE_INPUT_STATE)
 
         // Idempotency
-        assertThat(expectConflict(emptyList(), secondTxId, timeWindow, references = listOf(referenceState))).isEqualTo(consumedStates)
+        assertThat(expectConflict(emptyList(), secondTxId, timeWindow, references = listOf(referenceState))).isEqualTo(conflict)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with previously used reference states and invalid time window`() {
         val firstTxId = digestService.randomHash()
         val referenceState = generateStateRef()
@@ -298,13 +303,13 @@ class UniquenessProviderTests(
         // Transaction referencing the spent state fails.
         val secondTxId = digestService.randomHash()
         val invalidTimeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().minus(30.minutes))
-        val consumedStates = expectConflict(emptyList(), secondTxId, invalidTimeWindow, references = listOf(referenceState))
-        assertThat(consumedStates[referenceState]).isEqualTo(StateConsumptionDetails(firstTxId.reHash(), REFERENCE_INPUT_STATE))
+        expectConflict(emptyList(), secondTxId, invalidTimeWindow, references = listOf(referenceState))
+                .assertStateConsumed(referenceState, firstTxId, REFERENCE_INPUT_STATE)
     }
 
     /* Group D: only input states */
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction with unused inputs`() {
         val inputState = generateStateRef()
 
@@ -314,7 +319,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(listOf(inputState), txID)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction with multiple inputs (less than 10)`() {
         val inputs = Array(6) { generateStateRef() }.asList()
 
@@ -324,7 +329,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(inputs, txID)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction with multiple inputs (more than 10)`() {
         val inputs = Array(16) { generateStateRef() }.asList()
 
@@ -334,22 +339,22 @@ class UniquenessProviderTests(
         expectCommitSuccess(inputs, txID)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with one of the inputs previously used`() {
         val unusedInput = generateStateRef()
         val usedInput = generateStateRef()
         expectCommitSuccess(listOf(usedInput), txID)
 
         val secondTxId = digestService.randomHash()
-        val consumedStates = expectConflict(listOf(unusedInput, usedInput), secondTxId)
-        assertThat(consumedStates).doesNotContainKey(unusedInput)
-        assertThat(consumedStates[usedInput]).isEqualTo(StateConsumptionDetails(txID.reHash(), INPUT_STATE))
+        val conflict = expectConflict(listOf(unusedInput, usedInput), secondTxId)
+                .assertStateConsumed(usedInput, txID, INPUT_STATE)
+        assertThat(conflict.consumedStates).doesNotContainKey(unusedInput)
 
         // Idempotency
-        assertThat(expectConflict(listOf(unusedInput, usedInput), secondTxId)).isEqualTo(consumedStates)
+        assertThat(expectConflict(listOf(unusedInput, usedInput), secondTxId)).isEqualTo(conflict)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with all used inputs`() {
         // The two states consumed by different transactions.
         val secondTxId = digestService.randomHash()
@@ -360,15 +365,15 @@ class UniquenessProviderTests(
         expectCommitSuccess(listOf(input1), txID)
         expectCommitSuccess(listOf(input2), secondTxId)
 
-        val consumedStates = expectConflict(listOf(input1, input2), thirdTxId)
-        assertThat(consumedStates[input1]).isEqualTo(StateConsumptionDetails(txID.reHash(), INPUT_STATE))
-        assertThat(consumedStates[input2]).isEqualTo(StateConsumptionDetails(secondTxId.reHash(), INPUT_STATE))
+        val conflict = expectConflict(listOf(input1, input2), thirdTxId)
+                .assertStateConsumed(input1, txID, INPUT_STATE)
+                .assertStateConsumed(input2, secondTxId, INPUT_STATE)
 
         // Idempotency
-        assertThat(expectConflict(listOf(input1, input2), thirdTxId)).isEqualTo(consumedStates)
+        assertThat(expectConflict(listOf(input1, input2), thirdTxId)).isEqualTo(conflict)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `input state only transactions are processed correctly when duplicate requests occur in succession`() {
         val firstTxId = digestService.randomHash()
         val secondTxId = digestService.randomHash()
@@ -388,7 +393,7 @@ class UniquenessProviderTests(
 
     /* Group E: input states & time window */
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction with unused inputs and valid time window`() {
         val inputState = generateStateRef()
         val timeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().plus(30.minutes))
@@ -400,7 +405,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(listOf(inputState), txID, timeWindow)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with unused inputs and invalid time window, and input isn't used`() {
         val inputState = generateStateRef()
         val invalidTimeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().minus(30.minutes))
@@ -411,7 +416,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(listOf(inputState), digestService.randomHash())
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with previously used inputs and valid time window`() {
         val inputState = generateStateRef()
         val inputs = listOf(inputState)
@@ -421,14 +426,14 @@ class UniquenessProviderTests(
         val secondTxId = digestService.randomHash()
 
         val timeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().plus(30.minutes))
-        val consumedStates = expectConflict(inputs, secondTxId, timeWindow)
-        assertThat(consumedStates[inputState]).isEqualTo(StateConsumptionDetails(firstTxId.reHash(), INPUT_STATE))
+        val conflict = expectConflict(inputs, secondTxId, timeWindow)
+                .assertStateConsumed(inputState, firstTxId, INPUT_STATE)
 
         // Idempotency
-        assertThat(expectConflict(inputs, secondTxId, timeWindow)).isEqualTo(consumedStates)
+        assertThat(expectConflict(inputs, secondTxId, timeWindow)).isEqualTo(conflict)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with previously used inputs and invalid time window`() {
         val inputState = generateStateRef()
         val inputs = listOf(inputState)
@@ -438,13 +443,13 @@ class UniquenessProviderTests(
         val secondTxId = digestService.randomHash()
 
         val invalidTimeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().minus(30.minutes))
-        val consumedStates = expectConflict(inputs, secondTxId, invalidTimeWindow)
-        assertThat(consumedStates[inputState]).isEqualTo(StateConsumptionDetails(firstTxId.reHash(), INPUT_STATE))
+        expectConflict(inputs, secondTxId, invalidTimeWindow)
+                .assertStateConsumed(inputState, firstTxId, INPUT_STATE)
     }
 
     /* Group F: input & reference states */
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `commits transaction with unused input & reference states`() {
         val firstTxId = digestService.randomHash()
         val inputState = generateStateRef()
@@ -458,7 +463,7 @@ class UniquenessProviderTests(
         expectCommitSuccess(listOf(inputState), firstTxId, timeWindow, references = listOf(referenceState))
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `re-notarise after reference state is spent`() {
         val firstTxId = digestService.randomHash()
         val inputState = generateStateRef()
@@ -480,7 +485,7 @@ class UniquenessProviderTests(
         assertThat(commit(listOf(inputState), firstTxId, timeWindow, listOf(referenceState)).get()).isEqualTo(result)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with unused reference states and used input states`() {
         val firstTxId = digestService.randomHash()
         val inputState = generateStateRef()
@@ -491,14 +496,14 @@ class UniquenessProviderTests(
         // Transaction referencing the spent sate fails.
         val secondTxId = digestService.randomHash()
         val timeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().plus(30.minutes))
-        val consumedStates = expectConflict(listOf(inputState), secondTxId, timeWindow, references = listOf(referenceState))
-        assertThat(consumedStates[inputState]).isEqualTo(StateConsumptionDetails(firstTxId.reHash(), INPUT_STATE))
+        val conflict = expectConflict(listOf(inputState), secondTxId, timeWindow, references = listOf(referenceState))
+                .assertStateConsumed(inputState, firstTxId, INPUT_STATE)
 
         // Idempotency
-        assertThat(expectConflict(listOf(inputState), secondTxId, timeWindow, listOf(referenceState))).isEqualTo(consumedStates)
+        assertThat(expectConflict(listOf(inputState), secondTxId, timeWindow, listOf(referenceState))).isEqualTo(conflict)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `rejects transaction with used reference states and unused input states`() {
         val firstTxId = digestService.randomHash()
         val inputState = generateStateRef()
@@ -509,14 +514,14 @@ class UniquenessProviderTests(
         // Transaction referencing the spent state fails.
         val secondTxId = digestService.randomHash()
         val timeWindow = TimeWindow.untilOnly(Clock.systemUTC().instant().plus(30.minutes))
-        val consumedStates = expectConflict(listOf(inputState), secondTxId, timeWindow, references = listOf(referenceState))
-        assertThat(consumedStates[referenceState]).isEqualTo(StateConsumptionDetails(firstTxId.reHash(), REFERENCE_INPUT_STATE))
+        val conflict = expectConflict(listOf(inputState), secondTxId, timeWindow, references = listOf(referenceState))
+                .assertStateConsumed(referenceState, firstTxId, REFERENCE_INPUT_STATE)
 
         // Idempotency
-        assertThat(expectConflict(listOf(inputState), secondTxId, timeWindow, listOf(referenceState))).isEqualTo(consumedStates)
+        assertThat(expectConflict(listOf(inputState), secondTxId, timeWindow, listOf(referenceState))).isEqualTo(conflict)
     }
 
-    @Test(timeout=300_000)
+    @Test(timeout = 300_000)
     fun `input and reference state transactions are processed correctly when duplicate requests occur in succession`() {
         val firstTxId = digestService.randomHash()
         val secondTxId = digestService.randomHash()
@@ -539,22 +544,34 @@ class UniquenessProviderTests(
 
     /* Group G: input, reference states and time window – covered by previous tests. */
 
+    @Test(timeout = 300_000)
+    fun `by default notary instructions are not supported`() {
+        assumeThat(uniquenessProviderFactory.isNotaryInstructionSupported).isFalse
+
+        class FakeNotaryInstruction : NotaryInstruction
+
+        assertThat(uniquenessProvider.isNotaryInstructionsValid(listOf())).isTrue
+        assertThat(uniquenessProvider.isNotaryInstructionsValid(listOf(FakeNotaryInstruction()))).isFalse
+    }
+
     private fun commit(
             states: List<StateRef>,
             txId: SecureHash,
             timeWindow: TimeWindow? = null,
-            references: List<StateRef> = emptyList()
+            references: List<StateRef> = emptyList(),
+            notaryInstructions: List<NotaryInstruction> = emptyList()
     ): CordaFuture<Result> {
-        return uniquenessProvider.commit(states, txId, identity, requestSignature, timeWindow, references)
+        return uniquenessProvider.commit(states, txId, identity, requestSignature, timeWindow, references, notaryInstructions)
     }
 
     private fun expectCommitSuccess(
             states: List<StateRef>,
             txId: SecureHash,
             timeWindow: TimeWindow? = null,
-            references: List<StateRef> = emptyList()
+            references: List<StateRef> = emptyList(),
+            notaryInstructions: List<NotaryInstruction> = emptyList()
     ) {
-        val result = commit(states, txId, timeWindow, references).get()
+        val result = commit(states, txId, timeWindow, references, notaryInstructions).get()
         assertThat(result).isInstanceOf(Result.Success::class.java)
         result as Result.Success
         result.signature.verify(txId)
@@ -564,9 +581,10 @@ class UniquenessProviderTests(
             states: List<StateRef>,
             txId: SecureHash,
             timeWindow: TimeWindow? = null,
-            references: List<StateRef> = emptyList()
+            references: List<StateRef> = emptyList(),
+            notaryInstructions: List<NotaryInstruction> = emptyList()
     ): NotaryError {
-        val result = commit(states, txId, timeWindow, references).get()
+        val result = commit(states, txId, timeWindow, references, notaryInstructions).get()
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         return (result as Result.Failure).error
     }
@@ -575,7 +593,7 @@ class UniquenessProviderTests(
             states: List<StateRef>,
             txId: SecureHash,
             timeWindow: TimeWindow,
-            references: List<StateRef> = emptyList()
+            references: List<StateRef> = emptyList(),
     ) {
         val notaryError = expectCommitFailure(states, txId, timeWindow, references)
         assertThat(notaryError).isInstanceOf(NotaryError.TimeWindowInvalid::class.java)
@@ -586,19 +604,32 @@ class UniquenessProviderTests(
             states: List<StateRef>,
             txId: SecureHash,
             timeWindow: TimeWindow? = null,
-            references: List<StateRef> = emptyList()
-    ): Map<StateRef, StateConsumptionDetails> {
+            references: List<StateRef> = emptyList(),
+    ): NotaryError.Conflict {
         val notaryError = expectCommitFailure(states, txId, timeWindow, references)
         assertThat(notaryError).isInstanceOf(NotaryError.Conflict::class.java)
         val conflict = notaryError as NotaryError.Conflict
         assertThat(conflict.txId).isEqualTo(txId)
-        return conflict.consumedStates
+        return conflict
+    }
+
+    private fun NotaryError.Conflict.assertStateConsumed(
+            stateRef: StateRef,
+            consumingTxId: SecureHash,
+            expectedType: ConsumedStateType,
+    ): NotaryError.Conflict {
+        assertThat(consumedStates).containsKey(stateRef)
+        val consumptionDetails = consumedStates.getValue(stateRef)
+        assertThat(consumptionDetails.type).isEqualTo(expectedType)
+        assertThat(consumptionDetails.hashOfTransactionId).isEqualTo(consumingTxId.reHash())
+        return this
     }
 }
 
-interface UniquenessProviderFactory {
+interface UniquenessProviderFactory : AutoCloseable {
+    val isNotaryInstructionSupported: Boolean
+        get() = false
     fun create(clock: Clock): UniquenessProvider
-    fun cleanUp() {}
 }
 
 class RaftUniquenessProviderFactory : UniquenessProviderFactory {
@@ -607,7 +638,13 @@ class RaftUniquenessProviderFactory : UniquenessProviderFactory {
 
     override fun create(clock: Clock): UniquenessProvider {
         database?.close()
-        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null }, NodeSchemaService(extraSchemas = setOf(RaftNotarySchemaV1)))
+        database = configureDatabase(
+                makeTestDataSourceProperties(),
+                DatabaseConfig(),
+                { null },
+                { null },
+                NodeSchemaService(extraSchemas = setOf(RaftNotarySchemaV1))
+        )
 
         val testSSL = configureTestSSL(CordaX500Name("Raft", "London", "GB"))
         val raftNodePort = 10987
@@ -627,10 +664,12 @@ class RaftUniquenessProviderFactory : UniquenessProviderFactory {
         }
     }
 
-    override fun cleanUp() {
+    override fun close() {
         provider?.stop()
         database?.close()
     }
+
+    override fun toString(): String = "Raft"
 }
 
 class JPAUniquenessProviderFactory(private val digestService: DigestService) : UniquenessProviderFactory {
@@ -640,7 +679,13 @@ class JPAUniquenessProviderFactory(private val digestService: DigestService) : U
 
     override fun create(clock: Clock): UniquenessProvider {
         database?.close()
-        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null }, NodeSchemaService(extraSchemas = setOf(JPANotarySchemaV1)))
+        database = configureDatabase(
+                makeTestDataSourceProperties(),
+                DatabaseConfig(),
+                { null },
+                { null },
+                NodeSchemaService(extraSchemas = setOf(JPANotarySchemaV1))
+        )
         return JPAUniquenessProvider(
                 clock,
                 database!!,
@@ -650,9 +695,11 @@ class JPAUniquenessProviderFactory(private val digestService: DigestService) : U
         )
     }
 
-    override fun cleanUp() {
+    override fun close() {
         database?.close()
     }
+
+    override fun toString(): String = "JPA"
 
     fun signBatch(it: Iterable<SecureHash>): BatchSignature {
         val root = MerkleTree.getMerkleTree(it.map { it.reHash() }, digestService)

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt
@@ -35,7 +35,7 @@ class CustomNotaryTest {
                 cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
                 notarySpecs = listOf(MockNetworkNotarySpec(
                         name = CordaX500Name("Custom Notary", "Amsterdam", "NL"),
-                        className = "net.corda.testing.node.CustomNotaryTest\$CustomNotaryService",
+                        className = CustomNotaryService::class.java.name,
                         validating = false // Can also be validating if preferred.
                 ))
         ))

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -2,6 +2,7 @@ package net.corda.testing.internal
 
 import net.corda.core.context.AuthServiceId
 import net.corda.core.contracts.Command
+import net.corda.core.contracts.NotaryInstruction
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
@@ -164,9 +165,21 @@ fun createWireTransaction(inputs: List<StateRef>,
                           notary: Party?,
                           timeWindow: TimeWindow?,
                           legacyAttachments: List<SecureHash> = emptyList(),
+                          notaryInstructions: List<NotaryInstruction> = emptyList(),
                           privacySalt: PrivacySalt = PrivacySalt(),
                           digestService: DigestService = DigestService.default): WireTransaction {
-    val componentGroups = createComponentGroups(inputs, outputs, commands, attachments, notary, timeWindow, emptyList(), null, legacyAttachments)
+    val componentGroups = createComponentGroups(
+            inputs,
+            outputs,
+            commands,
+            attachments,
+            notary,
+            timeWindow,
+            emptyList(),
+            null,
+            legacyAttachments,
+            notaryInstructions
+    )
     return WireTransaction(componentGroups, privacySalt, digestService)
 }
 


### PR DESCRIPTION
Introducing a new transaction component group, notary instructions.

These instructions are represented by the marker interface `NotaryInstruction` and represent arbitrary instructions that notaries can perform alongside the notarisation of the transaction. This is not a plugin mechanism, and only R3 will provide implementations either in Core or via extension SDKs. For now the notary implementations do not support instructions, and in fact expect no instructions to be present. This later point is to prevent unknown instructions being used.

Notary instructions are added via `TransactionBuilder.addNotaryInstruction` and can be queried in `LedgerTransaction`s. This can be used in contract verification to mandate certain instructions are present alongside the Corda ledger state transition. Filtered transactions also have this component group, and are included when sent to non-validating notaries.

There's also some cleanup, including back-porting changes made in `UniquenessProviderTests` in ENT.