### PR TITLE
ENT-12499: Add `useGlobalThreadPools` parameter to `CordaRPCClient`

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -427,8 +427,18 @@ class CordaRPCClient private constructor(
     @JvmOverloads
     constructor(
             hostAndPort: NetworkHostAndPort,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            configuration = configuration
+    )
+
+    @JvmOverloads
+    constructor(
+            hostAndPort: NetworkHostAndPort,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -439,8 +449,19 @@ class CordaRPCClient private constructor(
     constructor(
             hostAndPort: NetworkHostAndPort,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            classLoader: ClassLoader
+    ): this(
+            hostAndPort,
+            configuration,
+            null,
+            classLoader = classLoader
+    )
+
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             classLoader: ClassLoader,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ): this(
             hostAndPort,
             configuration,
@@ -452,8 +473,19 @@ class CordaRPCClient private constructor(
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader
+    )
+
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -467,8 +499,22 @@ class CordaRPCClient private constructor(
             hostAndPort: NetworkHostAndPort,
             configuration: CordaRPCClientConfiguration,
             sslConfiguration: ClientRpcSslOptions?,
+            classLoader: ClassLoader? = null
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader
+    )
+
+    @JvmOverloads
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            configuration: CordaRPCClientConfiguration,
+            sslConfiguration: ClientRpcSslOptions?,
             classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -483,8 +529,22 @@ class CordaRPCClient private constructor(
             haAddressPool: List<NetworkHostAndPort>,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null
+    ) : this(
+            hostAndPort = null,
+            haAddressPool = haAddressPool,
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader
+    )
+
+    @JvmOverloads
+    constructor(
+            haAddressPool: List<NetworkHostAndPort>,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = null,
             haAddressPool = haAddressPool,
@@ -500,8 +560,24 @@ class CordaRPCClient private constructor(
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
+            customSerializers: Set<SerializationCustomSerializer<*, *>>?
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader,
+            customSerializers = customSerializers
+    )
+
+    @JvmOverloads
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null,
             customSerializers: Set<SerializationCustomSerializer<*, *>>?,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -518,8 +594,24 @@ class CordaRPCClient private constructor(
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
+            customSerializers: Set<SerializationCustomSerializer<*, *>>?
+    ) : this(
+            hostAndPort = null,
+            haAddressPool = haAddressPool,
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader,
+            customSerializers = customSerializers
+    )
+
+    @JvmOverloads
+    constructor(
+            haAddressPool: List<NetworkHostAndPort>,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null,
             customSerializers: Set<SerializationCustomSerializer<*, *>>?,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = null,
             haAddressPool = haAddressPool,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -409,6 +409,10 @@ class GracefulReconnect(val onDisconnect: () -> Unit = {}, val onReconnect: () -
  * @param customSerializers a set of [SerializationCustomSerializer]s to be used. If this parameter is specified, then no classpath scanning
  *  will be performed for custom serializers, the provided ones will be used instead. This parameter serves as a more user-friendly option
  *  to specify your serializers and disable the classpath scanning (e.g. for performance reasons).
+ * @param useGlobalThreadPools If `true`, Artemis global thread pools are used for all RPC clients. This allows multiple
+ *  connections to share a bounded set of scheduler and worker threads, controlled via Artemis system properties
+ *  (`activemq.artemis.client.global.thread.pool.max.size`, `activemq.artemis.client.global.scheduled.thread.pool.core.size`).
+ *  Defaults to `false`, meaning each client creates its own pools.
  */
 class CordaRPCClient private constructor(
         private val hostAndPort: NetworkHostAndPort?,
@@ -416,39 +420,46 @@ class CordaRPCClient private constructor(
         private val configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
         private val sslConfiguration: ClientRpcSslOptions? = null,
         private val classLoader: ClassLoader? = null,
-        private val customSerializers: Set<SerializationCustomSerializer<*, *>>? = null
+        private val customSerializers: Set<SerializationCustomSerializer<*, *>>? = null,
+        private val useGlobalThreadPools: Boolean = false
 ) {
 
     @JvmOverloads
     constructor(
             hostAndPort: NetworkHostAndPort,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
-            configuration = configuration
+            configuration = configuration,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     constructor(
             hostAndPort: NetworkHostAndPort,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            classLoader: ClassLoader
+            classLoader: ClassLoader,
+            useGlobalThreadPools: Boolean = false
     ): this(
             hostAndPort,
             configuration,
             null,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null
+            classLoader: ClassLoader? = null,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
             sslConfiguration = sslConfiguration,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -456,13 +467,15 @@ class CordaRPCClient private constructor(
             hostAndPort: NetworkHostAndPort,
             configuration: CordaRPCClientConfiguration,
             sslConfiguration: ClientRpcSslOptions?,
-            classLoader: ClassLoader? = null
+            classLoader: ClassLoader? = null,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
             configuration = configuration,
             sslConfiguration = sslConfiguration,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -470,13 +483,15 @@ class CordaRPCClient private constructor(
             haAddressPool: List<NetworkHostAndPort>,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null
+            classLoader: ClassLoader? = null,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = null,
             haAddressPool = haAddressPool,
             configuration = configuration,
             sslConfiguration = sslConfiguration,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -485,14 +500,16 @@ class CordaRPCClient private constructor(
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
-            customSerializers: Set<SerializationCustomSerializer<*, *>>?
+            customSerializers: Set<SerializationCustomSerializer<*, *>>?,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
             configuration = configuration,
             sslConfiguration = sslConfiguration,
             classLoader = classLoader,
-            customSerializers = customSerializers
+            customSerializers = customSerializers,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -501,14 +518,16 @@ class CordaRPCClient private constructor(
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
-            customSerializers: Set<SerializationCustomSerializer<*, *>>?
+            customSerializers: Set<SerializationCustomSerializer<*, *>>?,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = null,
             haAddressPool = haAddressPool,
             configuration = configuration,
             sslConfiguration = sslConfiguration,
             classLoader = classLoader,
-            customSerializers = customSerializers
+            customSerializers = customSerializers,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     // Here to keep the keep ABI compatibility happy
@@ -532,12 +551,16 @@ class CordaRPCClient private constructor(
             haAddressPool.isEmpty() -> RPCClient(
                     rpcConnectorTcpTransport(hostAndPort!!, config = sslConfiguration),
                     configuration,
-                    if (classLoader != null) AMQP_RPC_CLIENT_CONTEXT.withClassLoader(classLoader) else AMQP_RPC_CLIENT_CONTEXT)
+                    if (classLoader != null) AMQP_RPC_CLIENT_CONTEXT.withClassLoader(classLoader) else AMQP_RPC_CLIENT_CONTEXT,
+                     useGlobalThreadPools = useGlobalThreadPools
+            )
             else -> {
                 RPCClient(haAddressPool,
                         sslConfiguration,
                         configuration,
-                        if (classLoader != null) AMQP_RPC_CLIENT_CONTEXT.withClassLoader(classLoader) else AMQP_RPC_CLIENT_CONTEXT)
+                        if (classLoader != null) AMQP_RPC_CLIENT_CONTEXT.withClassLoader(classLoader) else AMQP_RPC_CLIENT_CONTEXT,
+                        useGlobalThreadPools
+                )
             }
         }
     }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -454,17 +454,6 @@ class CordaRPCClient private constructor(
             configuration = configuration
     )
 
-    @JvmOverloads
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            haAddressPool = emptyList(),
-            configuration = configuration,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
 
     constructor(
             hostAndPort: NetworkHostAndPort,
@@ -477,18 +466,6 @@ class CordaRPCClient private constructor(
             classLoader = classLoader
     )
 
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            classLoader: ClassLoader,
-            useGlobalThreadPools: Boolean
-    ): this(
-            hostAndPort,
-            configuration,
-            null,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
 
     constructor(
             hostAndPort: NetworkHostAndPort,
@@ -501,18 +478,6 @@ class CordaRPCClient private constructor(
             classLoader = classLoader
     )
 
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            haAddressPool = emptyList(),
-            sslConfiguration = sslConfiguration,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
 
     @JvmOverloads
     constructor(
@@ -528,21 +493,6 @@ class CordaRPCClient private constructor(
             classLoader = classLoader
     )
 
-    @JvmOverloads
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            configuration: CordaRPCClientConfiguration,
-            sslConfiguration: ClientRpcSslOptions?,
-            classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            haAddressPool = emptyList(),
-            configuration = configuration,
-            sslConfiguration = sslConfiguration,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
 
     @JvmOverloads
     constructor(
@@ -558,21 +508,6 @@ class CordaRPCClient private constructor(
             classLoader = classLoader
     )
 
-    @JvmOverloads
-    constructor(
-            haAddressPool: List<NetworkHostAndPort>,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = null,
-            haAddressPool = haAddressPool,
-            configuration = configuration,
-            sslConfiguration = sslConfiguration,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
 
     @JvmOverloads
     constructor(

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -454,7 +454,6 @@ class CordaRPCClient private constructor(
             configuration = configuration
     )
 
-
     constructor(
             hostAndPort: NetworkHostAndPort,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
@@ -466,7 +465,6 @@ class CordaRPCClient private constructor(
             classLoader = classLoader
     )
 
-
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: ClientRpcSslOptions? = null,
@@ -477,7 +475,6 @@ class CordaRPCClient private constructor(
             sslConfiguration = sslConfiguration,
             classLoader = classLoader
     )
-
 
     @JvmOverloads
     constructor(
@@ -493,7 +490,6 @@ class CordaRPCClient private constructor(
             classLoader = classLoader
     )
 
-
     @JvmOverloads
     constructor(
             haAddressPool: List<NetworkHostAndPort>,
@@ -507,7 +503,6 @@ class CordaRPCClient private constructor(
             sslConfiguration = sslConfiguration,
             classLoader = classLoader
     )
-
 
     @JvmOverloads
     constructor(

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -409,11 +409,31 @@ class GracefulReconnect(val onDisconnect: () -> Unit = {}, val onReconnect: () -
  * @param customSerializers a set of [SerializationCustomSerializer]s to be used. If this parameter is specified, then no classpath scanning
  *  will be performed for custom serializers, the provided ones will be used instead. This parameter serves as a more user-friendly option
  *  to specify your serializers and disable the classpath scanning (e.g. for performance reasons).
- * @param useGlobalThreadPools If `true`, Artemis global thread pools are used for all RPC clients. This allows multiple
- *  connections to share a bounded set of scheduler and worker threads, controlled via Artemis system properties
- *  (`activemq.artemis.client.global.thread.pool.max.size`, `activemq.artemis.client.global.scheduled.thread.pool.core.size`).
- *  Defaults to `false`, meaning each client creates its own pools.
- */
+ * @param useGlobalThreadPools If `true`, Artemis global thread pools are used for all RPC clients.
+ * This allows multiple connections to share a bounded set of scheduler and worker threads, rather
+ * than creating dedicated pools per client.
+ *
+ * The global pool sizes can be controlled in two ways:
+ *
+ * 1. **System properties** (evaluated when global executors are first created):
+ *    - `activemq.artemis.client.global.thread.pool.max.size` — maximum number of worker threads
+ *    - `activemq.artemis.client.global.scheduled.thread.pool.core.size` — core scheduled threads
+ *
+ * 2. **Programmatic configuration via static methods on
+ *    [org.apache.activemq.artemis.api.core.client.ActiveMQClient](https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/org/apache/activemq/artemis/api/core/client/ActiveMQClient.html):**
+ *    - [ActiveMQClient.initializeGlobalThreadPoolProperties] — initialises the global thread pools
+ *      properties from System properties.
+ *    - [ActiveMQClient.setGlobalThreadPoolProperties] — allows programmatical configuration of
+ *      global thread pools properties, such as `globalThreadMaxPoolSize`.
+ *    - [ActiveMQClient.injectPools] — allows supplying custom `ExecutorService` and
+ *      `ScheduledExecutorService` instances to override the global pools entirely.
+ *
+ * To check or update the currently configured pools, follow the static methods in
+ * ActiveMQClient that manage the global executors. These are consulted whenever
+ * `useGlobalThreadPools = true` is set.
+ *
+ * Defaults to `false`, meaning each client creates and manages its own dedicated pools.
+*/
 class CordaRPCClient private constructor(
         private val hostAndPort: NetworkHostAndPort?,
         private val haAddressPool: List<NetworkHostAndPort>,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
@@ -119,24 +119,6 @@ class MultiRPCClient<I : RPCOps> private constructor(
             configuration = configuration
     )
 
-    @JvmOverloads
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            rpcOpsClass: Class<I>,
-            username: String,
-            password: String,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            haAddressPool = emptyList(),
-            rpcOpsClass = rpcOpsClass,
-            username = username,
-            password = password,
-            configuration = configuration,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
-
     constructor(
             hostAndPort: NetworkHostAndPort,
             rpcOpsClass: Class<I>,
@@ -159,25 +141,6 @@ class MultiRPCClient<I : RPCOps> private constructor(
             rpcOpsClass: Class<I>,
             username: String,
             password: String,
-            classLoader: ClassLoader,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            rpcOpsClass = rpcOpsClass,
-            username = username,
-            password = password,
-            configuration = configuration,
-            sslConfiguration = null,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
-
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            rpcOpsClass: Class<I>,
-            username: String,
-            password: String,
             sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null
     ) : this(
@@ -188,25 +151,6 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password = password,
             sslConfiguration = sslConfiguration,
             classLoader = classLoader
-    )
-
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            rpcOpsClass: Class<I>,
-            username: String,
-            password: String,
-            sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            haAddressPool = emptyList(),
-            rpcOpsClass = rpcOpsClass,
-            username = username,
-            password = password,
-            sslConfiguration = sslConfiguration,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -231,28 +175,6 @@ class MultiRPCClient<I : RPCOps> private constructor(
 
     @JvmOverloads
     constructor(
-            hostAndPort: NetworkHostAndPort,
-            rpcOpsClass: Class<I>,
-            username: String,
-            password: String,
-            configuration: CordaRPCClientConfiguration,
-            sslConfiguration: ClientRpcSslOptions?,
-            classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            haAddressPool = emptyList(),
-            rpcOpsClass = rpcOpsClass,
-            username = username,
-            password = password,
-            configuration = configuration,
-            sslConfiguration = sslConfiguration,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
-
-    @JvmOverloads
-    constructor(
             haAddressPool: List<NetworkHostAndPort>,
             rpcOpsClass: Class<I>,
             username: String,
@@ -269,28 +191,6 @@ class MultiRPCClient<I : RPCOps> private constructor(
             configuration = configuration,
             sslConfiguration = sslConfiguration,
             classLoader = classLoader
-    )
-
-    @JvmOverloads
-    constructor(
-            haAddressPool: List<NetworkHostAndPort>,
-            rpcOpsClass: Class<I>,
-            username: String,
-            password: String,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = null,
-            haAddressPool = haAddressPool,
-            rpcOpsClass = rpcOpsClass,
-            username = username,
-            password = password,
-            configuration = configuration,
-            sslConfiguration = sslConfiguration,
-            classLoader = classLoader,
-            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
@@ -58,12 +58,31 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param externalTrace external [Trace] for correlation.
  * @param impersonatedActor the actor on behalf of which all the invocations will be made.
  * @param targetLegalIdentity in case of multi-identity RPC endpoint specific legal identity to which the calls must be addressed.
- * @param useGlobalThreadPools If `true`, Artemis global thread pools are used for all RPC clients. This allows multiple
- *  connections to share a bounded set of scheduler and worker threads, controlled via Artemis system properties
- *  (`activemq.artemis.client.global.thread.pool.max.size`,
- *  `activemq.artemis.client.global.scheduled.thread.pool.core.size`).
- *  Defaults to `false`, meaning each client creates its own pools.
- *  */
+ * @param useGlobalThreadPools If `true`, Artemis global thread pools are used for all RPC clients.
+ * This allows multiple connections to share a bounded set of scheduler and worker threads, rather
+ * than creating dedicated pools per client.
+ *
+ * The global pool sizes can be controlled in two ways:
+ *
+ * 1. **System properties** (evaluated when global executors are first created):
+ *    - `activemq.artemis.client.global.thread.pool.max.size` — maximum number of worker threads
+ *    - `activemq.artemis.client.global.scheduled.thread.pool.core.size` — core scheduled threads
+ *
+ * 2. **Programmatic configuration via static methods on
+ *    [org.apache.activemq.artemis.api.core.client.ActiveMQClient](https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/org/apache/activemq/artemis/api/core/client/ActiveMQClient.html):**
+ *    - [ActiveMQClient.initializeGlobalThreadPoolProperties] — initialises the global thread pools
+ *      properties from System properties.
+ *    - [ActiveMQClient.setGlobalThreadPoolProperties] — allows programmatical configuration of
+ *      global thread pools properties, such as `globalThreadMaxPoolSize`.
+ *    - [ActiveMQClient.injectPools] — allows supplying custom `ExecutorService` and
+ *      `ScheduledExecutorService` instances to override the global pools entirely.
+ *
+ * To check or update the currently configured pools, follow the static methods in
+ * ActiveMQClient that manage the global executors. These are consulted whenever
+ * `useGlobalThreadPools = true` is set.
+ *
+ * Defaults to `false`, meaning each client creates and manages its own dedicated pools.
+ */
 class MultiRPCClient<I : RPCOps> private constructor(
         private val hostAndPort: NetworkHostAndPort?,
         private val haAddressPool: List<NetworkHostAndPort>,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
@@ -90,8 +90,24 @@ class MultiRPCClient<I : RPCOps> private constructor(
             rpcOpsClass: Class<I>,
             username: String,
             password: String,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            configuration = configuration
+    )
+
+    @JvmOverloads
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -108,8 +124,25 @@ class MultiRPCClient<I : RPCOps> private constructor(
             username: String,
             password: String,
             classLoader: ClassLoader,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
+    ) : this(
+            hostAndPort = hostAndPort,
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            configuration = configuration,
+            sslConfiguration = null,
+            classLoader = classLoader
+    )
+
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
+            classLoader: ClassLoader,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             rpcOpsClass = rpcOpsClass,
@@ -127,8 +160,25 @@ class MultiRPCClient<I : RPCOps> private constructor(
             username: String,
             password: String,
             sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader
+    )
+
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
+            sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -148,8 +198,28 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password: String,
             configuration: CordaRPCClientConfiguration,
             sslConfiguration: ClientRpcSslOptions?,
+            classLoader: ClassLoader? = null
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader
+    )
+
+    @JvmOverloads
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
+            configuration: CordaRPCClientConfiguration,
+            sslConfiguration: ClientRpcSslOptions?,
             classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -170,8 +240,28 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password: String,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null
+    ) : this(
+            hostAndPort = null,
+            haAddressPool = haAddressPool,
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader
+    )
+
+    @JvmOverloads
+    constructor(
+            haAddressPool: List<NetworkHostAndPort>,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            sslConfiguration: ClientRpcSslOptions? = null,
             classLoader: ClassLoader? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = null,
             haAddressPool = haAddressPool,
@@ -196,8 +286,36 @@ class MultiRPCClient<I : RPCOps> private constructor(
             classLoader: ClassLoader? = null,
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
+            targetLegalIdentity: CordaX500Name? = null
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader,
+            customSerializers = customSerializers,
+            externalTrace = externalTrace,
+            impersonatedActor = impersonatedActor,
+            targetLegalIdentity = targetLegalIdentity
+    )
+
+    @JvmOverloads
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
+            customSerializers: Set<SerializationCustomSerializer<*, *>>?,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null,
+            externalTrace: Trace? = null,
+            impersonatedActor: Actor? = null,
             targetLegalIdentity: CordaX500Name? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -211,7 +329,36 @@ class MultiRPCClient<I : RPCOps> private constructor(
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
             targetLegalIdentity = targetLegalIdentity,
-            useGlobalThreadPools = useGlobalThreadPools
+            useGlobalThreadPools =  useGlobalThreadPools
+    )
+
+    @JvmOverloads
+    constructor(
+            haAddressPool: List<NetworkHostAndPort>,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
+            customSerializers: Set<SerializationCustomSerializer<*, *>>?,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            sslConfiguration: ClientRpcSslOptions? = null,
+            classLoader: ClassLoader? = null,
+            externalTrace: Trace? = null,
+            impersonatedActor: Actor? = null,
+            targetLegalIdentity: CordaX500Name? = null
+
+    ) : this(
+            hostAndPort = null,
+            haAddressPool = haAddressPool,
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            configuration = configuration,
+            sslConfiguration = sslConfiguration,
+            classLoader = classLoader,
+            customSerializers = customSerializers,
+            externalTrace = externalTrace,
+            impersonatedActor = impersonatedActor,
+            targetLegalIdentity = targetLegalIdentity
     )
 
     @JvmOverloads
@@ -227,7 +374,7 @@ class MultiRPCClient<I : RPCOps> private constructor(
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
             targetLegalIdentity: CordaX500Name? = null,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
 
     ) : this(
             hostAndPort = null,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
@@ -58,7 +58,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param externalTrace external [Trace] for correlation.
  * @param impersonatedActor the actor on behalf of which all the invocations will be made.
  * @param targetLegalIdentity in case of multi-identity RPC endpoint specific legal identity to which the calls must be addressed.
- */
+ * @param useGlobalThreadPools If `true`, Artemis global thread pools are used for all RPC clients. This allows multiple
+ *  connections to share a bounded set of scheduler and worker threads, controlled via Artemis system properties
+ *  (`activemq.artemis.client.global.thread.pool.max.size`,
+ *  `activemq.artemis.client.global.scheduled.thread.pool.core.size`).
+ *  Defaults to `false`, meaning each client creates its own pools.
+ *  */
 class MultiRPCClient<I : RPCOps> private constructor(
         private val hostAndPort: NetworkHostAndPort?,
         private val haAddressPool: List<NetworkHostAndPort>,
@@ -71,7 +76,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
         private val customSerializers: Set<SerializationCustomSerializer<*, *>>? = null,
         private val externalTrace: Trace? = null,
         private val impersonatedActor: Actor? = null,
-        private val targetLegalIdentity: CordaX500Name? = null
+        private val targetLegalIdentity: CordaX500Name? = null,
+        private val useGlobalThreadPools: Boolean = false
 ) : AutoCloseable {
 
     private companion object {
@@ -84,14 +90,16 @@ class MultiRPCClient<I : RPCOps> private constructor(
             rpcOpsClass: Class<I>,
             username: String,
             password: String,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
             rpcOpsClass = rpcOpsClass,
             username = username,
             password = password,
-            configuration = configuration
+            configuration = configuration,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     constructor(
@@ -100,7 +108,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             username: String,
             password: String,
             classLoader: ClassLoader,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             rpcOpsClass = rpcOpsClass,
@@ -108,7 +117,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password = password,
             configuration = configuration,
             sslConfiguration = null,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     constructor(
@@ -117,7 +127,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             username: String,
             password: String,
             sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null
+            classLoader: ClassLoader? = null,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -125,7 +136,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             username = username,
             password = password,
             sslConfiguration = sslConfiguration,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -136,7 +148,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password: String,
             configuration: CordaRPCClientConfiguration,
             sslConfiguration: ClientRpcSslOptions?,
-            classLoader: ClassLoader? = null
+            classLoader: ClassLoader? = null,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -145,7 +158,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password = password,
             configuration = configuration,
             sslConfiguration = sslConfiguration,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -156,7 +170,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password: String,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             sslConfiguration: ClientRpcSslOptions? = null,
-            classLoader: ClassLoader? = null
+            classLoader: ClassLoader? = null,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = null,
             haAddressPool = haAddressPool,
@@ -165,7 +180,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             password = password,
             configuration = configuration,
             sslConfiguration = sslConfiguration,
-            classLoader = classLoader
+            classLoader = classLoader,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -180,7 +196,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             classLoader: ClassLoader? = null,
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
-            targetLegalIdentity: CordaX500Name? = null
+            targetLegalIdentity: CordaX500Name? = null,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             hostAndPort = hostAndPort,
             haAddressPool = emptyList(),
@@ -193,7 +210,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             customSerializers = customSerializers,
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
-            targetLegalIdentity = targetLegalIdentity
+            targetLegalIdentity = targetLegalIdentity,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     @JvmOverloads
@@ -208,7 +226,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             classLoader: ClassLoader? = null,
             externalTrace: Trace? = null,
             impersonatedActor: Actor? = null,
-            targetLegalIdentity: CordaX500Name? = null
+            targetLegalIdentity: CordaX500Name? = null,
+            useGlobalThreadPools: Boolean = false
 
     ) : this(
             hostAndPort = null,
@@ -222,7 +241,8 @@ class MultiRPCClient<I : RPCOps> private constructor(
             customSerializers = customSerializers,
             externalTrace = externalTrace,
             impersonatedActor = impersonatedActor,
-            targetLegalIdentity = targetLegalIdentity
+            targetLegalIdentity = targetLegalIdentity,
+            useGlobalThreadPools = useGlobalThreadPools
     )
 
     init {
@@ -248,9 +268,11 @@ class MultiRPCClient<I : RPCOps> private constructor(
             haAddressPool.isEmpty() -> RPCClient(
                     ArtemisTcpTransport.rpcConnectorTcpTransport(hostAndPort!!, config = sslConfiguration),
                     configuration,
-                    serializationContext)
+                    serializationContext,
+                    useGlobalThreadPools = useGlobalThreadPools
+            )
             else -> {
-                RPCClient(haAddressPool, sslConfiguration, configuration, serializationContext)
+                RPCClient(haAddressPool, sslConfiguration, configuration, serializationContext, useGlobalThreadPools)
             }
         }
     }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
@@ -119,6 +119,24 @@ class MultiRPCClient<I : RPCOps> private constructor(
             configuration = configuration
     )
 
+    @JvmOverloads
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            rpcOpsClass: Class<I>,
+            username: String,
+            password: String,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            useGlobalThreadPools: Boolean
+    ) : this(
+            hostAndPort = hostAndPort,
+            haAddressPool = emptyList(),
+            rpcOpsClass = rpcOpsClass,
+            username = username,
+            password = password,
+            configuration = configuration,
+            useGlobalThreadPools = useGlobalThreadPools
+    )
+
     constructor(
             hostAndPort: NetworkHostAndPort,
             rpcOpsClass: Class<I>,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/ext/MultiRPCClient.kt
@@ -119,24 +119,6 @@ class MultiRPCClient<I : RPCOps> private constructor(
             configuration = configuration
     )
 
-    @JvmOverloads
-    constructor(
-            hostAndPort: NetworkHostAndPort,
-            rpcOpsClass: Class<I>,
-            username: String,
-            password: String,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            useGlobalThreadPools: Boolean
-    ) : this(
-            hostAndPort = hostAndPort,
-            haAddressPool = emptyList(),
-            rpcOpsClass = rpcOpsClass,
-            username = username,
-            password = password,
-            configuration = configuration,
-            useGlobalThreadPools = useGlobalThreadPools
-    )
-
     constructor(
             hostAndPort: NetworkHostAndPort,
             rpcOpsClass: Class<I>,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -37,21 +37,24 @@ class RPCClient<I : RPCOps>(
         private val transport: TransportConfiguration,
         private val rpcConfiguration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
         private val serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
-        private val haPoolTransportConfigurations: List<TransportConfiguration> = emptyList()
+        private val haPoolTransportConfigurations: List<TransportConfiguration> = emptyList(),
+        private val useGlobalThreadPools: Boolean = false
 ) {
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: ClientRpcSslOptions? = null,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
-    ) : this(rpcConnectorTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext)
+            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
+            useGlobalThreadPools: Boolean = false
+    ) : this(rpcConnectorTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext, useGlobalThreadPools = useGlobalThreadPools)
 
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: SslConfiguration,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
-    ) : this(rpcInternalClientTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext)
+            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
+            useGlobalThreadPools: Boolean = false
+    ) : this(rpcInternalClientTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext, useGlobalThreadPools = useGlobalThreadPools)
 
     /**
      * A way to create RPC connections to a pool of RPC addresses for resiliency
@@ -60,12 +63,13 @@ class RPCClient<I : RPCOps>(
             haAddressPool: List<NetworkHostAndPort>,
             sslConfiguration: ClientRpcSslOptions? = null,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
+            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
+            useGlobalThreadPools: Boolean = false
     ) : this(
             rpcConnectorTcpTransport(haAddressPool.first(), sslConfiguration),
             configuration,
             serializationContext,
-            haAddressPool.map { rpcConnectorTcpTransport(it, sslConfiguration) }
+            haAddressPool.map { rpcConnectorTcpTransport(it, sslConfiguration) }, useGlobalThreadPools = useGlobalThreadPools
     )
 
     companion object {
@@ -95,7 +99,7 @@ class RPCClient<I : RPCOps>(
                 maxRetryInterval = rpcConfiguration.connectionMaxRetryInterval.toMillis()
                 reconnectAttempts = if (haPoolTransportConfigurations.isEmpty()) rpcConfiguration.maxReconnectAttempts else 0
                 minLargeMessageSize = rpcConfiguration.maxFileSize
-                isUseGlobalPools = nodeSerializationEnv != null
+                isUseGlobalPools = useGlobalThreadPools || nodeSerializationEnv != null
                 // By default RoundRobinConnectionLoadBalancingPolicy is used that picks first endpoint from the pool
                 // at random. This may be undesired and non-deterministic. For more information, see [RoundRobinConnectionPolicy]
                 connectionLoadBalancingPolicyClassName = RoundRobinConnectionPolicy::class.java.canonicalName

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -44,16 +44,30 @@ class RPCClient<I : RPCOps>(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: ClientRpcSslOptions? = null,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
+    ) : this(rpcConnectorTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext)
+
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            sslConfiguration: ClientRpcSslOptions? = null,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(rpcConnectorTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext, useGlobalThreadPools = useGlobalThreadPools)
 
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: SslConfiguration,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
+    ) : this(rpcInternalClientTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext)
+
+    constructor(
+            hostAndPort: NetworkHostAndPort,
+            sslConfiguration: SslConfiguration,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
             serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
-            useGlobalThreadPools: Boolean = false
+            useGlobalThreadPools: Boolean
     ) : this(rpcInternalClientTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext, useGlobalThreadPools = useGlobalThreadPools)
 
     /**
@@ -63,13 +77,29 @@ class RPCClient<I : RPCOps>(
             haAddressPool: List<NetworkHostAndPort>,
             sslConfiguration: ClientRpcSslOptions? = null,
             configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
-            useGlobalThreadPools: Boolean = false
+            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
     ) : this(
             rpcConnectorTcpTransport(haAddressPool.first(), sslConfiguration),
             configuration,
             serializationContext,
-            haAddressPool.map { rpcConnectorTcpTransport(it, sslConfiguration) }, useGlobalThreadPools = useGlobalThreadPools
+            haAddressPool.map { rpcConnectorTcpTransport(it, sslConfiguration) }
+    )
+
+    /**
+     * A way to create RPC connections to a pool of RPC addresses for resiliency
+     */
+    constructor(
+            haAddressPool: List<NetworkHostAndPort>,
+            sslConfiguration: ClientRpcSslOptions? = null,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+            serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
+            useGlobalThreadPools: Boolean
+    ) : this(
+            rpcConnectorTcpTransport(haAddressPool.first(), sslConfiguration),
+            configuration,
+            serializationContext,
+            haAddressPool.map { rpcConnectorTcpTransport(it, sslConfiguration) },
+            useGlobalThreadPools
     )
 
     companion object {

--- a/node/src/integration-test/kotlin/net/corda/node/multiRpc/MultiRpcClientTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/multiRpc/MultiRpcClientTest.kt
@@ -5,6 +5,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import net.corda.client.rpc.ConnectionFailureException
+import net.corda.client.rpc.CordaRPCClientConfiguration
 import net.corda.client.rpc.ext.MultiRPCClient
 import net.corda.client.rpc.ext.RPCConnectionListener
 import net.corda.core.internal.messaging.AttachmentTrustInfoRPCOps
@@ -108,8 +109,21 @@ class MultiRpcClientTest {
         val rpcAddress = incrementalPortAllocation().nextHostAndPort()
         val rpcUser = User("MultiRpcClient1", "MultiRpcClient1Pwd", setOf(all()))
 
-        // Create two clients using global pools
-        val globalClient = MultiRPCClient(rpcAddress, AttachmentTrustInfoRPCOps::class.java, rpcUser.username, rpcUser.password, useGlobalThreadPools = true)
+        val globalClient = MultiRPCClient(
+                rpcAddress,
+                AttachmentTrustInfoRPCOps::class.java,
+                rpcUser.username,
+                rpcUser.password,
+                customSerializers = null,
+                configuration = CordaRPCClientConfiguration.DEFAULT,
+                sslConfiguration = null,
+                classLoader = null,
+                externalTrace = null,
+                impersonatedActor = null,
+                targetLegalIdentity = null,
+                useGlobalThreadPools = true
+        )
+
         // Right from the start attach a listener such that it will be informed of all the activity happening for this RPC client
         val globalListener = mock<RPCConnectionListener<AttachmentTrustInfoRPCOps>>()
         globalClient.addConnectionListener(globalListener)
@@ -144,8 +158,21 @@ class MultiRpcClientTest {
         val rpcAddress = incrementalPortAllocation().nextHostAndPort()
         val rpcUser = User("MultiRpcClient1", "MultiRpcClient1Pwd", setOf(all()))
 
-        // Create two clients using global pools
-        val localClient = MultiRPCClient(rpcAddress, AttachmentTrustInfoRPCOps::class.java, rpcUser.username, rpcUser.password, useGlobalThreadPools = false)
+        val localClient = MultiRPCClient(
+                rpcAddress,
+                AttachmentTrustInfoRPCOps::class.java,
+                rpcUser.username,
+                rpcUser.password,
+                customSerializers = null,
+                configuration = CordaRPCClientConfiguration.DEFAULT,
+                sslConfiguration = null,
+                classLoader = null,
+                externalTrace = null,
+                impersonatedActor = null,
+                targetLegalIdentity = null,
+                useGlobalThreadPools = false
+        )
+
         // Right from the start attach a listener such that it will be informed of all the activity happening for this RPC client
         val localListener = mock<RPCConnectionListener<AttachmentTrustInfoRPCOps>>()
         localClient.addConnectionListener(localListener)
@@ -168,10 +195,10 @@ class MultiRpcClientTest {
         val schedPool = ActiveMQClient.getGlobalScheduledThreadPool() as? ScheduledThreadPoolExecutor
                 ?: error("Expected global scheduled pool to be a ScheduledThreadPoolExecutor")
 
-        assertEquals(0,globalPool.poolSize, "Global thread pool should not be initialised and should have zero pool size")
-        assertEquals(0,globalPool.completedTaskCount, "Global thread pool should not be initialised and should have zero completed tasks")
-        assertEquals(0,schedPool.poolSize, "Scheduled thread pool should not be initialised and should have zero pool size")
-        assertEquals(0,schedPool.completedTaskCount, "Scheduled thread pool should not be initialised and should have zero completed tasks")
+        assertEquals(0, globalPool.poolSize, "Global thread pool should not be initialised and should have zero pool size")
+        assertEquals(0, globalPool.completedTaskCount, "Global thread pool should not be initialised and should have zero completed tasks")
+        assertEquals(0, schedPool.poolSize, "Scheduled thread pool should not be initialised and should have zero pool size")
+        assertEquals(0, schedPool.completedTaskCount, "Scheduled thread pool should not be initialised and should have zero completed tasks")
     }
 
     @Test(timeout = 300_000)

--- a/node/src/integration-test/kotlin/net/corda/node/multiRpc/MultiRpcClientTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/multiRpc/MultiRpcClientTest.kt
@@ -22,13 +22,18 @@ import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.User
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import rx.Observer
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.ThreadPoolExecutor
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.use
 
 class MultiRpcClientTest {
 
@@ -95,6 +100,78 @@ class MultiRpcClientTest {
                 assertSame(connFuture, client.start())
             }
         }
+    }
+
+    @Test(timeout = 300_000)
+    fun `client with useGlobalThreadPools set to true should start global thread pools`() {
+        // Allocate named port to be used for RPC interaction
+        val rpcAddress = incrementalPortAllocation().nextHostAndPort()
+        val rpcUser = User("MultiRpcClient1", "MultiRpcClient1Pwd", setOf(all()))
+
+        // Create two clients using global pools
+        val globalClient = MultiRPCClient(rpcAddress, AttachmentTrustInfoRPCOps::class.java, rpcUser.username, rpcUser.password, useGlobalThreadPools = true)
+        // Right from the start attach a listener such that it will be informed of all the activity happening for this RPC client
+        val globalListener = mock<RPCConnectionListener<AttachmentTrustInfoRPCOps>>()
+        globalClient.addConnectionListener(globalListener)
+
+        globalClient.use {
+            // Starting node out-of-process to ensure it is completely independent from RPC client
+            driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = false)) {
+                startNode(providedName = ALICE_NAME,
+                        defaultParameters = NodeParameters(rpcAddress = rpcAddress, rpcUsers = listOf(rpcUser))).getOrThrow()
+
+                val connFuture = globalClient.start()
+                eventually(duration = 60.seconds) {
+                    verify(globalListener, times(1)).onConnect(argThat { connectionOpt === connFuture.get() })
+                }
+            }
+        }
+
+        val globalPool = ActiveMQClient.getGlobalThreadPool() as? ThreadPoolExecutor
+                ?: error("Expected global thread pool to be a ThreadPoolExecutor")
+        val schedPool = ActiveMQClient.getGlobalScheduledThreadPool() as? ScheduledThreadPoolExecutor
+                ?: error("Expected global scheduled pool to be a ScheduledThreadPoolExecutor")
+
+        assertTrue(globalPool.poolSize > 0, "Global thread pool should be initialised and should have non-zero pool size")
+        assertTrue(globalPool.completedTaskCount > 0, "Global thread pool should be initialised and should have some completed tasks")
+        assertTrue(schedPool.poolSize > 0, "Scheduled thread pool should be initialised and should have non-zero pool size")
+        assertTrue(schedPool.completedTaskCount > 0, "Scheduled thread pool should be initialised and should have some completed tasks")
+    }
+
+    @Test(timeout = 300_000)
+    fun `client with useGlobalThreadPools set to false should not start global thread pools`() {
+        // Allocate named port to be used for RPC interaction
+        val rpcAddress = incrementalPortAllocation().nextHostAndPort()
+        val rpcUser = User("MultiRpcClient1", "MultiRpcClient1Pwd", setOf(all()))
+
+        // Create two clients using global pools
+        val localClient = MultiRPCClient(rpcAddress, AttachmentTrustInfoRPCOps::class.java, rpcUser.username, rpcUser.password, useGlobalThreadPools = false)
+        // Right from the start attach a listener such that it will be informed of all the activity happening for this RPC client
+        val localListener = mock<RPCConnectionListener<AttachmentTrustInfoRPCOps>>()
+        localClient.addConnectionListener(localListener)
+
+        localClient.use {
+            // Starting node out-of-process to ensure it is completely independent from RPC client
+            driver(DriverParameters(notarySpecs = emptyList(), startNodesInProcess = false)) {
+                startNode(providedName = ALICE_NAME,
+                        defaultParameters = NodeParameters(rpcAddress = rpcAddress, rpcUsers = listOf(rpcUser))).getOrThrow()
+
+                val connFuture = localClient.start()
+                eventually(duration = 60.seconds) {
+                    verify(localListener, times(1)).onConnect(argThat { connectionOpt === connFuture.get() })
+                }
+            }
+        }
+
+        val globalPool = ActiveMQClient.getGlobalThreadPool() as? ThreadPoolExecutor
+                ?: error("Expected global thread pool to be a ThreadPoolExecutor")
+        val schedPool = ActiveMQClient.getGlobalScheduledThreadPool() as? ScheduledThreadPoolExecutor
+                ?: error("Expected global scheduled pool to be a ScheduledThreadPoolExecutor")
+
+        assertEquals(0,globalPool.poolSize, "Global thread pool should not be initialised and should have zero pool size")
+        assertEquals(0,globalPool.completedTaskCount, "Global thread pool should not be initialised and should have zero completed tasks")
+        assertEquals(0,schedPool.poolSize, "Scheduled thread pool should not be initialised and should have zero pool size")
+        assertEquals(0,schedPool.completedTaskCount, "Scheduled thread pool should not be initialised and should have zero completed tasks")
     }
 
     @Test(timeout = 300_000)

--- a/node/src/integration-test/kotlin/net/corda/node/multiRpc/MultiRpcClientTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/multiRpc/MultiRpcClientTest.kt
@@ -28,6 +28,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import rx.Observer
+import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import kotlin.test.assertEquals
@@ -154,6 +155,12 @@ class MultiRpcClientTest {
 
     @Test(timeout = 300_000)
     fun `client with useGlobalThreadPools set to false should not start global thread pools`() {
+        // Reset global thread pools before the test
+        val emptyThreadPool = Executors.newCachedThreadPool()
+        val emptyScheduledPool = Executors.newScheduledThreadPool(0)
+        val emptyFlowControlPool = Executors.newCachedThreadPool()
+        ActiveMQClient.injectPools(emptyThreadPool, emptyScheduledPool, emptyFlowControlPool)
+
         // Allocate named port to be used for RPC interaction
         val rpcAddress = incrementalPortAllocation().nextHostAndPort()
         val rpcUser = User("MultiRpcClient1", "MultiRpcClient1Pwd", setOf(all()))


### PR DESCRIPTION
Added a new `useGlobalThreadPools` flag to `RPCClient`, `MultiRPCClient` and `CordaRPCClient` so clients can opt into Artemis’ shared global pools. Thread counts can now be controlled via Artemis system properties, such as `activemq.artemis.client.global.thread.pool.max.size` and `activemq.artemis.client.global.scheduled.thread.pool.core.size`, listed here: https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/constant-values.html.

Most of the changes in this PR is boilerplate code with a couple of new constructors with the new `useGlobalThreadPools` parameter.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
