### PR TITLE
ENT-15730 : Upgraded log4j from 2.25.4 to 2.25.5

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -52,7 +52,7 @@ servletVersion=4.0.1
 assertjVersion=3.27.7
 
 slf4JVersion=2.0.12
-log4JVersion=2.25.4
+log4JVersion=2.25.5
 okhttpVersion=4.12.0
 nettyVersion=4.1.135.Final
 fileuploadVersion=2.0.0-M1


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

This PR upgrades log4j version from 2.25.4 to 2.25.5 in-order to resolve CVE-2026-49844

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
