### PR TITLE
ENT-15024 updating jetty version to 9.4.58.v20250814

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -52,7 +52,7 @@ artemisVersion=2.19.1
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.17.3
 jacksonKotlinVersion=2.9.7
-jettyVersion=9.4.57.v20241219
+jettyVersion=9.4.58.v20250814
 jerseyVersion=2.47
 servletVersion=4.0.1
 assertjVersion=3.27.7


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

This PR upgrades the jetty version to 9.4.58.v20250814 (current latest version compatible with java 8).
Currently there's no new version for jetty 9.x (compatible with java 8) that resolves the vulnerability CVE-2025-11143, hence we've opted to waiver it for now.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
