### PR TITLE
ENT-14801: disabled Snyk scanning for 4.6

### DIFF
--- a/.ci/dev/nightly-regression/JenkinsfileSnykScan
+++ b/.ci/dev/nightly-regression/JenkinsfileSnykScan
@@ -3,5 +3,7 @@
 cordaSnykScanPipeline (
     snykTokenId: 'c4-os-snyk-api-token-secret',
     // specify the Gradle submodules to scan and monitor on snyk Server
-    modulesToScan: ['node', 'capsule']
+    modulesToScan: ['node', 'capsule'],
+    // do not set up cron trigger, after 4.6 went out of support
+    dailyBuildCron: ''
 )


### PR DESCRIPTION
* removed cron trigger from `cordaSnykScanPipeline` to avoid nightly builds of a version out of support
* this is the same change for 4.6 as for 4.5, see #8076