### PR TITLE
ENT-14904 - add ignoreDistributionRecord flag to SignedTransactionWithDistributionList

### DIFF
--- a/core-tests/src/test/kotlin/net/corda/coretests/serialization/TransactionSerializationTests.kt
+++ b/core-tests/src/test/kotlin/net/corda/coretests/serialization/TransactionSerializationTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.generateKeyPair
+import net.corda.core.flows.SignedTransactionWithDistributionList
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.node.NotaryInfo
@@ -109,6 +110,27 @@ class TransactionSerializationTests {
         assertFailsWith(SignatureException::class) {
             stx.verifyRequiredSignatures()
         }
+    }
+
+    @Test(timeout = 300_000)
+    fun `SignedTransactionWithDistributionList round-trips the ignoreDistributionRecord flag (ENT-14904)`() {
+        val stx = notaryServices.addSignature(megaCorpServices.signInitialTransaction(tx))
+        val distributionList = byteArrayOf(1, 2, 3)
+
+        // 4-arg form: the flag survives an AMQP round-trip. The class holds a ByteArray, so its data-class
+        // equals() is reference-based - assert the meaningful fields rather than whole-object equality.
+        val flagged = SignedTransactionWithDistributionList(stx, distributionList, isFinality = true, ignoreDistributionRecord = true)
+                .serialize().deserialize()
+        assertEquals(stx.id, flagged.stx.id)
+        assertEquals(true, flagged.isFinality)
+        assertEquals(true, flagged.ignoreDistributionRecord)
+
+        // The @DeprecatedConstructorForDeserialization 3-arg constructor - the shape an un-upgraded node uses -
+        // defaults the flag to false, and that survives a round-trip. (The generic old-blob -> new-class
+        // evolution mechanism is covered by EvolvabilityTests.addAdditionalParam; this asserts our class uses it.)
+        val legacy = SignedTransactionWithDistributionList(stx, distributionList, isFinality = true)
+                .serialize().deserialize()
+        assertEquals(false, legacy.ignoreDistributionRecord)
     }
 
     @Test(timeout=300_000)

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -149,11 +149,13 @@ open class ReceiveTransactionFlow constructor(private val otherSideSession: Flow
 
     open fun resolvePayload(payload: Any): SignedTransaction {
         return if (payload is SignedTransactionWithDistributionList) {
-            if (checkSufficientSignatures) {
+            if (checkSufficientSignatures && !payload.ignoreDistributionRecord) {
                 (serviceHub as ServiceHubCoreInternal).recordReceiverTransactionRecoveryMetadata(payload.stx.id, otherSideSession.counterparty.name,
                         TransactionMetadata(otherSideSession.counterparty.name, DistributionList.ReceiverDistributionList(payload.distributionList, statesToRecord)))
-                payload.stx
-            } else payload.stx
+            } else if (payload.ignoreDistributionRecord) {
+                logger.debug { "ENT-14904: skipping receiver distribution record for ${payload.stx.id} from ${otherSideSession.counterparty.name} (duplicate session to same peer)." }
+            }
+            payload.stx
         } else payload as SignedTransaction
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -339,4 +339,11 @@ data class SignedTransactionWithDistributionList(
     @DeprecatedConstructorForDeserialization(version = 1)
     constructor(stx: SignedTransaction, distributionList: ByteArray, isFinality: Boolean) :
             this(stx, distributionList, isFinality, false)
+
+    // Backward-compatible copy() method (3-param version) to maintain API stability for existing code.
+    // The data class-generated copy(4 params) remains available alongside this deprecated overload.
+    @Deprecated("Use copy(stx, distributionList, isFinality, ignoreDistributionRecord) with the 4-parameter version instead",
+            replaceWith = ReplaceWith("copy(stx, distributionList, isFinality, false)"))
+    fun copy(stx: SignedTransaction, distributionList: ByteArray, isFinality: Boolean) =
+            copy(stx, distributionList, isFinality, false)
 }

--- a/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt
@@ -328,5 +328,15 @@ open class DataVendingFlow(val otherSessions: Set<FlowSession>, val payload: Any
 data class SignedTransactionWithDistributionList(
         val stx: SignedTransaction,
         val distributionList: ByteArray,
-        val isFinality: Boolean
-)
+        val isFinality: Boolean,
+        // ENT-14904: when true, this transaction reached the peer over a duplicate session to the same
+        // counterparty; the receiver must skip writing its distribution record to avoid a PK violation.
+        val ignoreDistributionRecord: Boolean
+) {
+    // AMQP evolution (serialization-default-evolution): keep the original 3-arg constructor so a payload
+    // serialized by an older node (which has no ignoreDistributionRecord property) deserialises here with the
+    // flag defaulted to false. A new payload received by an older node simply ignores the extra property.
+    @DeprecatedConstructorForDeserialization(version = 1)
+    constructor(stx: SignedTransaction, distributionList: ByteArray, isFinality: Boolean) :
+            this(stx, distributionList, isFinality, false)
+}


### PR DESCRIPTION
## Summary
Part 1 of 2 (OS core) for ENT-14904. Enterprise counterpart: **corda/enterprise#5884**.

Under Two-Phase Finality, a transaction whose states resolve to multiple anonymous keys hosted by the same well-known party produces duplicate `FlowSession`s to that counterparty. Each duplicate session independently wrote the receiver distribution record, violating the `node_receiver_distr_recs` primary key.

This adds the wire-level mechanism so the **sender** can tell the receiver a given session is a duplicate and its distribution record must not be written again — avoiding any per-save existence check on the receiver's happy path.

## Changes
- `SignedTransactionWithDistributionList`: new `ignoreDistributionRecord: Boolean = false` (defaulted for serialization evolution).
- `ReceiveTransactionFlow.resolvePayload`: skips `recordReceiverTransactionRecoveryMetadata` when the flag is set; all other messaging unchanged.

## Interop
The field is defaulted, so it is safe in every mixed-version combination (an un-upgraded peer omits/ignores it and behaves exactly as today). The fix takes effect only when both ends are upgraded. No hard version gate required.

## Status / open items
- [ ] **Draft** — not yet built/tested locally (see build note). 
- [x] Serialization round-trip test added (`TransactionSerializationTests`): 4-arg flag preserved, 3-arg deprecated-ctor defaults false. Field added via `@DeprecatedConstructorForDeserialization` (StatePointer pattern) per Adel.
- [x] **Target branch pending decision:** ticket suggests a feature release (4.15) first, then possibly a 4.12 patch. Currently based on `release/os/4.12` to match the enterprise PR; retarget if we go 4.15-first.
- [ ] The sender that sets the flag lives in the enterprise repo (`EnterpriseSendTransactionFlow`); this PR must publish before that one can compile.

Refs: https://r3-cev.atlassian.net/browse/ENT-14904