### PR TITLE
ENT-14431: Replace dots with slashes when extracting a missing class in NoClassDefFoundError

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
@@ -35,6 +35,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.time.Instant
 import kotlin.io.path.inputStream
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class TransactionBuilderTest {
@@ -285,5 +286,23 @@ class TransactionBuilderTest {
         assertThatIllegalArgumentException()
                 .isThrownBy { builder.toWireTransaction(services) }
                 .withMessageContaining("Multiple attachments specified for the same contract net.corda.testing.contracts.DummyContract")
+    }
+
+    @Test(timeout=300_000)
+    fun `extract missing class from ClassNotFoundException`() {
+        val ex = ClassNotFoundException("net.corda.coretests.doesnotexist")
+        val missingClass = TransactionBuilder().run {
+            extractMissingClass(ex)
+        }
+        assertEquals("net/corda/coretests/doesnotexist", missingClass)
+    }
+
+    @Test(timeout=300_000)
+    fun `extract missing class from NoClassDefFoundError`() {
+        val ex = NoClassDefFoundError("net.corda.coretests.doesnotexist")
+        val missingClass = TransactionBuilder().run {
+            extractMissingClass(ex)
+        }
+        assertEquals("net/corda/coretests/doesnotexist", missingClass)
     }
 }

--- a/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/transactions/TransactionBuilderTest.kt
@@ -35,7 +35,6 @@ import org.junit.Rule
 import org.junit.Test
 import java.time.Instant
 import kotlin.io.path.inputStream
-import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class TransactionBuilderTest {
@@ -286,23 +285,5 @@ class TransactionBuilderTest {
         assertThatIllegalArgumentException()
                 .isThrownBy { builder.toWireTransaction(services) }
                 .withMessageContaining("Multiple attachments specified for the same contract net.corda.testing.contracts.DummyContract")
-    }
-
-    @Test(timeout=300_000)
-    fun `extract missing class from ClassNotFoundException`() {
-        val ex = ClassNotFoundException("net.corda.coretests.doesnotexist")
-        val missingClass = TransactionBuilder().run {
-            extractMissingClass(ex)
-        }
-        assertEquals("net/corda/coretests/doesnotexist", missingClass)
-    }
-
-    @Test(timeout=300_000)
-    fun `extract missing class from NoClassDefFoundError`() {
-        val ex = NoClassDefFoundError("net.corda.coretests.doesnotexist")
-        val missingClass = TransactionBuilder().run {
-            extractMissingClass(ex)
-        }
-        assertEquals("net/corda/coretests/doesnotexist", missingClass)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -284,18 +284,18 @@ open class TransactionBuilder(
         }
     }
 
-    private fun extractMissingClass(throwable: Throwable): String? {
+    fun extractMissingClass(throwable: Throwable): String? {
         var current = throwable
         while (true) {
             if (current is ClassNotFoundException) {
                 return current.message?.replace('.', '/')
             }
             if (current is NoClassDefFoundError) {
-                return current.message
+                return current.message?.replace('.', '/')
             }
             val message = current.message
             if (message != null) {
-                message.extractClassAfter(NoClassDefFoundError::class)?.let { return it }
+                message.extractClassAfter(NoClassDefFoundError::class)?.let { return it.replace('.', '/') }
                 message.extractClassAfter(ClassNotFoundException::class)?.let { return it.replace('.', '/') }
             }
             current = current.cause ?: return null

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -284,7 +284,7 @@ open class TransactionBuilder(
         }
     }
 
-    fun extractMissingClass(throwable: Throwable): String? {
+    private fun extractMissingClass(throwable: Throwable): String? {
         var current = throwable
         while (true) {
             if (current is ClassNotFoundException) {


### PR DESCRIPTION
Replace dots with slashes in NoClassDefFoundError so that the regex pattern can extract the missing class.
See https://github.com/corda/corda/pull/7996 

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
