### PR TITLE
ENT-16547 Upgrading reactor-netty version in 1.3.7

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -112,4 +112,4 @@ javaassistVersion=3.27.0-GA
 httpClientVersion=4.5.14
 okioVersion=1.17.6
 commonsDbcpVersion=2.14.0
-reactorNettyVersion=1.2.18
+reactorNettyVersion=1.3.7

--- a/tools/network-builder/build.gradle
+++ b/tools/network-builder/build.gradle
@@ -34,6 +34,7 @@ configurations {
         exclude group: "log4j", module: "log4j"
         // The Node only needs this for binary compatibility with Cordapps written in Kotlin 1.1.
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jre8'
+        exclude group: "io.netty", module: "netty-codec-http3"
     }
 }
 


### PR DESCRIPTION
This PR upgrades reactor-netty-http version to 1.3.7 to address CVE-2026-47874

reactor-netty-http to 1.3.7 pulls in netty-codec-http3, which only exists in version 4.2.x , but Corda forces all Netty artifacts to 4.1.136.Final — so resolution failed on a version that doesn't exist.
Hence we exclude io.netty:netty-codec-http3 from tools/network-builder and enterprise-utils so it's never requested, also corda doesn't support HTTP/3
