### PR TITLE
Ensure that a CorDapp is present in cordapps directory when choosing an attachment for a missing class dependency

### DIFF
--- a/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
+++ b/core-tests/src/integration-test/kotlin/net/corda/coretests/transactions/TransactionBuilderDriverTest.kt
@@ -74,10 +74,19 @@ class TransactionBuilderDriverTest {
                 createTransaction(node)
             }.hasMessageContaining("Transaction being built has a missing attachment for class net/corda/finance/contracts/asset/")
 
-            // Upload the missing dependency
-            dependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+            node.stop()
+            FileUtils.deleteDirectory(node.baseDirectory.toFile())
 
-            val stx = createTransaction(node)
+            // Now restart the node with the missing dependency
+            val restartedNode = startNode(NodeParameters(
+                    ALICE_NAME,
+                    additionalCordapps = listOf(cordapp, dependency),
+            )).getOrThrow()
+
+            // Upload the missing dependency manually as it does not contain a contract so it won't be automatically uploaded
+            dependency.jarFile.inputStream().use(restartedNode.rpc::uploadAttachment)
+
+            val stx = createTransaction(restartedNode)
             assertThat(stx.tx.attachments).contains(cordapp.jarFile.hash, dependency.jarFile.hash)
         }
     }
@@ -116,7 +125,7 @@ class TransactionBuilderDriverTest {
             }.hasMessageContaining("Transaction being built has a missing legacy attachment for class net/corda/finance/contracts/asset/")
 
             node.stop()
-            FileUtils.deleteDirectory(node.baseDirectory.toFile());
+            FileUtils.deleteDirectory(node.baseDirectory.toFile())
 
             // Now restart the node with the missing dependency
             val restartedNode = startNode(NodeParameters(
@@ -157,6 +166,116 @@ class TransactionBuilderDriverTest {
             assertThatThrownBy { node.rpc.startFlow(::TwoContractTransactionFlow).returnValue.getOrThrow() }
                     .hasMessageContaining("Transaction being built has a missing legacy attachment")
                     .hasMessageContaining("CommercialPaper")
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `prevents addition of a dependency from outside of the CorDapps`() {
+        internalDriver(cordappsForAllNodes = listOf(FINANCE_WORKFLOWS_CORDAPP), startNodesInProcess = false) {
+            val (cordapp, dependency) = splitFinanceContractCordapp(currentFinanceContractsJar)
+
+            cordapp.jarFile.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+            dependency.jarFile.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+
+            // Start the node without the missing dependency CorDapp
+            val node = startNode(NodeParameters(ALICE_NAME, additionalCordapps = listOf(cordapp))).getOrThrow()
+
+            // Upload the missing dependency but don't include it in the CorDapps of the node
+            dependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+
+            // Ensure the missing dependency causes an issue
+            assertThatThrownBy {
+                createTransaction(node)
+            }.hasMessageContaining("Transaction being built has a missing attachment for class net/corda/finance/contracts/asset/")
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `prevents addition of a legacy dependency from outside of the legacy CorDapps`() {
+        internalDriver(
+                cordappsForAllNodes = listOf(FINANCE_WORKFLOWS_CORDAPP),
+                startNodesInProcess = false,
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4),
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = false))
+        ) {
+            val (legacyContracts, legacyDependency) = splitFinanceContractCordapp(legacyFinanceContractsJar)
+            val currentContracts = TestCordapp.of(currentFinanceContractsJar.toUri()).asSigned() as TestCordappInternal
+
+            currentContracts.jarFile.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+
+            // Start the node without the missing legacy dependency CorDapp
+            val node = startNode(NodeParameters(
+                    ALICE_NAME,
+                    additionalCordapps = listOf(currentContracts),
+                    legacyContracts = listOf(legacyContracts)
+            )).getOrThrow()
+
+            // Upload the missing legacy dependency but don't include it in the legacy CorDapps of the node
+            legacyDependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+
+            // Ensure the missing dependency causes an issue
+            assertThatThrownBy {
+                createTransaction(node)
+            }.hasMessageContaining("Transaction being built has a missing legacy attachment for class net/corda/finance/contracts/asset/")
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `prevents addition of a dependency when multiple CorDapps contain it`() {
+        internalDriver(cordappsForAllNodes = listOf(FINANCE_WORKFLOWS_CORDAPP), startNodesInProcess = false) {
+            val (cordapp, dependency) = splitFinanceContractCordapp(currentFinanceContractsJar)
+            val duplicateDependency = TestCordapp.of(dependency.jarFile.toUri()).asSigned() as UriTestCordapp
+
+            cordapp.jarFile.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+            dependency.jarFile.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+
+            // Start the node with the 2 CorDapps which contain the same missing dependency
+            val node = startNode(NodeParameters(
+                    ALICE_NAME,
+                    additionalCordapps = listOf(cordapp, dependency, duplicateDependency)
+            )).getOrThrow()
+
+            // Upload the missing dependencies manually as they do not contain a contract so they won't be automatically uploaded
+            dependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+            duplicateDependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+
+            // Ensure the duplicate dependency causes an issue
+            assertThatThrownBy {
+                createTransaction(node)
+            }.hasMessageContaining("Transaction being built has a missing attachment for class net/corda/finance/contracts/asset/CashUtilities. " +
+                    "Found more than one possible attachments")
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `allows addition of a legacy dependency when multiple legacy CorDapps contain it`() {
+        internalDriver(
+                cordappsForAllNodes = listOf(FINANCE_WORKFLOWS_CORDAPP),
+                startNodesInProcess = false,
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4),
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = false))
+        ) {
+            val (legacyContracts, legacyDependency) = splitFinanceContractCordapp(legacyFinanceContractsJar)
+            val currentContracts = TestCordapp.of(currentFinanceContractsJar.toUri()).asSigned() as TestCordappInternal
+            val duplicateLegacyDependency = TestCordapp.of(legacyDependency.jarFile.toUri()).asSigned() as UriTestCordapp
+
+            currentContracts.jarFile.inputStream().use(defaultNotaryNode.getOrThrow().rpc::uploadAttachment)
+
+            // Start the node with the 2 legacy CorDapps which contain the same missing legacy dependency
+            val node = startNode(NodeParameters(
+                    ALICE_NAME,
+                    additionalCordapps = listOf(currentContracts),
+                    legacyContracts = listOf(legacyContracts, legacyDependency, duplicateLegacyDependency)
+            )).getOrThrow()
+
+            // Upload the missing legacy dependencies manually as they do not contain a contract so they won't be automatically uploaded
+            legacyDependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+            duplicateLegacyDependency.jarFile.inputStream().use(node.rpc::uploadAttachment)
+
+            val stx = createTransaction(node)
+            assertThat(stx.tx.legacyAttachments).contains(legacyContracts.jarFile.hash)
+            assertThat(stx.tx.legacyAttachments).size().isEqualTo(2)
+            assertThat(stx.tx.legacyAttachments).containsAnyOf(legacyDependency.jarFile.hash, duplicateLegacyDependency.jarFile.hash)
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -348,22 +348,31 @@ open class TransactionBuilder(
         }
 
         val attachments = serviceHub.getTrustedClassAttachments(missingClass)
-        val attachment = if (isLegacy) {
+        val attachmentCandidates = if (isLegacy) {
             // Any (legacy) missing attachments must also be present in the legacy-contracts folder to be attached to a transaction
             val legacyContractCordapps = serviceHub.cordappProvider.legacyContractCordapps.mapToSet { it.jarHash }
-            attachments.firstOrNull { it.id in legacyContractCordapps } 
+            attachments.filter { it.id in legacyContractCordapps }
         } else {
-            attachments.firstOrNull()
+            // Any (non-legacy) missing attachments must also be present in the cordapps folder to be attached to a transaction
+            val nonLegacyCordapps = serviceHub.cordappProvider.cordapps.mapToSet { it.jarHash }
+            attachments.filter { it.id in nonLegacyCordapps }
         }
-
+        // We only want to attach an attachment if we can do it in a deterministic manner. Otherwise, the attachment being added can vary between
+        // nodes which build the same transaction but have attachments in a different order in the database. We only enforce this for non-legacy part of transactions
+        // in order to not break existing CordApps that rely on this mechanic.
+        if (!isLegacy && attachmentCandidates.size > 1) {
+            throw IllegalStateException("Transaction being built has a missing attachment for class " +
+                    "$missingClass. Found more than one possible attachments: ${attachmentCandidates.map { it.id }}. It is impossible to choose one in a deterministic way." +
+                    " Please contact the developer of the CorDapp for further instructions.", originalException)
+        }
+        val attachment = attachmentCandidates.firstOrNull()
         if (attachment == null) {
             throw IllegalStateException("Transaction being built has a missing ${if (isLegacy) "legacy " else ""}attachment for class " +
                     "$missingClass. Could not find a suitable attachment from storage. Please contact the developer of the CorDapp for " +
                     "further instructions.", originalException)
         }
-
         log.warnOnce("""The transaction currently built is missing an attachment for class: $missingClass.
-                        Automatically attaching contract dependency $attachment.
+                        Automatically attaching cordapp dependency $attachment.
                         Please contact the developer of the CorDapp and install the latest version, as this approach might be insecure.
                     """.trimIndent())
 


### PR DESCRIPTION
## Problem description:
When building a transaction, the TransactionBuilder attempts to verify a transaction, and if it encounters a missing class dependency, it looks for it in the attachments and adds the attachment with the missing class to the transaction. However, it considers all of the attachments from the Attachment Storage rather than the CorDapps present in the node. This allows it to add an arbitrary trusted attachment that contains the missing class, even a legacy one! Moreover, it doesn't check if multiple attachments contain said class; it simply chooses the first one. Because of this, the attachment it chooses is runtime-dependent and non-deterministic. With the same set of attachments in the storage, one node may attach CorDapp A with the missing class and the other CorDapp B.

## Implemented solution:
When fetching potential attachments which contain the missing class, we only consider the ones that are part of the cordapps folder in our node. We also check that only one such CorDapp is found to ensure deterministic behaviour.
For the legacy part of the transaction, we relax this requirement to maintain backwards compatibility, as existing CorDapps are already using this functionality.


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
