### PR TITLE
ENT-16262 - Fixed a bug in the `CashPaymentFlow` so the value of the property `anonymous` is passed downstream.

### DIFF
--- a/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/workflows/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -69,7 +69,8 @@ open class CashPaymentFlow(
                     amount,
                     ourIdentityAndCert,
                     anonymousRecipient,
-                    issuerConstraint
+                    issuerConstraint,
+                    anonymous = anonymous
             )
         } catch (e: InsufficientBalanceException) {
             throw CashException("Insufficient cash for spend: ${e.message}", e)


### PR DESCRIPTION
Before this fix, the CashPaymentFlow would use the old CI keys regardless of the value passed to the property `anonymous`.