### PR TITLE
ENT-15106 updating guava version from 28.0-jre to 32.0.0-jre

### DIFF
--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -45,7 +45,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
-import org.junit.Rule
 import org.junit.Test
 import java.io.FilterInputStream
 import java.io.InputStream

--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.kotlin.rpc
 
 import com.google.common.hash.Hashing

--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.kotlin.rpc
 
 import com.google.common.hash.Hashing
@@ -43,19 +41,17 @@ import net.corda.sleeping.SleepingFlow
 import net.corda.smoketesting.NodeConfig
 import net.corda.smoketesting.NodeProcess
 import org.apache.commons.io.output.NullOutputStream
-import org.hamcrest.text.MatchesPattern
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import java.io.FilterInputStream
 import java.io.InputStream
 import java.util.Currency
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.regex.Pattern
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
@@ -88,9 +84,6 @@ class StandaloneCordaRPClientTest {
             isNotary = true,
             users = listOf(superUser, nonUser, rpcUser, flowUser)
     )
-
-    @get:Rule
-    val exception: ExpectedException = ExpectedException.none()
 
     @Before
     fun setUp() {
@@ -256,13 +249,12 @@ class StandaloneCordaRPClientTest {
 
     @Test(timeout=300_000)
 	fun `test kill flow without killFlow permission`() {
-        exception.expect(PermissionException::class.java)
-        exception.expectMessage(MatchesPattern(Pattern.compile("User not authorized to perform RPC call .*killFlow.*")))
-
         val flowHandle = rpcProxy.startFlow(::SleepingFlow, 1.minutes)
         notary.connect(nonUser).use { connection ->
             val rpcProxy = connection.proxy
-            rpcProxy.killFlow(flowHandle.id)
+            assertThatThrownBy {
+                rpcProxy.killFlow(flowHandle.id)
+            }.isInstanceOf(PermissionException::class.java).hasMessageMatching("User not authorized to perform RPC call .*killFlow.*")
         }
     }
 

--- a/constants.properties
+++ b/constants.properties
@@ -15,7 +15,7 @@ java8MinUpdateVersion=171
 platformVersion=13
 openTelemetryVersion=1.20.1
 openTelemetrySemConvVersion=1.20.1-alpha
-guavaVersion=28.0-jre
+guavaVersion=32.0.0-jre
 # Quasar version to use with Java 8:
 quasarVersion=0.7.16_r3
 # Quasar version to use with Java 11:

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/CollectSignaturesFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/CollectSignaturesFlowTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.coretests.flows
 
 import co.paralleluniverse.fibers.Suspendable

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/CollectSignaturesFlowTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/CollectSignaturesFlowTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.coretests.flows
 
 import co.paralleluniverse.fibers.Suspendable
@@ -38,11 +36,10 @@ import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.enclosedCordapp
-import org.hamcrest.CoreMatchers.`is`
 import org.junit.AfterClass
-import org.junit.Assert
 import org.junit.Test
 import java.security.PublicKey
+import kotlin.test.assertTrue
 
 class CollectSignaturesFlowTests : WithContracts {
     companion object {
@@ -94,7 +91,7 @@ class CollectSignaturesFlowTests : WithContracts {
         mockNet.runNetwork()
         val stx = future.get()
         val missingSigners = stx.getMissingSigners()
-        Assert.assertThat(missingSigners, `is`(emptySet()))
+        assertTrue(missingSigners.isEmpty())
     }
 
     @Test(timeout=300_000)
@@ -124,7 +121,7 @@ class CollectSignaturesFlowTests : WithContracts {
         mockNet.runNetwork()
         val stx = future.get()
         val missingSigners = stx.getMissingSigners()
-        Assert.assertThat(missingSigners, `is`(emptySet()))
+        assertTrue(missingSigners.isEmpty())
     }
 
     @Test(expected = IllegalArgumentException::class, timeout=300_000)
@@ -154,7 +151,7 @@ class CollectSignaturesFlowTests : WithContracts {
                 listOf(bobNode.info.singleIdentity(), alice))).resultFuture
         mockNet.runNetwork()
         val signedTx = future.getOrThrow()
-        Assert.assertThat(signedTx.getMissingSigners(), `is`(emptySet()))
+        assertTrue(signedTx.getMissingSigners().isEmpty())
     }
 
     @Test(timeout=300_000)

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.coretests.flows
 
 import co.paralleluniverse.fibers.Fiber

--- a/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/flows/FastThreadLocalTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.coretests.flows
 
 import co.paralleluniverse.fibers.Fiber
@@ -14,8 +12,6 @@ import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.rootCause
 import net.corda.core.utilities.getOrThrow
 import org.assertj.core.api.Assertions.catchThrowable
-import org.hamcrest.Matchers.lessThanOrEqualTo
-import org.junit.Assert.assertThat
 import org.junit.Test
 import java.util.*
 import java.util.concurrent.ExecutorService
@@ -23,6 +19,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class FastThreadLocalTest {
     private inner class ExpensiveObj {
@@ -67,7 +64,7 @@ class FastThreadLocalTest {
                     override fun initialValue() = ExpensiveObj()
                 }
                 runFibers(100, threadLocal::get) // Return value could be anything.
-                assertThat(expensiveObjCount.get(), lessThanOrEqualTo(3))
+                assertTrue(expensiveObjCount.get() <= 3)
             }
 
     /** @return the number of times a different expensive object was obtained post-suspend. */

--- a/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.coretests.utilities
 
 import com.esotericsoftware.kryo.KryoException
@@ -15,7 +13,8 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 object EmptyWhitelist : ClassWhitelist {
     override fun hasListed(type: Class<*>): Boolean = false
@@ -25,9 +24,6 @@ class KotlinUtilsTest {
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
-    @JvmField
-    @Rule
-    val expectedEx: ExpectedException = ExpectedException.none()
 
     private val KRYO_CHECKPOINT_NOWHITELIST_CONTEXT = CheckpointSerializationContextImpl(
             javaClass.classLoader,
@@ -56,10 +52,11 @@ class KotlinUtilsTest {
 
     @Test(timeout=300_000)
 	fun `deserialise transient property with non-capturing lambda`() {
-        expectedEx.expect(KryoException::class.java)
-        expectedEx.expectMessage("is not annotated or on the whitelist, so cannot be used in serialization")
         val original = NonCapturingTransientProperty()
-        original.checkpointSerialize(context = KRYO_CHECKPOINT_CONTEXT).checkpointDeserialize(context = KRYO_CHECKPOINT_NOWHITELIST_CONTEXT)
+        val ex = assertFailsWith<KryoException> {
+            original.checkpointSerialize(context = KRYO_CHECKPOINT_CONTEXT).checkpointDeserialize(context = KRYO_CHECKPOINT_NOWHITELIST_CONTEXT)
+        }
+        assertTrue(ex.message!!.contains("is not annotated or on the whitelist, so cannot be used in serialization"))
     }
 
     @Test(timeout=300_000)
@@ -75,12 +72,11 @@ class KotlinUtilsTest {
 
     @Test(timeout=300_000)
 	fun `deserialise transient property with capturing lambda`() {
-        expectedEx.expect(KryoException::class.java)
-        expectedEx.expectMessage("is not annotated or on the whitelist, so cannot be used in serialization")
-
         val original = CapturingTransientProperty("Hello")
-
-        original.checkpointSerialize(context = KRYO_CHECKPOINT_CONTEXT).checkpointDeserialize(context = KRYO_CHECKPOINT_NOWHITELIST_CONTEXT)
+        val ex = assertFailsWith<KryoException> {
+            original.checkpointSerialize(context = KRYO_CHECKPOINT_CONTEXT).checkpointDeserialize(context = KRYO_CHECKPOINT_NOWHITELIST_CONTEXT)
+        }
+        assertTrue(ex.message!!.contains("is not annotated or on the whitelist, so cannot be used in serialization"))
     }
 
     private class NullTransientProperty {

--- a/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/utilities/KotlinUtilsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.coretests.utilities
 
 import com.esotericsoftware.kryo.KryoException

--- a/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
@@ -5,15 +5,12 @@ import net.corda.core.internal.lazyMapped
 import net.corda.core.internal.TransactionDeserialisationException
 import net.corda.core.internal.eagerDeserialise
 import net.corda.core.serialization.MissingAttachmentsException
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class LazyMappedListTest {
-
-    @get:Rule
-    val exception: ExpectedException = ExpectedException.none()
 
     @Test(timeout=300_000)
 	fun `LazyMappedList works`() {
@@ -44,14 +41,14 @@ class LazyMappedListTest {
 
     @Test(timeout=300_000)
 	fun testMissingAttachments() {
-        exception.expect(MissingAttachmentsException::class.java)
-        exception.expectMessage("Uncatchable!")
-
         val lazyList = (0 until 5).toList().lazyMapped<Int, Int> { _, _ ->
             throw MissingAttachmentsException(emptyList(), "Uncatchable!")
         }
 
-        lazyList.eagerDeserialise { _, _ -> -999 }
+        val ex = assertFailsWith<MissingAttachmentsException> {
+            lazyList.eagerDeserialise { _, _ -> -999 }
+        }
+        assertTrue(ex.message!!.contains("Uncatchable!"))
     }
 
     @Test(timeout=300_000)

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.nodeapitests.internal.network
 
 import com.typesafe.config.ConfigFactory

--- a/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
+++ b/node-api-tests/src/test/kotlin/net/corda/nodeapitests/internal/network/NetworkBootstrapperTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.nodeapitests.internal.network
 
 import com.typesafe.config.ConfigFactory
@@ -40,7 +38,6 @@ import org.junit.After
 import org.junit.AfterClass
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Files
 import java.nio.file.Path
@@ -52,10 +49,6 @@ class NetworkBootstrapperTest {
     @Rule
     @JvmField
     val tempFolder = TemporaryFolder()
-
-    @Rule
-    @JvmField
-    val expectedEx: ExpectedException = ExpectedException.none()
 
     @Rule
     @JvmField
@@ -297,9 +290,9 @@ class NetworkBootstrapperTest {
         assertContainsPackageOwner("alice", mapOf(Pair(greedyNamespace, ALICE.publicKey)))
         // register overlapping package name
         createNodeConfFile("bob", bobConfig)
-        expectedEx.expect(IllegalArgumentException::class.java)
-        expectedEx.expectMessage("Multiple packages added to the packageOwnership overlap.")
-        bootstrap(packageOwnership = mapOf(Pair(greedyNamespace, ALICE.publicKey), Pair(bobPackageName, BOB.publicKey)))
+        assertThatThrownBy {
+            bootstrap(packageOwnership = mapOf(Pair(greedyNamespace, ALICE.publicKey), Pair(bobPackageName, BOB.publicKey)))
+        }.isInstanceOf(IllegalArgumentException::class.java).hasMessageContaining("Multiple packages added to the packageOwnership overlap.")
     }
 
     @Test(timeout=300_000)

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowOverrideTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowOverrideTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.node.flows
 
 import co.paralleluniverse.fibers.Suspendable

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowOverrideTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowOverrideTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
@@ -16,9 +14,8 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.cordappForClasses
-import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert.assertThat
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class FlowOverrideTests {
 
@@ -79,7 +76,7 @@ class FlowOverrideTests {
                     .map { startNode(it) }
                     .transpose()
                     .getOrThrow()
-            assertThat(nodeB.rpc.startFlow(::Ping, nodeA.nodeInfo.singleIdentity()).returnValue.getOrThrow(), `is`(Pongiest.GORGONZOLA))
+            assertEquals(Pongiest.GORGONZOLA, nodeB.rpc.startFlow(::Ping, nodeA.nodeInfo.singleIdentity()).returnValue.getOrThrow())
         }
     }
 
@@ -96,7 +93,7 @@ class FlowOverrideTests {
                     .map { startNode(it) }
                     .transpose()
                     .getOrThrow()
-            assertThat(nodeB.rpc.startFlow(::Ping, nodeA.nodeInfo.singleIdentity()).returnValue.getOrThrow(), `is`(Pong.PONG))
+            assertEquals(Pong.PONG, nodeB.rpc.startFlow(::Ping, nodeA.nodeInfo.singleIdentity()).returnValue.getOrThrow())
         }
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.node.services.network
 
 import net.corda.core.crypto.random63BitValue

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.node.services.network
 
 import net.corda.core.crypto.random63BitValue
@@ -27,10 +25,8 @@ import net.corda.testing.node.internal.*
 import net.corda.testing.node.internal.network.NetworkMapServer
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.hamcrest.CoreMatchers.`is`
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -282,9 +278,9 @@ class NetworkMapTest {
         // Make sure the nodes aren't getting the node infos from their additional-node-infos directories
         val nodeInfosDir = baseDirectory / NODE_INFO_DIRECTORY
         if (nodeInfosDir.exists()) {
-            assertThat(nodeInfosDir.list().size, `is`(1))
-            assertThat(nodeInfosDir.list().single().readObject<SignedNodeInfo>()
-                    .verified().legalIdentities.first(), `is`(this.nodeInfo.legalIdentities.first()))
+            assertEquals(1, nodeInfosDir.list().size)
+            assertEquals(this.nodeInfo.legalIdentities.first(), nodeInfosDir.list().single().readObject<SignedNodeInfo>()
+                    .verified().legalIdentities.first())
         }
         assertThat(rpc.networkMapSnapshot()).containsOnly(*nodes)
     }

--- a/node/src/test/kotlin/net/corda/node/internal/NodeFlowManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeFlowManagerTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.node.internal
 
 import net.corda.core.flows.FlowLogic
@@ -8,12 +6,10 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.node.services.config.FlowOverride
 import net.corda.node.services.config.FlowOverrideConfig
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.instanceOf
-import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
 import java.lang.IllegalStateException
+import kotlin.test.assertTrue
 
 private val marker = "This is a special marker"
 
@@ -75,7 +71,7 @@ class NodeFlowManagerTest {
         nodeFlowManager.validateRegistrations()
         val factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         val flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
-        Assert.assertThat(flow, `is`(instanceOf(RespSub::class.java)))
+        assertTrue(flow is RespSub)
     }
 
     @Test(timeout = 300_000)
@@ -86,14 +82,14 @@ class NodeFlowManagerTest {
         nodeFlowManager.validateRegistrations()
         var factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         var flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
-        Assert.assertThat(flow, `is`(instanceOf(RespSub::class.java)))
+        assertTrue(flow is RespSub)
         // update
         nodeFlowManager.registerInitiatedFlow(Init::class.java, RespSubSub::class.java)
         nodeFlowManager.validateRegistrations()
 
         factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
-        Assert.assertThat(flow, `is`(instanceOf(RespSubSub::class.java)))
+        assertTrue(flow is RespSubSub)
     }
 
     @Test(timeout=300_000)
@@ -107,6 +103,6 @@ class NodeFlowManagerTest {
         val factory = nodeFlowManager.getFlowFactoryForInitiatingFlow(Init::class.java)!!
         val flow = factory.createFlow(Mockito.mock(FlowSession::class.java))
 
-        Assert.assertThat(flow, `is`(instanceOf(Resp::class.java)))
+        assertTrue(flow is Resp)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/internal/NodeFlowManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeFlowManagerTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.node.internal
 
 import net.corda.core.flows.FlowLogic

--- a/node/src/test/kotlin/net/corda/node/migration/IdentityServiceToStringShortMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/IdentityServiceToStringShortMigrationTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.node.migration
 
 import com.nhaarman.mockito_kotlin.doReturn
@@ -19,13 +17,11 @@ import net.corda.nodeapi.internal.persistence.contextTransactionOrNull
 import net.corda.testing.core.*
 import net.corda.testing.internal.configureDatabase
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
-import org.hamcrest.CoreMatchers
-import org.hamcrest.Matcher
-import org.hamcrest.Matchers.*
 import org.junit.After
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  */
@@ -102,9 +98,9 @@ class IdentityServiceToStringShortMigrationTest {
                 val hashToIdentityResultSet = hashToIdentityStatement.executeQuery()
 
                 //check that there is a row for every "new" hash
-                Assert.assertThat(hashToIdentityResultSet.next(), `is`(true))
+                assertTrue(hashToIdentityResultSet.next())
                 //check that the pk_hash actually matches what we expect (kinda redundant, but deserializing the whole PartyAndCertificate feels like overkill)
-                Assert.assertThat(hashToIdentityResultSet.getString(1), `is`(it.owningKey.toStringShort()))
+                assertEquals(it.owningKey.toStringShort(), hashToIdentityResultSet.getString(1))
 
                 val nameToHashStatement = connection.prepareStatement("SELECT name FROM node_named_identities WHERE pk_hash=?")
                 nameToHashStatement.setString(1, it.owningKey.toStringShort())
@@ -112,7 +108,8 @@ class IdentityServiceToStringShortMigrationTest {
 
                 //if there is no result for this key, this means its an identity that is not stored in the DB (IE, it's been seen after another identity has already been mapped to it)
                 if (nameToHashResultSet.next()) {
-                    Assert.assertThat(nameToHashResultSet.getString(1), `is`(anyOf(groupedByNameIdentities.getValue(it.name).map<PartyAndCertificate, Matcher<String>?> { identity -> CoreMatchers.equalTo(identity.name.toString()) })))
+                    val expectedNames = groupedByNameIdentities.getValue(it.name).map { identity -> identity.name.toString() }
+                    assertTrue(nameToHashResultSet.getString(1) in expectedNames)
                 } else {
                     logger.warn("did not find a PK_HASH for ${it.name}")
                     listOfNamesWithoutPkHash.add(it.name)
@@ -123,7 +120,7 @@ class IdentityServiceToStringShortMigrationTest {
 
         listOfNamesWithoutPkHash.forEach {
             //the only time an identity name does not have a PK_HASH is if there are multiple identities associated with that name
-            Assert.assertThat(groupedByNameIdentities[it]?.size, `is`(greaterThan(1)))
+            assertTrue((groupedByNameIdentities[it]?.size ?: 0) > 1)
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/migration/IdentityServiceToStringShortMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/IdentityServiceToStringShortMigrationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.node.migration
 
 import com.nhaarman.mockito_kotlin.doReturn

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.node.services.network
 
 import com.google.common.jimfs.Configuration.unix

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.node.services.network
 
 import com.google.common.jimfs.Configuration.unix
@@ -58,9 +56,7 @@ import net.corda.testing.node.internal.network.NetworkMapServer
 import net.corda.testing.node.makeTestIdentityService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.hamcrest.collection.IsIterableContainingInAnyOrder
 import org.junit.After
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -163,7 +159,7 @@ class NetworkMapUpdaterTest {
         //TODO: Remove sleep in unit test.
         Thread.sleep(2L * cacheExpiryMs)
 
-        Assert.assertThat(networkMapCache.allNodeHashes, IsIterableContainingInAnyOrder.containsInAnyOrder(signedNodeInfo1.raw.hash, signedNodeInfo2.raw.hash))
+        assertThat(networkMapCache.allNodeHashes).containsExactlyInAnyOrder(signedNodeInfo1.raw.hash, signedNodeInfo2.raw.hash)
 
         assertThat(nodeReadyFuture).isDone()
 
@@ -175,13 +171,13 @@ class NetworkMapUpdaterTest {
         Thread.sleep(2L * cacheExpiryMs)
         //4 node info from network map, and 1 from file.
 
-        Assert.assertThat(networkMapCache.allNodeHashes, IsIterableContainingInAnyOrder.containsInAnyOrder(
+        assertThat(networkMapCache.allNodeHashes).containsExactlyInAnyOrder(
                 signedNodeInfo1.raw.hash,
                 signedNodeInfo2.raw.hash,
                 signedNodeInfo3.raw.hash,
                 signedNodeInfo4.raw.hash,
                 fileNodeInfoAndSigned.signed.raw.hash
-        ))
+        )
     }
 
     @Test(timeout=300_000)
@@ -206,13 +202,13 @@ class NetworkMapUpdaterTest {
         Thread.sleep(2L * cacheExpiryMs)
 
 
-        Assert.assertThat(networkMapCache.allNodeHashes, IsIterableContainingInAnyOrder.containsInAnyOrder(
+        assertThat(networkMapCache.allNodeHashes).containsExactlyInAnyOrder(
                 signedNodeInfo1.raw.hash,
                 signedNodeInfo2.raw.hash,
                 signedNodeInfo3.raw.hash,
                 signedNodeInfo4.raw.hash,
                 fileNodeInfoAndSigned.signed.raw.hash
-        ))
+        )
 
         //Test remove node.
         listOf(nodeInfo1, nodeInfo2, nodeInfo3, nodeInfo4).forEach {
@@ -250,10 +246,10 @@ class NetworkMapUpdaterTest {
         //TODO: Remove sleep in unit test.
         Thread.sleep(2L * cacheExpiryMs)
 
-        Assert.assertThat(networkMapCache.allNodeHashes, IsIterableContainingInAnyOrder.containsInAnyOrder(
+        assertThat(networkMapCache.allNodeHashes).containsExactlyInAnyOrder(
                 signedNodeInfo1.raw.hash,
                 signedNodeInfo2.raw.hash
-        ))
+        )
 
         // remove one node, add another and update a third.
         server.removeNodeInfo(nodeInfo1)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.node.services.vault
 
 import net.corda.core.internal.packageName
@@ -13,7 +11,6 @@ import net.corda.testing.core.*
 import net.corda.testing.internal.vault.DummyLinearStateSchemaV1
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.*
-import org.junit.rules.ExpectedException
 
 class VaultQueryExceptionsTests : VaultQueryParties by rule {
 
@@ -31,10 +28,6 @@ class VaultQueryExceptionsTests : VaultQueryParties by rule {
                     DummyLinearStateSchemaV1::class.packageName)
         }
     }
-
-    @Rule
-    @JvmField
-    val expectedEx: ExpectedException = ExpectedException.none()
 
     @Rule
     @JvmField

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.node.services.vault
 
 import net.corda.core.internal.packageName

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.node.services.vault
 
 import com.nhaarman.mockito_kotlin.mock
@@ -49,7 +47,6 @@ import org.junit.ClassRule
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.rules.ExternalResource
 import java.time.Duration
 import java.time.Instant
@@ -187,10 +184,6 @@ class VaultQueryRollbackRule(private val vaultQueryParties: VaultQueryParties) :
 }
 
 abstract class VaultQueryTestsBase : VaultQueryParties {
-
-    @Rule
-    @JvmField
-    val expectedEx: ExpectedException = ExpectedException.none()
 
     companion object {
         @ClassRule @JvmField
@@ -1010,10 +1003,10 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             assertThat(resultsUnlockedAndByLockIds.states).hasSize(5)
 
             // missing lockId
-            expectedEx.expect(VaultQueryException::class.java)
-            expectedEx.expectMessage("Must specify one or more lockIds")
             val criteriaMissingLockId = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.UNLOCKED_AND_SPECIFIED))
-            vaultService.queryBy<ContractState>(criteriaMissingLockId)
+            org.assertj.core.api.Assertions.assertThatThrownBy {
+                vaultService.queryBy<ContractState>(criteriaMissingLockId)
+            }.isInstanceOf(VaultQueryException::class.java).hasMessageContaining("Must specify one or more lockIds")
         }
     }
 
@@ -1712,44 +1705,41 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     @Test(timeout=300_000)
 	fun `invalid page number`() {
         Assume.assumeTrue(!IS_OPENJ9) // openj9 OOM issue
-        expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("Page specification: invalid page number")
+        org.assertj.core.api.Assertions.assertThatThrownBy {
+            database.transaction {
+                vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
+                val pagingSpec = PageSpecification(0, 10)
 
-        database.transaction {
-            vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
-            val pagingSpec = PageSpecification(0, 10)
-
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
-        }
+                val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+                vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
+            }
+        }.isInstanceOf(VaultQueryException::class.java).hasMessageContaining("Page specification: invalid page number")
     }
 
     // pagination: invalid page size
     @Suppress("INTEGER_OVERFLOW")
     @Test(timeout=300_000)
 	fun `invalid page size`() {
-        expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("Page specification: invalid page size")
-
-        database.transaction {
-            vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
-            val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, Integer.MAX_VALUE + 1)  // overflow = -2147483648
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
-        }
+        org.assertj.core.api.Assertions.assertThatThrownBy {
+            database.transaction {
+                vaultFiller.fillWithSomeTestCash(100.DOLLARS, notaryServices, 100, DUMMY_CASH_ISSUER)
+                val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, Integer.MAX_VALUE + 1)  // overflow = -2147483648
+                val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+                vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
+            }
+        }.isInstanceOf(VaultQueryException::class.java).hasMessageContaining("Page specification: invalid page size")
     }
 
     // pagination not specified but more than DEFAULT_PAGE_SIZE results available (fail-fast test)
     @Test(timeout=300_000)
 	fun `pagination not specified but more than default results available`() {
-        expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("provide a PageSpecification")
-
-        database.transaction {
-            vaultFiller.fillWithSomeTestCash(201.DOLLARS, notaryServices, 201, DUMMY_CASH_ISSUER)
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            vaultService.queryBy<ContractState>(criteria)
-        }
+        org.assertj.core.api.Assertions.assertThatThrownBy {
+            database.transaction {
+                vaultFiller.fillWithSomeTestCash(201.DOLLARS, notaryServices, 201, DUMMY_CASH_ISSUER)
+                val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+                vaultService.queryBy<ContractState>(criteria)
+            }
+        }.isInstanceOf(VaultQueryException::class.java).hasMessageContaining("provide a PageSpecification")
     }
 
     // example of querying states with paging using totalStatesAvailable

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.node.services.vault
 
 import com.nhaarman.mockito_kotlin.mock

--- a/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTNotaryServiceTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.notary.experimental.bftsmart
 
 import com.nhaarman.mockito_kotlin.doReturn

--- a/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTNotaryServiceTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.notary.experimental.bftsmart
 
 import com.nhaarman.mockito_kotlin.doReturn
@@ -32,9 +30,7 @@ import net.corda.testing.core.dummyCommand
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.TestClock
 import net.corda.testing.node.internal.*
-import org.hamcrest.Matchers.instanceOf
 import org.junit.AfterClass
-import org.junit.Assert.assertThat
 import org.junit.BeforeClass
 import org.junit.Ignore
 import org.junit.Test
@@ -164,9 +160,9 @@ class BFTNotaryServiceTests {
             val resultFuture = services.startFlow(flow).resultFuture
             mockNet.runNetwork()
             val exception = assertFailsWith<ExecutionException> { resultFuture.get() }
-            assertThat(exception.cause, instanceOf(NotaryException::class.java))
+            assertTrue(exception.cause is NotaryException)
             val error = (exception.cause as NotaryException).error
-            assertThat(error, instanceOf(NotaryError.TimeWindowInvalid::class.java))
+            assertTrue(error is NotaryError.TimeWindowInvalid)
         }
     }
 

--- a/node/src/test/kotlin/net/corda/notary/experimental/raft/RaftTransactionCommitLogTests.kt
+++ b/node/src/test/kotlin/net/corda/notary/experimental/raft/RaftTransactionCommitLogTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.notary.experimental.raft
 
 import io.atomix.catalyst.transport.Address

--- a/node/src/test/kotlin/net/corda/notary/experimental/raft/RaftTransactionCommitLogTests.kt
+++ b/node/src/test/kotlin/net/corda/notary/experimental/raft/RaftTransactionCommitLogTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.notary.experimental.raft
 
 import io.atomix.catalyst.transport.Address
@@ -28,9 +26,7 @@ import net.corda.testing.internal.LogHelper
 import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.configureDatabase
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
-import org.hamcrest.Matchers.instanceOf
 import org.junit.After
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -39,6 +35,7 @@ import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class RaftTransactionCommitLogTests {
     data class Member(val client: CopycatClient, val server: CopycatServer)
@@ -121,7 +118,7 @@ class RaftTransactionCommitLogTests {
                 states, txId, requestingPartyName.toString(), requestSignature, timeWindow
         )
         val commitError = client.submit(commitCommand).getOrThrow()
-        assertThat(commitError, instanceOf(NotaryError.TimeWindowInvalid::class.java))
+        assertTrue(commitError is NotaryError.TimeWindowInvalid)
     }
 
     @Test(timeout=300_000)

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.serialization.internal
 
 import com.esotericsoftware.kryo.*
@@ -26,15 +24,15 @@ import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.coretesting.internal.rigorousMock
 import net.corda.testing.internal.services.InternalMockAttachmentStorage
 import net.corda.testing.services.MockAttachmentStorage
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import java.net.URL
 import java.sql.Connection
 import java.util.*
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @CordaSerializable
 enum class Foo {
@@ -243,16 +241,14 @@ class CordaClassResolverTests {
     }
 
     // Blacklist tests. Note: leave the variable public or else expected messages do not work correctly
-    @get:Rule
-    val expectedEx = ExpectedException.none()!!
-
     @Test(timeout=300_000)
 	fun `Check blacklisted class`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("Class java.util.HashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(allButBlacklistedContext)
         // HashSet is blacklisted.
-        resolver.getRegistration(HashSet::class.java)
+        val ex = assertFailsWith<IllegalStateException> {
+            resolver.getRegistration(HashSet::class.java)
+        }
+        assertTrue(ex.message!!.contains("Class java.util.HashSet is blacklisted, so it cannot be used in serialization."))
     }
 
     @Test(timeout=300_000)
@@ -325,33 +321,36 @@ class CordaClassResolverTests {
 
     @Test(timeout=300_000)
 	fun `Check blacklisted subclass`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubHashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(allButBlacklistedContext)
         // SubHashSet extends the blacklisted HashSet.
-        resolver.getRegistration(SubHashSet::class.java)
+        val ex = assertFailsWith<IllegalStateException> {
+            resolver.getRegistration(SubHashSet::class.java)
+        }
+        assertTrue(ex.message!!.contains("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubHashSet is blacklisted, so it cannot be used in serialization."))
     }
 
     class SubSubHashSet<E> : SubHashSet<E>()
 
     @Test(timeout=300_000)
 	fun `Check blacklisted subsubclass`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubSubHashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(allButBlacklistedContext)
         // SubSubHashSet extends SubHashSet, which extends the blacklisted HashSet.
-        resolver.getRegistration(SubSubHashSet::class.java)
+        val ex = assertFailsWith<IllegalStateException> {
+            resolver.getRegistration(SubSubHashSet::class.java)
+        }
+        assertTrue(ex.message!!.contains("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$SubSubHashSet is blacklisted, so it cannot be used in serialization."))
     }
 
     class ConnectionImpl(private val connection: Connection) : Connection by connection
 
     @Test(timeout=300_000)
 	fun `Check blacklisted interface impl`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$ConnectionImpl is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(allButBlacklistedContext)
         // ConnectionImpl implements blacklisted Connection.
-        resolver.getRegistration(ConnectionImpl::class.java)
+        val ex = assertFailsWith<IllegalStateException> {
+            resolver.getRegistration(ConnectionImpl::class.java)
+        }
+        assertTrue(ex.message!!.contains("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$ConnectionImpl is blacklisted, so it cannot be used in serialization."))
     }
 
     interface SubConnection : Connection
@@ -359,11 +358,12 @@ class CordaClassResolverTests {
 
     @Test(timeout=300_000)
 	fun `Check blacklisted super-interface impl`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$SubConnectionImpl is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(allButBlacklistedContext)
         // SubConnectionImpl implements SubConnection, which extends the blacklisted Connection.
-        resolver.getRegistration(SubConnectionImpl::class.java)
+        val ex = assertFailsWith<IllegalStateException> {
+            resolver.getRegistration(SubConnectionImpl::class.java)
+        }
+        assertTrue(ex.message!!.contains("The superinterface java.sql.Connection of net.corda.serialization.internal.CordaClassResolverTests\$SubConnectionImpl is blacklisted, so it cannot be used in serialization."))
     }
 
     @Test(timeout=300_000)
@@ -378,10 +378,11 @@ class CordaClassResolverTests {
 
     @Test(timeout=300_000)
 	fun `Check blacklist precedes CordaSerializable`() {
-        expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$CordaSerializableHashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(allButBlacklistedContext)
         // CordaSerializableHashSet is @CordaSerializable, but extends the blacklisted HashSet.
-        resolver.getRegistration(CordaSerializableHashSet::class.java)
+        val ex = assertFailsWith<IllegalStateException> {
+            resolver.getRegistration(CordaSerializableHashSet::class.java)
+        }
+        assertTrue(ex.message!!.contains("The superclass java.util.HashSet of net.corda.serialization.internal.CordaClassResolverTests\$CordaSerializableHashSet is blacklisted, so it cannot be used in serialization."))
     }
 }

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.serialization.internal
 
 import com.esotericsoftware.kryo.*

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/amqp/AbstractAMQPSerializationSchemeTest.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/amqp/AbstractAMQPSerializationSchemeTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.corda.serialization.internal.amqp
 
 import net.corda.core.internal.toSynchronised
@@ -11,14 +9,12 @@ import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.SerializationContextImpl
 import net.corda.serialization.internal.amqp.testutils.serializationProperties
 import net.corda.coretesting.internal.createTestSerializationEnv
-import org.hamcrest.CoreMatchers
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.Matchers
-import org.junit.Assert
 import org.junit.Test
 import java.net.URLClassLoader
 import java.util.concurrent.ThreadLocalRandom
 import java.util.stream.IntStream
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class AbstractAMQPSerializationSchemeTest {
 
@@ -63,10 +59,10 @@ class AbstractAMQPSerializationSchemeTest {
             val testString = "TEST${ThreadLocalRandom.current().nextInt()}"
             val serialized = scheme.serialize(testString, context)
             val deserialized = serialized.deserialize(context = context, serializationFactory = serializationEnvironment.serializationFactory)
-            Assert.assertThat(testString, `is`(deserialized))
-            Assert.assertThat(backingMap.size, `is`(Matchers.lessThanOrEqualTo(maxFactories)))
+            assertEquals(testString, deserialized)
+            assertTrue(backingMap.size <= maxFactories)
         }
-        Assert.assertThat(backingMap.size, CoreMatchers.`is`(Matchers.lessThanOrEqualTo(maxFactories)))
+        assertTrue(backingMap.size <= maxFactories)
     }
 }
 

--- a/serialization-tests/src/test/kotlin/net/corda/serialization/internal/amqp/AbstractAMQPSerializationSchemeTest.kt
+++ b/serialization-tests/src/test/kotlin/net/corda/serialization/internal/amqp/AbstractAMQPSerializationSchemeTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package net.corda.serialization.internal.amqp
 
 import net.corda.core.internal.toSynchronised

--- a/serialization/src/test/java/net/corda/serialization/internal/amqp/JavaEvolutionTests.java
+++ b/serialization/src/test/java/net/corda/serialization/internal/amqp/JavaEvolutionTests.java
@@ -13,6 +13,7 @@ import java.io.NotSerializableException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+@SuppressWarnings("deprecation")
 public class JavaEvolutionTests {
     @Rule
     public final ExpectedException exception = ExpectedException.none();

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolationInJava.java
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolationInJava.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.instanceOf;
  *
  * but using the `registerFlowFactory` method implemented in response to https://r3-cev.atlassian.net/browse/CORDA-916
  */
+@SuppressWarnings("deprecation")
 public class TestResponseFlowInIsolationInJava {
 
     private final MockNetwork network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(cordappsForPackages()));


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

This PR contains the guava version upgrade that addresses the following vulnerability 
CVE-2023-2976


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
