### PR TITLE
ENT-16578 Upgrade jackson-databind to 2.21.6

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -44,7 +44,7 @@ capsuleVersion=1.0.4_r3
 asmVersion=9.5
 artemisVersion=2.55.0
 # TODO Upgrade Jackson only when corda is using kotlin 1.3.10
-jacksonVersion=2.21.5
+jacksonVersion=2.21.6
 jacksonKotlinVersion=2.19.4
 jettyVersion=12.0.36
 jerseyVersion=3.1.11


### PR DESCRIPTION
This PR upgrades Jackson-databind to version 2.21.6 to address CVE-2026-83557