### PR TITLE
ENT-14534: Set `alsoFinalize` to true by default to finalise inactive inflight transactions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/LedgerRecoverFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/LedgerRecoverFlow.kt
@@ -72,7 +72,7 @@ data class LedgerRecoveryParameters(
     val useTimeWindowNarrowing: Boolean = true,
     val verboseLogging: Boolean = false,
     val recoveryBatchSize: Int = 1000,
-    val alsoFinalize: Boolean = false
+    val alsoFinalize: Boolean = true
 )
 
 @CordaSerializable


### PR DESCRIPTION
Set `alsoFinalize` to true to finalise inactive inflight transactions by default.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
