### PR TITLE
ENT-15126: Add missing Netty dependencies to fix corda-shell Netty version mismatch

### DIFF
--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -24,6 +24,15 @@ dependencies {
 
     compile "io.netty:netty-handler-proxy:$netty_version"
 
+    // Override Artemis's older Netty native classifier JARs to prevent a JNI version mismatch at runtime in corda-shell
+    runtimeOnly "io.netty:netty-transport-native-epoll:$netty_version:linux-x86_64"
+    runtimeOnly "io.netty:netty-transport-native-epoll:$netty_version:linux-aarch_64"
+    runtimeOnly "io.netty:netty-transport-native-kqueue:$netty_version:osx-x86_64"
+    runtimeOnly "io.netty:netty-transport-native-kqueue:$netty_version:osx-aarch_64"
+    runtimeOnly "io.netty:netty-transport-native-unix-common:$netty_version"
+    runtimeOnly "io.netty:netty-transport-classes-epoll:$netty_version"
+    runtimeOnly "io.netty:netty-transport-classes-kqueue:$netty_version"
+
     // TypeSafe Config: for simple and human friendly config files.
     compile "com.typesafe:config:$typesafe_config_version"
 


### PR DESCRIPTION
Artemis 2.19.2_r3 declares these native classifier JARs at its own Netty version (4.1.73); without explicit declarations here at $netty_version, the older native lib is bundled against newer Java classes, causing UnsatisfiedLinkError on errorEHOSTUNREACH() when Netty initialises native transport.


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
