### PR TITLE
ENT-14944: Allow log-path to be set via a system property for the command.

### DIFF
--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -139,7 +139,9 @@ abstract class CliWrapperBase(val alias: String, val description: String) : Call
         if (verbose) {
             System.setProperty("consoleLogLevel", specifiedLogLevel)
         }
-        System.setProperty("log-path", Paths.get(".").toString())
+        if (System.getProperty("log-path") == null) {
+            System.setProperty("log-path", Paths.get(".").toString())
+        }
         return true
     }
 


### PR DESCRIPTION
ENT-14944: Allow log-path to be set via a system property for the command line tools.

