### PR TITLE
ENT-14787: Fix for the rate-limiting backoff

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
@@ -21,6 +21,7 @@ import net.corda.testing.node.internal.NodeBasedTest
 import net.corda.testing.node.internal.cordappForClasses
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
 import org.apache.shiro.authc.credential.DefaultPasswordService
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Assume
 import org.junit.Before
@@ -95,6 +96,11 @@ class AuthDBTests : NodeBasedTest(cordappPackages = CORDAPPS) {
                                         "cache" to mapOf(
                                                 "expireAfterSecs" to cacheExpireAfterSecs,
                                                 "maxEntries" to 50
+                                        ),
+                                        "rateLimit" to mapOf(
+                                                "backoffBaseSeconds" to 2,
+                                                "backoffMaxSeconds" to 60,
+                                                "attemptExpireMinutes" to 15
                                         )
                                 )
                         )
@@ -214,6 +220,53 @@ class AuthDBTests : NodeBasedTest(cordappPackages = CORDAPPS) {
                 proxy.stateMachinesFeed()
             }
         }
+    }
+
+    @Test(timeout=300_000)
+    fun `user+ip is suspended after repeated failures`() {
+        // first 3 failures – free attempts, no backoff
+        repeat(3) {
+            assertThatThrownBy {
+                client.start("user", "wrong").close()
+            }.isInstanceOf(ActiveMQSecurityException::class.java)
+        }
+
+        // 4th failure – backoff starts
+        assertThatThrownBy {
+            client.start("user", "wrong").close()
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        // retry immediately with correct password - should fail as the user is blocked
+        assertThatThrownBy {
+            client.start("user", "foo").close()
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        Thread.sleep(2100) // wait 2s for the backoff to expire
+        client.start("user", "foo").close()
+    }
+
+    @Test(timeout=300_000)
+    fun `ip is suspended after repeated failures`() {
+        // first 10 failures – free attempts, no backoff
+        repeat(10) { attempt ->
+            assertThatThrownBy {
+                client.start("user$attempt", "wrong").close()
+            }.isInstanceOf(ActiveMQSecurityException::class.java)
+        }
+
+        // 11th failure from the same IP - backoff starts - failure due to suspension
+        assertThatThrownBy {
+            client.start("user11", "wrong").close()
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        // Wait for IP backoff to expire
+        Thread.sleep(2100)
+        // 12th failure from the same IP - backoff expired - so the failure is due to login not suspension
+        assertThatThrownBy {
+            client.start("user12", "wrong").close()
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        client.start("user", "foo").close()
     }
 
     @StartableByRPC

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
@@ -11,6 +11,7 @@ import net.corda.node.internal.artemis.ArtemisBroker
 import net.corda.node.internal.security.RPCSecurityManager
 import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.Permissions.Companion.all
+import net.corda.node.services.config.SecurityConfiguration.AuthService.Options.RateLimit
 import net.corda.node.utilities.createKeyPairAndSelfSignedTLSCertificate
 import net.corda.node.utilities.saveToKeyStore
 import net.corda.node.utilities.saveToTrustStore
@@ -25,6 +26,7 @@ import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.fromUserList
 import net.corda.testing.internal.p2pSslOptions
 import org.apache.activemq.artemis.api.core.ActiveMQConnectionTimedOutException
+import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -94,6 +96,88 @@ class ArtemisRpcTests {
         assertThatThrownBy {
             testSslCommunication(p2pSslOptions(tempFolder.root.toPath()), brokerSslOptions, true, clientSslOptions)
         }.isInstanceOf(RPCException::class.java)
+    }
+
+    @Test(timeout = 300_000)
+    fun `user+ip is suspended after repeated failures`() {
+        val rateLimitConfig = RateLimit(
+                backoffBaseSeconds = 2L,
+                backoffMaxSeconds = 60L,
+                attemptExpireMinutes = 15
+        )
+
+        val client = startRpcClient(rateLimitConfig)
+
+        // first 3 failures – free attempts, no backoff
+        repeat(3) {
+            assertThatThrownBy {
+                client.start(TestRpcOps::class.java, user.username, "wrong")
+            }.isInstanceOf(ActiveMQSecurityException::class.java)
+        }
+
+        // 4th failure – backoff starts
+        assertThatThrownBy {
+            client.start(TestRpcOps::class.java, user.username,"wrong")
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        // retry immediately with correct password - should fail as the user is blocked
+        assertThatThrownBy {
+            client.start(TestRpcOps::class.java, user.username, user.password)
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        Thread.sleep(2100) // wait 2s for the backoff to expire
+        client.start(TestRpcOps::class.java, user.username, user.password)
+    }
+
+    @Test(timeout = 300_000)
+    fun `ip is suspended after repeated failures`() {
+        val rateLimitConfig = RateLimit(
+                backoffBaseSeconds = 2L,
+                backoffMaxSeconds = 60L,
+                attemptExpireMinutes = 15
+        )
+
+        val client = startRpcClient(rateLimitConfig)
+        val userName = "user"
+        // first 10 failures – free attempts, no backoff
+        repeat(10) { attempt ->
+            assertThatThrownBy {
+                client.start(TestRpcOps::class.java, "$userName$attempt", "wrong")
+            }.isInstanceOf(ActiveMQSecurityException::class.java)
+        }
+
+        // 11th failure from the same IP - backoff starts - failure due to suspension
+        assertThatThrownBy {
+            client.start(TestRpcOps::class.java, "username11", "wrong")
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        // Wait for IP backoff to expire
+        Thread.sleep(2100)
+        // 12th failure from the same IP - backoff expired - so the failure is due to login not suspension
+        assertThatThrownBy {
+            client.start(TestRpcOps::class.java, "username12", "wrong")
+        }.isInstanceOf(ActiveMQSecurityException::class.java)
+
+        client.start(TestRpcOps::class.java, user.username, user.password)
+    }
+
+    private fun startRpcClient(rateLimitConfig: RateLimit): RPCClient<TestRpcOps> {
+        val maxMessageSize = 10000
+        val jmxEnabled = false
+        val nodeSSlconfig = p2pSslOptions(tempFolder.root.toPath())
+        val address = ports.nextHostAndPort()
+        val adminAddress = ports.nextHostAndPort()
+        val baseDirectory = tempFolder.root.toPath()
+
+        val artemisBroker = ArtemisRpcBroker.withoutSsl(nodeSSlconfig, address, adminAddress, securityManager, maxMessageSize, null, jmxEnabled, baseDirectory, false, rateLimitConfig)
+        artemisBroker.start()
+
+        InternalRPCMessagingClient(nodeSSlconfig, adminAddress, maxMessageSize, CordaX500Name("MegaCorp", "London", "GB"), RPCServerConfiguration.DEFAULT
+        ).apply {
+            init(listOf(TestRpcOpsImpl()), securityManager, TestingNamedCacheFactory())
+            start(artemisBroker.serverControl)
+        }
+        return RPCClient(rpcConnectorTcpTransport(artemisBroker.addresses.primary, null))
     }
 
     private fun testSslCommunication(nodeSSlconfig: MutualSslConfiguration,

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
@@ -11,7 +11,6 @@ import net.corda.node.internal.artemis.ArtemisBroker
 import net.corda.node.internal.security.RPCSecurityManager
 import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.Permissions.Companion.all
-import net.corda.node.services.config.SecurityConfiguration.AuthService.Options.RateLimit
 import net.corda.node.utilities.createKeyPairAndSelfSignedTLSCertificate
 import net.corda.node.utilities.saveToKeyStore
 import net.corda.node.utilities.saveToTrustStore
@@ -26,7 +25,6 @@ import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.fromUserList
 import net.corda.testing.internal.p2pSslOptions
 import org.apache.activemq.artemis.api.core.ActiveMQConnectionTimedOutException
-import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -96,88 +94,6 @@ class ArtemisRpcTests {
         assertThatThrownBy {
             testSslCommunication(p2pSslOptions(tempFolder.root.toPath()), brokerSslOptions, true, clientSslOptions)
         }.isInstanceOf(RPCException::class.java)
-    }
-
-    @Test(timeout = 300_000)
-    fun `user+ip is suspended after repeated failures`() {
-        val rateLimitConfig = RateLimit(
-                backoffBaseSeconds = 2L,
-                backoffMaxSeconds = 60L,
-                attemptExpireMinutes = 15
-        )
-
-        val client = startRpcClient(rateLimitConfig)
-
-        // first 3 failures – free attempts, no backoff
-        repeat(3) {
-            assertThatThrownBy {
-                client.start(TestRpcOps::class.java, user.username, "wrong")
-            }.isInstanceOf(ActiveMQSecurityException::class.java)
-        }
-
-        // 4th failure – backoff starts
-        assertThatThrownBy {
-            client.start(TestRpcOps::class.java, user.username,"wrong")
-        }.isInstanceOf(ActiveMQSecurityException::class.java)
-
-        // retry immediately with correct password - should fail as the user is blocked
-        assertThatThrownBy {
-            client.start(TestRpcOps::class.java, user.username, user.password)
-        }.isInstanceOf(ActiveMQSecurityException::class.java)
-
-        Thread.sleep(2100) // wait 2s for the backoff to expire
-        client.start(TestRpcOps::class.java, user.username, user.password)
-    }
-
-    @Test(timeout = 300_000)
-    fun `ip is suspended after repeated failures`() {
-        val rateLimitConfig = RateLimit(
-                backoffBaseSeconds = 2L,
-                backoffMaxSeconds = 60L,
-                attemptExpireMinutes = 15
-        )
-
-        val client = startRpcClient(rateLimitConfig)
-        val userName = "user"
-        // first 10 failures – free attempts, no backoff
-        repeat(10) { attempt ->
-            assertThatThrownBy {
-                client.start(TestRpcOps::class.java, "$userName$attempt", "wrong")
-            }.isInstanceOf(ActiveMQSecurityException::class.java)
-        }
-
-        // 11th failure from the same IP - backoff starts - failure due to suspension
-        assertThatThrownBy {
-            client.start(TestRpcOps::class.java, "username11", "wrong")
-        }.isInstanceOf(ActiveMQSecurityException::class.java)
-
-        // Wait for IP backoff to expire
-        Thread.sleep(2100)
-        // 12th failure from the same IP - backoff expired - so the failure is due to login not suspension
-        assertThatThrownBy {
-            client.start(TestRpcOps::class.java, "username12", "wrong")
-        }.isInstanceOf(ActiveMQSecurityException::class.java)
-
-        client.start(TestRpcOps::class.java, user.username, user.password)
-    }
-
-    private fun startRpcClient(rateLimitConfig: RateLimit): RPCClient<TestRpcOps> {
-        val maxMessageSize = 10000
-        val jmxEnabled = false
-        val nodeSSlconfig = p2pSslOptions(tempFolder.root.toPath())
-        val address = ports.nextHostAndPort()
-        val adminAddress = ports.nextHostAndPort()
-        val baseDirectory = tempFolder.root.toPath()
-
-        val artemisBroker = ArtemisRpcBroker.withoutSsl(nodeSSlconfig, address, adminAddress, securityManager, maxMessageSize, null, jmxEnabled, baseDirectory, false, rateLimitConfig)
-        artemisBroker.start()
-
-        InternalRPCMessagingClient(nodeSSlconfig, adminAddress, maxMessageSize, CordaX500Name("MegaCorp", "London", "GB"), RPCServerConfiguration.DEFAULT
-        ).apply {
-            init(listOf(TestRpcOpsImpl()), securityManager, TestingNamedCacheFactory())
-            start(artemisBroker.serverControl)
-        }
-        return RPCClient(rpcConnectorTcpTransport(artemisBroker.addresses.primary, null))
     }
 
     private fun testSslCommunication(nodeSSlconfig: MutualSslConfiguration,

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RateLimitingActiveMQJAASSecurityManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RateLimitingActiveMQJAASSecurityManager.kt
@@ -117,7 +117,7 @@ class RateLimitingActiveMQJAASSecurityManager(
 
         // 7. Plain authentication failure
         if (thrown != null) throw thrown
-        return null
+        throw NoCacheLoginException("Uncached failure")
     }
 
     private fun recordFailure(

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RateLimitingActiveMQJAASSecurityManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RateLimitingActiveMQJAASSecurityManager.kt
@@ -72,7 +72,13 @@ class RateLimitingActiveMQJAASSecurityManager(
         }
 
         // 2. Attempt authentication
-        val subject = super.authenticate(user, password, remotingConnection, securityDomain)
+        var thrown: Exception? = null
+        val subject = try {
+            super.authenticate(user, password, remotingConnection, securityDomain)
+        } catch (e: Exception) {
+            thrown = e
+            null
+        }
         if (subject != null) {
             // success - clear user cache only
             if (userKey != null) {
@@ -110,6 +116,7 @@ class RateLimitingActiveMQJAASSecurityManager(
         }
 
         // 7. Plain authentication failure
+        if (thrown != null) throw thrown
         return null
     }
 


### PR DESCRIPTION
1. Fix for the logic bug in `RateLimitingActiveMQJAASSecurityManager`: catch and throw the auth exception after all the rate-limiting checks completed, instead of not catching it and throwing right away
2. Moved the tests to `AuthDBTests` where they belong better

Tested the corda.jar locally through the new rate-limiting CRAFT test, works fine.


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
