### PR TITLE
ENT-12545: Fix external verifier process not exiting in certain scenarios

### DIFF
--- a/node/src/main/kotlin/net/corda/node/verification/ExternalVerifierHandleImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/verification/ExternalVerifierHandleImpl.kt
@@ -134,7 +134,7 @@ class ExternalVerifierHandleImpl(
     private fun processError(attempt: Int, e: Exception) {
         try {
             if (attempt == MAX_ATTEMPTS) {
-                log.error("External verifier failed after $attempt attempts, giving up", e)
+                log.error("External verifier failed after $attempt attempts, exiting.", e)
             } else {
                 log.warn("Unable to verify with external verifier, trying again...", e)
             }

--- a/node/src/main/kotlin/net/corda/node/verification/ExternalVerifierHandleImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/verification/ExternalVerifierHandleImpl.kt
@@ -132,17 +132,23 @@ class ExternalVerifierHandleImpl(
     }
 
     private fun processError(attempt: Int, e: Exception) {
+        try {
+            if (attempt == MAX_ATTEMPTS) {
+                log.error("External verifier failed after $attempt attempts, giving up", e)
+            } else {
+                log.warn("Unable to verify with external verifier, trying again...", e)
+            }
+        } finally {
+            try {
+                connection?.close() // always kill verifier process
+            } catch (e: Exception) {
+                log.debug("Problem closing external verifier connection", e)
+            }
+            connection = null
+        }
         if (attempt == MAX_ATTEMPTS) {
             throw IOException("Unable to verify with external verifier", e)
-        } else {
-            log.warn("Unable to verify with external verifier, trying again...", e)
         }
-        try {
-            connection?.close()
-        } catch (e: Exception) {
-            log.debug("Problem closing external verifier connection", e)
-        }
-        connection = null
     }
 
     private fun tryVerification(request: VerificationRequest): Try<Unit> {


### PR DESCRIPTION
On the final retry/attempt, the external verifier process is never closed. This is now fixed.

**BEFORE**, on the last attempt:
- IOException is thrown
- connection?.close() is never reached, therefore verifierProcess.destroyForcibly() is never called either
- External verifier process may continue running

**NOW**, on the last attempt:
- The error is logged
- connection?.close() is always called and verifierProcess.destroyForcibly() is called too - external verifier process is killed after each retry
- IOException is thrown at the end

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
