### PR TITLE
ENT-16574 Upgrade jackson-databind to 2.18.10

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -50,7 +50,7 @@ capsuleVersion=1.0.3
 asmVersion=7.1
 artemisVersion=2.19.2_r3
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.18.9
+jacksonVersion=2.18.10
 jacksonKotlinVersion=2.9.10
 jettyVersion=9.4.58.v20250814
 jerseyVersion=2.47


### PR DESCRIPTION
This PR upgrades Jackson-databind to 2.18.10 to address CVE-2026-83557