### PR TITLE
Replace printStackTrace with SLF4J logging to improve observability

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -213,7 +213,7 @@ internal class RPCClientProxyHandler(
                         "where the leak is coming from, set -Dnet.corda.client.rpc.trackRpcCallSites=true on the JVM",
                         "command line and you will get a stack trace with this warning."
                 ).joinToString(" "), rpcCallSite)
-                rpcCallSite?.printStackTrace()
+                rpcCallSite?.let { log.warn("Call site stack trace:", it) }
             }
             observablesToReap.locked { observables.add(observableId) }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -197,17 +197,21 @@ fun secureRandomBytes(numOfBytes: Int): ByteArray = ByteArray(numOfBytes).apply 
  * TODO remove this once deserialisation is figured out.
  */
 private class DummySecureRandomSpi : SecureRandomSpi() {
+    companion object {
+        private val log = contextLogger()
+    }
+
     override fun engineSetSeed(bytes: ByteArray?) {
-        Exception("DummySecureRandomSpi.engineSetSeed called").printStackTrace(System.out)
+        log.warn("DummySecureRandomSpi.engineSetSeed called", Exception("DummySecureRandomSpi.engineSetSeed called"))
     }
 
     override fun engineNextBytes(bytes: ByteArray?) {
-        Exception("DummySecureRandomSpi.engineNextBytes called").printStackTrace(System.out)
+        log.warn("DummySecureRandomSpi.engineNextBytes called", Exception("DummySecureRandomSpi.engineNextBytes called"))
         bytes?.fill(0)
     }
 
     override fun engineGenerateSeed(numberOfBytes: Int): ByteArray {
-        Exception("DummySecureRandomSpi.engineGenerateSeed called").printStackTrace(System.out)
+        log.warn("DummySecureRandomSpi.engineGenerateSeed called", Exception("DummySecureRandomSpi.engineGenerateSeed called"))
         return ByteArray(numberOfBytes)
     }
 }


### PR DESCRIPTION
This PR replaces direct calls to printStackTrace() with proper SLF4J logging in RPCClientProxyHandler.kt and CryptoUtils.kt. Using a logger improves observability by ensuring stack traces are directed to the configured log appenders rather than stdout/stderr, and allows for better log level management.

Changes:

RPCClientProxyHandler.kt: Replaced rpcCallSite?.printStackTrace() with log.warn("Call site stack trace:", rpcCallSite). This ensures that call site stack traces are logged as warnings and preserved in the node logs.

CryptoUtils.kt: Added a companion object with a logger to DummySecureRandomSpi and replaced printStackTrace(System.out) with log.warn(...). This unifies the logging approach within the class.

Motivation:
Usage of printStackTrace() is generally discouraged in production code as it bypasses the logging framework, making it harder to track errors and debug issues continuously. These changes align with the codebase's standard logging practices.

Verification:

Verified that CallSite is a Throwable and will be correctly logged by SLF4J.

Ran net.corda.core.crypto.CryptoUtilsTest to ensure no regressions in crypto utilities.

Verified compilation of the client:rpc module.