### PR TITLE
ENT-16546 Upgrading proton-j version in 0.35.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ buildscript {
     ext.proguard_version = constants.getProperty('proguardVersion')
     ext.jsch_version = constants.getProperty("jschVersion")
     ext.protonj_version = constants.getProperty("protonjVersion")
+    ext.qpid_version = constants.getProperty("qpidVersion")
     ext.snappy_version = constants.getProperty("snappyVersion")
     ext.class_graph_version = constants.getProperty('classgraphVersion')
     ext.jcabi_manifests_version = constants.getProperty("jcabiManifestsVersion")

--- a/constants.properties
+++ b/constants.properties
@@ -86,7 +86,7 @@ seleniumVersion=3.141.59
 ghostdriverVersion=2.1.0
 jschVersion=0.1.55
 # Override Artemis version
-protonjVersion=0.33.0
+protonjVersion=0.35.0
 snappyVersion=0.5
 jcabiManifestsVersion=1.1
 picocliVersion=3.9.6

--- a/constants.properties
+++ b/constants.properties
@@ -87,6 +87,9 @@ ghostdriverVersion=2.1.0
 jschVersion=0.1.55
 # Override Artemis version
 protonjVersion=0.35.0
+# Version of qpid-jms-client used by integration tests only. Its version numbering is independent of proton-j
+# (they only coincidentally overlap around 0.3x from ~2018) - do NOT tie this to protonjVersion.
+qpidVersion=0.33.0
 snappyVersion=0.5
 jcabiManifestsVersion=1.1
 picocliVersion=3.9.6

--- a/constants.properties
+++ b/constants.properties
@@ -87,8 +87,6 @@ ghostdriverVersion=2.1.0
 jschVersion=0.1.55
 # Override Artemis version
 protonjVersion=0.35.0
-# Version of qpid-jms-client used by integration tests only. Its version numbering is independent of proton-j
-# (they only coincidentally overlap around 0.3x from ~2018) - do NOT tie this to protonjVersion.
 qpidVersion=0.33.0
 snappyVersion=0.5
 jcabiManifestsVersion=1.1

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     integrationTestImplementation "de.javakaffee:kryo-serializers:$kryo_serializer_version"
     integrationTestImplementation "junit:junit:$junit_version"
     integrationTestImplementation "org.assertj:assertj-core:${assertj_version}"
-    integrationTestImplementation "org.apache.qpid:qpid-jms-client:${protonj_version}"
+    integrationTestImplementation "org.apache.qpid:qpid-jms-client:${qpid_version}"
 
     // used by FinalityFlowErrorHandlingTest
     slowIntegrationTestImplementation project(':testing:cordapps:cashobservers')


### PR DESCRIPTION
This PR upgrades proton-j version to 0.35.0 to address CVE-2026-66275

Also, qpid-jms-client's version numbers coincidentally overlap proton-j's around 0.33 from 2018. Upgrading protonj_version to 0.35.0 (for CVE-2026-66273) also moved qpid-jms-client from its 0.33.0 to 0.35.0 release, which changed internal SPI, that broke SimpleAMQPClient.kt compilation.
hence we decoupled both
