### PR TITLE
ENT-16352 Upgrading micrometer version in 4.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -537,10 +537,7 @@ allprojects {
                         details.useVersion reactor_netty_version
                     }
 
-                    // SNYK-JAVA-IOMICROMETER-17339194 / CVE-2026-40983
-                    // SNYK-JAVA-IOMICROMETER-17260885 / CVE-2026-40984
-                    // vulnerability in io.micrometer:micrometer-core@1.16.5 fixed in micrometer-core@1.16.6
-                    // micrometer-core@1.16.5 is a transitive dependency via artemis-server@2.54.0
+                    // SNYK-JAVA-IOMICROMETER-19233327 / CVE-2026-59296
                     // force-upgrade micrometer-core to a fixed version
                     // Review when Artemis is upgraded
                     if (details.requested.group == 'io.micrometer' && details.requested.name == "micrometer-core") {

--- a/constants.properties
+++ b/constants.properties
@@ -107,4 +107,4 @@ snakeYamlVersion=2.2
 nimbusJoseJwtVersion=10.0.2
 commonsConfiguration2Version=2.15.0
 reactorNettyVersion=1.2.18
-micrometerCoreVersion=1.16.6
+micrometerCoreVersion=1.17.1


### PR DESCRIPTION
This PR upgrades micrometerVersion to 1.17.1 to address CVE-2026-59296