### PR TITLE
ENT-14952, ENT-14954: Add missing jersey-hk2 dependency to fix webservers not starting

### DIFF
--- a/testing/testserver/build.gradle
+++ b/testing/testserver/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-continuation:${jetty_version}"
 
     compile "org.glassfish.jersey.core:jersey-server:$jersey_version"
+    compile "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
     compile "org.glassfish.jersey.containers:jersey-container-servlet:$jersey_version"
     compile "org.glassfish.jersey.containers:jersey-container-jetty-http:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"


### PR DESCRIPTION
The Jersey version upgrade in https://github.com/corda/corda/pull/8056 broke the Webservers used in sample cordapps. The fix is to add a missing dependency, which the new Jersey version needs: `org.glassfish.jersey.inject:jersey-hk2` 

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
