### PR TITLE
ENT-14675 Notary change log fix

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -395,7 +395,7 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
     }
 
     private fun logCommandData() {
-        if (logger.isDebugEnabled) {
+        if (logger.isDebugEnabled && transaction.coreTransaction is WireTransaction) {
             val commandDataTypes = transaction.tx.commands.asSequence().mapNotNull { it.value::class.qualifiedName }.distinct()
             logger.debug("Started finalization, commands are ${commandDataTypes.joinToString(", ", "[", "]")}.")
         }


### PR DESCRIPTION
With introduction of` NotaryChangeWireTransaction` in PR https://github.com/corda/corda/pull/7963 `CoreTransaction` may fail to be cast to `WireTransaction` when called from `logCommandData` method. Add a guard. `NotaryChangeWireTransaction` has no command per se, so we don't need to log that debug message.