### PR TITLE
ENT-16547 Upgrading reactor-netty version in 1.3.7

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -106,5 +106,5 @@ nimbusOauth2Version=8.36.2
 snakeYamlVersion=2.2
 nimbusJoseJwtVersion=10.0.2
 commonsConfiguration2Version=2.15.0
-reactorNettyVersion=1.2.18
+reactorNettyVersion=1.3.7
 micrometerCoreVersion=1.16.6

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -33,6 +33,7 @@ configurations {
     implementation {
         exclude group: "log4j", module: "log4j"
         exclude group: "org.apache.logging.log4j"
+        exclude group: "io.netty", module: "netty-codec-http3"
     }
 }
 


### PR DESCRIPTION
This PR upgrades reactor-netty-http version to 1.3.7 to address CVE-2026-47874

reactor-netty-http to 1.3.7 pulls in netty-codec-http3, which only exists in version 4.2.x , but Corda forces all Netty artifacts to 4.1.136.Final — so resolution failed on a version that doesn't exist.
Hence we exclude io.netty:netty-codec-http3 from tools/network-builder/build.gradle so it's never requested, also corda doesn't support HTTP/3
