### PR TITLE
ENT-12311: Add JUnit 5 equivalent of JUnit 4 SerializationEnvironmentRule

### DIFF
--- a/testing/core-test-utils/build.gradle
+++ b/testing/core-test-utils/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation "com.google.guava:guava-testlib:$guava_version"
     implementation "io.reactivex:rxjava:$rxjava_version"
     implementation "junit:junit:$junit_version"
+    implementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     implementation("org.apache.activemq:artemis-server:${artemis_version}") {
         exclude group: 'org.apache.commons', module: 'commons-dbcp2'
         exclude group: 'org.jgroups', module: 'jgroups'
@@ -35,6 +36,10 @@ dependencies {
 
     testImplementation "org.assertj:assertj-core:${assertj_version}"
     testImplementation 'org.hamcrest:hamcrest-library:2.1'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 jar {

--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
@@ -21,7 +21,7 @@ import java.lang.reflect.Method
  */
 class SerializationEnvironmentExtension(
         private val inheritable: Boolean = false
-) : InvocationInterceptor, ParameterResolver {
+) : BeforeEachCallback, InvocationInterceptor, ParameterResolver {
 
     companion object {
         init {
@@ -37,10 +37,15 @@ class SerializationEnvironmentExtension(
         }
     }
 
-    private var env: SerializationEnvironment? = null
+    private lateinit var env: SerializationEnvironment
 
     val serializationFactory: SerializationFactory
-        get() = env?.serializationFactory ?: throw IllegalStateException("Environment not initialized")
+        get() = env.serializationFactory
+
+    override fun beforeEach(context: ExtensionContext) {
+        // Eager init of environment before parameter resolution
+        env = createTestSerializationEnv()
+    }
 
     /**
      * Wraps the test body in the test serialization environment.
@@ -50,10 +55,7 @@ class SerializationEnvironmentExtension(
             context: ReflectiveInvocationContext<Method>,
             extensionContext: ExtensionContext
     ) {
-        // Ensure env is initialized
-        val environment = env ?: createTestSerializationEnv().also { env = it }
-
-        environment.asTestContextEnv {
+        env.asTestContextEnv {
             invocation.proceed()
         }
     }
@@ -72,10 +74,6 @@ class SerializationEnvironmentExtension(
             parameterContext: ParameterContext,
             extensionContext: ExtensionContext
     ): Any {
-        // Lazily initialize env if needed
-        if (env == null) {
-            env = createTestSerializationEnv()
-        }
-        return env!!.serializationFactory
+        return serializationFactory
     }
 }

--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
@@ -25,12 +25,8 @@ import java.lang.reflect.Method
 
 /**
  * A JUnit 5 extension that sets up a [SerializationEnvironment] for tests.
- *
- * @param inheritable whether new threads inherit the environment, use sparingly.
  */
-class SerializationEnvironmentExtension(
-        private val inheritable: Boolean = false
-) : BeforeEachCallback, InvocationInterceptor, ParameterResolver {
+class SerializationEnvironmentExtension : BeforeEachCallback, InvocationInterceptor, ParameterResolver {
 
     companion object {
         init {

--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
@@ -1,0 +1,81 @@
+package net.corda.testing.core
+
+import net.corda.core.internal.staticField
+import net.corda.core.serialization.SerializationFactory
+import net.corda.core.serialization.internal.SerializationEnvironment
+import net.corda.core.serialization.internal.effectiveSerializationEnv
+import net.corda.coretesting.internal.*
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnector
+import org.junit.jupiter.api.extension.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.lang.reflect.Method
+
+/**
+ * A JUnit 5 extension that sets up a [SerializationEnvironment] for tests.
+ *
+ * @param inheritable whether new threads inherit the environment, use sparingly.
+ */
+class SerializationEnvironmentExtension(
+        private val inheritable: Boolean = false
+) : InvocationInterceptor, ParameterResolver {
+
+    companion object {
+        init {
+            // Hack Artemis's static executor service like the JUnit 4 rule
+            InVMConnector::class.staticField<ExecutorService>("executorService").value =
+                    rigorousMock<ExecutorService>().also { mockExec ->
+                        doAnswer { invocation ->
+                            inVMExecutors.computeIfAbsent(effectiveSerializationEnv) {
+                                Executors.newCachedThreadPool(testThreadFactory(true))
+                            }.execute(invocation.arguments[0] as Runnable)
+                        }.whenever(mockExec).execute(any())
+                    }
+        }
+    }
+
+    private var env: SerializationEnvironment? = null
+
+    val serializationFactory: SerializationFactory
+        get() = env?.serializationFactory ?: throw IllegalStateException("Environment not initialized")
+
+    /**
+     * Wraps the test body in the test serialization environment.
+     */
+    override fun interceptTestMethod(
+            invocation: InvocationInterceptor.Invocation<Void>,
+            context: ReflectiveInvocationContext<Method>,
+            extensionContext: ExtensionContext
+    ) {
+        // Ensure env is initialized
+        val environment = env ?: createTestSerializationEnv().also { env = it }
+
+        environment.asTestContextEnv {
+            invocation.proceed()
+        }
+    }
+
+    /**
+     * Allow tests to inject [SerializationFactory] directly as a parameter.
+     */
+    override fun supportsParameter(
+            parameterContext: ParameterContext,
+            extensionContext: ExtensionContext
+    ): Boolean {
+        return parameterContext.parameter.type == SerializationFactory::class.java
+    }
+
+    override fun resolveParameter(
+            parameterContext: ParameterContext,
+            extensionContext: ExtensionContext
+    ): Any {
+        // Lazily initialize env if needed
+        if (env == null) {
+            env = createTestSerializationEnv()
+        }
+        return env!!.serializationFactory
+    }
+}

--- a/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
+++ b/testing/core-test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentExtension.kt
@@ -4,9 +4,18 @@ import net.corda.core.internal.staticField
 import net.corda.core.serialization.SerializationFactory
 import net.corda.core.serialization.internal.SerializationEnvironment
 import net.corda.core.serialization.internal.effectiveSerializationEnv
-import net.corda.coretesting.internal.*
+import net.corda.coretesting.internal.asTestContextEnv
+import net.corda.coretesting.internal.createTestSerializationEnv
+import net.corda.coretesting.internal.inVMExecutors
+import net.corda.coretesting.internal.rigorousMock
+import net.corda.coretesting.internal.testThreadFactory
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnector
-import org.junit.jupiter.api.extension.*
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.whenever
@@ -60,7 +69,7 @@ class SerializationEnvironmentExtension(
         }
     }
 
-    /**
+    /*
      * Allow tests to inject [SerializationFactory] directly as a parameter.
      */
     override fun supportsParameter(

--- a/testing/core-test-utils/src/test/kotlin/net/corda/testing/core/SerializationEnvironmentExtensionTests.kt
+++ b/testing/core-test-utils/src/test/kotlin/net/corda/testing/core/SerializationEnvironmentExtensionTests.kt
@@ -1,0 +1,35 @@
+package net.corda.testing.core
+
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class SerializationEnvironmentExtensionTests {
+
+    @JvmField
+    @RegisterExtension
+    val extension = SerializationEnvironmentExtension()
+
+    @Test
+    fun `serializationFactory is injected as a parameter`(factory: net.corda.core.serialization.SerializationFactory) {
+        // JUnit 5 will automatically inject the SerializationFactory here
+        assertNotNull(factory, "SerializationFactory should be injected")
+        val original = "Injected Factory Test"
+        val bytes = original.serialize()
+        val restored = bytes.deserialize<String>()
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun `serialization environment is available during test`() {
+        // effectiveSerializationEnv is automatically set
+        assertNotNull(extension.serializationFactory)
+        val original = "Hello Corda"
+        val bytes = original.serialize()
+        val restored = bytes.deserialize<String>()
+        assertEquals(original, restored)
+    }
+}


### PR DESCRIPTION
Add a JUnit 5 equivalent of `net.corda.testing.core.SerializationEnvironmentRule`.
The new `SerializationEnvironmentExtension` provides the same test serialization environment, wraps each test in asTestContextEnv, and allows direct injection of SerializationFactory into test methods.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
