### PR TITLE
ENT-15916 - Upgrade jetty version to  12.0.36

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -46,7 +46,7 @@ artemisVersion=2.55.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
 jacksonVersion=2.21.5
 jacksonKotlinVersion=2.19.4
-jettyVersion=12.0.33
+jettyVersion=12.0.36
 jerseyVersion=3.1.11
 servletVersion=4.0.1
 assertjVersion=3.27.7


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

This PR upgrades jetty-version to 12.0.36 to resolve CVE-2026-10050, CVE-2026-10051, CVE-2026-6790, CVE-2026-8384

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.r3.com/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs/kdocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially the [release notes](https://docs.r3.com/release-notes.html) (`https://docs.r3.com/release-notes.html`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.r3.com/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.r3.com/contributing.html).

Thanks for your code, it's appreciated! :)
