### PR TITLE
ENT-14401 - Fixing the nightly publishing Jenkins pipeline

### DIFF
--- a/.ci/dev/publish-branch/Jenkinsfile.nightly
+++ b/.ci/dev/publish-branch/Jenkinsfile.nightly
@@ -9,13 +9,38 @@
  * unfinished builds are not required.
  * This feature doesn't play well with disableConcurrentBuilds() option
  */
-@Library('corda-shared-build-pipeline-steps')
+@Library('corda-shared-build-pipeline-steps@5.3')
 import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+import com.r3.build.agents.KubernetesAgent
+import com.r3.build.enums.KubernetesCluster
+import com.r3.build.enums.BuildEnvironment
 
 killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 
+KubernetesAgent k8s = new KubernetesAgent(
+        BuildEnvironment.AMD64_LINUX_JAVA17_CORDA4,
+        KubernetesCluster.JenkinsAgents,
+        1
+).withDocker(
+        1,
+        false,
+        true
+)
+
 pipeline {
-    agent { label 'standard' }
+    agent {
+        kubernetes {
+            cloud k8s.buildCluster.cloudName
+            yaml k8s.JSON
+            yamlMergeStrategy merge() // important to keep tolerations from the inherited template
+            idleMinutes 15
+            podRetention always()
+            nodeSelector k8s.nodeSelector
+            label k8s.jenkinsLabel
+            showRawYaml true
+            defaultContainer k8s.defaultContainer.name
+        }
+    }
 
     options {
         timestamps()


### PR DESCRIPTION
This PR fixes the publishing pipeline for the Solana SDK artifacts. The publishing pipeline fails in ENT and in order to fix it we need to first make changes in OS that later will be moved to ENT.