### PR TITLE
ENT-14980,ENT-15013,ENT-15014,ENT-15015 - Security dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -531,7 +531,7 @@ allprojects {
                     substitute module('com.google.guava:guava') with module("com.google.guava:guava:$guava_version")
 
                     // Effectively delete this unused and unwanted transitive dependency of Artemis.
-                    substitute module('org.jgroups:jgroups') with module("org.apache.activemq:artemis-commons:$artemis_version")
+                    substitute module('org.jgroups:jgroups') with module("org.apache.artemis:artemis-commons:$artemis_version")
 
                     // Force use of LTS version of BC everywhere
                     substitute module('org.bouncycastle:bcutil-jdk18on') with module("org.bouncycastle:bcutil-lts8on:$bouncycastle_version")

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -143,20 +143,6 @@ class CordaModule : SimpleModule("corda-core") {
 }
 
 private class CordaSerializableClassIntrospector(private val context: Module.SetupContext) : BasicClassIntrospector() {
-    override fun constructPropertyCollector(
-            config: MapperConfig<*>?,
-            ac: AnnotatedClass?,
-            type: JavaType,
-            forSerialization: Boolean,
-            mutatorPrefix: String?
-    ): POJOPropertiesCollector {
-        if (hasCordaSerializable(type.rawClass)) {
-            // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.
-            context.configOverride(type.rawClass).visibility = Value.defaultVisibility().withFieldVisibility(Visibility.ANY)
-        }
-        return super.constructPropertyCollector(config, ac, type, forSerialization, mutatorPrefix)
-    }
-
     override fun constructPropertyCollector(config: MapperConfig<*>?, classDef: AnnotatedClass?, type: JavaType, forSerialization: Boolean, accNaming: AccessorNamingStrategy?): POJOPropertiesCollector {
         if (hasCordaSerializable(type.rawClass)) {
             // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     // TODO: remove the forced update of commons-collections and beanutils when artemis updates them
     implementation "org.apache.commons:commons-collections4:${commons_collections_version}"
     implementation "commons-beanutils:commons-beanutils:${beanutils_version}"
-    implementation("org.apache.activemq:artemis-core-client:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-core-client:${artemis_version}") {
         exclude group: 'org.jgroups', module: 'jgroups'
     }
 

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "io.reactivex:rxjava:$rxjava_version"
-    implementation("org.apache.activemq:artemis-core-client:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-core-client:${artemis_version}") {
         exclude group: 'org.jgroups', module: 'jgroups'
     }
     implementation "com.google.guava:guava-testlib:$guava_version"

--- a/constants.properties
+++ b/constants.properties
@@ -42,11 +42,11 @@ tcnativeVersion=2.0.74.Final
 # We must configure it manually to use the latest capsule version.
 capsuleVersion=1.0.4_r3
 asmVersion=9.5
-artemisVersion=2.44.0
+artemisVersion=2.52.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.17.3
-jacksonKotlinVersion=2.17.0
-jettyVersion=12.0.14
+jacksonVersion=2.18.6
+jacksonKotlinVersion=2.18.0
+jettyVersion=12.0.33
 jerseyVersion=3.1.11
 servletVersion=4.0.1
 assertjVersion=3.27.7

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -19,10 +19,10 @@ dependencies {
     // TODO: remove the forced update of commons-collections and beanutils when artemis updates them
     implementation "org.apache.commons:commons-collections4:${commons_collections_version}"
     implementation "commons-beanutils:commons-beanutils:${beanutils_version}"
-    implementation("org.apache.activemq:artemis-core-client:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-core-client:${artemis_version}") {
         exclude group: 'org.jgroups', module: 'jgroups'
     }
-    implementation "org.apache.activemq:artemis-commons:${artemis_version}"
+    implementation "org.apache.artemis:artemis-commons:${artemis_version}"
     implementation "javax.json:javax.json-api:$json_api_version"
     implementation "com.google.code.findbugs:jsr305:$jsr305_version"
 
@@ -84,7 +84,7 @@ dependencies {
     testImplementation project(':core-test-utils')
     testImplementation project(':test-utils')
 
-    implementation ("org.apache.activemq:artemis-amqp-protocol:${artemis_version}") {
+    implementation ("org.apache.artemis:artemis-amqp-protocol:${artemis_version}") {
         // Gains our proton-j version from core module.
         exclude group: 'org.apache.qpid', module: 'proton-j'
         exclude group: 'org.jgroups', module: 'jgroups'

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -163,11 +163,11 @@ dependencies {
     // TODO: remove the forced update of commons-collections and beanutils when artemis updates them
     implementation "org.apache.commons:commons-collections4:${commons_collections_version}"
     implementation "commons-beanutils:commons-beanutils:${beanutils_version}"
-    implementation("org.apache.activemq:artemis-server:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-server:${artemis_version}") {
         exclude group: 'org.apache.commons', module: 'commons-dbcp2'
         exclude group: 'org.jgroups', module: 'jgroups'
     }
-    implementation("org.apache.activemq:artemis-core-client:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-core-client:${artemis_version}") {
         exclude group: 'org.jgroups', module: 'jgroups'
     }
     // Bouncy castle support needed for X509 certificate manipulation
@@ -186,7 +186,7 @@ dependencies {
     // TypeSafe Config: for simple and human friendly config files.
     implementation "com.typesafe:config:$typesafe_config_version"
     implementation "io.reactivex:rxjava:$rxjava_version"
-    implementation("org.apache.activemq:artemis-amqp-protocol:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-amqp-protocol:${artemis_version}") {
         // Gains our proton-j version from core module.
         exclude group: 'org.apache.qpid', module: 'proton-j'
         exclude group: 'org.jgroups', module: 'jgroups'

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(":core")
     implementation "io.reactivex:rxjava:$rxjava_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "org.apache.activemq:artemis-commons:${artemis_version}"
+    implementation "org.apache.artemis:artemis-commons:${artemis_version}"
     implementation "org.ow2.asm:asm:$asm_version"
     implementation "com.google.guava:guava:$guava_version"
     // For AMQP serialisation.

--- a/testing/core-test-utils/build.gradle
+++ b/testing/core-test-utils/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation "io.reactivex:rxjava:$rxjava_version"
     implementation "junit:junit:$junit_version"
     implementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
-    implementation("org.apache.activemq:artemis-server:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-server:${artemis_version}") {
         exclude group: 'org.apache.commons', module: 'commons-dbcp2'
         exclude group: 'org.jgroups', module: 'jgroups'
     }

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
 
     implementation "io.reactivex:rxjava:$rxjava_version"
-    implementation("org.apache.activemq:artemis-core-client:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-core-client:${artemis_version}") {
         exclude group: 'org.jgroups', module: 'jgroups'
     }
 
@@ -95,7 +95,7 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-core:$log4j_version"
     implementation "junit:junit:$junit_version"
 
-    implementation("org.apache.activemq:artemis-server:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-server:${artemis_version}") {
         exclude group: 'org.apache.commons', module: 'commons-dbcp2'
         exclude group: 'org.jgroups', module: 'jgroups'
     }

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     // ControlsFX: Extra controls for JavaFX.
     implementation "org.controlsfx:controlsfx:$controlsfx_version"
 
-    implementation("org.apache.activemq:artemis-core-client:${artemis_version}") {
+    implementation("org.apache.artemis:artemis-core-client:${artemis_version}") {
         exclude group: 'org.jgroups', module: 'jgroups'
     }
 }


### PR DESCRIPTION
**CVE-2025-11143 / SNYK-JAVA-ORGECLIPSEJETTY-15426540
CVE-2026-1605 / SNYK-JAVA-ORGECLIPSEJETTY-15426509**
Upgraded Jetty to 12.0.33

**CVE-2026-27446 / SNYK-JAVA-ORGAPACHEACTIVEMQ-15423960**
Upgrade Artemis to 2.52.0

**CWE-770 / SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924**
Upgrade Jackson to 2.18.6
