### PR TITLE
ENT-14982 - Revert Jackson Kotlin version

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -45,7 +45,7 @@ asmVersion=9.5
 artemisVersion=2.52.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.18.6
-jacksonKotlinVersion=2.18.0
+jacksonKotlinVersion=2.17.0
 jettyVersion=12.0.33
 jerseyVersion=3.1.11
 servletVersion=4.0.1


### PR DESCRIPTION
Reverted _jacksonKotlinVersion_. This was updated by mistake in a previous PR that intended to upgrade only _jacksonVersion_.
