### PR TITLE
ENT-16291 - Improve key rotation proof chain validation

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2515,8 +2515,6 @@ public final class net.corda.core.crypto.keyrotation.crossprovider.KeyRotationPr
   @NotNull
   public final java.security.PublicKey getCurrentKey()
   @NotNull
-  public final java.util.List getKeyLineage()
-  @NotNull
   public final java.security.PublicKey getOriginalKey()
   public int hashCode()
   public final boolean isEmpty()
@@ -2533,8 +2531,6 @@ public static final class net.corda.core.crypto.keyrotation.crossprovider.KeyRot
   public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public final class net.corda.core.crypto.keyrotation.crossprovider.KeyRotationUtilsKt extends java.lang.Object
-  @NotNull
-  public static final java.util.Set getKeyLineage(java.util.List)
   @NotNull
   public static final java.security.PublicKey getOriginalKey(net.corda.core.crypto.TransactionSignature)
 ##

--- a/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
@@ -35,42 +35,47 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
 
     fun size() = proofChain.size
 
-    fun isValid(currentKey: PublicKey): Boolean {
+    fun isValid(rotatedToKey: PublicKey): Boolean {
         if(isEmpty()) {
             return true
         }
 
-        return isValid(originalKey, currentKey)
+        return isValid(originalKey, rotatedToKey)
     }
 
     fun asList(): List<KeyRotationProof> = proofChain
 
     /**
-     * Checks that a key rotation proof chain is valid.
+     * Checks whether this proof chain proves a valid rotation lineage FROM [rotatedFromKey] TO [rotatedToKey].
      *
-     * The chain is valid if:
-     * 1. It starts with the original key.
-     * 2. Each key change follows the previous one (continuous chain).
-     * 3. It ends with the current key.
-     * 4. Each key change is signed by the previous key.
+     * The chain is valid only if all of the following hold:
+     * 1. It STARTS at [rotatedFromKey] - the chain's first proof.publicKeyOld must equal [rotatedFromKey].
+     * 2. It ENDS at [rotatedToKey] - the chain's last proof.publicKeyNew must equal [rotatedToKey].
+     * 3. Each proof is continuous with the next (previous.publicKeyNew == next.publicKeyOld).
+     * 4. Each proof is cryptographically signed by its own publicKeyOld.
+     * 5. No key appears more than once, so the lineage is acyclic.
      *
-     * This ensures the history of key rotations is complete and trustworthy.
+     * [rotatedFromKey] and [rotatedToKey] must be the exact endpoints: it is NOT enough for them to
+     * appear somewhere inside the chain. A chain that merely contains them in the middle is rejected.
+     *
+     * @param rotatedFromKey the key the lineage must start from (matched against the chain's first publicKeyOld).
+     * @param rotatedToKey the key the lineage must end at (matched against the chain's last publicKeyNew).
      */
     @Suppress("ComplexMethod")
-    fun isValid(originalKey: PublicKey, currentKey: PublicKey): Boolean {
+    fun isValid(rotatedFromKey: PublicKey, rotatedToKey: PublicKey): Boolean {
         if (isEmpty()) {
-            logger.warn("Validation failed. Chain is empty. Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+            logger.warn("Validation failed. Chain is empty. Rotated-from key: ${rotatedFromKey.toStringShort()}, Rotated-to key: ${rotatedToKey.toStringShort()}")
             return false
         }
 
         // Validate first proof
-        if(!startsWithKey(originalKey)){
-            logger.warn("Validation failed. The chain does not start with the expected original key. Expected: ${originalKey.toStringShort()}, Actual: ${this.originalKey.toStringShort()}, Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+        if(!startsWithKey(rotatedFromKey)){
+            logger.warn("Validation failed. The chain does not start with the expected original key. Expected: ${rotatedFromKey.toStringShort()}, Actual: ${originalKey.toStringShort()}")
             return false
         }
 
         if(!isValid(proofChain[0])){
-            logger.warn("Validation failed. Proof is invalid. Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+            logger.warn("Validation failed. Proof is invalid. Rotated-from key: ${rotatedFromKey.toStringShort()}, Rotated-to key: ${rotatedToKey.toStringShort()}")
             return false
         }
 
@@ -78,24 +83,24 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
         // (A -> A) or a loop (A -> B -> A) is rejected on the offending proof.
         val seenKeys = hashSetOf(proofChain[0].publicKeyOld)
         if(!seenKeys.add(proofChain[0].publicKeyNew)) {
-            logger.warn("Validation failed. The chain revisits a key; each key must appear only once. Repeated key: ${proofChain[0].publicKeyNew.toStringShort()}, Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+            logger.warn("Validation failed. The chain revisits a key; each key must appear only once. Repeated key: ${proofChain[0].publicKeyNew.toStringShort()}, Rotated-from key: ${rotatedFromKey.toStringShort()}, Rotated-to key: ${rotatedToKey.toStringShort()}")
             return false
         }
 
         // Validate intermediate proofChain (continuity + proof)
-        proofChain.zipWithNext().forEach { (previous, current) ->
-            if(!isContinuous(previous, current)) {
-                logger.warn("Validation failed. The chain is not continuous. Previous proof new key and current proof old key must match. Previous proof new key: ${previous.publicKeyOld.toStringShort()}, Current proof old key: ${current.publicKeyOld.toStringShort()}, Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+        proofChain.zipWithNext().forEach { (previousProof, nextProof) ->
+            if(!isContinuous(previousProof, nextProof)) {
+                logger.warn("Validation failed. The chain is not continuous. The previous proof's new key must match the next proof's old key. Previous proof new key: ${previousProof.publicKeyNew.toStringShort()}, Next proof old key: ${nextProof.publicKeyOld.toStringShort()}, Rotated-from key: ${rotatedFromKey.toStringShort()}, Rotated-to key: ${rotatedToKey.toStringShort()}")
                 return false
             }
 
-            if(!isValid(current)) {
-                logger.warn("Validation failed. Proof is invalid. Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+            if(!isValid(nextProof)) {
+                logger.warn("Validation failed. Proof is invalid. Rotated-from key: ${rotatedFromKey.toStringShort()}, Rotated-to key: ${rotatedToKey.toStringShort()}")
                 return false
             }
 
-            if(!seenKeys.add(current.publicKeyNew)) {
-                logger.warn("Validation failed. The chain revisits a key. Each key must appear only once. Repeated key: ${current.publicKeyNew.toStringShort()}, Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+            if(!seenKeys.add(nextProof.publicKeyNew)) {
+                logger.warn("Validation failed. The chain revisits a key. Each key must appear only once. Repeated key: ${nextProof.publicKeyNew.toStringShort()}, Rotated-from key: ${rotatedFromKey.toStringShort()}, Rotated-to key: ${rotatedToKey.toStringShort()}")
                 return false
             }
         }
@@ -104,20 +109,20 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
         // Check it ends with the expected current key
         // The validation of the last proof is already covered in the intermediate proofChain validation,
         // so we only need to check the current key matches
-        if(!endsWithKey(currentKey)) {
-            logger.warn("Validation failed. The chain does not end with the expected key. Expected: ${currentKey.toStringShort()}, Actual: ${this.currentKey.toStringShort()}, Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+        if(!endsWithKey(rotatedToKey)) {
+            logger.warn("Validation failed. The chain does not end with the expected key. Expected: ${rotatedToKey.toStringShort()}, Actual: ${currentKey.toStringShort()}")
             return false
         }
 
         return true
     }
 
-    private fun startsWithKey(expectedOriginalKey: PublicKey): Boolean {
-        return originalKey == expectedOriginalKey
+    private fun startsWithKey(rotatedFromKey: PublicKey): Boolean {
+        return originalKey == rotatedFromKey
     }
 
-    private fun endsWithKey(expectedCurrentKey: PublicKey): Boolean {
-        return currentKey == expectedCurrentKey
+    private fun endsWithKey(rotatedToKey: PublicKey): Boolean {
+        return currentKey == rotatedToKey
     }
 
     private fun isContinuous(previous: KeyRotationProof, current: KeyRotationProof): Boolean {

--- a/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
@@ -71,6 +71,7 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
      *
      * This ensures the history of key rotations is complete and trustworthy.
      */
+    @Suppress("ComplexMethod")
     fun isValid(originalKey: PublicKey, currentKey: PublicKey): Boolean {
         if (isEmpty()) {
             logger.warn("Validation failed. Chain is empty. Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")

--- a/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
@@ -35,21 +35,6 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
 
     fun size() = proofChain.size
 
-    fun getKeyLineage(): List<PublicKey> {
-        if (isEmpty()) {
-            return emptyList()
-        }
-
-        val keys = mutableListOf<PublicKey>()
-        keys.add(originalKey)
-
-        proofChain.forEach { proof ->
-            keys.add(proof.publicKeyNew) // Add the new key from each proof
-        }
-
-        return keys
-    }
-
     fun isValid(currentKey: PublicKey): Boolean {
         if(isEmpty()) {
             return true

--- a/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
@@ -92,6 +92,14 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
             return false
         }
 
+        // Track keys as the chain is processed: a key may appear only once, so a self-proof
+        // (A -> A) or a loop (A -> B -> A) is rejected on the offending proof.
+        val seenKeys = hashSetOf(proofChain[0].publicKeyOld)
+        if(!seenKeys.add(proofChain[0].publicKeyNew)) {
+            logger.warn("Validation failed. The chain revisits a key; each key must appear only once. Repeated key: ${proofChain[0].publicKeyNew.toStringShort()}, Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+            return false
+        }
+
         // Validate intermediate proofChain (continuity + proof)
         proofChain.zipWithNext().forEach { (previous, current) ->
             if(!isContinuous(previous, current)) {
@@ -101,6 +109,11 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
 
             if(!isValid(current)) {
                 logger.warn("Validation failed. Proof is invalid. Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
+                return false
+            }
+
+            if(!seenKeys.add(current.publicKeyNew)) {
+                logger.warn("Validation failed. The chain revisits a key. Each key must appear only once. Repeated key: ${current.publicKeyNew.toStringShort()}, Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
                 return false
             }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChain.kt
@@ -72,10 +72,6 @@ data class KeyRotationProofChain(private val proofChain: List<KeyRotationProof>)
      * This ensures the history of key rotations is complete and trustworthy.
      */
     fun isValid(originalKey: PublicKey, currentKey: PublicKey): Boolean {
-        if(originalKey == currentKey) {
-            return true
-        }
-        
         if (isEmpty()) {
             logger.warn("Validation failed. Chain is empty. Original key: ${originalKey.toStringShort()}, Current key: ${currentKey.toStringShort()}")
             return false

--- a/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationUtils.kt
@@ -3,10 +3,6 @@ package net.corda.core.crypto.keyrotation.crossprovider
 import net.corda.core.crypto.TransactionSignature
 import java.security.PublicKey
 
-fun List<TransactionSignature>.getKeyLineage(): Set<PublicKey> {
-    return mapNotNull { signature -> signature.signatureMetadata.proofChain?.getKeyLineage() }.flatten().toSet()
-}
-
 fun TransactionSignature.getOriginalKey(): PublicKey {
     if (signatureMetadata.proofChain != null && signatureMetadata.proofChain.isNotEmpty()) {
         // If there is a proof chain, the original key is the first key in the chain.

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -4,7 +4,7 @@ import net.corda.core.DoNotImplement
 import net.corda.core.contracts.NamedByHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.isFulfilledBy
-import net.corda.core.crypto.keyrotation.crossprovider.getKeyLineage
+import net.corda.core.crypto.keyrotation.crossprovider.getOriginalKey
 import net.corda.core.internal.mapToSet
 import net.corda.core.transactions.SignedTransaction.SignaturesMissingException
 import net.corda.core.utilities.toNonEmptySet
@@ -101,7 +101,7 @@ interface TransactionWithSignatures : NamedByHash {
      * Return the [PublicKey]s for which we still need signatures.
      */
     fun getMissingSigners(): Set<PublicKey> {
-        val sigKeys = sigs.mapToSet { it.by } + sigs.getKeyLineage()
+        val sigKeys = sigs.mapToSet { it.by } + sigs.map { sig -> sig.getOriginalKey() }
 
         // TODO Problem is that we can get single PublicKey wrapped as CompositeKey in allowedToBeMissing/mustSign
         //  equals on CompositeKey won't catch this case (do we want to single PublicKey be equal to the same key wrapped in CompositeKey with threshold 1?)

--- a/core/src/test/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChainTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChainTest.kt
@@ -172,6 +172,69 @@ class KeyRotationProofChainTest {
         assertFalse(chain.isValid(k2.public))
     }
 
+    @Test(timeout=300_000)
+    fun `self-proof where a key rotates to itself is invalid`() {
+        val k1 = generateKeyPair()
+
+        // A -> A: a validly-signed proof, but a key cannot rotate to itself.
+        val chain = KeyRotationProofChain(listOf(createProof(k1, k1.public)))
+
+        assertFalse(chain.isValid(k1.public, k1.public), "A self-proof A -> A must be rejected")
+        assertFalse(chain.isValid(k1.public), "A self-proof A -> A must be rejected via the single-key overload")
+    }
+
+    @Test(timeout=300_000)
+    fun `chain that loops back to the original key is invalid`() {
+        val k1 = generateKeyPair()
+        val k2 = generateKeyPair()
+
+        // A -> B -> A: every link is validly signed and continuous, but A is seen twice.
+        val chain = KeyRotationProofChain(
+            listOf(
+                createProof(k1, k2.public),
+                createProof(k2, k1.public)
+            )
+        )
+
+        assertFalse(chain.isValid(k1.public, k1.public), "A loop A -> B -> A must be rejected")
+        assertFalse(chain.isValid(k1.public), "A loop A -> B -> A must be rejected via the single-key overload")
+    }
+
+    @Test(timeout=300_000)
+    fun `chain that revisits an intermediate key is invalid`() {
+        val k1 = generateKeyPair()
+        val k2 = generateKeyPair()
+        val k3 = generateKeyPair()
+
+        // A -> B -> C -> B: continuous and validly signed, but B is seen twice.
+        val chain = KeyRotationProofChain(
+            listOf(
+                createProof(k1, k2.public),
+                createProof(k2, k3.public),
+                createProof(k3, k2.public)
+            )
+        )
+
+        assertFalse(chain.isValid(k1.public, k2.public), "A chain revisiting an intermediate key must be rejected")
+        assertFalse(chain.isValid(k2.public), "A chain revisiting an intermediate key must be rejected via the single-key overload")
+    }
+
+    @Test(timeout=300_000)
+    fun `isValid does not short-circuit when the original and current key are the same`() {
+        val k1 = generateKeyPair()
+        val k2 = generateKeyPair()
+
+        // A genuine, fully valid rotation A -> B.
+        val chain = KeyRotationProofChain(listOf(createProof(k1, k2.public)))
+
+        // Sanity: still valid for its real endpoints.
+        assertTrue(chain.isValid(k1.public, k2.public), "A genuine A -> B rotation must remain valid")
+
+        // Passing the same key as original and current must NOT return true.
+        assertFalse(chain.isValid(k1.public, k1.public), "isValid(originalKey, originalKey) must not short-circuit to true")
+        assertFalse(chain.isValid(k1.public), "isValid(originalKey) must not short-circuit to true")
+    }
+
     private fun createProof(oldKeyPair: java.security.KeyPair, newKey: PublicKey): KeyRotationProof {
         val signature = Crypto.doSign(oldKeyPair.private, newKey.encoded)
         return KeyRotationProof(oldKeyPair.public, newKey, signature)

--- a/core/src/test/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChainTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/keyrotation/crossprovider/KeyRotationProofChainTest.kt
@@ -17,7 +17,6 @@ class KeyRotationProofChainTest {
         assertTrue(chain.isEmpty(), "Expected chain to report empty when initialized with no proofs")
         assertFalse(chain.isNotEmpty(), "Expected chain to report empty when initialized with no proofs")
         assertEquals(0, chain.size(), "Expected chain size to be 0 when initialized with no proofs")
-        assertTrue(chain.getKeyLineage().isEmpty(), "Expected key lineage to be empty when initialized with no proofs")
         assertTrue(chain.isValid(key), "Any empty chain should be valid for any key since it implies original and current keys are the same")
         assertFalse(chain.isValid(key, generateKeyPair().public), "Any empty chain should be invalid if original and current keys are different since there is no proof of rotation")
     }
@@ -33,7 +32,6 @@ class KeyRotationProofChainTest {
         assertEquals(1, chain.size())
         assertEquals(old.public, chain.originalKey, "Expected original key to match the old key from the proof")
         assertEquals(new.public, chain.currentKey, "Expected current key to match the new key from the proof")
-        assertEquals(listOf(old.public, new.public), chain.getKeyLineage(), "Expected key lineage to include both the old and new keys in order")
     }
 
     @Test(timeout=300_000)
@@ -54,7 +52,6 @@ class KeyRotationProofChainTest {
         assertEquals(2, chain.size())
         assertEquals(k1.public, chain.originalKey, "Expected original key to match the old key from the proof")
         assertEquals(k3.public, chain.currentKey, "Expected current key to match the new key from the proof")
-        assertEquals(listOf(k1.public, k2.public, k3.public), chain.getKeyLineage(), "Expected key lineage to include both the old and new keys in order")
         assertTrue(chain.isValid(k1.public, k3.public), "Expected chain to be valid when validating against the original key and the current key")
         assertTrue(chain.isValid(k3.public), "The chain is expected to be valid without specifying the original key, as the proofs in the chain should establish a link from the original key to the current key.")
     }


### PR DESCRIPTION
Updated the function KeyRotationProofChain.isValid. 
A chain is invalid if a key is seen multiple times.
Removed the short-circuit to avoid potential exploits. Besides, if the original key and the current key are the same, by definition the proof cannot validate them because a key cannot be rotated to itself.
Added tests to validate the changes made.
Some variables were renamed to improve readability.