### PR TITLE
ENT-15121 - security dependency updates

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -142,6 +142,20 @@ class CordaModule : SimpleModule("corda-core") {
 }
 
 private class CordaSerializableClassIntrospector(private val context: Module.SetupContext) : BasicClassIntrospector() {
+    override fun constructPropertyCollector(
+            config: MapperConfig<*>?,
+            ac: AnnotatedClass?,
+            type: JavaType,
+            forSerialization: Boolean,
+            mutatorPrefix: String?
+    ): POJOPropertiesCollector {
+        if (hasCordaSerializable(type.rawClass)) {
+            // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.
+            context.configOverride(type.rawClass).visibility = Value.defaultVisibility().withFieldVisibility(Visibility.ANY)
+        }
+        return super.constructPropertyCollector(config, ac, type, forSerialization, mutatorPrefix)
+    }
+
     override fun constructPropertyCollector(config: MapperConfig<*>?, classDef: AnnotatedClass?, type: JavaType, forSerialization: Boolean, accNaming: AccessorNamingStrategy?): POJOPropertiesCollector {
         if (hasCordaSerializable(type.rawClass)) {
             // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt
@@ -142,20 +142,6 @@ class CordaModule : SimpleModule("corda-core") {
 }
 
 private class CordaSerializableClassIntrospector(private val context: Module.SetupContext) : BasicClassIntrospector() {
-    override fun constructPropertyCollector(
-            config: MapperConfig<*>?,
-            ac: AnnotatedClass?,
-            type: JavaType,
-            forSerialization: Boolean,
-            mutatorPrefix: String?
-    ): POJOPropertiesCollector {
-        if (hasCordaSerializable(type.rawClass)) {
-            // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.
-            context.configOverride(type.rawClass).visibility = Value.defaultVisibility().withFieldVisibility(Visibility.ANY)
-        }
-        return super.constructPropertyCollector(config, ac, type, forSerialization, mutatorPrefix)
-    }
-
     override fun constructPropertyCollector(config: MapperConfig<*>?, classDef: AnnotatedClass?, type: JavaType, forSerialization: Boolean, accNaming: AccessorNamingStrategy?): POJOPropertiesCollector {
         if (hasCordaSerializable(type.rawClass)) {
             // Adjust the field visibility of CordaSerializable classes on the fly as they are encountered.

--- a/constants.properties
+++ b/constants.properties
@@ -50,7 +50,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.2_r3
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.18.7
+jacksonVersion=2.17.3
 jacksonKotlinVersion=2.9.7
 jettyVersion=9.4.58.v20250814
 jerseyVersion=2.47

--- a/constants.properties
+++ b/constants.properties
@@ -50,7 +50,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.2_r3
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.17.3
+jacksonVersion=2.18.7
 jacksonKotlinVersion=2.9.7
 jettyVersion=9.4.58.v20250814
 jerseyVersion=2.47
@@ -59,7 +59,7 @@ assertjVersion=3.27.7
 slf4JVersion=1.7.30
 log4JVersion=2.17.1
 okhttpVersion=3.14.9
-nettyVersion=4.1.132.Final
+nettyVersion=4.1.133.Final
 fileuploadVersion=1.6.0
 kryoVersion=4.0.2
 kryoSerializerVersion=0.43


### PR DESCRIPTION
Upgraded netty to address security vulnerabilities:

CVE-2026-41417  HTTP Request Smuggling
CVE-2026-42583  Allocation of Resources Without Limits or Throttling
CVE-2026-42585  HTTP Request Smuggling
CVE-2026-42584  HTTP Request Smuggling
CVE-2026-42580  HTTP Request Smuggling
CVE-2026-42587  Improper Handling of Highly Compressed Data (Data Amplification)
CVE-2026-42581  HTTP Request Smuggling
CVE-2026-42578  CRLF Injection
CVE-2026-42579  Null Byte Interaction Error (Poison Null Byte)
