### PR TITLE
ENT-12964: Improve log messages in external verifier

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -414,47 +414,64 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         try {
             ltx.verify()
         } catch (e: NoClassDefFoundError) {
-            checkReverifyAllowed(e, disableWarnings)
+            checkReverifyAllowed(e, ltx, disableWarnings)
             val missingClass = e.message ?: throw e
             log.warn("Transaction {} has missing class: {}", ltx.id, missingClass)
             reverifyWithFixups(ltx, verificationSupport, missingClass)
         } catch (e: NotSerializableException) {
-            checkReverifyAllowed(e, disableWarnings)
+            checkReverifyAllowed(e, ltx, disableWarnings)
             retryVerification(e, e, ltx, verificationSupport)
         } catch (e: TransactionDeserialisationException) {
-            checkReverifyAllowed(e, disableWarnings)
+            checkReverifyAllowed(e, ltx, disableWarnings)
             retryVerification(e.cause, e, ltx, verificationSupport)
         }
         return ltx
     }
 
-    private fun checkReverifyAllowed(ex: Throwable, disableWarnings: Boolean) {
+    private fun checkReverifyAllowed(ex: Throwable, ltx: LedgerTransaction, disableWarnings: Boolean) {
         // If that transaction was created with and after Corda 4 then just fail.
         // The lenient dependency verification is only supported for Corda 3 transactions.
         // To detect if the transaction was created before Corda 4 we check if the transaction has the NetworkParameters component group.
         if (networkParametersHash != null) {
-            if (!disableWarnings) log.info("TRANSACTION VERIFY FAILED - No attempt to auto-repair as TX is Corda 4+")
+            if (!disableWarnings) {
+                log.warn("TRANSACTION VERIFY FAILED - No attempt to auto-repair as TX is Corda 4+")
+                logRetryVerificationCause(ex.cause, ex, ltx)
+            }
             throw ex
         }
     }
 
     private fun retryVerification(cause: Throwable?, ex: Throwable, ltx: LedgerTransaction, verificationSupport: VerificationSupport) {
+        logRetryVerificationCause(cause, ex, ltx)
         when (cause) {
             is MissingSerializerException -> {
-                log.warn("Missing serializers: typeDescriptor={}, typeNames={}", cause.typeDescriptor ?: "<unknown>", cause.typeNames)
                 reverifyWithFixups(ltx, verificationSupport, null)
             }
             is NotSerializableException -> {
                 val underlying = cause.cause
                 if (underlying is ClassNotFoundException) {
                     val missingClass = underlying.message?.replace('.', '/') ?: throw ex
-                    log.warn("Transaction {} has missing class: {}", ltx.id, missingClass)
                     reverifyWithFixups(ltx, verificationSupport, missingClass)
                 } else {
                     throw ex
                 }
             }
             else -> throw ex
+        }
+    }
+
+    private fun logRetryVerificationCause(cause: Throwable?, ex: Throwable, ltx: LedgerTransaction) {
+        when (cause) {
+            is MissingSerializerException -> {
+                log.warn("Missing serializers: typeDescriptor={}, typeNames={}", cause.typeDescriptor ?: "<unknown>", cause.typeNames)
+            }
+            is NotSerializableException -> {
+                val underlying = cause.cause
+                if (underlying is ClassNotFoundException) {
+                    val missingClass = underlying.message?.replace('.', '/') ?: throw ex
+                    log.warn("Transaction {} has missing class: {}", ltx.id, missingClass)
+                }
+            }
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -433,7 +433,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         // The lenient dependency verification is only supported for Corda 3 transactions.
         // To detect if the transaction was created before Corda 4 we check if the transaction has the NetworkParameters component group.
         if (networkParametersHash != null) {
-            if (!disableWarnings) log.warn("TRANSACTION VERIFY FAILED - No attempt to auto-repair as TX is Corda 4+")
+            if (!disableWarnings) log.info("TRANSACTION VERIFY FAILED - No attempt to auto-repair as TX is Corda 4+")
             throw ex
         }
     }

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
@@ -115,8 +115,7 @@ class ExternalVerifier(private val channel: SocketChannel) {
             log.info("${ctx.toSimpleString()} verified")
             Try.Success(Unit)
         } catch (t: Throwable) {
-            log.info("${request.ctx.toSimpleString()} failed to verify: ${t.message}")
-            if (log.isDebugEnabled) log.debug("Verification failure stacktrace:", t)
+            log.info("${request.ctx.toSimpleString()} failed to verify", t)
             Try.Failure(t)
         }
         channel.writeCordaSerializable(VerificationResult(result))

--- a/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/ExternalVerifier.kt
@@ -115,7 +115,8 @@ class ExternalVerifier(private val channel: SocketChannel) {
             log.info("${ctx.toSimpleString()} verified")
             Try.Success(Unit)
         } catch (t: Throwable) {
-            log.info("${request.ctx.toSimpleString()} failed to verify", t)
+            log.info("${request.ctx.toSimpleString()} failed to verify: ${t.message}")
+            if (log.isDebugEnabled) log.debug("Verification failure stacktrace:", t)
             Try.Failure(t)
         }
         channel.writeCordaSerializable(VerificationResult(result))


### PR DESCRIPTION
Improved log messages in the external verifier - added more logging with the cause when the verify failed.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
