### PR TITLE
ENT-14714 - Artemis dependency updates

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -42,7 +42,7 @@ tcnativeVersion=2.0.74.Final
 # We must configure it manually to use the latest capsule version.
 capsuleVersion=1.0.4_r3
 asmVersion=9.5
-artemisVersion=2.42.0
+artemisVersion=2.44.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.17.3
 jacksonKotlinVersion=2.17.0

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
@@ -237,8 +237,20 @@ class ArtemisTcpTransport {
                 options[TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME] = CIPHER_SUITES.joinToString(",")
                 options[TransportConstants.ENABLED_PROTOCOLS_PROP_NAME] = TLS_VERSIONS.joinToString(",")
             }
-            // By default, use only one remoting thread in tests (https://github.com/corda/corda/pull/2357)
-            options[TransportConstants.REMOTING_THREADS_PROPNAME] = remotingThreads ?: if (nodeSerializationEnv == null) 1 else -1
+            /**
+             * ENT-14714
+             * As of Artemis 2.44.0 - Artemis no longer interprets REMOTING_THREADS_PROPNAME=-1 as 'not set' and doesn't default it to
+             * whatever value Artemis deems fit. To express 'not set' just don't add it to the options at all and then Artemis WILL default
+             * it. Here, REMOTING_THREADS_PROPNAME is only set if there's a value to give to it.
+             */
+            remotingThreads?.let {
+                options[TransportConstants.REMOTING_THREADS_PROPNAME] = it
+            } ?: run {
+                // Only execute this block if remotingThreads was null
+                if (nodeSerializationEnv == null) {
+                    options[TransportConstants.REMOTING_THREADS_PROPNAME] = 1
+                }
+            }
             options[THREAD_POOL_NAME_NAME] = threadPoolName
             options[TRACE_NAME] = trace
             return TransportConfiguration(className, options)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
@@ -243,13 +243,9 @@ class ArtemisTcpTransport {
              * whatever value Artemis deems fit. To express 'not set' just don't add it to the options at all and then Artemis WILL default
              * it. Here, REMOTING_THREADS_PROPNAME is only set if there's a value to give to it.
              */
-            remotingThreads?.let {
-                options[TransportConstants.REMOTING_THREADS_PROPNAME] = it
-            } ?: run {
-                // Only execute this block if remotingThreads was null
-                if (nodeSerializationEnv == null) {
-                    options[TransportConstants.REMOTING_THREADS_PROPNAME] = 1
-                }
+            when {
+                remotingThreads != null -> options[TransportConstants.REMOTING_THREADS_PROPNAME] = remotingThreads
+                nodeSerializationEnv == null -> options[TransportConstants.REMOTING_THREADS_PROPNAME] = 1
             }
             options[THREAD_POOL_NAME_NAME] = threadPoolName
             options[TRACE_NAME] = trace

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
@@ -46,7 +46,7 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                                 threadPool: Executor,
                                 scheduledThreadPool: ScheduledExecutorService,
                                 protocolMap: MutableMap<String, ProtocolManager<BaseInterceptor<*>, RoutingHandler<*>>>?,
-                                threadFactoryGroupName: String,
+                                threadFactoryGroupName: String?,
                                 metricsManager: MetricsManager?): Acceptor {
         val threadPoolName = ConfigurationHelper.getStringProperty(ArtemisTcpTransport.THREAD_POOL_NAME_NAME, "Acceptor", configuration)
         threadPool.setThreadPoolName("$threadPoolName-artemis")
@@ -76,7 +76,7 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                                     scheduledThreadPool: ScheduledExecutorService?,
                                     failureExecutor: Executor,
                                     protocolMap: MutableMap<String, ProtocolManager<BaseInterceptor<*>, RoutingHandler<*>>>?,
-                                    threadFactoryGroupName: String,
+                                    threadFactoryGroupName: String?,
                                     metricsManager: MetricsManager?,
                                     private val threadPoolName: String
                                     ) :

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
@@ -47,7 +47,7 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                                 scheduledThreadPool: ScheduledExecutorService,
                                 protocolMap: MutableMap<String, ProtocolManager<BaseInterceptor<*>, RoutingHandler<*>>>?,
                                 threadFactoryGroupName: String,
-                                metricsManager: MetricsManager): Acceptor {
+                                metricsManager: MetricsManager?): Acceptor {
         val threadPoolName = ConfigurationHelper.getStringProperty(ArtemisTcpTransport.THREAD_POOL_NAME_NAME, "Acceptor", configuration)
         threadPool.setThreadPoolName("$threadPoolName-artemis")
         scheduledThreadPool.setThreadPoolName("$threadPoolName-artemis-scheduler")
@@ -77,7 +77,7 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                                     failureExecutor: Executor,
                                     protocolMap: MutableMap<String, ProtocolManager<BaseInterceptor<*>, RoutingHandler<*>>>?,
                                     threadFactoryGroupName: String,
-                                    metricsManager: MetricsManager,
+                                    metricsManager: MetricsManager?,
                                     private val threadPoolName: String
                                     ) :
             NettyAcceptor(name,

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
@@ -16,6 +16,7 @@ import net.corda.nodeapi.internal.setThreadPoolName
 import org.apache.activemq.artemis.api.core.BaseInterceptor
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection
+import org.apache.activemq.artemis.core.server.metrics.MetricsManager
 import org.apache.activemq.artemis.core.server.routing.RoutingHandler
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor
@@ -44,7 +45,9 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                                 listener: ServerConnectionLifeCycleListener?,
                                 threadPool: Executor,
                                 scheduledThreadPool: ScheduledExecutorService,
-                                protocolMap: MutableMap<String, ProtocolManager<BaseInterceptor<*>, RoutingHandler<*>>>?): Acceptor {
+                                protocolMap: MutableMap<String, ProtocolManager<BaseInterceptor<*>, RoutingHandler<*>>>?,
+                                threadFactoryGroupName: String,
+                                metricsManager: MetricsManager): Acceptor {
         val threadPoolName = ConfigurationHelper.getStringProperty(ArtemisTcpTransport.THREAD_POOL_NAME_NAME, "Acceptor", configuration)
         threadPool.setThreadPoolName("$threadPoolName-artemis")
         scheduledThreadPool.setThreadPoolName("$threadPoolName-artemis-scheduler")
@@ -58,7 +61,9 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                 scheduledThreadPool,
                 failureExecutor,
                 protocolMap,
-                "$threadPoolName-netty"
+                threadFactoryGroupName,
+                metricsManager,
+                "$threadPoolName-netty",
         )
     }
 
@@ -71,8 +76,20 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                                     scheduledThreadPool: ScheduledExecutorService?,
                                     failureExecutor: Executor,
                                     protocolMap: MutableMap<String, ProtocolManager<BaseInterceptor<*>, RoutingHandler<*>>>?,
-                                    private val threadPoolName: String) :
-            NettyAcceptor(name, clusterConnection, configuration, handler, listener, scheduledThreadPool, failureExecutor, protocolMap)
+                                    threadFactoryGroupName: String,
+                                    metricsManager: MetricsManager,
+                                    private val threadPoolName: String
+                                    ) :
+            NettyAcceptor(name,
+                    clusterConnection,
+                    configuration,
+                    handler,
+                    listener,
+                    scheduledThreadPool,
+                    failureExecutor,
+                    protocolMap,
+                    threadFactoryGroupName,
+                    metricsManager)
     {
         companion object {
             private val defaultThreadPoolNamePattern = Pattern.compile("""Thread-(\d+) \(activemq-netty-threads\)""")

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeNettyAcceptorFactory.kt
@@ -63,7 +63,7 @@ class NodeNettyAcceptorFactory : AcceptorFactory {
                 protocolMap,
                 threadFactoryGroupName,
                 metricsManager,
-                "$threadPoolName-netty",
+                "$threadPoolName-netty"
         )
     }
 


### PR DESCRIPTION
**Artemis 2.42.0 to 2.44.0**
The interface for creating an acceptor has changed - a couple of extra arguments are required that are merely passed through to the acceptor object upon construction.
The transport configuration option `REMOTING_THREADS_PROPNAME` is no longer defaulted by Artemis when set to -1, so our code doesn't bother setting it at all - in which Artemis _does_ default it.

