### PR TITLE
ENT-15745: upgrading jacksonVersion and jacksonKotlinVersion to 2.21.5

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -45,7 +45,7 @@ asmVersion=9.5
 artemisVersion=2.54.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.21.5
-jacksonKotlinVersion=2.21.5
+jacksonKotlinVersion=2.19.4
 jettyVersion=12.0.33
 jerseyVersion=3.1.11
 servletVersion=4.0.1

--- a/constants.properties
+++ b/constants.properties
@@ -44,8 +44,8 @@ capsuleVersion=1.0.4_r3
 asmVersion=9.5
 artemisVersion=2.54.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.21.4
-jacksonKotlinVersion=2.19.4
+jacksonVersion=2.21.5
+jacksonKotlinVersion=2.21.5
 jettyVersion=12.0.33
 jerseyVersion=3.1.11
 servletVersion=4.0.1


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

This PR upgrades jacksonVersion and jacksonKotlinVersion to 2.21.5 in-order to resolve CVE-2026-59889

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
