### PR TITLE
Replace dots with slashes when extracting a missing class

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -291,11 +291,11 @@ open class TransactionBuilder(
                 return current.message?.replace('.', '/')
             }
             if (current is NoClassDefFoundError) {
-                return current.message
+                return current.message?.replace('.', '/')
             }
             val message = current.message
             if (message != null) {
-                message.extractClassAfter(NoClassDefFoundError::class)?.let { return it }
+                message.extractClassAfter(NoClassDefFoundError::class)?.let { return it.replace('.', '/') }
                 message.extractClassAfter(ClassNotFoundException::class)?.let { return it.replace('.', '/') }
             }
             current = current.cause ?: return null


### PR DESCRIPTION
Replace dots with slashes in NoClassDefFoundError so that the regex pattern can extract the missing class.


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
