### PR TITLE
ENT-12570: Improve logging in case of errors from RPC server

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -429,7 +429,7 @@ internal class RPCClientProxyHandler(
                 log.info("Message duplication detected, discarding message")
                 return
             }
-            log.warn("Got message from RPC server $serverToClient")
+            log.warn("Got message from RPC server: $serverToClient")
             when (serverToClient) {
                 is RPCApi.ServerToClient.RpcReply -> {
                     val replyFuture = rpcReplyMap.remove(serverToClient.id)

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -429,7 +429,7 @@ internal class RPCClientProxyHandler(
                 log.info("Message duplication detected, discarding message")
                 return
             }
-            log.warn("Got message from RPC server: $serverToClient")
+            log.debug { "Got message from RPC server: $serverToClient" }
             when (serverToClient) {
                 is RPCApi.ServerToClient.RpcReply -> {
                     val replyFuture = rpcReplyMap.remove(serverToClient.id)
@@ -440,6 +440,7 @@ internal class RPCClientProxyHandler(
                         when (result) {
                             is Try.Success -> replyFuture.set(result.value)
                             is Try.Failure -> {
+                                log.warn("Received error response from RPC server: $serverToClient")
                                 completeExceptionally(serverToClient.id, result.exception, replyFuture)
                             }
                         }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -429,7 +429,7 @@ internal class RPCClientProxyHandler(
                 log.info("Message duplication detected, discarding message")
                 return
             }
-            log.debug { "Got message from RPC server $serverToClient" }
+            log.warn("Got message from RPC server $serverToClient")
             when (serverToClient) {
                 is RPCApi.ServerToClient.RpcReply -> {
                     val replyFuture = rpcReplyMap.remove(serverToClient.id)


### PR DESCRIPTION
Add a new WARN log message in case of errors from RPC server.
Before this fix, such messages were only printed at DEBUG level, which were easy to miss in the logs and lead to problems such as CS-3881.

The new message looks like this:
```
[WARN ] 2026-03-04T16:13:18,875Z [RPCClient-artemis-15-1] internal.RPCClientProxyHandler. - Received error response from RPC server: RpcReply(id=4b84b0c3-cdf4-433a-b0e9-4a9bd6b0463a, timestamp: 2026-03-04T16:13:18.128Z, entityType: Invocation, result=Failure(net.corda.client.rpc.PermissionException: User not authorized to perform RPC call public abstract net.corda.core.messaging.FlowHandle net.corda.core.messaging.CordaRPCOps.startFlowDynamic(java.lang.Class,java.lang.Object[]) with target [class net.corda.node.flows.AsyncRetryFlow]), deduplicationIdentity=02774e51-3a0c-498d-ac74-65bc0763f4a5) {}
```

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
